### PR TITLE
feat(search): search quality improvements — workspace isolation, temporal scoring, length normalization

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,7 @@ const args = process.argv.slice(2);
 // Prefer the pre-compiled dist/index.js — works on any platform without esbuild.
 // Fall back to tsx (TypeScript source) only when dist is absent (e.g. dev checkout
 // without a build step).
-const distEntry = join(__dirname, '..', 'dist', 'index.js');
+const distEntry = join(__dirname, '..', 'dist', 'cli', 'index.js');
 
 if (existsSync(distEntry)) {
   // Run compiled JS directly — no tsx / esbuild dependency at all.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - OLLAMA_HOST=http://host.docker.internal:11434
       - NODE_OPTIONS=--max-old-space-size=1536
       - NANO_BRAIN_EMBEDDING_CONCURRENCY=3
-    command: sh -c "npm install --omit=dev --prefer-offline --legacy-peer-deps && npm rebuild tree-sitter tree-sitter-python tree-sitter-typescript tree-sitter-javascript && ./node_modules/.bin/tsx src/index.ts mcp --http --port=3100 --host=0.0.0.0 --root=${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}"
+    command: sh -c "npm install --omit=dev --prefer-offline --legacy-peer-deps --no-audit --no-fund && npm rebuild tree-sitter tree-sitter-python tree-sitter-typescript tree-sitter-javascript && ./node_modules/.bin/tsx src/index.ts mcp --http --port=3100 --host=0.0.0.0 --root=${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}"
     depends_on:
       - qdrant
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - nano-brain-node-modules:/app/node_modules
       - ${NANO_BRAIN_HOME:-~/.nano-brain}:/root/.nano-brain
       - ${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}:${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}:ro
-      - ${OPENCODE_SESSION_DIR:-~/.local/share/opencode/storage}:/root/.local/share/opencode/storage:ro
+      - ${OPENCODE_SESSION_DIR:-~/.ai-sandbox/tools/opencode/home/.local/share/opencode/storage}:/root/.local/share/opencode/storage:ro
     environment:
       - NODE_ENV=production
       - OLLAMA_HOST=http://host.docker.internal:11434

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - nano-brain-node-modules:/app/node_modules
       - ${NANO_BRAIN_HOME:-~/.nano-brain}:/root/.nano-brain
       - ${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}:${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}:ro
-      - ${OPENCODE_SESSION_DIR:-~/.ai-sandbox/tools/opencode/home/.local/share/opencode/storage}:/root/.local/share/opencode/storage:ro
+      - ${OPENCODE_SESSION_DIR:-~/.local/share/opencode/storage}:/root/.local/share/opencode/storage:ro
     environment:
       - NODE_ENV=production
       - OLLAMA_HOST=http://host.docker.internal:11434

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - nano-brain-node-modules:/app/node_modules
       - ${NANO_BRAIN_HOME:-~/.nano-brain}:/root/.nano-brain
       - ${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}:${NANO_BRAIN_WORKSPACE:-/Users/tamlh/workspaces/NUSTechnology/Projects/zengamingx}:ro
+      - ${OPENCODE_SESSION_DIR:-~/.ai-sandbox/tools/opencode/home/.local/share/opencode/storage}:/root/.local/share/opencode/storage:ro
     environment:
       - NODE_ENV=production
       - OLLAMA_HOST=http://host.docker.internal:11434

--- a/openspec/changes/nano-brain-docker-networking-fixes/.openspec.yaml
+++ b/openspec/changes/nano-brain-docker-networking-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/nano-brain-docker-networking-fixes/design.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/design.md
@@ -1,0 +1,93 @@
+## Context
+
+**Deployment topology:**
+```
+macOS Host
+├── Ollama (native, port 11434)
+├── [docker-compose network: nano-brain_default]
+│   ├── nano-brain-server (node:22, port 3100)
+│   └── nano-brain-qdrant (qdrant:latest, port 6333)
+└── opencode container (ai-sandbox-wrapper, isolated bridge network)
+      --add-host=host.docker.internal:host-gateway  ← always injected
+      -v ~/.nano-brain:/home/agent/.nano-brain        ← always mounted
+```
+
+The CLI runs inside the opencode container. The server runs in a separate docker-compose network. The two containers share no Docker network, but both resolve `host.docker.internal` to the macOS host gateway. The CLI uses `host.docker.internal:3100` to reach the server (via host-gateway → compose port mapping).
+
+**Current failures:**
+1. `proxyPost`/`proxyGet` hang forever when server is unreachable (no timeout)
+2. Non-2xx responses are silently deserialized, masking server errors
+3. `docker.ts` health checks hardcode `localhost:3100` — fails inside container
+4. `isRunningInContainer()` misses containerd runtimes (no cgroup check)
+5. Duplicate `*Container` proxy functions add dead weight and confuse call sites
+6. SSE and Streamable HTTP connections drop silently after proxy idle timeout (no heartbeat)
+7. User config has `vector.url: http://host.docker.internal:6333` (set when qdrant was exposed on host) — qdrant is now on the compose-internal network but user config is never migrated
+
+## Goals / Non-Goals
+
+**Goals:**
+- All `npx nano-brain` commands work correctly from inside the opencode container
+- All proxy calls fail fast (≤30s) with actionable error messages
+- SSE and Streamable HTTP MCP connections survive 60+ seconds of idle time
+- User config migration runs automatically on `docker start`
+
+**Non-Goals:**
+- Supporting arbitrary Docker network topologies (only the ai-sandbox-wrapper + docker-compose setup is supported)
+- CORS fixes for the web dashboard (separate concern)
+- Adding retry logic to proxy calls (single attempt with timeout is sufficient)
+
+## Decisions
+
+### D1: Use `isInsideContainer()` from `host.ts` instead of `isRunningInContainer()` from `cli/utils.ts`
+
+`isInsideContainer()` checks both `/.dockerenv` and `/proc/self/cgroup` for container markers, while `isRunningInContainer()` only checks `/.dockerenv`. `isInsideContainer()` also caches its result.
+
+**Alternative considered:** Patch `isRunningInContainer()` in-place. Rejected — `isInsideContainer()` already exists in `host.ts` with the correct logic; patching in-place creates two implementations to maintain.
+
+### D2: Delete `*Container` duplicate functions entirely
+
+`proxyPostContainer`, `proxyGetContainer`, and `detectRunningServerContainer` are functionally identical to their non-Container counterparts because `getHttpHost()` already handles container routing. The only difference is a 1s vs 2s timeout in `detectRunningServer`.
+
+**Alternative considered:** Keep both and deprecate. Rejected — the Container variants are already incorrect abstractions and no external callers exist outside this codebase.
+
+### D3: Use `AbortSignal.timeout(30_000)` not manual `AbortController`
+
+`AbortSignal.timeout()` is the established pattern in this codebase (see `src/embedding/embeddings.ts`, `src/llm/llm-provider.ts`, `src/search/reranker.ts`). No cleanup code required.
+
+**Alternative considered:** Manual `AbortController` with `setTimeout` + `clearTimeout`. Rejected — more boilerplate, inconsistent with codebase style.
+
+### D4: Expose optional `timeoutMs` parameter on proxy functions
+
+Signature: `proxyPost(port, path, body, timeoutMs = 30_000)`. This allows callers that need different timeouts (e.g., `detectRunningServer` needs 2s) to pass it inline rather than duplicating the function.
+
+### D5: Migrate qdrant URL in user config during `docker start`
+
+The user's `~/.nano-brain/config.yml` has `vector.url: http://host.docker.internal:6333`. This worked when qdrant was port-mapped, but is fragile and wrong now that qdrant is only reachable internally via compose DNS (`qdrant:6333`) from the server container.
+
+The migration runs in `docker.ts` before spawning containers: read config YAML, check for the legacy URL, rewrite to `http://qdrant:6333`, write back, log notice. Uses `js-yaml` (already a dependency).
+
+**Alternative considered:** Document it and ask users to fix manually. Rejected — the bug is invisible and the migration is a single YAML key rewrite.
+
+### D6: SSE heartbeat as SSE comment, 30s interval, per-connection local var
+
+`setInterval` stored in a local `const heartbeatInterval` inside the SSE/HTTP connection handler. Cleared in all three close paths: `transport.onclose`, `res.on('close')`, `res.on('error')`. Write guarded by `!res.writableEnded && !res.destroyed`.
+
+SSE comment format: `: ping\n\n` — valid SSE per RFC, ignored by compliant clients.
+
+**Alternative considered:** Global heartbeat map. Rejected — per-connection local var is simpler and has no coordination risk.
+
+## Risks / Trade-offs
+
+- **[Risk] Config migration is one-way** → No rollback. If user intentionally had `host.docker.internal:6333` for an atypical setup, migration overwrites it. Mitigation: print notice with old and new value so user can revert manually.
+- **[Risk] Bug 2+4 is large atomic change (12 import sites, ~20 call sites)** → A missed call site causes a compile error caught by `tsc`, not a runtime failure. Mitigation: run `npx tsc --noEmit` after each file, not only at the end.
+- **[Risk] `init.ts` container guard** → `isRunningInContainer()` on line 24 blocks `--force --all` (destructive op that deletes all databases). Must be replaced with `isInsideContainer()` with identical `if (inContainer) return` semantics. Mitigation: explicit before/after behavior check in implementation task.
+
+## Migration Plan
+
+1. `docker start` command: read config, check for legacy URL, rewrite if found, log notice, then proceed with container startup as normal.
+2. No server restart required for other fixes — all changes are in CLI code or HTTP handler code loaded at request time.
+3. Rollback: `git revert` on the docker.ts change; restore old config URL manually if needed.
+
+## Open Questions
+
+None — all design questions resolved by cross-critique phase.

--- a/openspec/changes/nano-brain-docker-networking-fixes/proposal.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+When `npx nano-brain` CLI commands run inside the opencode container (started by ai-sandbox-wrapper) and the nano-brain server runs in a separate docker-compose network, several networking bugs cause silent failures, hangs, and incorrect host resolution. These bugs block nano-brain from being usable as an MCP server and memory tool in any containerized AI agent workflow.
+
+## What Changes
+
+- **Delete** the `*Container` duplicate proxy functions (`proxyPostContainer`, `proxyGetContainer`, `detectRunningServerContainer`) from `cli/utils.ts` — they are redundant because `getHttpHost()` already handles container routing
+- **Replace** `isRunningInContainer()` (only checks `/.dockerenv`) with `isInsideContainer()` from `host.ts` (also checks cgroups, works in containerd and Docker-in-Docker environments) across all 7 call sites
+- **Add** `AbortSignal.timeout(30_000)` to `proxyGet` and `proxyPost` — currently these hang indefinitely if the server is unreachable
+- **Add** `resp.ok` check to `proxyGet` and `proxyPost` — currently non-2xx HTTP responses are silently deserialized as if successful
+- **Fix** 3 hardcoded `localhost:3100` URLs in `docker.ts` to use `getHttpHost()` — currently health checks fail when run from inside a container
+- **Add** SSE heartbeat (30s `setInterval`) to `src/http/sse.ts` and Streamable HTTP transport in `src/http/routes.ts` — currently idle connections are killed by proxies with no keepalive, leaking session entries and disconnecting MCP clients silently
+- **Add** migration logic to `docker start` command to rewrite legacy `vector.url: http://host.docker.internal:6333` → `http://qdrant:6333` in user config **BREAKING** (behavior change: qdrant accessed via compose DNS instead of host-gateway)
+
+## Capabilities
+
+### New Capabilities
+- `container-aware-cli`: CLI commands correctly detect container context and route all HTTP calls through `host.docker.internal` when running inside any container runtime (Docker, containerd, Docker-in-Docker)
+- `resilient-proxy-calls`: All CLI-to-server proxy calls have a 30s timeout and validate HTTP response status before deserializing, with actionable error messages including the `NANO_BRAIN_HOST` env var hint
+- `sse-heartbeat`: SSE and Streamable HTTP MCP transports send a keepalive ping every 30s to prevent proxy-induced disconnections, with proper cleanup on all close/error events
+
+### Modified Capabilities
+- `mcp-server`: SSE transport gains heartbeat and error-handler cleanup (behavioral change to connection lifecycle)
+
+## Impact
+
+- **Files**: `src/cli/utils.ts`, `src/cli/commands/docker.ts`, `src/cli/commands/wake-up.ts`, `src/cli/commands/search.ts`, `src/cli/commands/write.ts`, `src/cli/commands/embed.ts`, `src/cli/commands/reindex.ts`, `src/cli/commands/init.ts`, `src/http/sse.ts`, `src/http/routes.ts`
+- **Breaking**: Users with `vector.url: http://host.docker.internal:6333` in `~/.nano-brain/config.yml` will have that URL migrated to `http://qdrant:6333` on next `docker start`
+- **Dependencies**: No new npm dependencies
+- **APIs**: No public API changes; proxy function signatures gain optional `timeoutMs` parameter

--- a/openspec/changes/nano-brain-docker-networking-fixes/specs/container-aware-cli/spec.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/specs/container-aware-cli/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: CLI detects container runtime via cgroups fallback
+The CLI SHALL detect whether it is running inside a container by checking both `/.dockerenv` (Docker) and `/proc/self/cgroup` content (containerd, Docker-in-Docker, and other OCI runtimes). The result SHALL be cached after first evaluation.
+
+#### Scenario: Detection in standard Docker container
+- **WHEN** the CLI runs inside a container that has `/.dockerenv` present
+- **THEN** `isInsideContainer()` SHALL return `true`
+
+#### Scenario: Detection in containerd-only environment
+- **WHEN** the CLI runs inside a container where `/.dockerenv` is absent but `/proc/self/cgroup` contains `docker` or `containerd`
+- **THEN** `isInsideContainer()` SHALL return `true`
+
+#### Scenario: Detection on host machine
+- **WHEN** the CLI runs on a macOS or Linux host with neither `/.dockerenv` nor container cgroup markers
+- **THEN** `isInsideContainer()` SHALL return `false`
+
+#### Scenario: Result is cached
+- **WHEN** `isInsideContainer()` is called multiple times in the same process
+- **THEN** the filesystem checks SHALL be performed only once
+
+### Requirement: CLI routes HTTP calls to host.docker.internal inside containers
+The CLI SHALL use `host.docker.internal` as the HTTP server host when running inside any container, and `localhost` when running on the host.
+
+#### Scenario: Host resolution inside container
+- **WHEN** a CLI command executes inside a container and calls `getHttpHost()`
+- **THEN** the returned host SHALL be `host.docker.internal`
+
+#### Scenario: Host resolution on macOS host
+- **WHEN** a CLI command executes on the macOS host and calls `getHttpHost()`
+- **THEN** the returned host SHALL be `localhost`
+
+### Requirement: Container-specific duplicate proxy functions are removed
+The CLI SHALL NOT expose `proxyPostContainer`, `proxyGetContainer`, or `detectRunningServerContainer` functions. All container-awareness SHALL be encapsulated inside `proxyPost`, `proxyGet`, and `detectRunningServer` via `getHttpHost()`.
+
+#### Scenario: No Container-suffixed imports in command files
+- **WHEN** any CLI command file is compiled
+- **THEN** it SHALL NOT import any symbol ending in `Container` from `cli/utils`
+
+### Requirement: docker.ts health checks use dynamic host resolution
+The `docker status`, `docker start`, and `docker stop` commands SHALL resolve the nano-brain server host dynamically using `getHttpHost()` rather than hardcoding `localhost`.
+
+#### Scenario: docker status from inside container
+- **WHEN** `npx nano-brain docker status` runs inside a container
+- **THEN** the health check request SHALL target `http://host.docker.internal:3100/health`
+
+#### Scenario: docker status from host
+- **WHEN** `npx nano-brain docker status` runs on the macOS host
+- **THEN** the health check request SHALL target `http://localhost:3100/health`
+
+### Requirement: User config qdrant URL is migrated on docker start
+On `npx nano-brain docker start`, if `~/.nano-brain/config.yml` contains `vector.url: http://host.docker.internal:6333`, the CLI SHALL rewrite it to `http://qdrant:6333` and log a migration notice.
+
+#### Scenario: Legacy qdrant URL is migrated
+- **WHEN** `docker start` runs and config contains `vector.url: http://host.docker.internal:6333`
+- **THEN** config SHALL be updated to `http://qdrant:6333` before containers start
+- **AND** a migration notice SHALL be printed to stdout
+
+#### Scenario: Already-correct qdrant URL is not modified
+- **WHEN** `docker start` runs and config already contains `vector.url: http://qdrant:6333`
+- **THEN** config SHALL NOT be modified

--- a/openspec/changes/nano-brain-docker-networking-fixes/specs/mcp-server/spec.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/specs/mcp-server/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: SSE transport maintains persistent connections with keepalive
+The SSE transport SHALL send a keepalive ping (SSE comment `: ping\n\n`) every 30 seconds, register cleanup handlers for `transport.onclose`, `res.on('close')`, and `res.on('error')`, and guard all writes with `res.writableEnded` and `res.destroyed` checks. This replaces any prior requirement that did not mandate keepalive behavior.
+
+#### Scenario: MCP client connected via SSE survives proxy idle timeout
+- **WHEN** an MCP client connects via SSE and is idle for 60 seconds
+- **THEN** the connection SHALL remain open
+- **AND** the client SHALL NOT receive an unexpected disconnection
+
+#### Scenario: SSE session entry is removed on all disconnect paths
+- **WHEN** an SSE client disconnects via any means (explicit close, network error, ECONNRESET)
+- **THEN** the session entry SHALL be removed from the sessions map
+- **AND** the heartbeat interval SHALL be cleared

--- a/openspec/changes/nano-brain-docker-networking-fixes/specs/resilient-proxy-calls/spec.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/specs/resilient-proxy-calls/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Proxy calls time out after 30 seconds
+`proxyGet` and `proxyPost` SHALL abort the HTTP request and throw an error if the server does not respond within 30 seconds. The timeout SHALL be implemented via `AbortSignal.timeout(timeoutMs)` with a default of 30,000ms.
+
+#### Scenario: Server unreachable causes timeout error
+- **WHEN** a CLI command calls `proxyPost` and the server does not respond within 30 seconds
+- **THEN** the call SHALL throw an `AbortError` (or `TimeoutError`)
+- **AND** the process SHALL NOT hang indefinitely
+
+#### Scenario: Custom timeout can be passed
+- **WHEN** a caller passes `timeoutMs` explicitly (e.g., 5000)
+- **THEN** the abort SHALL fire after that many milliseconds
+
+#### Scenario: Fast server response is unaffected
+- **WHEN** the server responds within 1 second
+- **THEN** the response SHALL be returned normally without any timeout interference
+
+### Requirement: Proxy calls validate HTTP response status
+`proxyGet` and `proxyPost` SHALL check `response.ok` and throw an error with the HTTP status code and status text if the response is not 2xx.
+
+#### Scenario: Non-2xx response throws with status info
+- **WHEN** the server returns HTTP 500 or any non-2xx status
+- **THEN** the proxy function SHALL throw an `Error` with message containing the status code and status text
+- **AND** the response body SHALL NOT be silently deserialized
+
+#### Scenario: 2xx response is deserialized normally
+- **WHEN** the server returns HTTP 200
+- **THEN** the response JSON SHALL be returned as normal
+
+### Requirement: Proxy error messages include actionable hints
+When a proxy call fails due to connection refusal or timeout, the error message SHALL include a hint about setting the `NANO_BRAIN_HOST` environment variable.
+
+#### Scenario: Connection refused includes NANO_BRAIN_HOST hint
+- **WHEN** `proxyPost` fails because the server is not running
+- **THEN** the error output SHALL mention `NANO_BRAIN_HOST` as a configuration option

--- a/openspec/changes/nano-brain-docker-networking-fixes/specs/sse-heartbeat/spec.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/specs/sse-heartbeat/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: SSE transport sends keepalive pings every 30 seconds
+The SSE transport in `src/http/sse.ts` SHALL send an SSE comment (`: ping\n\n`) to the client every 30 seconds to prevent proxy-induced idle disconnections.
+
+#### Scenario: Heartbeat keeps idle connection alive
+- **WHEN** an MCP client connects via SSE and sends no messages for 60 seconds
+- **THEN** the connection SHALL remain open
+- **AND** the client SHALL have received at least one `: ping` comment
+
+#### Scenario: Heartbeat interval is per-connection
+- **WHEN** multiple MCP clients are connected simultaneously
+- **THEN** each connection SHALL have its own independent heartbeat interval
+
+### Requirement: SSE heartbeat is cleaned up on all close and error events
+The heartbeat `setInterval` SHALL be cleared when the connection closes via any code path: `transport.onclose`, `res.on('close')`, or `res.on('error')`.
+
+#### Scenario: Heartbeat stops on client disconnect
+- **WHEN** an MCP client disconnects (closes the HTTP connection)
+- **THEN** the heartbeat `setInterval` SHALL be cleared
+- **AND** no further pings SHALL be written to the response
+
+#### Scenario: Heartbeat stops on network error
+- **WHEN** the connection is terminated with ECONNRESET or EPIPE
+- **THEN** `res.on('error')` handler SHALL clear the heartbeat interval
+- **AND** the error SHALL NOT propagate as an uncaught exception
+
+### Requirement: SSE writes are guarded against writing to closed responses
+Before each SSE write (both heartbeat pings and message writes), the handler SHALL check `res.writableEnded` and `res.destroyed` and skip the write if either is true.
+
+#### Scenario: No write to ended response
+- **WHEN** a heartbeat fires after the response has already ended
+- **THEN** the write SHALL be skipped without error
+
+### Requirement: Streamable HTTP transport also has keepalive and cleanup
+The Streamable HTTP transport in `src/http/routes.ts` SHALL apply the same 30s heartbeat and cleanup pattern as the SSE transport.
+
+#### Scenario: Streamable HTTP idle connection survives
+- **WHEN** an MCP client connects via Streamable HTTP and is idle for 60 seconds
+- **THEN** the connection SHALL remain open

--- a/openspec/changes/nano-brain-docker-networking-fixes/tasks.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/tasks.md
@@ -1,0 +1,53 @@
+## 1. Container Detection (Bug 3)
+
+- [x] 1.1 In `src/cli/utils.ts`: remove `isRunningInContainer()` function and its import of `existsSync` if no longer needed
+- [x] 1.2 In `src/cli/utils.ts`: update `getHttpHost()` to call `isInsideContainer()` from `'../host.js'`
+- [x] 1.3 In `src/cli/commands/wake-up.ts`: replace `isRunningInContainer` import with `isInsideContainer` from `'../../host.js'`
+- [x] 1.4 In `src/cli/commands/search.ts`: replace `isRunningInContainer` import with `isInsideContainer`
+- [x] 1.5 In `src/cli/commands/write.ts`: replace `isRunningInContainer` import with `isInsideContainer`
+- [x] 1.6 In `src/cli/commands/embed.ts`: replace `isRunningInContainer` import with `isInsideContainer`
+- [x] 1.7 In `src/cli/commands/reindex.ts`: replace `isRunningInContainer` import with `isInsideContainer`
+- [x] 1.8 In `src/cli/commands/init.ts`: replace `isRunningInContainer` import with `isInsideContainer`; verify the container guard that blocks `--force --all` still uses the same `if (inContainer) return` semantics
+- [x] 1.9 Run `npx tsc --noEmit` — must be clean before proceeding
+
+## 2. Proxy Unification + Timeouts + resp.ok (Bug 2 + Bug 4, ATOMIC)
+
+- [x] 2.1 In `src/cli/utils.ts`: delete `proxyGetContainer`, `proxyPostContainer`, `detectRunningServerContainer`
+- [x] 2.2 In `src/cli/utils.ts`: add `AbortSignal.timeout(timeoutMs)` to `proxyGet` with `timeoutMs = 30_000` default parameter
+- [x] 2.3 In `src/cli/utils.ts`: add `AbortSignal.timeout(timeoutMs)` to `proxyPost` with `timeoutMs = 30_000` default parameter
+- [x] 2.4 In `src/cli/utils.ts`: add `if (!resp.ok) throw new Error(\`HTTP \${resp.status}: \${resp.statusText}\`)` to both `proxyGet` and `proxyPost` after the fetch call
+- [x] 2.5 In `src/cli/utils.ts`: update `detectRunningServer` timeout to 2000ms (was 1000ms)
+- [x] 2.6 In `src/cli/commands/wake-up.ts`: remove `proxyPostContainer` and `detectRunningServerContainer` imports; collapse the `inContainer` ternary for proxy selection to always call `proxyPost`; keep `inContainer` variable for the error-path message
+- [x] 2.7 In `src/cli/commands/search.ts`: same as 2.6 — remove Container imports, collapse proxy ternary, keep `inContainer` for error path
+- [x] 2.8 In `src/cli/commands/write.ts`: remove `proxyPostContainer` import; replace with `proxyPost`
+- [x] 2.9 In `src/cli/commands/embed.ts`: remove `proxyPostContainer` import; replace with `proxyPost`
+- [x] 2.10 In `src/cli/commands/reindex.ts`: remove `proxyPostContainer` import; replace with `proxyPost`
+- [x] 2.11 Run `npx tsc --noEmit` — must be clean
+- [x] 2.12 Verify: `grep -r 'Container' src/cli/` returns zero matches
+
+## 3. docker.ts Health Check URLs (Bug 1)
+
+- [x] 3.1 In `src/cli/commands/docker.ts`: import `getHttpHost` from `'../utils.js'`
+- [x] 3.2 Replace hardcoded `localhost:3100` fetch URLs at lines ~54, ~105, ~163 with `` `http://${getHttpHost()}:3100` `` (functional URLs only — leave `cliOutput` display strings at ~69, ~123, ~165 as-is)
+- [x] 3.5 Run `npx tsc --noEmit` — must be clean
+
+## 4. User Config Migration (Bug 5 — user config)
+
+- [x] 4.1 In `src/cli/commands/docker.ts`: in the `start` command handler, before spawning docker-compose, read `~/.nano-brain/config.yml` using `js-yaml`
+- [x] 4.2 Check if `config.vector?.url === 'http://host.docker.internal:6333'`; if so, rewrite to `http://qdrant:6333`, write back to disk, and print migration notice
+- [x] 4.3 Run `npx tsc --noEmit` — must be clean
+
+## 5. SSE + Streamable HTTP Heartbeat (Bug 6)
+
+- [ ] 5.1 In `src/http/sse.ts` `handleSseConnect`: add `const heartbeatInterval = setInterval(() => { if (!res.writableEnded && !res.destroyed) res.write(': ping\n\n'); }, 30_000)`
+- [ ] 5.2 In `src/http/sse.ts`: add `res.on('close', () => clearInterval(heartbeatInterval))` and `res.on('error', () => clearInterval(heartbeatInterval))`
+- [ ] 5.3 In `src/http/sse.ts`: add `transport.onclose = () => clearInterval(heartbeatInterval)` after transport is created
+- [ ] 5.4 In `src/http/routes.ts`: locate the Streamable HTTP connection handler and apply the identical heartbeat + cleanup pattern
+- [ ] 5.5 Run `npx tsc --noEmit` — must be clean
+
+## 6. Verification
+
+- [ ] 6.1 Run full TypeScript check: `npx tsc --noEmit` across entire project
+- [ ] 6.2 Verify no Container-suffixed symbols remain: `grep -r 'Container' src/cli/` → zero matches
+- [ ] 6.3 Verify no hardcoded `localhost:3100` in docker.ts: `grep 'localhost:3100' src/cli/commands/docker.ts` → zero matches
+- [ ] 6.4 Manual smoke test: from inside container, run `npx nano-brain query "test"` and verify it reaches server or fails fast with actionable error (not hang)

--- a/openspec/changes/nano-brain-docker-networking-fixes/tasks.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/tasks.md
@@ -39,11 +39,11 @@
 
 ## 5. SSE + Streamable HTTP Heartbeat (Bug 6)
 
-- [ ] 5.1 In `src/http/sse.ts` `handleSseConnect`: add `const heartbeatInterval = setInterval(() => { if (!res.writableEnded && !res.destroyed) res.write(': ping\n\n'); }, 30_000)`
-- [ ] 5.2 In `src/http/sse.ts`: add `res.on('close', () => clearInterval(heartbeatInterval))` and `res.on('error', () => clearInterval(heartbeatInterval))`
-- [ ] 5.3 In `src/http/sse.ts`: add `transport.onclose = () => clearInterval(heartbeatInterval)` after transport is created
-- [ ] 5.4 In `src/http/routes.ts`: locate the Streamable HTTP connection handler and apply the identical heartbeat + cleanup pattern
-- [ ] 5.5 Run `npx tsc --noEmit` — must be clean
+- [x] 5.1 In `src/http/sse.ts` `handleSseConnect`: add `const heartbeatInterval = setInterval(() => { if (!res.writableEnded && !res.destroyed) res.write(': ping\n\n'); }, 30_000)`
+- [x] 5.2 In `src/http/sse.ts`: add `res.on('close', () => clearInterval(heartbeatInterval))` and `res.on('error', () => clearInterval(heartbeatInterval))`
+- [x] 5.3 In `src/http/sse.ts`: add `transport.onclose = () => clearInterval(heartbeatInterval)` after transport is created
+- [x] 5.4 In `src/http/routes.ts`: locate the Streamable HTTP connection handler and apply the identical heartbeat + cleanup pattern
+- [x] 5.5 Run `npx tsc --noEmit` — must be clean
 
 ## 6. Verification
 

--- a/openspec/changes/nano-brain-docker-networking-fixes/tasks.md
+++ b/openspec/changes/nano-brain-docker-networking-fixes/tasks.md
@@ -47,7 +47,7 @@
 
 ## 6. Verification
 
-- [ ] 6.1 Run full TypeScript check: `npx tsc --noEmit` across entire project
-- [ ] 6.2 Verify no Container-suffixed symbols remain: `grep -r 'Container' src/cli/` → zero matches
-- [ ] 6.3 Verify no hardcoded `localhost:3100` in docker.ts: `grep 'localhost:3100' src/cli/commands/docker.ts` → zero matches
-- [ ] 6.4 Manual smoke test: from inside container, run `npx nano-brain query "test"` and verify it reaches server or fails fast with actionable error (not hang)
+- [x] 6.1 Run full TypeScript check: `npx tsc --noEmit` across entire project
+- [x] 6.2 Verify no Container-suffixed symbols remain: `grep -r 'Container' src/cli/` → zero matches (only `isInsideContainer` and `inContainer` remain, which are correct)
+- [x] 6.3 Verify no hardcoded `localhost:3100` fetch URLs in docker.ts: all fetch calls use `getHttpHost()` (display strings intentionally left as-is per spec)
+- [x] 6.4 Manual smoke test: from inside container, run `npx nano-brain query "test"` and verify it reaches server or fails fast with actionable error (not hang)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.5",
+  "version": "2026.8.1-beta.6",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.3",
+  "version": "2026.8.1-beta.4",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.7",
+  "version": "2026.8.1-beta.8",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.10",
+  "version": "2026.8.1-beta.11",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.2",
+  "version": "2026.8.1-beta.3",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.0",
+  "version": "2026.8.1-beta.1",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.8",
+  "version": "2026.8.1-beta.9",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.4",
+  "version": "2026.8.1-beta.5",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.7.13",
+  "version": "2026.8.0",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.6",
+  "version": "2026.8.1-beta.7",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.1",
+  "version": "2026.8.1-beta.2",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.11",
+  "version": "2026.8.1-beta.12",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.1-beta.9",
+  "version": "2026.8.1-beta.10",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/cli/commands/docker.ts
+++ b/src/cli/commands/docker.ts
@@ -6,6 +6,31 @@ import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
 import { NANO_BRAIN_HOME, getHttpHost } from '../utils.js';
 
+function resolveDockerBin(): string | null {
+  const candidates = [
+    '/usr/local/bin/docker',
+    '/usr/bin/docker',
+    '/opt/homebrew/bin/docker',
+    '/Applications/Docker.app/Contents/Resources/bin/docker',
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      try {
+        const v = execSync(`"${p}" --version`, { encoding: 'utf-8' }).trim();
+        if (v.toLowerCase().startsWith('docker version') || v.toLowerCase().startsWith('docker desktop')) return p;
+      } catch {}
+    }
+  }
+  try {
+    const found = execSync('which docker', { encoding: 'utf-8' }).trim();
+    if (found) {
+      const v = execSync(`"${found}" --version`, { encoding: 'utf-8' }).trim();
+      if (v.toLowerCase().startsWith('docker version') || v.toLowerCase().startsWith('docker desktop')) return found;
+    }
+  } catch {}
+  return null;
+}
+
 export async function handleDocker(globalOpts: GlobalOptions, commandArgs: string[]): Promise<void> {
   const subcommand = commandArgs[0];
 
@@ -24,16 +49,9 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
     process.exit(1);
   }
 
-  try {
-    const dockerVersion = execSync('docker --version', { encoding: 'utf-8' }).trim();
-    if (!dockerVersion.toLowerCase().includes('docker version') && !dockerVersion.toLowerCase().includes('docker desktop')) {
-      cliError(`"docker" binary is not Docker Desktop: ${dockerVersion}`);
-      cliError('Run: which -a docker — you may have "npm install -g docker" (a doc generator) shadowing Docker.');
-      cliError('Fix: npm uninstall -g docker');
-      process.exit(1);
-    }
-  } catch {
-    cliError('Docker CLI not found. Is Docker Desktop running?');
+  const dockerBin = resolveDockerBin();
+  if (!dockerBin) {
+    cliError('Docker CLI not found. Is Docker Desktop installed?');
     process.exit(1);
   }
 
@@ -70,7 +88,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
 
       cliOutput('Starting nano-brain + qdrant...');
       try {
-        execSync(`docker compose -f "${composeFile}" up -d`, { stdio: 'inherit', env });
+        execSync(`${dockerBin} compose -f "${composeFile}" up -d`, { stdio: 'inherit', env });
       } catch {
         cliError('Failed to start. Is Docker running?');
         process.exit(1);
@@ -102,7 +120,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
     case 'stop': {
       cliOutput('Stopping nano-brain + qdrant...');
       try {
-        execSync(`docker compose -f "${composeFile}" down`, { stdio: 'inherit', env });
+        execSync(`${dockerBin} compose -f "${composeFile}" down`, { stdio: 'inherit', env });
       } catch {
         cliError('Failed to stop containers');
         process.exit(1);
@@ -122,7 +140,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
       const label = service || 'nano-brain + qdrant';
       cliOutput(`Restarting ${label}...`);
       try {
-        execSync(`docker compose -f "${composeFile}" restart ${service}`, { stdio: 'inherit', env });
+        execSync(`${dockerBin} compose -f "${composeFile}" restart ${service}`, { stdio: 'inherit', env });
       } catch {
         cliError('Failed to restart. Is Docker running?');
         process.exit(1);
@@ -157,7 +175,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
       let containerOutput = '';
       try {
         containerOutput = execSync(
-          `docker compose -f "${composeFile}" ps --format json 2>/dev/null`,
+          `${dockerBin} compose -f "${composeFile}" ps --format json 2>/dev/null`,
           { env, encoding: 'utf-8' }
         ).trim();
       } catch {

--- a/src/cli/commands/docker.ts
+++ b/src/cli/commands/docker.ts
@@ -1,9 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
-import { NANO_BRAIN_HOME } from '../utils.js';
+import { NANO_BRAIN_HOME, getHttpHost } from '../utils.js';
 
 export async function handleDocker(globalOpts: GlobalOptions, commandArgs: string[]): Promise<void> {
   const subcommand = commandArgs[0];
@@ -43,6 +44,17 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
         fs.mkdirSync(path.join(NANO_BRAIN_HOME, dir), { recursive: true });
       }
 
+      try {
+        const configYmlPath = path.join(NANO_BRAIN_HOME, 'config.yml');
+        const rawConfig = fs.readFileSync(configYmlPath, 'utf-8');
+        const config = parseYaml(rawConfig) as Record<string, any>;
+        if (config?.vector?.url === 'http://host.docker.internal:6333') {
+          config.vector.url = 'http://qdrant:6333';
+          fs.writeFileSync(configYmlPath, stringifyYaml(config), 'utf-8');
+          cliOutput('[nano-brain] Migrated vector.url from host.docker.internal:6333 → qdrant:6333');
+        }
+      } catch {}
+
       cliOutput('Starting nano-brain + qdrant...');
       try {
         execSync(`docker compose -f "${composeFile}" up -d`, { stdio: 'inherit', env });
@@ -51,7 +63,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
         process.exit(1);
       }
 
-      const healthUrl = 'http://localhost:3100/health';
+      const healthUrl = `http://${getHttpHost()}:3100/health`;
       let healthy = false;
       for (let i = 0; i < 10; i++) {
         await new Promise(r => setTimeout(r, 2000));
@@ -102,12 +114,12 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
         process.exit(1);
       }
 
-      const healthUrl = 'http://localhost:3100/health';
+      const restartHealthUrl = `http://${getHttpHost()}:3100/health`;
       let healthy = false;
       for (let i = 0; i < 15; i++) {
         await new Promise(r => setTimeout(r, 2000));
         try {
-          const res = await fetch(healthUrl);
+          const res = await fetch(restartHealthUrl);
           if (res.ok) {
             const data = await res.json() as { ready?: boolean };
             if (data.ready) {
@@ -160,7 +172,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
 
       cliOutput('');
       try {
-        const res = await fetch('http://localhost:3100/health');
+        const res = await fetch(`http://${getHttpHost()}:3100/health`);
         if (res.ok) {
           cliOutput('  API: ✅ http://localhost:3100');
         } else {

--- a/src/cli/commands/docker.ts
+++ b/src/cli/commands/docker.ts
@@ -24,6 +24,19 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
     process.exit(1);
   }
 
+  try {
+    const dockerVersion = execSync('docker --version', { encoding: 'utf-8' }).trim();
+    if (!dockerVersion.toLowerCase().includes('docker version') && !dockerVersion.toLowerCase().includes('docker desktop')) {
+      cliError(`"docker" binary is not Docker Desktop: ${dockerVersion}`);
+      cliError('Run: which -a docker — you may have "npm install -g docker" (a doc generator) shadowing Docker.');
+      cliError('Fix: npm uninstall -g docker');
+      process.exit(1);
+    }
+  } catch {
+    cliError('Docker CLI not found. Is Docker Desktop running?');
+    process.exit(1);
+  }
+
   const env = {
     ...process.env,
     NANO_BRAIN_APP: packageRoot,

--- a/src/cli/commands/docker.ts
+++ b/src/cli/commands/docker.ts
@@ -65,8 +65,9 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
 
       const healthUrl = `http://${getHttpHost()}:3100/health`;
       let healthy = false;
-      for (let i = 0; i < 10; i++) {
-        await new Promise(r => setTimeout(r, 2000));
+      const maxRetries = 20;
+      for (let i = 0; i < maxRetries; i++) {
+        await new Promise(r => setTimeout(r, 3000));
         try {
           const res = await fetch(healthUrl);
           if (res.ok) {
@@ -74,7 +75,7 @@ export async function handleDocker(globalOpts: GlobalOptions, commandArgs: strin
             break;
           }
         } catch {}
-        cliOutput(`Waiting for nano-brain... (${i + 1}/10)`);
+        cliOutput(`Waiting for nano-brain... (${i + 1}/${maxRetries})`);
       }
 
       if (healthy) {

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -9,11 +9,11 @@ import * as path from 'path';
 import { log, cliOutput, cliError } from '../../logger.js';
 import { resolveWorkspaceDbPath } from '../../store.js';
 import type { GlobalOptions } from '../types.js';
+import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServerContainer,
-  proxyPostContainer,
-  isRunningInContainer,
+  detectRunningServer,
+  proxyPost,
   getHttpHost,
   getHttpPort,
 } from '../utils.js';
@@ -29,15 +29,15 @@ export async function handleEmbed(globalOpts: GlobalOptions, commandArgs: string
 
   log('cli', 'embed start force=' + force);
 
-  if (isRunningInContainer()) {
-    const serverRunning = await detectRunningServerContainer(DEFAULT_HTTP_PORT);
+  if (isInsideContainer()) {
+    const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
     if (!serverRunning) {
       cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
       cliError('  docker start nano-brain');
       process.exit(1);
     }
     try {
-      const result = await proxyPostContainer(DEFAULT_HTTP_PORT, '/api/embed', {});
+      const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/embed', {});
       if (result.error) {
         cliError('Error:', result.error);
         process.exit(1);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -9,19 +9,19 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
+import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
   DEFAULT_OUTPUT_DIR,
   DEFAULT_MEMORY_DIR,
   detectRunningServer,
   proxyPost,
-  isRunningInContainer,
   resolveDbPath,
   resolveOpenCodeStorageDir,
 } from '../utils.js';
 
 export async function handleInit(globalOpts: GlobalOptions, commandArgs: string[]): Promise<void> {
-  if (isRunningInContainer()) {
+  if (isInsideContainer()) {
     cliError('Error: Destructive operations must be run on the host, not from containers.');
     cliError('Run this command directly on the host: npx nano-brain init --force');
     process.exit(1);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -44,6 +44,22 @@ export async function handleInit(globalOpts: GlobalOptions, commandArgs: string[
     }
   }
 
+  try {
+    const { execSync } = await import('child_process');
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', { cwd: root, stdio: ['pipe', 'pipe', 'pipe'] })
+      .toString().trim();
+    const gitTopLevel = execSync('git rev-parse --show-toplevel', { cwd: root, stdio: ['pipe', 'pipe', 'pipe'] })
+      .toString().trim();
+    const isWorktree = !gitCommonDir.startsWith(path.join(root, '.git')) && gitTopLevel !== root;
+    if (isWorktree) {
+      const mainRepoRoot = path.dirname(gitCommonDir);
+      cliOutput(`⚠️  Detected git worktree at: ${root}`);
+      cliOutput(`   Redirecting init to main repo root: ${mainRepoRoot}`);
+      root = mainRepoRoot;
+    }
+  } catch {
+  }
+
   log('cli', 'init start root=' + root + ' force=' + force + ' all=' + all);
 
   globalOpts.dbPath = resolveDbPath(globalOpts.dbPath, root);

--- a/src/cli/commands/reindex.ts
+++ b/src/cli/commands/reindex.ts
@@ -5,11 +5,11 @@ import { isTreeSitterAvailable } from '../../treesitter.js';
 import * as crypto from 'crypto';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
+import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServerContainer,
-  proxyPostContainer,
-  isRunningInContainer,
+  detectRunningServer,
+  proxyPost,
   getHttpHost,
   getHttpPort,
   resolveDbPath,
@@ -29,15 +29,15 @@ export async function handleReindex(globalOpts: GlobalOptions, commandArgs: stri
 
   log('cli', 'reindex root=' + root);
 
-  if (isRunningInContainer()) {
-    const serverRunning = await detectRunningServerContainer(DEFAULT_HTTP_PORT);
+  if (isInsideContainer()) {
+    const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
     if (!serverRunning) {
       cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
       cliError('  docker start nano-brain');
       process.exit(1);
     }
     try {
-      const result = await proxyPostContainer(DEFAULT_HTTP_PORT, '/api/reindex', { root });
+      const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/reindex', { root });
       if (result.error) {
         cliError('Error:', result.error);
         process.exit(1);

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -10,13 +10,11 @@ import type { SearchResult } from '../../types.js';
 import * as crypto from 'crypto';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
+import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
   detectRunningServer,
-  detectRunningServerContainer,
   proxyPost,
-  proxyPostContainer,
-  isRunningInContainer,
   getHttpHost,
   getHttpPort,
 } from '../utils.js';
@@ -72,10 +70,8 @@ export async function handleSearch(
     }
   }
 
-  const inContainer = isRunningInContainer();
-  const serverRunning = inContainer
-    ? await detectRunningServerContainer(DEFAULT_HTTP_PORT)
-    : await detectRunningServer(DEFAULT_HTTP_PORT);
+  const inContainer = isInsideContainer();
+  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
 
   if (inContainer && !serverRunning) {
     cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
@@ -86,9 +82,7 @@ export async function handleSearch(
   if (serverRunning) {
     try {
       const endpoint = mode === 'fts' ? '/api/search' : '/api/query';
-      const data = inContainer
-        ? await proxyPostContainer(DEFAULT_HTTP_PORT, endpoint, { query, limit, tags: tags?.join(','), scope })
-        : await proxyPost(DEFAULT_HTTP_PORT, endpoint, { query, limit, tags: tags?.join(','), scope });
+      const data = await proxyPost(DEFAULT_HTTP_PORT, endpoint, { query, limit, tags: tags?.join(','), scope });
       if (format === 'json') {
         cliOutput(JSON.stringify(data, null, 2));
       } else if (format === 'files') {

--- a/src/cli/commands/wake-up.ts
+++ b/src/cli/commands/wake-up.ts
@@ -3,13 +3,11 @@ import { generateBriefing } from '../../wake-up.js';
 import * as crypto from 'crypto';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
+import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
   detectRunningServer,
-  detectRunningServerContainer,
   proxyPost,
-  proxyPostContainer,
-  isRunningInContainer,
   getHttpHost,
   getHttpPort,
   resolveDbPath,
@@ -28,10 +26,8 @@ export async function handleWakeUp(globalOpts: GlobalOptions, commandArgs: strin
     }
   }
 
-  const inContainer = isRunningInContainer();
-  const serverRunning = inContainer
-    ? await detectRunningServerContainer(DEFAULT_HTTP_PORT)
-    : await detectRunningServer(DEFAULT_HTTP_PORT);
+  const inContainer = isInsideContainer();
+  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
 
   if (inContainer && !serverRunning) {
     cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
@@ -44,8 +40,7 @@ export async function handleWakeUp(globalOpts: GlobalOptions, commandArgs: strin
       const body: Record<string, any> = {};
       if (format === 'json') body.json = true;
       body.workspace = workspaceRoot;
-      const proxyFn = inContainer ? proxyPostContainer : proxyPost;
-      const data = await proxyFn(DEFAULT_HTTP_PORT, '/api/wake-up', body);
+      const data = await proxyPost(DEFAULT_HTTP_PORT, '/api/wake-up', body);
       if (format === 'json') {
         cliOutput(JSON.stringify(data, null, 2));
       } else {

--- a/src/cli/commands/write.ts
+++ b/src/cli/commands/write.ts
@@ -4,12 +4,12 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
+import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
   DEFAULT_MEMORY_DIR,
-  detectRunningServerContainer,
-  proxyPostContainer,
-  isRunningInContainer,
+  detectRunningServer,
+  proxyPost,
   getHttpHost,
   getHttpPort,
 } from '../utils.js';
@@ -35,15 +35,15 @@ export async function handleWrite(globalOpts: GlobalOptions, commandArgs: string
     }
   }
 
-  if (isRunningInContainer()) {
-    const serverRunning = await detectRunningServerContainer(DEFAULT_HTTP_PORT);
+  if (isInsideContainer()) {
+    const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
     if (!serverRunning) {
       cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
       cliError('  docker start nano-brain');
       process.exit(1);
     }
     try {
-      const result = await proxyPostContainer(DEFAULT_HTTP_PORT, '/api/write', {
+      const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/write', {
         content,
         tags: tags?.join(','),
       });

--- a/src/cli/commands/write.ts
+++ b/src/cli/commands/write.ts
@@ -77,32 +77,33 @@ export async function handleWrite(globalOpts: GlobalOptions, commandArgs: string
   let tagInfo = ''
   const store = await createStore(globalOpts.dbPath)
 
+  const fileContent = fs.readFileSync(targetPath, 'utf-8')
+  const title = path.basename(targetPath, path.extname(targetPath))
+  const hash = crypto.createHash('sha256').update(fileContent).digest('hex')
+  store.insertContent(hash, fileContent)
+  const stats = fs.statSync(targetPath)
+  const newDocId = store.insertDocument({
+    collection: 'memory',
+    path: targetPath,
+    title,
+    hash,
+    createdAt: stats.birthtime.toISOString(),
+    modifiedAt: stats.mtime.toISOString(),
+    active: true,
+    projectHash,
+  })
+
   if (supersedes) {
     const targetDoc = store.findDocument(supersedes)
     if (targetDoc) {
-      store.supersedeDocument(targetDoc.id, 0)
+      store.supersedeDocument(targetDoc.id, newDocId)
     } else {
       supersedeWarning = `\n⚠️ Supersede target not found: ${supersedes}`
     }
   }
 
   if (tags && tags.length > 0) {
-    const fileContent = fs.readFileSync(targetPath, 'utf-8')
-    const title = path.basename(targetPath, path.extname(targetPath))
-    const hash = crypto.createHash('sha256').update(fileContent).digest('hex')
-    store.insertContent(hash, fileContent)
-    const stats = fs.statSync(targetPath)
-    const docId = store.insertDocument({
-      collection: 'memory',
-      path: targetPath,
-      title,
-      hash,
-      createdAt: stats.birthtime.toISOString(),
-      modifiedAt: stats.mtime.toISOString(),
-      active: true,
-      projectHash,
-    })
-    store.insertTags(docId, tags)
+    store.insertTags(newDocId, tags)
     tagInfo = `\n📌 Tags: ${tags.join(', ')}`
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -140,6 +140,7 @@ export async function main() {
 }
 
 const isMain = process.argv[1]?.endsWith('index.ts') ||
+  process.argv[1]?.endsWith('index.js') ||
   process.argv[1]?.endsWith('cli.js') ||
   import.meta.url === `file://${process.argv[1]}`;
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -5,57 +5,11 @@ import * as crypto from 'crypto';
 import { setProjectLabelDataDir } from '../store.js';
 import type { SearchResult } from '../types.js';
 import { cliOutput } from '../logger.js';
+import { isInsideContainer } from '../host.js';
 
 export const DEFAULT_HTTP_PORT = 3100;
 
 export async function detectRunningServer(port: number = getHttpPort()): Promise<boolean> {
-  const host = getHttpHost();
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 1000);
-    const resp = await fetch(`http://${host}:${port}/health`, { signal: controller.signal });
-    clearTimeout(timeout);
-    return resp.ok;
-  } catch {
-    return false;
-  }
-}
-
-export async function proxyGet(port: number, path: string): Promise<any> {
-  const host = getHttpHost();
-  const resp = await fetch(`http://${host}:${port}${path}`);
-  return resp.json();
-}
-
-export async function proxyPost(port: number, path: string, body: any): Promise<any> {
-  const host = getHttpHost();
-  const resp = await fetch(`http://${host}:${port}${path}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  return resp.json();
-}
-
-export function isRunningInContainer(): boolean {
-  try {
-    return fs.existsSync('/.dockerenv');
-  } catch {
-    return false;
-  }
-}
-
-export function getHttpHost(): string {
-  if (process.env.NANO_BRAIN_HOST) return process.env.NANO_BRAIN_HOST;
-  return isRunningInContainer() ? 'host.docker.internal' : 'localhost';
-}
-
-export function getHttpPort(): number {
-  if (process.env.NANO_BRAIN_PORT) return parseInt(process.env.NANO_BRAIN_PORT, 10);
-  return DEFAULT_HTTP_PORT;
-}
-
-export async function detectRunningServerContainer(port: number = getHttpPort()): Promise<boolean> {
   const host = getHttpHost();
   try {
     const controller = new AbortController();
@@ -68,20 +22,35 @@ export async function detectRunningServerContainer(port: number = getHttpPort())
   }
 }
 
-export async function proxyGetContainer(port: number, path: string): Promise<any> {
+export async function proxyGet(port: number, path: string, timeoutMs = 30_000): Promise<any> {
   const host = getHttpHost();
-  const resp = await fetch(`http://${host}:${port}${path}`);
+  const resp = await fetch(`http://${host}:${port}${path}`, {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
   return resp.json();
 }
 
-export async function proxyPostContainer(port: number, path: string, body: any): Promise<any> {
+export async function proxyPost(port: number, path: string, body: unknown, timeoutMs = 30_000): Promise<any> {
   const host = getHttpHost();
   const resp = await fetch(`http://${host}:${port}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
   return resp.json();
+}
+
+export function getHttpHost(): string {
+  if (process.env.NANO_BRAIN_HOST) return process.env.NANO_BRAIN_HOST;
+  return isInsideContainer() ? 'host.docker.internal' : 'localhost';
+}
+
+export function getHttpPort(): number {
+  if (process.env.NANO_BRAIN_PORT) return parseInt(process.env.NANO_BRAIN_PORT, 10);
+  return DEFAULT_HTTP_PORT;
 }
 
 export function resolveOpenCodeStorageDir(): string {

--- a/src/fts-worker.ts
+++ b/src/fts-worker.ts
@@ -47,10 +47,8 @@ const dbPath = workerData.dbPath as string;
 const db = new Database(dbPath, { readonly: true });
 db.pragma('busy_timeout = 0');
 
-// Prepared statement: look up doc id+hash by path for enrichment.
-// Uses the indexed (path) column — fast single-row lookup, no JOIN with FTS.
 const enrichByPathStmt = db.prepare(`
-  SELECT id, hash FROM documents WHERE path = ? AND active = 1 LIMIT 1
+  SELECT id, hash, created_at FROM documents WHERE path = ? AND active = 1 LIMIT 1
 `);
 
 // Try to load sqlite-vec extension for vector search
@@ -103,18 +101,17 @@ function searchFTS(query: string, options: StoreSearchOptions = {}): SearchResul
     const coll = slashIdx >= 0 ? row.filepath.substring(0, slashIdx) : '';
     const path = slashIdx >= 0 ? row.filepath.substring(slashIdx + 1) : row.filepath;
 
-    // Enrich: look up id + hash by path using a single indexed SELECT.
-    // This is safe even on a read-only connection — no WAL lock contention.
     let docId = '';
     let docHash = '';
+    let createdAt: string | undefined;
     try {
-      const docRow = enrichByPathStmt.get(path) as { id: number; hash: string } | undefined;
+      const docRow = enrichByPathStmt.get(path) as { id: number; hash: string; created_at: string } | undefined;
       if (docRow) {
         docId = String(docRow.id);
         docHash = docRow.hash.substring(0, 6);
+        createdAt = docRow.created_at;
       }
     } catch {
-      // Ignore enrichment failure — return result without id/docid
     }
 
     return {
@@ -127,6 +124,7 @@ function searchFTS(query: string, options: StoreSearchOptions = {}): SearchResul
       startLine: 0,
       endLine: 0,
       docid: docHash,
+      createdAt,
     };
   });
 }

--- a/src/fts-worker.ts
+++ b/src/fts-worker.ts
@@ -48,7 +48,11 @@ const db = new Database(dbPath, { readonly: true });
 db.pragma('busy_timeout = 0');
 
 const enrichByPathStmt = db.prepare(`
-  SELECT id, hash, created_at FROM documents WHERE path = ? AND active = 1 LIMIT 1
+  SELECT d.id, d.hash, d.created_at, LENGTH(c.body) as char_length
+  FROM documents d
+  LEFT JOIN content c ON c.hash = d.hash
+  WHERE d.path = ? AND d.active = 1
+  LIMIT 1
 `);
 
 // Try to load sqlite-vec extension for vector search
@@ -104,12 +108,14 @@ function searchFTS(query: string, options: StoreSearchOptions = {}): SearchResul
     let docId = '';
     let docHash = '';
     let createdAt: string | undefined;
+    let charLength: number | undefined;
     try {
-      const docRow = enrichByPathStmt.get(path) as { id: number; hash: string; created_at: string } | undefined;
+      const docRow = enrichByPathStmt.get(path) as { id: number; hash: string; created_at: string; char_length: number | null } | undefined;
       if (docRow) {
         docId = String(docRow.id);
         docHash = docRow.hash.substring(0, 6);
         createdAt = docRow.created_at;
+        charLength = docRow.char_length ?? undefined;
       }
     } catch {
     }
@@ -125,6 +131,7 @@ function searchFTS(query: string, options: StoreSearchOptions = {}): SearchResul
       endLine: 0,
       docid: docHash,
       createdAt,
+      charLength,
     };
   });
 }
@@ -142,8 +149,10 @@ function searchVec(query: string, embedding: number[], options: StoreSearchOptio
     let sql = `
       SELECT v.hash_seq, v.distance, d.id, d.path, d.collection, d.title, d.hash, d.agent, d.project_hash,
              d.centrality, d.cluster_id, d.superseded_by,
+             d.created_at as createdAt,
              d.access_count, d.last_accessed_at as lastAccessedAt,
-             substr(c.body, 1, 700) as snippet
+             substr(c.body, 1, 700) as snippet,
+             LENGTH(c.body) as char_length
       FROM vectors_vec v
       JOIN documents d ON substr(v.hash_seq, 1, instr(v.hash_seq, ':') - 1) = d.hash
       LEFT JOIN content c ON c.hash = d.hash
@@ -158,7 +167,7 @@ function searchVec(query: string, embedding: number[], options: StoreSearchOptio
       params.push(collection);
     }
     if (projectHash && projectHash !== 'all') {
-      sql += ` AND d.project_hash IN (?, 'global')`;
+      sql += ` AND d.project_hash = ?`;
       params.push(projectHash);
     }
     if (since) {
@@ -201,6 +210,8 @@ function searchVec(query: string, embedding: number[], options: StoreSearchOptio
       supersededBy: row.superseded_by as number | null | undefined,
       access_count: row.access_count as number | undefined,
       lastAccessedAt: row.lastAccessedAt as string | null | undefined,
+      createdAt: row.createdAt as string | undefined,
+      charLength: row.char_length as number | undefined,
     }));
   } catch {
     return [];

--- a/src/harvester.ts
+++ b/src/harvester.ts
@@ -216,16 +216,18 @@ export function messagesToMarkdown(messages: Array<{ role: string; agent?: strin
   return lines.join('\n');
 }
 
-export function getOutputPath(outputDir: string, projectPath: string, date: string, slug: string): string {
+export function getOutputPath(outputDir: string, projectPath: string, date: string, slug: string, title?: string): string {
   const hash = createHash('sha256').update(projectPath).digest('hex');
   const projectHash = hash.substring(0, 12);
-  
-  const sanitizedSlug = (slug || 'untitled')
+
+  const raw = (title && title.trim()) ? title : (slug || 'untitled');
+  const sanitizedSlug = raw
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .replace(/-+/g, '-');
-  
+    .replace(/-+/g, '-')
+    .substring(0, 60);
+
   return join(outputDir, projectHash, `${date}-${sanitizedSlug}.md`);
 }
 
@@ -353,7 +355,7 @@ async function harvestFromDb(
 
       const date = new Date(session.time_created);
       const dateStr = date.toISOString().split('T')[0];
-      const outputPath = getOutputPath(outputDir, session.directory, dateStr, session.slug);
+      const outputPath = getOutputPath(outputDir, session.directory, dateStr, session.slug, session.title);
       const outputDirPath = dirname(outputPath);
 
       const isIncremental = previousMessageCount > 0 && existsSync(outputPath);
@@ -642,7 +644,7 @@ export async function harvestSessions(options: HarvesterOptions): Promise<Harves
         if (session) {
           const date = new Date(session.created);
           const dateStr = date.toISOString().split('T')[0];
-          const outputPath = getOutputPath(outputDir, session.directory, dateStr, session.slug);
+          const outputPath = getOutputPath(outputDir, session.directory, dateStr, session.slug, session.title);
           if (existsSync(outputPath)) {
             // Quick check: count message files to catch additions within same mtime granularity
             const msgDir = join(sessionDir, 'message', session.id);
@@ -696,7 +698,7 @@ export async function harvestSessions(options: HarvesterOptions): Promise<Harves
       
       const date = new Date(session.created);
       const dateStr = date.toISOString().split('T')[0];
-      const outputPath = getOutputPath(outputDir, session.directory, dateStr, session.slug);
+      const outputPath = getOutputPath(outputDir, session.directory, dateStr, session.slug, session.title);
       const outputDirPath = dirname(outputPath);
       
       const effectivePreviousCount = previousMessageCount ?? 0;

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -936,7 +936,7 @@ export async function handleRequest(
         clearInterval(heartbeatInterval);
         if (transport.sessionId) {
           streamableSessions.delete(transport.sessionId);
-          log('server', `Streamable HTTP client disconnected sessionId=${transport.sessionId}`);
+           log('server', `🔌 Streamable HTTP client disconnected sessionId=${transport.sessionId}`);
         }
       };
 
@@ -948,7 +948,7 @@ export async function handleRequest(
 
       if (transport.sessionId) {
         streamableSessions.set(transport.sessionId, { transport, server: clientServer });
-        log('server', `Streamable HTTP client connected sessionId=${transport.sessionId}`);
+         log('server', `🔌 Streamable HTTP client connected sessionId=${transport.sessionId}`);
       }
       return;
     }

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -926,19 +926,29 @@ export async function handleRequest(
       });
       const clientServer = createMcpServer(deps);
 
+      const heartbeatInterval = setInterval(() => {
+        if (!res.writableEnded && !res.destroyed) {
+          res.write(': ping\n\n');
+        }
+      }, 30_000);
+
+      transport.onclose = () => {
+        clearInterval(heartbeatInterval);
+        if (transport.sessionId) {
+          streamableSessions.delete(transport.sessionId);
+          log('server', `Streamable HTTP client disconnected sessionId=${transport.sessionId}`);
+        }
+      };
+
+      res.on('close', () => clearInterval(heartbeatInterval));
+      res.on('error', () => clearInterval(heartbeatInterval));
+
       await clientServer.connect(transport);
       await transport.handleRequest(req, res);
 
       if (transport.sessionId) {
         streamableSessions.set(transport.sessionId, { transport, server: clientServer });
         log('server', `Streamable HTTP client connected sessionId=${transport.sessionId}`);
-
-        transport.onclose = () => {
-          if (transport.sessionId) {
-            streamableSessions.delete(transport.sessionId);
-            log('server', `Streamable HTTP client disconnected sessionId=${transport.sessionId}`);
-          }
-        };
       }
       return;
     }

--- a/src/http/sse.ts
+++ b/src/http/sse.ts
@@ -12,16 +12,27 @@ export async function handleSseConnect(
 ): Promise<void> {
   const transport = new SSEServerTransport('/messages', res);
 
+  const heartbeatInterval = setInterval(() => {
+    if (!res.writableEnded && !res.destroyed) {
+      res.write(': ping\n\n');
+    }
+  }, 30_000);
+
   transport.onclose = () => {
+    clearInterval(heartbeatInterval);
     sseSessions.delete(transport.sessionId);
     log('server', `SSE client disconnected sessionId=${transport.sessionId}`);
   };
+
+  res.on('close', () => clearInterval(heartbeatInterval));
+  res.on('error', () => clearInterval(heartbeatInterval));
 
   try {
     sseSessions.set(transport.sessionId, { transport, server: clientServer });
     log('server', `SSE client connected sessionId=${transport.sessionId}`);
     await clientServer.connect(transport);
   } catch (err) {
+    clearInterval(heartbeatInterval);
     sseSessions.delete(transport.sessionId);
     log('server', `SSE client connect failed sessionId=${transport.sessionId}: ${err instanceof Error ? err.message : String(err)}`, 'error');
   }

--- a/src/mcp/tools/memory.ts
+++ b/src/mcp/tools/memory.ts
@@ -473,16 +473,6 @@ export function registerMemoryTools(server: McpServer, ctx: McpToolContext): voi
 
         sequentialFileAppend(targetPath, entry);
 
-        let supersedeWarning = '';
-        if (supersedes) {
-          const targetDoc = effectiveStore.findDocument(supersedes);
-          if (targetDoc) {
-            effectiveStore.supersedeDocument(targetDoc.id, 0);
-          } else {
-            supersedeWarning = `\n⚠️ Supersede target not found: ${supersedes}`;
-          }
-        }
-
         const fileContent = fs.readFileSync(targetPath, 'utf-8');
         const title = path.basename(targetPath, path.extname(targetPath));
         const hash = crypto.createHash('sha256').update(fileContent).digest('hex');
@@ -498,6 +488,16 @@ export function registerMemoryTools(server: McpServer, ctx: McpToolContext): voi
           active: true,
           projectHash: effectiveProjectHash,
         });
+
+        let supersedeWarning = '';
+        if (supersedes) {
+          const targetDoc = effectiveStore.findDocument(supersedes);
+          if (targetDoc) {
+            effectiveStore.supersedeDocument(targetDoc.id, docId);
+          } else {
+            supersedeWarning = `\n⚠️ Supersede target not found: ${supersedes}`;
+          }
+        }
 
         let tagInfo = '';
         const autoTags = categorize(content);

--- a/src/providers/embeddings.ts
+++ b/src/providers/embeddings.ts
@@ -450,7 +450,7 @@ export async function createEmbeddingProvider(
     try {
       const provider = new OpenAICompatibleEmbeddingProvider(url, model, apiKey, config.maxChars, config.rpmLimit, options?.onTokenUsage, config.dimensions);
       await provider.embed('test');
-      log('embed', 'Using OpenAI-compatible provider: ' + model + ' at ' + url + ' (' + provider.getRpmLimit() + ' rpm)');
+       log('embed', '🤖 AI proxy connected: ' + model + ' at ' + url + ' (' + provider.getRpmLimit() + ' rpm)');
       return provider;
     } catch (err) {
       log('embed', 'OpenAI-compatible provider error: ' + (err instanceof Error ? err.message : String(err)), 'error');
@@ -470,20 +470,20 @@ export async function createEmbeddingProvider(
         const provider = new OllamaEmbeddingProvider(url, model);
         await provider.detectModelContext();
         await provider.embed('test');
-        log('embed', 'Using Ollama provider: ' + model + ' at ' + url);
+         log('embed', '🦙 Ollama connected: ' + model + ' at ' + url);
         return provider;
       }
     } catch (err) {
-      log('embed', 'Ollama not reachable at ' + url + ': ' + (err instanceof Error ? err.message : String(err)), 'warn');
+       log('embed', '⚠️  Ollama not reachable at ' + url + ': ' + (err instanceof Error ? err.message : String(err)), 'warn');
       if (config?.provider === 'ollama') {
-        log('embed', 'Ollama explicitly configured but not reachable, no fallback', 'error');
+         log('embed', '❌ Ollama explicitly configured but not reachable, no fallback', 'error');
         return null;
       }
-      log('embed', 'Ollama not reachable, no fallback available', 'warn');
+       log('embed', '❌ Ollama not reachable, no fallback available', 'warn');
     }
   }
 
-  log('embed', 'No embedding provider available. Configure openai or ollama in config.yml', 'error');
+  log('embed', '❌ No embedding provider available. Configure openai or ollama in config.yml', 'error');
   return null;
 }
 

--- a/src/providers/qdrant.ts
+++ b/src/providers/qdrant.ts
@@ -20,7 +20,7 @@ export interface QdrantVecStoreOptions {
 // UUID v5-style deterministic ID from hash:seq string.
 // Uses SHA-256 truncated to 128 bits, formatted as UUID.
 // Collision-safe for millions of vectors (vs 32-bit hashStringToInt which collided at 49K).
-function stringToUuid(str: string): string {
+export function stringToUuid(str: string): string {
   const sha = createHash('sha256').update(str).digest('hex');
   return [
     sha.slice(0, 8),
@@ -273,6 +273,25 @@ export class QdrantVecStore implements VectorStore {
         vectorCount: 0,
         error: err instanceof Error ? err.message : String(err),
       };
+    }
+  }
+
+  async batchSetPayload(updates: Array<{ id: string; payload: Record<string, unknown> }>): Promise<void> {
+    if (updates.length === 0) return;
+    await this.ensureCollection();
+
+    const BATCH_SIZE = 100;
+    for (let i = 0; i < updates.length; i += BATCH_SIZE) {
+      const batch = updates.slice(i, i + BATCH_SIZE);
+      for (const update of batch) {
+        await this.retryOnSocketError(() =>
+          this.client.setPayload(this.collectionName, {
+            payload: update.payload,
+            points: [update.id],
+            wait: true,
+          })
+        );
+      }
     }
   }
 

--- a/src/providers/vector-store.ts
+++ b/src/providers/vector-store.ts
@@ -22,6 +22,7 @@ export interface VectorPointMetadata {
   model: string;
   collection?: string;
   projectHash?: string;
+  createdAt?: string;
 }
 
 export interface VectorPoint {

--- a/src/search.ts
+++ b/src/search.ts
@@ -384,7 +384,7 @@ export function applyRecencyBoost(
   const now = Date.now();
 
   return results.map(r => {
-    if (r.collection === 'codebase') return r;
+    if (r.collection !== 'sessions' && r.collection !== 'memory') return r;
     if (!r.createdAt) return r;
 
     const parsed = Date.parse(r.createdAt);

--- a/src/search.ts
+++ b/src/search.ts
@@ -120,6 +120,18 @@ export function parseSearchConfig(partial?: Partial<SearchConfig>): SearchConfig
     };
   }
 
+  if (partial.length_norm_anchor !== undefined) {
+    config.length_norm_anchor = partial.length_norm_anchor > 0 ? partial.length_norm_anchor : DEFAULT_SEARCH_CONFIG.length_norm_anchor;
+  }
+
+  if (partial.recency_weight !== undefined) {
+    config.recency_weight = partial.recency_weight >= 0 && partial.recency_weight <= 1 ? partial.recency_weight : DEFAULT_SEARCH_CONFIG.recency_weight;
+  }
+
+  if (partial.recency_half_life_days !== undefined) {
+    config.recency_half_life_days = partial.recency_half_life_days > 0 ? partial.recency_half_life_days : DEFAULT_SEARCH_CONFIG.recency_half_life_days;
+  }
+
   return config;
 }
 
@@ -347,6 +359,41 @@ export function applyCategoryWeightBoost(
       ...r,
       score: r.score * maxWeight,
     };
+  });
+}
+
+export function applyLengthNorm(
+  results: SearchResult[],
+  config: SearchConfig
+): SearchResult[] {
+  const anchor = config.length_norm_anchor ?? 2000;
+  return results.map(r => {
+    const charLength = r.charLength;
+    if (!charLength || charLength <= 0) return r;
+    const penalty = 1 / (1 + Math.log2(Math.max(1, charLength / anchor)));
+    return { ...r, score: r.score * penalty };
+  });
+}
+
+export function applyRecencyBoost(
+  results: SearchResult[],
+  config: SearchConfig
+): SearchResult[] {
+  const weight = config.recency_weight ?? 0.3;
+  const halfLife = config.recency_half_life_days ?? 180;
+  const now = Date.now();
+
+  return results.map(r => {
+    if (r.collection === 'codebase') return r;
+    if (!r.createdAt) return r;
+
+    const parsed = Date.parse(r.createdAt);
+    if (isNaN(parsed)) return r;
+
+    const ageDays = (now - parsed) / 86400000;
+    const decayFactor = Math.exp(-Math.log(2) * ageDays / halfLife);
+    const score = r.score * (1 - weight) + r.score * weight * decayFactor;
+    return { ...r, score };
   });
 }
 
@@ -648,6 +695,10 @@ export async function hybridSearch(
   }
 
   fusedResults = applySupersedeDemotion(fusedResults, config.supersede_demotion);
+
+  fusedResults = applyLengthNorm(fusedResults, config);
+
+  fusedResults = applyRecencyBoost(fusedResults, config);
 
   if (options.importanceScorer) {
     fusedResults = fusedResults.map(r => {

--- a/src/search.ts
+++ b/src/search.ts
@@ -165,6 +165,12 @@ export function rrfFuse(
       const existing = scoreMap.get(result.id);
       if (existing) {
         existing.score += rrfScore;
+        if (!existing.result.createdAt && result.createdAt) {
+          existing.result.createdAt = result.createdAt;
+        }
+        if (!existing.result.charLength && result.charLength) {
+          existing.result.charLength = result.charLength;
+        }
       } else {
         scoreMap.set(result.id, {
           result: { ...result },

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -10,6 +10,7 @@ import { log, initLogger, setStdioMode } from '../logger.js';
 import { loadCollectionConfig, getCollections, getWorkspaceConfig } from '../collections.js';
 import { parseStorageConfig } from '../storage.js';
 import { createStore, resolveWorkspaceDbPath, setProjectLabelDataDir, migrateToRelativePaths, cleanupDuplicatePaths, getLastCorruptionRecovery, closeAllCachedStores } from '../store.js';
+import { backfillQdrantProjectHash } from '../store/vectors.js';
 import { parseSearchConfig } from '../search.js';
 import { createVectorStore, type VectorStore } from '../vector-store.js';
 import { createEmbeddingProvider, detectOllamaUrl, checkOllamaHealth } from '../embeddings.js';
@@ -378,6 +379,13 @@ export async function startServer(options: ServerOptions): Promise<void> {
     readyState.value = true;
     log('server', '✅ Server ready (Phase 2 complete)');
     log('server', '✅ Server ready');
+
+    const currentVectorStore = store.getVectorStore();
+    if (currentVectorStore) {
+      backfillQdrantProjectHash(store.getDb(), currentVectorStore).catch(err => {
+        log('server', 'backfillQdrantProjectHash failed err=' + (err instanceof Error ? err.message : String(err)), 'warn');
+      });
+    }
 
     if (config?.consolidation?.enabled) {
       const consolidationConfig = config.consolidation as import('../types.js').ConsolidationConfig;

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -124,24 +124,24 @@ export async function startServer(options: ServerOptions): Promise<void> {
     try {
       vectorStore = createVectorStore(config.vector);
       vectorStore.health().then((health) => {
-        log('server', 'vector provider=' + health.provider + ' ok=' + health.ok + ' vectors=' + health.vectorCount);
-        log('server', `Vector store: ${health.provider} (ok=${health.ok}, vectors=${health.vectorCount})`);
+        log('server', '🗄️  Qdrant connected provider=' + health.provider + ' ok=' + health.ok + ' vectors=' + health.vectorCount);
+        log('server', `🗄️  Qdrant connected: ${health.provider} (ok=${health.ok}, vectors=${health.vectorCount})`);
         if (health.dimensions && configuredDimensions && health.dimensions !== configuredDimensions) {
           log('server', 'vector dimension mismatch config=' + configuredDimensions + ' qdrant=' + health.dimensions);
           log('server', `Vector dimension mismatch: config=${configuredDimensions}, qdrant=${health.dimensions}`, 'warn');
           log('server', 'Will validate against embedder dimensions after provider loads.', 'warn');
         }
       }).catch((err) => {
-        log('server', 'vector health check failed error=' + (err instanceof Error ? err.message : String(err)));
-        log('server', `Vector store health check failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+        log('server', '❌ Qdrant health check failed error=' + (err instanceof Error ? err.message : String(err)));
+        log('server', `❌ Qdrant health check failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
       });
     } catch (err) {
       log('server', 'vector store creation failed error=' + (err instanceof Error ? err.message : String(err)));
       log('server', `Vector store creation failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
     }
   } else {
-    log('server', 'vector provider=sqlite-vec (default)');
-    log('server', 'Vector store: sqlite-vec (default)');
+    log('server', '🗄️  Vector store: sqlite-vec (default)');
+    log('server', '🗄️  Vector store: sqlite-vec (default)');
   }
 
   if (vectorStore) {
@@ -332,7 +332,7 @@ export async function startServer(options: ServerOptions): Promise<void> {
     setStdioMode(true);
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    log('server', 'MCP server started on stdio');
+    log('server', '🔌 MCP server started on stdio');
   }
 
   Promise.all([
@@ -348,14 +348,14 @@ export async function startServer(options: ServerOptions): Promise<void> {
             log('server', 'vector store reinitialized dims=' + loadedEmbedder.getDimensions());
           }
         }
-        log('server', 'Embedding provider initialized model=' + store.modelStatus.embedding);
-        log('server', `Embedding model: ${store.modelStatus.embedding}`);
+         log('server', '🧠 Embedding provider ready model=' + store.modelStatus.embedding);
+         log('server', `🧠 Embedding provider ready: ${store.modelStatus.embedding}`);
         startFileWatcher();
       })
       .catch((err) => {
-        store.modelStatus.embedding = 'failed';
-        log('server', 'Embedding provider failed error=' + (err instanceof Error ? err.message : String(err)));
-        log('server', `Embedding model failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+         store.modelStatus.embedding = 'failed';
+         log('server', '❌ Embedding provider failed error=' + (err instanceof Error ? err.message : String(err)));
+         log('server', `❌ Embedding provider failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
         startFileWatcher();
       }),
     createReranker({
@@ -366,18 +366,18 @@ export async function startServer(options: ServerOptions): Promise<void> {
       .then((loadedReranker) => {
         providers.reranker = loadedReranker;
         store.modelStatus.reranker = loadedReranker ? (config?.reranker?.model || 'rerank-2.5-lite') : 'disabled';
-        log('server', 'Reranker initialized model=' + store.modelStatus.reranker);
-        log('server', `Reranker model: ${store.modelStatus.reranker}`);
+         log('server', '🔀 Reranker ready model=' + store.modelStatus.reranker);
+         log('server', `🔀 Reranker ready: ${store.modelStatus.reranker}`);
       })
       .catch((err) => {
-        store.modelStatus.reranker = 'failed';
-        log('server', 'Reranker failed error=' + (err instanceof Error ? err.message : String(err)));
-        log('server', `Reranker model failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+         store.modelStatus.reranker = 'failed';
+         log('server', '❌ Reranker failed error=' + (err instanceof Error ? err.message : String(err)));
+         log('server', `❌ Reranker failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
       }),
   ]).then(() => {
     readyState.value = true;
-    log('server', 'Server ready (Phase 2 complete)');
-    log('server', 'Server ready');
+    log('server', '✅ Server ready (Phase 2 complete)');
+    log('server', '✅ Server ready');
 
     if (config?.consolidation?.enabled) {
       const consolidationConfig = config.consolidation as import('../types.js').ConsolidationConfig;
@@ -390,15 +390,15 @@ export async function startServer(options: ServerOptions): Promise<void> {
           maxCandidates: consolidationConfig.max_memories_per_cycle ?? 5,
         });
         consolidationWorker.start();
-        log('server', 'Consolidation worker started');
+        log('server', '🔄 Consolidation worker started');
 
         providers.expander = createLLMQueryExpander(llmProvider);
         store.modelStatus.expander = 'llm:' + (llmProvider.model ?? 'unknown');
         log('server', 'Query expander enabled with LLM');
-      } else {
-        log('server', 'Consolidation enabled but no LLM provider configured');
-        log('server', 'Consolidation enabled but no LLM provider configured', 'warn');
-      }
+       } else {
+         log('server', '⚠️  Consolidation enabled but no LLM provider configured');
+         log('server', '⚠️  Consolidation enabled but no LLM provider configured', 'warn');
+       }
     }
   });
 
@@ -433,8 +433,8 @@ export async function startServer(options: ServerOptions): Promise<void> {
             store.modelStatus.embedding = newProvider.getModel();
             store.ensureVecTable(newProvider.getDimensions());
             if (oldProvider && 'dispose' in oldProvider) (oldProvider as { dispose(): void }).dispose();
-            log('server', 'Reconnected to Ollama url=' + ollamaUrl + ' model=' + ollamaModel);
-            log('server', `Reconnected to Ollama at ${ollamaUrl} — switched from local GGUF`);
+             log('server', '🦙 Reconnected to Ollama url=' + ollamaUrl + ' model=' + ollamaModel);
+             log('server', `🦙 Reconnected to Ollama at ${ollamaUrl} — switched from local GGUF`);
             startedWithLocalGGUF = false;
             clearInterval(reconnectTimer);
           }

--- a/src/store/documents.ts
+++ b/src/store/documents.ts
@@ -194,7 +194,7 @@ export function makeDocumentMethods(
     },
 
     searchFTS(query: string, options: StoreSearchOptions = {}): SearchResult[] {
-      const { limit = 10, collection, projectHash, tags, since, until } = options;
+      const { limit = 10, collection, projectHash, tags, since, until, includeGlobal } = options;
       const sanitized = sanitizeFTS5Query(query);
       if (!sanitized) return [];
 
@@ -216,7 +216,11 @@ export function makeDocumentMethods(
         params.push(collection);
       }
       if (projectHash && projectHash !== 'all') {
-        sql += ` AND d.project_hash IN (?, 'global')`;
+        if (includeGlobal) {
+          sql += ` AND d.project_hash IN (?, 'global')`;
+        } else {
+          sql += ` AND d.project_hash = ?`;
+        }
         params.push(projectHash);
       }
       if (since) {

--- a/src/store/documents.ts
+++ b/src/store/documents.ts
@@ -93,10 +93,7 @@ export function makeDocumentMethods(
 
       if (!row) {
         const relativePath = toRel(pathOrDocid);
-        row = db.prepare(`
-          SELECT id, collection, path, title, hash, agent, created_at as createdAt, modified_at as modifiedAt, active, project_hash as projectHash
-          FROM documents WHERE path = ? AND active = 1 LIMIT 1
-        `).get(relativePath) as Record<string, unknown> | undefined;
+        row = stmts.findDocumentByPathAnyCollection.get(relativePath) as Record<string, unknown> | undefined;
       }
 
       if (!row) return null;
@@ -306,12 +303,12 @@ export function makeDocumentMethods(
 
         if (docs.length > 0) {
           const uniqueHashes = [...new Set(docs.map(d => d.hash))];
-          const placeholders = uniqueHashes.map(() => '?').join(',');
-          const referencedRows = db.prepare(
-            `SELECT hash FROM documents WHERE hash IN (${placeholders}) AND project_hash != ? GROUP BY hash`
-          ).all(...uniqueHashes, projectHash) as Array<{ hash: string }>;
-          const nonOrphans = new Set(referencedRows.map(r => r.hash));
-          const orphanedHashes = uniqueHashes.filter(h => !nonOrphans.has(h));
+          const orphanRows = db.prepare(
+            `SELECT hash FROM documents WHERE project_hash = ?
+             EXCEPT
+             SELECT hash FROM documents WHERE project_hash != ?`
+          ).all(projectHash, projectHash) as Array<{ hash: string }>;
+          const orphanedHashes = orphanRows.map(r => r.hash).filter(h => uniqueHashes.includes(h));
 
           for (const hash of orphanedHashes) {
             const cvResult = db.prepare('DELETE FROM content_vectors WHERE hash = ?').run(hash);

--- a/src/store/documents.ts
+++ b/src/store/documents.ts
@@ -77,7 +77,7 @@ export function makeDocumentMethods(
         doc.active ? 1 : 0,
         doc.projectHash ?? 'global'
       );
-      const existing = stmts.findDocumentByPath.get(relativePath) as { id: number } | undefined;
+      const existing = stmts.findDocumentByPath.get(relativePath, doc.collection) as { id: number } | undefined;
       if (existing) return existing.id;
       const rowid = Number(result.lastInsertRowid);
       if (rowid > 0) return rowid;
@@ -93,7 +93,10 @@ export function makeDocumentMethods(
 
       if (!row) {
         const relativePath = toRel(pathOrDocid);
-        row = stmts.findDocumentByPath.get(relativePath) as Record<string, unknown> | undefined;
+        row = db.prepare(`
+          SELECT id, collection, path, title, hash, agent, created_at as createdAt, modified_at as modifiedAt, active, project_hash as projectHash
+          FROM documents WHERE path = ? AND active = 1 LIMIT 1
+        `).get(relativePath) as Record<string, unknown> | undefined;
       }
 
       if (!row) return null;
@@ -294,15 +297,12 @@ export function makeDocumentMethods(
 
         if (docs.length > 0) {
           const uniqueHashes = [...new Set(docs.map(d => d.hash))];
-          const orphanedHashes: string[] = [];
-          for (const hash of uniqueHashes) {
-            const otherUses = db.prepare(
-              'SELECT COUNT(*) as count FROM documents WHERE hash = ? AND project_hash != ?'
-            ).get(hash, projectHash) as { count: number };
-            if (otherUses.count === 0) {
-              orphanedHashes.push(hash);
-            }
-          }
+          const placeholders = uniqueHashes.map(() => '?').join(',');
+          const referencedRows = db.prepare(
+            `SELECT hash FROM documents WHERE hash IN (${placeholders}) AND project_hash != ? GROUP BY hash`
+          ).all(...uniqueHashes, projectHash) as Array<{ hash: string }>;
+          const nonOrphans = new Set(referencedRows.map(r => r.hash));
+          const orphanedHashes = uniqueHashes.filter(h => !nonOrphans.has(h));
 
           for (const hash of orphanedHashes) {
             const cvResult = db.prepare('DELETE FROM content_vectors WHERE hash = ?').run(hash);

--- a/src/store/documents.ts
+++ b/src/store/documents.ts
@@ -203,10 +203,13 @@ export function makeDocumentMethods(
           d.id, d.path, d.collection, d.title, d.hash, d.agent, d.project_hash,
           d.centrality, d.cluster_id, d.superseded_by,
           d.access_count, d.last_accessed_at as lastAccessedAt,
+          d.created_at as createdAt,
+          LENGTH(c.body) as charLength,
           snippet(documents_fts, 2, '<mark>', '</mark>', '...', 64) as snippet,
           bm25(documents_fts) as score
         FROM documents_fts f
         JOIN documents d ON f.filepath = d.collection || '/' || d.path
+        LEFT JOIN content c ON c.hash = d.hash
         WHERE documents_fts MATCH ? AND d.active = 1
       `;
       const params: (string | number)[] = [sanitized];
@@ -265,6 +268,8 @@ export function makeDocumentMethods(
         supersededBy: row.superseded_by as number | null | undefined,
         access_count: row.access_count as number | undefined,
         lastAccessedAt: row.lastAccessedAt as string | null | undefined,
+        createdAt: row.createdAt as string | undefined,
+        charLength: row.charLength as number | undefined,
       }));
     },
 

--- a/src/store/graph.ts
+++ b/src/store/graph.ts
@@ -38,18 +38,12 @@ export function makeGraphMethods(
     },
 
     getFileDependencies(filePath: string, projectHash: string): string[] {
-      const rows = db.prepare(`
-        SELECT target_path FROM file_edges
-        WHERE source_path = ? AND project_hash = ?
-      `).all(toRel(filePath), projectHash) as Array<{ target_path: string }>;
+      const rows = stmts.getFileDependenciesStmt.all(toRel(filePath), projectHash) as Array<{ target_path: string }>;
       return rows.map(r => r.target_path);
     },
 
     getFileDependents(filePath: string, projectHash: string): string[] {
-      const rows = db.prepare(`
-        SELECT source_path FROM file_edges
-        WHERE target_path = ? AND project_hash = ?
-      `).all(toRel(filePath), projectHash) as Array<{ source_path: string }>;
+      const rows = stmts.getFileDependentsStmt.all(toRel(filePath), projectHash) as Array<{ source_path: string }>;
       return rows.map(r => r.source_path);
     },
 
@@ -75,20 +69,13 @@ export function makeGraphMethods(
     },
 
     getDocumentCentrality(filePath: string): { centrality: number; clusterId: number | null } | null {
-      const row = db.prepare(`
-        SELECT centrality, cluster_id FROM documents
-        WHERE path = ? AND active = 1
-      `).get(toRel(filePath)) as { centrality: number; cluster_id: number | null } | undefined;
+      const row = stmts.getDocumentCentralityStmt.get(toRel(filePath)) as { centrality: number; cluster_id: number | null } | undefined;
       if (!row) return null;
       return { centrality: row.centrality ?? 0, clusterId: row.cluster_id };
     },
 
     getClusterMembers(clusterId: number, projectHash: string): string[] {
-      const rows = db.prepare(`
-        SELECT path FROM documents
-        WHERE cluster_id = ? AND project_hash = ? AND active = 1
-        ORDER BY centrality DESC
-      `).all(clusterId, projectHash) as Array<{ path: string }>;
+      const rows = stmts.getClusterMembersStmt.all(clusterId, projectHash) as Array<{ path: string }>;
       return rows.map(r => r.path);
     },
 
@@ -98,27 +85,10 @@ export function makeGraphMethods(
       clusterCount: number;
       topCentrality: Array<{ path: string; centrality: number }>;
     } {
-      const edges = db.prepare(`SELECT COUNT(*) as count FROM file_edges WHERE project_hash = ?`).get(projectHash) as { count: number };
-
-      const nodes = db.prepare(`
-        SELECT COUNT(*) as count FROM (
-          SELECT source_path as node FROM file_edges WHERE project_hash = ?
-          UNION
-          SELECT target_path as node FROM file_edges WHERE project_hash = ?
-        )
-      `).get(projectHash, projectHash) as { count: number };
-
-      const clusters = db.prepare(`
-        SELECT COUNT(DISTINCT cluster_id) as count FROM documents
-        WHERE project_hash = ? AND cluster_id IS NOT NULL AND active = 1
-      `).get(projectHash) as { count: number };
-
-      const topCentrality = db.prepare(`
-        SELECT path, centrality FROM documents
-        WHERE project_hash = ? AND active = 1 AND centrality > 0
-        ORDER BY centrality DESC
-        LIMIT 10
-      `).all(projectHash) as Array<{ path: string; centrality: number }>;
+      const edges = stmts.graphEdgeCount.get(projectHash) as { count: number };
+      const nodes = stmts.graphNodeCount.get(projectHash, projectHash) as { count: number };
+      const clusters = stmts.graphClusterCount.get(projectHash) as { count: number };
+      const topCentrality = stmts.graphTopCentrality.all(projectHash) as Array<{ path: string; centrality: number }>;
 
       return {
         nodeCount: nodes.count,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -418,6 +418,8 @@ export function createStore(dbPath: string): Store {
   }
   storeCreating.add(resolvedPath);
 
+  try {
+
   log('store', 'createStore dbPath=' + resolvedPath);
 
   const recoveryResult = checkAndRecoverDB(resolvedPath, {
@@ -449,20 +451,6 @@ export function createStore(dbPath: string): Store {
 
   applySchema(db);
   runMigrations(db);
-
-  if (vecAvailable) {
-    try {
-      db.exec(`
-        CREATE VIRTUAL TABLE IF NOT EXISTS vectors_vec USING vec0(
-          hash_seq TEXT PRIMARY KEY,
-          embedding float[768] distance_metric=cosine
-        );
-      `);
-    } catch (err) {
-      log('store', `Failed to create vector table: ${err instanceof Error ? err.message : String(err)}`, 'warn');
-      vecAvailable = false;
-    }
-  }
 
   const stmts = initStatements(db);
 
@@ -1038,4 +1026,8 @@ export function createStore(dbPath: string): Store {
   storeCreating.delete(resolvedPath);
 
   return store;
+
+  } finally {
+    storeCreating.delete(resolvedPath);
+  }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1024,7 +1024,6 @@ export function createStore(dbPath: string): Store {
   _cached = true;
   storeCache.set(resolvedPath, store);
   storeCacheUncache.set(resolvedPath, () => { _cached = false; });
-  storeCreating.delete(resolvedPath);
 
   return store;
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -148,6 +148,7 @@ export function migrateToRelativePaths(store: Store, projectHash: string, worksp
       `SELECT path FROM documents WHERE path LIKE '/%' AND project_hash = ? LIMIT 10`
     ).all(projectHash) as Array<{ path: string }>;
     for (const doc of unmatchedDocs) {
+      if (doc.path.includes('/.nano-brain/')) continue;
       log('store', `Warning: document path does not match workspace prefix, left unchanged: ${doc.path}`, 'warn');
     }
 

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -264,7 +264,7 @@ export function runMigrations(db: Database.Database): void {
 
   // Schema versioning
   const currentVersion = (db.pragma('user_version') as Array<{ user_version: number }>)[0].user_version;
-  const TARGET_VERSION = 9;
+  const TARGET_VERSION = 10;
 
   if (currentVersion < 1) {
     db.exec(`
@@ -501,12 +501,25 @@ export function runMigrations(db: Database.Database): void {
     log('store', 'Schema migrated to version 9 (path prefix compression)');
   }
 
+  if (currentVersion < 10) {
+    const hasDomainType = (db.prepare("PRAGMA table_info(documents)").all() as Array<{ name: string }>).some(col => col.name === 'domain_type');
+    if (!hasDomainType) {
+      db.exec("ALTER TABLE documents ADD COLUMN domain_type TEXT DEFAULT 'general'");
+    }
+    const hasLastReinforcedAt = (db.prepare("PRAGMA table_info(documents)").all() as Array<{ name: string }>).some(col => col.name === 'last_reinforced_at');
+    if (!hasLastReinforcedAt) {
+      db.exec("ALTER TABLE documents ADD COLUMN last_reinforced_at TEXT");
+    }
+    db.pragma(`user_version = 10`);
+    log('store', 'Schema migrated to version 10 (domain_type, last_reinforced_at columns)');
+  }
+
   void TARGET_VERSION;
 }
 
-export type Stmts = ReturnType<typeof initStatements>;
+export type Stmts = Record<string, any>;
 
-export function initStatements(db: Database.Database) {
+export function initStatements(db: Database.Database): Stmts {
   return {
     insertContent: db.prepare(`INSERT OR IGNORE INTO content (hash, body) VALUES (?, ?)`),
     insertDocument: db.prepare(`

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -522,7 +522,7 @@ export function initStatements(db: Database.Database) {
     `),
     findDocumentByPath: db.prepare(`
       SELECT id, collection, path, title, hash, agent, created_at as createdAt, modified_at as modifiedAt, active, project_hash as projectHash
-      FROM documents WHERE path = ? AND active = 1
+      FROM documents WHERE path = ? AND collection = ? AND active = 1
     `),
     findDocumentByDocid: db.prepare(`
       SELECT id, collection, path, title, hash, agent, created_at as createdAt, modified_at as modifiedAt, active, project_hash as projectHash
@@ -945,5 +945,40 @@ export function initStatements(db: Database.Database) {
     `),
     insertPrefix: db.prepare(`INSERT OR IGNORE INTO path_prefixes (project_hash, prefix) VALUES (?, ?)`),
     getPrefix: db.prepare(`SELECT prefix FROM path_prefixes WHERE project_hash = ?`),
+    getFileDependenciesStmt: db.prepare(`
+      SELECT target_path FROM file_edges
+      WHERE source_path = ? AND project_hash = ?
+    `),
+    getFileDependentsStmt: db.prepare(`
+      SELECT source_path FROM file_edges
+      WHERE target_path = ? AND project_hash = ?
+    `),
+    getDocumentCentralityStmt: db.prepare(`
+      SELECT centrality, cluster_id FROM documents
+      WHERE path = ? AND active = 1
+    `),
+    getClusterMembersStmt: db.prepare(`
+      SELECT path FROM documents
+      WHERE cluster_id = ? AND project_hash = ? AND active = 1
+      ORDER BY centrality DESC
+    `),
+    graphEdgeCount: db.prepare(`SELECT COUNT(*) as count FROM file_edges WHERE project_hash = ?`),
+    graphNodeCount: db.prepare(`
+      SELECT COUNT(*) as count FROM (
+        SELECT source_path as node FROM file_edges WHERE project_hash = ?
+        UNION
+        SELECT target_path as node FROM file_edges WHERE project_hash = ?
+      )
+    `),
+    graphClusterCount: db.prepare(`
+      SELECT COUNT(DISTINCT cluster_id) as count FROM documents
+      WHERE project_hash = ? AND cluster_id IS NOT NULL AND active = 1
+    `),
+    graphTopCentrality: db.prepare(`
+      SELECT path, centrality FROM documents
+      WHERE project_hash = ? AND active = 1 AND centrality > 0
+      ORDER BY centrality DESC
+      LIMIT 10
+    `),
   };
 }

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -517,7 +517,7 @@ export function runMigrations(db: Database.Database): void {
   void TARGET_VERSION;
 }
 
-export function initStatements(db: Database.Database): Stmts {
+export function initStatements(db: Database.Database): Record<string, Database.Statement<unknown[], unknown>> {
   return {
     insertContent: db.prepare(`INSERT OR IGNORE INTO content (hash, body) VALUES (?, ?)`),
     insertDocument: db.prepare(`
@@ -1001,4 +1001,4 @@ export function initStatements(db: Database.Database): Stmts {
   };
 }
 
-export type Stmts = Record<string, Database.Statement<unknown[], unknown>>;
+export type Stmts = ReturnType<typeof initStatements>;

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -517,8 +517,6 @@ export function runMigrations(db: Database.Database): void {
   void TARGET_VERSION;
 }
 
-export type Stmts = Record<string, any>;
-
 export function initStatements(db: Database.Database): Stmts {
   return {
     insertContent: db.prepare(`INSERT OR IGNORE INTO content (hash, body) VALUES (?, ?)`),
@@ -540,6 +538,13 @@ export function initStatements(db: Database.Database): Stmts {
     findDocumentByDocid: db.prepare(`
       SELECT id, collection, path, title, hash, agent, created_at as createdAt, modified_at as modifiedAt, active, project_hash as projectHash
       FROM documents WHERE substr(hash, 1, 6) = ? AND active = 1
+    `),
+    findDocumentByPathAnyCollection: db.prepare(`
+      SELECT id, collection, path, title, hash, agent, created_at as createdAt, modified_at as modifiedAt, active, project_hash as projectHash
+      FROM documents WHERE path = ? AND active = 1 LIMIT 1
+    `),
+    findDocMetadataByHash: db.prepare(`
+      SELECT project_hash, created_at FROM documents WHERE hash = ? LIMIT 1
     `),
     getContent: db.prepare(`SELECT body FROM content WHERE hash = ?`),
     deactivateDocument: db.prepare(`UPDATE documents SET active = 0 WHERE collection = ? AND path = ?`),
@@ -995,3 +1000,5 @@ export function initStatements(db: Database.Database): Stmts {
     `),
   };
 }
+
+export type Stmts = Record<string, Database.Statement<unknown[], unknown>>;

--- a/src/store/vectors.ts
+++ b/src/store/vectors.ts
@@ -230,7 +230,8 @@ export function makeVectorMethods(
                      d.centrality, d.cluster_id, d.superseded_by, d.modified_at,
                      d.created_at as createdAt,
                      d.access_count, d.last_accessed_at as lastAccessedAt,
-                     substr(c.body, 1, 700) as snippet
+                     substr(c.body, 1, 700) as snippet,
+                     LENGTH(c.body) as char_length
               FROM documents d
               LEFT JOIN content c ON c.hash = d.hash
               WHERE d.hash = ? AND d.active = 1
@@ -269,7 +270,7 @@ export function makeVectorMethods(
               access_count: row.access_count as number | undefined,
               lastAccessedAt: row.lastAccessedAt as string | null | undefined,
               createdAt: row.createdAt as string | undefined,
-              charLength: (row.snippet as string | null)?.length,
+              charLength: row.char_length as number | undefined,
             });
           }
 

--- a/src/store/vectors.ts
+++ b/src/store/vectors.ts
@@ -60,16 +60,18 @@ export function makeVectorMethods(
 
       if (useExternalStore) {
         let projectHash: string | undefined;
+        let createdAt: string | undefined;
         try {
-          const docRow = db.prepare(`SELECT project_hash FROM documents WHERE hash = ? LIMIT 1`).get(hash) as { project_hash: string } | undefined;
+          const docRow = db.prepare(`SELECT project_hash, created_at FROM documents WHERE hash = ? LIMIT 1`).get(hash) as { project_hash: string; created_at: string } | undefined;
           projectHash = docRow?.project_hash ?? undefined;
+          createdAt = docRow?.created_at ?? undefined;
         } catch {
         }
 
         const point: VectorPoint = {
           id: `${hash}:${seq}`,
           embedding,
-          metadata: { hash, seq, pos, model, projectHash },
+          metadata: { hash, seq, pos, model, projectHash, createdAt },
         };
         externalVectorStore.upsert(point).catch((err) => {
           log('store', 'insertEmbedding external vector store upsert failed hash=' + hash.substring(0, 8));
@@ -226,6 +228,7 @@ export function makeVectorMethods(
             const row = db.prepare(`
               SELECT d.id, d.path, d.collection, d.title, d.hash, d.agent, d.project_hash,
                      d.centrality, d.cluster_id, d.superseded_by, d.modified_at,
+                     d.created_at as createdAt,
                      d.access_count, d.last_accessed_at as lastAccessedAt,
                      substr(c.body, 1, 700) as snippet
               FROM documents d
@@ -265,6 +268,8 @@ export function makeVectorMethods(
               supersededBy: row.superseded_by as number | null | undefined,
               access_count: row.access_count as number | undefined,
               lastAccessedAt: row.lastAccessedAt as string | null | undefined,
+              createdAt: row.createdAt as string | undefined,
+              charLength: (row.snippet as string | null)?.length,
             });
           }
 

--- a/src/store/vectors.ts
+++ b/src/store/vectors.ts
@@ -62,7 +62,7 @@ export function makeVectorMethods(
         let projectHash: string | undefined;
         let createdAt: string | undefined;
         try {
-          const docRow = db.prepare(`SELECT project_hash, created_at FROM documents WHERE hash = ? LIMIT 1`).get(hash) as { project_hash: string; created_at: string } | undefined;
+          const docRow = stmts.findDocMetadataByHash.get(hash) as { project_hash: string; created_at: string } | undefined;
           projectHash = docRow?.project_hash ?? undefined;
           createdAt = docRow?.created_at ?? undefined;
         } catch {

--- a/src/store/vectors.ts
+++ b/src/store/vectors.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import type { VectorStore, VectorPoint } from '../vector-store.js';
 import { SqliteVecStore } from '../providers/sqlite-vec.js';
+import { QdrantVecStore, stringToUuid } from '../providers/qdrant.js';
 import type { SearchResult, StoreSearchOptions } from '../types.js';
 import { log } from '../logger.js';
 import type { Stmts } from './schema.js';
@@ -58,10 +59,17 @@ export function makeVectorMethods(
       const useExternalStore = externalVectorStore && !(externalVectorStore instanceof SqliteVecStore);
 
       if (useExternalStore) {
+        let projectHash: string | undefined;
+        try {
+          const docRow = db.prepare(`SELECT project_hash FROM documents WHERE hash = ? LIMIT 1`).get(hash) as { project_hash: string } | undefined;
+          projectHash = docRow?.project_hash ?? undefined;
+        } catch {
+        }
+
         const point: VectorPoint = {
           id: `${hash}:${seq}`,
           embedding,
-          metadata: { hash, seq, pos, model },
+          metadata: { hash, seq, pos, model, projectHash },
         };
         externalVectorStore.upsert(point).catch((err) => {
           log('store', 'insertEmbedding external vector store upsert failed hash=' + hash.substring(0, 8));
@@ -209,7 +217,8 @@ export function makeVectorMethods(
 
       if (state.vectorStore) {
         try {
-          const vecResults = await state.vectorStore.search(embedding, { limit: limit * 3, collection });
+          const vecProjectHash = projectHash && projectHash !== 'all' ? projectHash : undefined;
+          const vecResults = await state.vectorStore.search(embedding, { limit: limit * 3, collection, projectHash: vecProjectHash });
           if (vecResults.length === 0) return [];
 
           const results: SearchResult[] = [];
@@ -348,4 +357,34 @@ export function makeVectorMethods(
       return stmts.getNextHashNeedingEmbedding.get() as { hash: string; body: string; path: string } | null;
     },
   };
+}
+
+export async function backfillQdrantProjectHash(db: Database.Database, vectorStore: VectorStore): Promise<void> {
+  if (!(vectorStore instanceof QdrantVecStore)) return;
+
+  const rows = db.prepare(`
+    SELECT cv.hash, cv.seq, d.project_hash
+    FROM content_vectors cv
+    JOIN documents d ON d.hash = cv.hash AND d.active = 1
+    WHERE d.project_hash IS NOT NULL
+  `).all() as Array<{ hash: string; seq: number; project_hash: string }>;
+
+  if (rows.length === 0) return;
+
+  log('store', 'backfillQdrantProjectHash starting rows=' + rows.length);
+
+  const BATCH_SIZE = 100;
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
+    try {
+      await (vectorStore as QdrantVecStore).batchSetPayload(batch.map(r => ({
+        id: stringToUuid(`${r.hash}:${r.seq}`),
+        payload: { projectHash: r.project_hash },
+      })));
+    } catch (err) {
+      log('store', 'backfillQdrantProjectHash batch failed i=' + i + ' err=' + (err instanceof Error ? err.message : String(err)), 'warn');
+    }
+  }
+
+  log('store', 'backfillQdrantProjectHash complete rows=' + rows.length);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,6 +259,9 @@ export interface SearchConfig {
   centrality_weight: number;
   supersede_demotion: number;
   usage_boost_weight: number;
+  length_norm_anchor: number;
+  recency_weight: number;
+  recency_half_life_days: number;
 }
 
 export const DEFAULT_SEARCH_CONFIG: SearchConfig = {
@@ -279,6 +282,9 @@ export const DEFAULT_SEARCH_CONFIG: SearchConfig = {
   centrality_weight: 0.1,
   supersede_demotion: 0.05,
   usage_boost_weight: 0.15,
+  length_norm_anchor: 2000,
+  recency_weight: 0.3,
+  recency_half_life_days: 180,
 };
 
 // === Self-Learning Types ===

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,7 +274,7 @@ export const DEFAULT_SEARCH_CONFIG: SearchConfig = {
     enabled: true,
   },
   centrality_weight: 0.1,
-  supersede_demotion: 0.3,
+  supersede_demotion: 0.05,
   usage_boost_weight: 0.15,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,7 @@ export interface StoreSearchOptions {
   tags?: string[];
   since?: string;
   until?: string;
+  includeGlobal?: boolean;
 }
 
 export interface SearchConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface SearchResult {
   access_count?: number;
   lastAccessedAt?: string | null;
   tags?: string[];
+  createdAt?: string;
+  charLength?: number;
 }
 
 export interface Document {


### PR DESCRIPTION
## Summary

Addresses the 4 core search quality issues diagnosed in the previous session:
- Cross-workspace result leakage (both FTS and Qdrant paths)
- Large files dominating BM25 scores with no length normalization
- Old/new docs scoring equally (no temporal awareness)
- `supersedeDocument` bug passing `0` instead of actual new doc ID

## Changes

### Wave 1 — Schema Migration
- Adds `domain_type TEXT DEFAULT 'general'` and `last_reinforced_at TEXT` columns to `documents` table via safe additive migration (`PRAGMA table_info` guard)

### Wave 2 — Fix Supersede Bug + Demotion
- Fixed `supersedeDocument(targetDoc.id, 0)` → passes actual new doc ID in both `src/mcp/tools/memory.ts` and `src/cli/commands/write.ts`
- Reduced `supersede_demotion` multiplier: `0.3` → `0.05` (superseded docs effectively buried)

### Wave 3 — FTS Workspace Isolation
- Changed `IN (?, 'global')` → `= ?` in all FTS SQL filters (`src/store/documents.ts`, `src/fts-worker.ts`)
- Added `includeGlobal?: boolean` to `StoreSearchOptions` as explicit escape hatch for cross-workspace queries

### Wave 4 — Qdrant Payload Filter
- All Qdrant upserts now include `project_hash` and `created_at` in point payload
- Vector search applies `must` filter on `project_hash` for per-workspace isolation
- `backfillQdrantProjectHash()` backfills existing points (batches of 100) on server startup (fire-and-forget)

### Wave 5 — Temporal Metadata in SearchResult
- Added `createdAt?: string` and `charLength?: number` to `SearchResult` interface
- Populated through FTS main path, FTS worker, vector main path, and fts-worker vector path
- RRF fusion (`rrfFuse`) preserves `createdAt`/`charLength` from whichever source has them

### Wave 6 — Length Normalization
- Added `length_norm_anchor: number` (default `2000`) to `SearchConfig`
- Applied after RRF: `score *= 1 / (1 + log2(max(1, charLength / anchor)))`
- Uses `LENGTH(body)` (full content) — not snippet length — for accurate penalty

### Wave 7 — Recency Boost
- Added `recency_weight: number` (default `0.3`) and `recency_half_life_days: number` (default `180`) to `SearchConfig`
- Exponential decay: `decayFactor = exp(-ln(2) * ageDays / halfLife)`
- Applied **only** to `sessions` and `memory` collections — `codebase` results unaffected

### Post-Oracle Fix
- `vectors.ts`: charLength source corrected from `snippet.length` → `LENGTH(body)` via SQL
- `fts-worker.ts`: workspace filter and missing field consistency fixes

## Test Results

- `npx tsc --noEmit` → exit 0 (zero type errors)
- All non-watcher tests pass
- Watcher test failures are pre-existing on `master` (unrelated to this PR)

## OpenSpec Reference

`openspec/changes/search-quality-and-temporal-knowledge/` — proposal, design, specs, tasks all present.