### PR TITLE
fix: server startup UX, DB integrity cooldown, async file read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,10 @@ Thompson Sampling tunes RRF blend weights and reranking thresholds based on sear
 - **CLI entrypoint**: `bin/cli.js` is a thin wrapper that runs `dist/cli/index.js` if it exists, otherwise falls back to `tsx src/cli/index.ts`. Do not require a build step for development.
 - **Incremental updates everywhere**: Hash-based dirty detection prevents redundant re-processing. Preserve this invariant when adding new index types.
 
+## Git & PR Conventions
+
+- **No agent footers in commits or PRs**: Do not add `Co-Authored-By`, `🤖 Generated with`, or any agent attribution lines to commit messages or PR descriptions.
+
 ## Testing Patterns
 
 Integration tests spin up real SQLite databases in temp directories. The `test/fixtures/` directory contains corpora for benchmark evaluation. RRI-T tests follow a 5-phase methodology (PREPARE → DISCOVER → STRUCTURE → EXECUTE → ANALYZE) — see `SKILL.md` for details.

--- a/openspec/changes/db-integrity-check-cooldown/.openspec.yaml
+++ b/openspec/changes/db-integrity-check-cooldown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/db-integrity-check-cooldown/design.md
+++ b/openspec/changes/db-integrity-check-cooldown/design.md
@@ -1,0 +1,103 @@
+## Context
+
+`checkAndRecoverDB()` in `src/db/corruption-recovery.ts` runs `PRAGMA quick_check` on every cold-start `createStore()` call. The function already dedups within a process via `checkedPaths: Set<string>`, but process-level state dies on each CLI exit. A 10K-doc DB takes 7-8s per check.
+
+## Decisions
+
+### Decision 1: Stamp file format
+
+**Choice:** Plain text, tab-separated: `{ISO timestamp}\t{DB mtime as epoch ms}`
+
+**Rationale:** No JSON parsing overhead, readable with any tool, single line, easy to validate. Two fields are enough: when was the last check, and what was the DB's mtime at that point.
+
+**Alternative considered:** JSON with richer metadata. Rejected — adds complexity with no benefit; the two-field format is sufficient and unambiguous.
+
+### Decision 2: Stamp file location
+
+**Choice:** `{dbPath}.checked` — same directory, derived name.
+
+**Rationale:** Same filesystem as the DB (avoids cross-mount inconsistency), obvious association, cleaned up naturally when the DB is deleted. No separate cache directory to manage.
+
+**Alternative considered:** `~/.nano-brain/cache/integrity/` central directory. Rejected — cross-mount risk, requires extra cleanup logic on DB removal.
+
+### Decision 3: Cooldown duration
+
+**Choice:** 30 minutes, overridable via `NANO_BRAIN_CHECK_COOLDOWN_MS` env var.
+
+**Rationale:** Long enough to cover normal agent session workflows (multiple CLI calls in quick succession) while short enough to catch corruption from external writes. Env override allows testing with short cooldown (e.g. 0 to force check every time) and production tuning.
+
+### Decision 4: Invalidation logic
+
+**Choice:** Skip check only when ALL of these hold:
+1. Stamp file exists and is readable
+2. `Date.now() - stampTimestamp < COOLDOWN_MS`
+3. `currentDbMtime === stampMtime`
+
+If any condition fails → run full check, then write fresh stamp.
+
+**Rationale:** The mtime check is the critical safety net. If anything writes to the DB between CLI calls (server, another CLI, external tool), mtime changes and the next CLI call re-checks. This provides automatic invalidation without requiring coordination between processes.
+
+### Decision 5: Stamp write timing
+
+**Choice:** Write stamp after successful `PRAGMA quick_check` AND after the in-process `checkedPaths.add()`. On corruption + recovery, write stamp for the fresh DB (which just passed its own quick_check).
+
+**Rationale:** Only write stamp on confirmed healthy state. Never write stamp if check was skipped (stamp already current) or if an error occurred.
+
+## Data Flow
+
+```
+checkAndRecoverDB(dbPath)
+  │
+  ├─ New DB (no file) → create fresh, write stamp, return
+  │
+  ├─ checkedPaths.has(path) → skip (in-process dedup, unchanged)
+  │
+  ├─ readStamp(dbPath) → { stampTs, stampMtime }
+  │   ├─ stamp valid (age < 30min && mtime matches) → open DB, applyPragmas, return
+  │   └─ stamp invalid/missing → fall through to PRAGMA quick_check
+  │
+  └─ Run PRAGMA quick_check
+      ├─ PASS → checkedPaths.add, writeStamp(dbPath, currentMtime), open DB, return
+      └─ FAIL → recovery path (rename, fresh DB), writeStamp for fresh DB, return
+```
+
+## Stamp File I/O
+
+```typescript
+function readStamp(dbPath: string): { ts: number; mtime: number } | null {
+  const stampPath = dbPath + '.checked';
+  try {
+    const raw = fs.readFileSync(stampPath, 'utf-8').trim();
+    const [tsStr, mtimeStr] = raw.split('\t');
+    const ts = parseInt(tsStr, 10);
+    const mtime = parseInt(mtimeStr, 10);
+    if (!isFinite(ts) || !isFinite(mtime)) return null;
+    return { ts, mtime };
+  } catch { return null; }
+}
+
+function writeStamp(dbPath: string, mtime: number): void {
+  const stampPath = dbPath + '.checked';
+  try {
+    fs.writeFileSync(stampPath, `${Date.now()}\t${mtime}`, 'utf-8');
+  } catch { /* non-fatal: missing stamp → check runs next time */ }
+}
+```
+
+## Error Handling
+
+- Stamp read fails (missing, corrupt, permission) → run full check, not an error
+- Stamp write fails → log warning, continue; next invocation runs full check
+- DB stat fails → treat as missing mtime, run full check
+- All existing error handling (ERR_DLOPEN_FAILED, corruption recovery) unchanged
+
+## Testing
+
+- Stamp written after successful check
+- Stamp skips check on next call when DB mtime unchanged
+- Stamp invalidated when DB mtime changes (write simulated via `touch`)
+- Stamp invalidated when cooldown expires (via `NANO_BRAIN_CHECK_COOLDOWN_MS=0`)
+- Stamp written for fresh DB after recovery
+- Stamp read failure → fallback to full check (no crash)
+- Stamp write failure → non-fatal, next call does full check
+- Existing dedup tests (`checkedPaths`) unchanged

--- a/openspec/changes/db-integrity-check-cooldown/design.md
+++ b/openspec/changes/db-integrity-check-cooldown/design.md
@@ -20,6 +20,14 @@
 
 **Alternative considered:** `~/.nano-brain/cache/integrity/` central directory. Rejected — cross-mount risk, requires extra cleanup logic on DB removal.
 
+### Decision 2b: Mtime dropped in favour of cooldown-only
+
+**Choice:** Stamp stores only a timestamp — no DB mtime.
+
+**Rationale:** WAL mode checkpoint writes update the main DB file's mtime on every normal `db.close()` call. A mtime-based comparison would invalidate the stamp on every routine close, defeating the optimization entirely. Since WAL mode itself provides crash safety, the cooldown window is sufficient protection. Corruption outside a crash scenario (e.g. external tool corruption) is an acceptable risk given the 30-minute window.
+
+**Alternative considered:** mtime comparison (initial design). Rejected after observing that `db.close()` + WAL checkpoint changes mtime, causing false "DB was modified" signals on every CLI invocation.
+
 ### Decision 3: Cooldown duration
 
 **Choice:** 30 minutes, overridable via `NANO_BRAIN_CHECK_COOLDOWN_MS` env var.

--- a/openspec/changes/db-integrity-check-cooldown/proposal.md
+++ b/openspec/changes/db-integrity-check-cooldown/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Every CLI invocation that calls `createStore()` triggers `PRAGMA quick_check` on the SQLite database. On a 10K-document (~600MB) database this takes **7-8 seconds** — every time, even for fast commands like `get` or `graph-stats` that finish their actual work in under 100ms.
+
+The existing in-process deduplication (`checkedPaths` Set) already prevents re-checking within the same process, but each CLI invocation is a new process, so the set is always empty at startup.
+
+## What Changes
+
+Add a **mtime-based stamp file** to `src/db/corruption-recovery.ts`:
+
+- After a successful integrity check, write `{dbPath}.checked` containing `{timestamp}\t{db_mtime}`
+- On the next call to `checkAndRecoverDB`:
+  - If stamp file exists, stamp age < 30 min, AND DB mtime matches → skip `PRAGMA quick_check`
+  - Otherwise → run full check as today
+- Self-invalidating: any write to the DB changes its mtime, invalidating the stamp and forcing re-check on next open
+
+The stamp file lives next to the DB (same directory, same filesystem), so there is no risk of cross-filesystem inconsistency.
+
+## Non-Goals
+
+- Does not affect corruption detection — if DB is modified or stamp is stale, full check runs
+- Does not change the recovery path — corrupt DB handling is unchanged
+- Does not skip the check on first-ever open of a DB
+- Does not require server awareness or async context

--- a/openspec/changes/db-integrity-check-cooldown/tasks.md
+++ b/openspec/changes/db-integrity-check-cooldown/tasks.md
@@ -1,0 +1,31 @@
+## 1. Core: stamp file helpers
+
+- [ ] 1.1 Add `readStamp(dbPath: string): { ts: number; mtime: number } | null` in `src/db/corruption-recovery.ts` — reads `{dbPath}.checked`, parses `timestamp\tmtime`, returns null on any error
+- [ ] 1.2 Add `writeStamp(dbPath: string, mtime: number): void` — writes `{Date.now()}\t{mtime}` to `{dbPath}.checked`, swallows write errors (non-fatal)
+- [ ] 1.3 Add `getDbMtime(dbPath: string): number | null` — returns `fs.statSync(dbPath).mtimeMs`, returns null on error
+- [ ] 1.4 Add `INTEGRITY_CHECK_COOLDOWN_MS` constant (default `30 * 60 * 1000`), overridable via `process.env.NANO_BRAIN_CHECK_COOLDOWN_MS`
+
+## 2. Core: integrate stamp into checkAndRecoverDB
+
+- [ ] 2.1 After the `checkedPaths.has()` early-return block, add stamp validation:
+  - Read stamp and current DB mtime
+  - If stamp valid (age < cooldown AND mtime matches) → open DB with applyPragmas, return `{ db, recovered: false }`
+  - Otherwise → fall through to existing PRAGMA quick_check path
+- [ ] 2.2 After successful PRAGMA quick_check (PASS branch): call `writeStamp(resolvedPath, currentMtime)` before the return
+- [ ] 2.3 After recovery path (fresh DB created and verified): call `writeStamp(resolvedPath, freshMtime)` before the return
+- [ ] 2.4 Export `clearStamp(dbPath: string): void` helper (deletes `{dbPath}.checked`) — needed for tests and for the corruption recovery path to clear stale stamp on detection
+
+## 3. Tests in `test/sqlite-corruption-fix.test.ts`
+
+- [ ] 3.1 **Stamp written after check**: call `checkAndRecoverDB`, verify `{dbPath}.checked` exists with correct mtime
+- [ ] 3.2 **Stamp skips check**: call twice on same DB; second call should not run `PRAGMA quick_check` (spy on `db.pragma`)
+- [ ] 3.3 **Stamp invalidated by mtime change**: after first check, update DB file mtime (`fs.utimesSync`), second call should re-run check
+- [ ] 3.4 **Stamp invalidated by cooldown**: set `NANO_BRAIN_CHECK_COOLDOWN_MS=0`, second call runs full check
+- [ ] 3.5 **Stamp written for fresh DB after recovery**: corrupt a DB, verify recovery runs, verify new stamp exists
+- [ ] 3.6 **Stamp read failure is non-fatal**: write garbage to stamp file, verify `checkAndRecoverDB` still works (falls back to full check)
+- [ ] 3.7 **Existing tests unchanged**: all existing 305 lines of tests still pass
+
+## 4. Cleanup
+
+- [ ] 4.1 Verify `rm` CLI command (`src/cli/commands/rm.ts`) also removes `{dbPath}.checked` when deleting a workspace DB
+- [ ] 4.2 Update `NANO_BRAIN_HOME` env var docs comment in `src/cli/utils.ts` to mention stamp files

--- a/openspec/changes/server-startup-ux/.openspec.yaml
+++ b/openspec/changes/server-startup-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/server-startup-ux/design.md
+++ b/openspec/changes/server-startup-ux/design.md
@@ -1,0 +1,102 @@
+## Context
+
+`startServer()` in `src/server/bootstrap.ts` calls `createStore()` at line 102, which runs `PRAGMA quick_check` (up to 8 minutes on large DBs). The HTTP server is created at line 326, after all bootstrap work. During the 8-minute window, the TCP port is closed and the CLI cannot distinguish "starting" from "not running".
+
+## Decisions
+
+### Decision 1: Early HTTP binding strategy
+
+**Choice:** Create a mutable handler reference before `createStore()`. Start listening immediately with a minimal handler that serves only `/health` → `{"status":"starting","ready":false}` and returns 503 for all other requests. After bootstrap, atomically swap to the full `handleRequest` handler.
+
+```typescript
+// Before createStore()
+let requestHandler: http.RequestListener = (req, res) => {
+  if (req.method === 'GET' && (req.url === '/health' || req.url?.startsWith('/health?'))) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'starting', ready: false }));
+    return;
+  }
+  res.writeHead(503, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'server is starting up, please retry in a moment' }));
+};
+httpServer = createHttpServer(httpPort, httpHost, (req, res) => requestHandler(req, res));
+
+// ... createStore(), full bootstrap ...
+
+// After bootstrap:
+const httpCtx = { ... };
+requestHandler = async (req, res) => { await handleRequest(req, res, httpCtx); };
+```
+
+**Rationale:** Zero-downtime swap of the inner handler; the `http.Server` instance stays the same, only the closure variable changes. Thread-safe because Node.js is single-threaded in the event loop.
+
+**Alternative considered:** Two `createHttpServer()` calls (close first, open second). Rejected — brief port closure window causes false "server down" readings.
+
+### Decision 2: detectRunningServer() semantics
+
+**Choice:** Change `detectRunningServer()` to return `true` only when `/health` responds with `ready: true`. When server is starting (`ready: false`), return `false`.
+
+**Rationale:** Commands that call `if (serverRunning) { proxy }` should only proxy when the server can actually handle requests. A starting server returns 503 for most endpoints; proxying to it would give confusing HTTP 503 errors.
+
+**Side-effect:** Commands will fall back to local SQLite during server startup (when not in container mode). This is correct — local mode is the fallback.
+
+### Decision 3: assertContainerServer() helper
+
+**Choice:** Add `assertContainerServer(port?)` to `src/cli/utils.ts`. Returns the `serverRunning` boolean (avoids double HTTP round-trip). Handles the container guard check internally:
+
+```typescript
+export async function assertContainerServer(port = DEFAULT_HTTP_PORT): Promise<boolean> {
+  const inContainer = isInsideContainer();
+  const serverRunning = await detectRunningServer(port);
+  if (serverRunning || !inContainer) return serverRunning;
+
+  // In container, server not ready — check if it's starting
+  const starting = await isServerStarting(port);
+  if (starting) {
+    cliError(`Server is starting up at ${getHttpHost()}:${port} — please retry in a moment.`);
+    cliError(`  Monitor: docker logs nano-brain`);
+  } else {
+    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${port}. Ensure the Docker container is running:`);
+    cliError(`  docker start nano-brain`);
+  }
+  process.exit(1);
+}
+```
+
+**Rationale:** 8 commands currently duplicate 5 lines of identical guard logic. Single point of change for future improvements. Returns `serverRunning` so callers can replace two separate calls with one.
+
+### Decision 4: isServerStarting() implementation
+
+**Choice:** Probe `/health` with a 2s timeout. If HTTP 200 AND `ready === false` → starting. Any error or non-200 → down.
+
+```typescript
+async function isServerStarting(port: number): Promise<boolean> {
+  const host = getHttpHost();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const resp = await fetch(`http://${host}:${port}/health`, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!resp.ok) return false;
+    const data = await resp.json() as { ready?: boolean };
+    return data.ready === false;
+  } catch { return false; }
+}
+```
+
+**Rationale:** Mirrors `detectRunningServer()` logic but checks for the opposite condition. Named `isServerStarting` not `detectServerState` to keep it narrowly scoped.
+
+## Error Messages
+
+| State | Message |
+|---|---|
+| Starting | `Server is starting up at host.docker.internal:3100 — please retry in a moment.\n  Monitor: docker logs nano-brain` |
+| Down | `Error: nano-brain server not reachable at host.docker.internal:3100. Ensure the Docker container is running:\n  docker start nano-brain` |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/server/bootstrap.ts` | Early HTTP binding with mutable handler |
+| `src/cli/utils.ts` | `detectRunningServer()` updated, `isServerStarting()` added, `assertContainerServer()` added |
+| `src/cli/commands/{embed,reindex,search,status,tags,update,wake-up,write}.ts` | Replace guard boilerplate with `await assertContainerServer()` |

--- a/openspec/changes/server-startup-ux/proposal.md
+++ b/openspec/changes/server-startup-ux/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+When `nano-brain docker start` is run and the CLI is called immediately from inside the agent container, the server is still running its DB integrity check (up to 8 minutes on large databases). The HTTP port is not yet open, so the CLI sees the same error as when the server has never been started:
+
+```
+Error: nano-brain server not reachable at host.docker.internal:3100. Ensure the Docker container is running:
+  docker start nano-brain
+```
+
+This is misleading. The container IS running; the server is just initializing. The user (or agent) gets no useful guidance.
+
+Discovered and confirmed during real container testing (PR #9).
+
+## What Changes
+
+**Server side:** Bind the HTTP port at the very start of `startServer()` — before `createStore()`. During the bootstrap phase the `/health` endpoint returns `{"status":"starting","ready":false}`. All other endpoints return 503. After bootstrap completes, the full request handler takes over.
+
+**CLI side:** 
+1. `detectRunningServer()` is updated to return `true` only when the server is fully ready (`ready: true`). Previously it returned `true` for any 200 response, including the starting state.
+2. New `assertContainerServer(port?)` helper centralizes the container guard across all 8 commands. It distinguishes "starting" from "down" and shows the appropriate message.
+3. All 8 CLI commands that duplicate the container guard boilerplate are simplified to a single `await assertContainerServer()` call.
+
+## Non-Goals
+
+- Does not wait/poll for the server to finish starting (user must retry manually)
+- Does not change `ready: false` responses for Qdrant/embedding checks — only the startup window
+- Does not change non-container behaviour

--- a/openspec/changes/server-startup-ux/tasks.md
+++ b/openspec/changes/server-startup-ux/tasks.md
@@ -1,0 +1,31 @@
+## 1. Server: early HTTP binding
+
+- [ ] 1.1 In `src/server/bootstrap.ts`, before `createStore()`: declare `let requestHandler: http.RequestListener` with a minimal implementation that returns `/health → {"status":"starting","ready":false}` and 503 for all others
+- [ ] 1.2 Start `httpServer = createHttpServer(httpPort, httpHost, (req, res) => requestHandler(req, res))` before `createStore()` (only in HTTP mode)
+- [ ] 1.3 After full bootstrap (after `httpCtx` is built): assign `requestHandler = async (req, res) => { await handleRequest(req, res, httpCtx); }`
+
+## 2. CLI utils: new helpers
+
+- [ ] 2.1 Update `detectRunningServer()` to return `true` only when `/health` returns `ready: true` (parse JSON, check `data.ready === true`)
+- [ ] 2.2 Add `isServerStarting(port)`: returns `true` when `/health` returns HTTP 200 with `ready: false`
+- [ ] 2.3 Add `assertContainerServer(port?)`: checks container + server state, shows right error message, calls `process.exit(1)` if container + not ready; returns `serverRunning: boolean`
+
+## 3. CLI commands: replace guard boilerplate
+
+Replace the 5-line guard pattern in each command with `const serverRunning = await assertContainerServer()`:
+
+- [ ] 3.1 `src/cli/commands/tags.ts`
+- [ ] 3.2 `src/cli/commands/update.ts`
+- [ ] 3.3 `src/cli/commands/status.ts`
+- [ ] 3.4 `src/cli/commands/write.ts`
+- [ ] 3.5 `src/cli/commands/search.ts`
+- [ ] 3.6 `src/cli/commands/embed.ts`
+- [ ] 3.7 `src/cli/commands/reindex.ts`
+- [ ] 3.8 `src/cli/commands/wake-up.ts`
+
+## 4. Tests
+
+- [ ] 4.1 `test/cli-proxy.test.ts`: add test — when `/health` returns `ready: false`, `assertContainerServer()` exits with "starting up" message (not "not running")
+- [ ] 4.2 `test/cli-proxy.test.ts`: add test — `detectRunningServer()` returns `false` when `/health` returns `ready: false`
+- [ ] 4.3 `test/cli-proxy.test.ts`: add test — `detectRunningServer()` returns `true` when `/health` returns `ready: true`
+- [ ] 4.4 Existing tests in `test/cli-proxy.test.ts` still pass (server mock updated to return `ready: true`)

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -27,8 +27,8 @@ export async function handleEmbed(globalOpts: GlobalOptions, commandArgs: string
 
   log('cli', 'embed start force=' + force);
 
-  await assertContainerServer();
-  if (isInsideContainer()) {
+  const serverRunning = await assertContainerServer();
+  if (serverRunning) {
     try {
       const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/embed', {});
       if (result.error) {
@@ -38,8 +38,11 @@ export async function handleEmbed(globalOpts: GlobalOptions, commandArgs: string
       cliOutput('✅ Embedding started in background on daemon');
       return;
     } catch (err) {
-      cliError('Error: Failed to communicate with daemon:', err instanceof Error ? err.message : String(err));
-      process.exit(1);
+      if (isInsideContainer()) {
+        cliError('Error: Failed to communicate with daemon:', err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      log('cli', 'HTTP proxy failed for embed, falling back to local: ' + (err instanceof Error ? err.message : String(err)));
     }
   }
 

--- a/src/cli/commands/embed.ts
+++ b/src/cli/commands/embed.ts
@@ -12,10 +12,8 @@ import type { GlobalOptions } from '../types.js';
 import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServer,
+  assertContainerServer,
   proxyPost,
-  getHttpHost,
-  getHttpPort,
 } from '../utils.js';
 
 export async function handleEmbed(globalOpts: GlobalOptions, commandArgs: string[]): Promise<void> {
@@ -29,13 +27,8 @@ export async function handleEmbed(globalOpts: GlobalOptions, commandArgs: string
 
   log('cli', 'embed start force=' + force);
 
+  await assertContainerServer();
   if (isInsideContainer()) {
-    const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-    if (!serverRunning) {
-      cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-      cliError('  docker start nano-brain');
-      process.exit(1);
-    }
     try {
       const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/embed', {});
       if (result.error) {

--- a/src/cli/commands/reindex.ts
+++ b/src/cli/commands/reindex.ts
@@ -27,8 +27,8 @@ export async function handleReindex(globalOpts: GlobalOptions, commandArgs: stri
 
   log('cli', 'reindex root=' + root);
 
-  await assertContainerServer();
-  if (isInsideContainer()) {
+  const serverRunning = await assertContainerServer();
+  if (serverRunning) {
     try {
       const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/reindex', { root });
       if (result.error) {
@@ -38,8 +38,11 @@ export async function handleReindex(globalOpts: GlobalOptions, commandArgs: stri
       cliOutput(`✅ Reindex started in background on daemon for ${result.root}`);
       return;
     } catch (err) {
-      cliError('Error: Failed to communicate with daemon:', err instanceof Error ? err.message : String(err));
-      process.exit(1);
+      if (isInsideContainer()) {
+        cliError('Error: Failed to communicate with daemon:', err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      log('cli', 'HTTP proxy failed for reindex, falling back to local: ' + (err instanceof Error ? err.message : String(err)));
     }
   }
 

--- a/src/cli/commands/reindex.ts
+++ b/src/cli/commands/reindex.ts
@@ -8,10 +8,8 @@ import type { GlobalOptions } from '../types.js';
 import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServer,
+  assertContainerServer,
   proxyPost,
-  getHttpHost,
-  getHttpPort,
   resolveDbPath,
 } from '../utils.js';
 
@@ -29,13 +27,8 @@ export async function handleReindex(globalOpts: GlobalOptions, commandArgs: stri
 
   log('cli', 'reindex root=' + root);
 
+  await assertContainerServer();
   if (isInsideContainer()) {
-    const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-    if (!serverRunning) {
-      cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-      cliError('  docker start nano-brain');
-      process.exit(1);
-    }
     try {
       const result = await proxyPost(DEFAULT_HTTP_PORT, '/api/reindex', { root });
       if (result.error) {

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -13,10 +13,8 @@ import type { GlobalOptions } from '../types.js';
 import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServer,
+  assertContainerServer,
   proxyPost,
-  getHttpHost,
-  getHttpPort,
 } from '../utils.js';
 import { formatSearchOutput } from '../utils.js';
 
@@ -71,13 +69,7 @@ export async function handleSearch(
   }
 
   const inContainer = isInsideContainer();
-  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-
-  if (inContainer && !serverRunning) {
-    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-    cliError('  docker start nano-brain');
-    process.exit(1);
-  }
+  const serverRunning = await assertContainerServer();
 
   if (serverRunning) {
     try {

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -27,6 +27,13 @@ function formatBytes(bytes: number): string {
   return `${mb.toFixed(1)} MB`;
 }
 
+function formatUptime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  return h > 0 ? `${h}h ${m}m ${s}s` : m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
 async function getVectorStoreHealth(
   config: ReturnType<typeof loadCollectionConfig>,
   serverRunning: boolean,
@@ -150,11 +157,7 @@ export async function handleStatus(globalOpts: GlobalOptions, commandArgs: strin
     cliOutput('═══════════════════════════════════════════════════');
     cliOutput('');
     if (serverInfo) {
-      const uptimeSec = Math.floor(serverInfo.uptime);
-      const hours = Math.floor(uptimeSec / 3600);
-      const mins = Math.floor((uptimeSec % 3600) / 60);
-      const secs = uptimeSec % 60;
-      const uptimeStr = hours > 0 ? `${hours}h ${mins}m ${secs}s` : mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+      const uptimeStr = formatUptime(Math.floor(serverInfo.uptime));
       cliOutput('Server:');
       cliOutput(`  Status:   running (port ${DEFAULT_HTTP_PORT})`);
       cliOutput(`  Uptime:   ${uptimeStr}`);
@@ -202,11 +205,7 @@ export async function handleStatus(globalOpts: GlobalOptions, commandArgs: strin
     cliOutput('');
 
     if (serverInfo) {
-      const uptimeSec = Math.floor(serverInfo.uptime);
-      const hours = Math.floor(uptimeSec / 3600);
-      const mins = Math.floor((uptimeSec % 3600) / 60);
-      const secs = uptimeSec % 60;
-      const uptimeStr = hours > 0 ? `${hours}h ${mins}m ${secs}s` : mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+      const uptimeStr = formatUptime(Math.floor(serverInfo.uptime));
       cliOutput('Server:');
       cliOutput(`  Status:   running (port ${DEFAULT_HTTP_PORT})`);
       cliOutput(`  Uptime:   ${uptimeStr}`);

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import { log, cliOutput, cliError } from '../../logger.js';
 import type { GlobalOptions } from '../types.js';
-import { DEFAULT_HTTP_PORT, detectRunningServer, proxyGet, resolveDbPath, getHttpHost, getHttpPort } from '../utils.js';
+import { DEFAULT_HTTP_PORT, assertContainerServer, proxyGet, resolveDbPath } from '../utils.js';
 import { isInsideContainer } from '../../host.js';
 
 function extractWorkspaceName(dbFilename: string): string {
@@ -125,13 +125,7 @@ async function printEmbeddingServerStatus(config: ReturnType<typeof loadCollecti
 export async function handleStatus(globalOpts: GlobalOptions, commandArgs: string[]): Promise<void> {
   log('cli', 'status command invoked');
   const inContainer = isInsideContainer();
-  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-
-  if (inContainer && !serverRunning) {
-    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-    cliError('  docker start nano-brain');
-    process.exit(1);
-  }
+  const serverRunning = await assertContainerServer();
   let serverInfo: { uptime: number; ready: boolean; index?: { documentCount: number; embeddedCount: number; pendingEmbeddings: number }; models?: { reranker?: string } } | null = null;
   if (serverRunning) {
     try {

--- a/src/cli/commands/tags.ts
+++ b/src/cli/commands/tags.ts
@@ -3,22 +3,14 @@ import { cliOutput, cliError, log } from '../../logger.js';
 import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServer,
+  assertContainerServer,
   proxyGet,
-  getHttpHost,
-  getHttpPort,
 } from '../utils.js';
 import type { GlobalOptions } from '../types.js';
 
 export async function handleTags(globalOpts: GlobalOptions): Promise<void> {
   const inContainer = isInsideContainer();
-  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-
-  if (inContainer && !serverRunning) {
-    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-    cliError('  docker start nano-brain');
-    process.exit(1);
-  }
+  const serverRunning = await assertContainerServer();
 
   if (serverRunning) {
     try {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -20,7 +20,7 @@ export async function handleUpdate(globalOpts: GlobalOptions): Promise<void> {
 
   if (serverRunning) {
     try {
-      await proxyPost(DEFAULT_HTTP_PORT, '/api/update', {});
+      await proxyPost(DEFAULT_HTTP_PORT, '/api/v1/update', {});
       cliOutput('✅ Update triggered');
       return;
     } catch (err) {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -8,23 +8,15 @@ import type { GlobalOptions } from '../types.js';
 import {
   DEFAULT_HTTP_PORT,
   DEFAULT_OUTPUT_DIR,
-  detectRunningServer,
+  assertContainerServer,
   proxyPost,
-  getHttpHost,
-  getHttpPort,
 } from '../utils.js';
 
 export async function handleUpdate(globalOpts: GlobalOptions): Promise<void> {
   log('cli', 'update start');
 
   const inContainer = isInsideContainer();
-  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-
-  if (inContainer && !serverRunning) {
-    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-    cliError('  docker start nano-brain');
-    process.exit(1);
-  }
+  const serverRunning = await assertContainerServer();
 
   if (serverRunning) {
     try {

--- a/src/cli/commands/wake-up.ts
+++ b/src/cli/commands/wake-up.ts
@@ -6,10 +6,8 @@ import type { GlobalOptions } from '../types.js';
 import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
-  detectRunningServer,
+  assertContainerServer,
   proxyPost,
-  getHttpHost,
-  getHttpPort,
   resolveDbPath,
 } from '../utils.js';
 
@@ -27,13 +25,7 @@ export async function handleWakeUp(globalOpts: GlobalOptions, commandArgs: strin
   }
 
   const inContainer = isInsideContainer();
-  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-
-  if (inContainer && !serverRunning) {
-    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-    cliError('  docker start nano-brain');
-    process.exit(1);
-  }
+  const serverRunning = await assertContainerServer();
 
   if (serverRunning) {
     try {

--- a/src/cli/commands/write.ts
+++ b/src/cli/commands/write.ts
@@ -8,10 +8,8 @@ import { isInsideContainer } from '../../host.js';
 import {
   DEFAULT_HTTP_PORT,
   DEFAULT_MEMORY_DIR,
-  detectRunningServer,
+  assertContainerServer,
   proxyPost,
-  getHttpHost,
-  getHttpPort,
 } from '../utils.js';
 
 export async function handleWrite(globalOpts: GlobalOptions, commandArgs: string[]): Promise<void> {
@@ -36,13 +34,7 @@ export async function handleWrite(globalOpts: GlobalOptions, commandArgs: string
   }
 
   const inContainer = isInsideContainer();
-  const serverRunning = await detectRunningServer(DEFAULT_HTTP_PORT);
-
-  if (inContainer && !serverRunning) {
-    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${getHttpPort()}. Ensure the Docker container is running:`);
-    cliError('  docker start nano-brain');
-    process.exit(1);
-  }
+  const serverRunning = await assertContainerServer();
 
   if (serverRunning) {
     try {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import { setProjectLabelDataDir } from '../store.js';
 import type { SearchResult } from '../types.js';
-import { cliOutput } from '../logger.js';
+import { cliOutput, cliError } from '../logger.js';
 import { isInsideContainer } from '../host.js';
 
 export const DEFAULT_HTTP_PORT = 3100;
@@ -16,10 +16,42 @@ export async function detectRunningServer(port: number = getHttpPort()): Promise
     const timeout = setTimeout(() => controller.abort(), 2000);
     const resp = await fetch(`http://${host}:${port}/health`, { signal: controller.signal });
     clearTimeout(timeout);
-    return resp.ok;
+    if (!resp.ok) return false;
+    const data = await resp.json() as { ready?: boolean };
+    return data.ready === true;
   } catch {
     return false;
   }
+}
+
+async function isServerStarting(port: number = getHttpPort()): Promise<boolean> {
+  const host = getHttpHost();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const resp = await fetch(`http://${host}:${port}/health`, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!resp.ok) return false;
+    const data = await resp.json() as { ready?: boolean };
+    return data.ready === false;
+  } catch {
+    return false;
+  }
+}
+
+export async function assertContainerServer(port: number = DEFAULT_HTTP_PORT): Promise<boolean> {
+  const serverRunning = await detectRunningServer(port);
+  if (serverRunning || !isInsideContainer()) return serverRunning;
+
+  const starting = await isServerStarting(port);
+  if (starting) {
+    cliError(`Server is starting up at ${getHttpHost()}:${port} — please retry in a moment.`);
+    cliError(`  Monitor: docker logs nano-brain`);
+  } else {
+    cliError(`Error: nano-brain server not reachable at ${getHttpHost()}:${port}. Ensure the Docker container is running:`);
+    cliError(`  docker start nano-brain`);
+  }
+  process.exit(1);
 }
 
 export async function proxyGet(port: number, path: string, timeoutMs = 30_000): Promise<any> {

--- a/src/db/corruption-recovery.ts
+++ b/src/db/corruption-recovery.ts
@@ -16,6 +16,36 @@ import { applyPragmas } from '../store.js';
 
 const checkedPaths = new Set<string>();
 
+// Cooldown between integrity checks — default 30 minutes.
+// Set NANO_BRAIN_CHECK_COOLDOWN_MS=0 to force check every time.
+const INTEGRITY_CHECK_COOLDOWN_MS = 30 * 60 * 1000;
+
+function getCooldownMs(): number {
+  const env = process.env.NANO_BRAIN_CHECK_COOLDOWN_MS;
+  if (env !== undefined) return Math.max(0, parseInt(env, 10) || 0);
+  return INTEGRITY_CHECK_COOLDOWN_MS;
+}
+
+// WAL mode makes mtime unreliable (checkpoint writes change mtime without corruption).
+// We use timestamp-only cooldown — sufficient since WAL protects against crash corruption.
+function readStamp(dbPath: string): number | null {
+  try {
+    const raw = fs.readFileSync(dbPath + '.checked', 'utf-8').trim();
+    const ts = parseInt(raw, 10);
+    return isFinite(ts) && ts > 0 ? ts : null;
+  } catch { return null; }
+}
+
+function writeStamp(dbPath: string): void {
+  try {
+    fs.writeFileSync(dbPath + '.checked', String(Date.now()), 'utf-8');
+  } catch { /* non-fatal: missing stamp means next call re-checks */ }
+}
+
+export function clearStamp(dbPath: string): void {
+  try { fs.unlinkSync(path.resolve(dbPath) + '.checked'); } catch { /* non-fatal */ }
+}
+
 export function resetCheckedPaths(): void {
   checkedPaths.clear();
 }
@@ -115,12 +145,24 @@ export function checkAndRecoverDB(
     const freshDb = new Database(resolvedPath);
     applyPragmas(freshDb);
     checkedPaths.add(resolvedPath);
+    writeStamp(resolvedPath);
     return { db: freshDb, recovered: false };
   }
 
   // Skip integrity check if already checked this path in this process
   if (checkedPaths.has(resolvedPath)) {
     logger?.log('corruption-recovery', `Skipping integrity check (already verified): ${resolvedPath}`);
+    const db = new Database(resolvedPath);
+    applyPragmas(db);
+    return { db, recovered: false };
+  }
+
+  // Skip integrity check if stamp is within cooldown window
+  const stampTs = readStamp(resolvedPath);
+  const cooldown = getCooldownMs();
+  if (stampTs !== null && cooldown > 0 && (Date.now() - stampTs) < cooldown) {
+    logger?.log('corruption-recovery', `Skipping integrity check (stamp valid, cooldown ${cooldown}ms): ${resolvedPath}`);
+    checkedPaths.add(resolvedPath);
     const db = new Database(resolvedPath);
     applyPragmas(db);
     return { db, recovered: false };
@@ -147,6 +189,7 @@ export function checkAndRecoverDB(
       } else {
         logger?.log('corruption-recovery', 'Quick check PASSED - database is valid');
         checkedPaths.add(resolvedPath);
+        writeStamp(resolvedPath);
       }
     } catch (checkError) {
       // If quick_check itself throws, database is corrupted
@@ -231,6 +274,7 @@ export function checkAndRecoverDB(
     }
 
     checkedPaths.add(resolvedPath);
+    writeStamp(resolvedPath);
     return { db: freshDb, recovered: true, recoveredAt: new Date().toISOString(), corruptedPath };
   }
 

--- a/src/http/routes.ts
+++ b/src/http/routes.ts
@@ -60,6 +60,8 @@ function readBody(req: http.IncomingMessage): Promise<string> {
   });
 }
 
+let updateInProgress = false;
+
 export async function handleRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -357,12 +359,18 @@ export async function handleRequest(
     return;
   }
 
-  if (req.method === 'POST' && pathname === '/api/update') {
+  if (req.method === 'POST' && (pathname === '/api/v1/update' || pathname === '/api/update')) {
+    if (updateInProgress) {
+      res.writeHead(202, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'already_running', message: 'Update already in progress' }));
+      return;
+    }
     try {
       const config = loadCollectionConfig(finalConfigPath);
       const collections = config ? getCollections(config) : [];
       const sessionsDir = path.join(outputDir, 'sessions');
 
+      updateInProgress = true;
       ;(async () => {
         let indexed = 0;
         let skipped = 0;
@@ -380,12 +388,15 @@ export async function handleRequest(
             } catch { /* skip unreadable files */ }
           }
         }
-        log('server', `[api/update] Complete: ${indexed} indexed, ${skipped} skipped`);
-      })().catch(err => log('server', `[api/update] Error: ${err instanceof Error ? err.message : String(err)}`));
+        log('server', `[api/v1/update] Complete: ${indexed} indexed, ${skipped} skipped`);
+      })()
+        .catch(err => log('server', `[api/v1/update] Error: ${err instanceof Error ? err.message : String(err)}`))
+        .finally(() => { updateInProgress = false; });
 
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'started', workspace: resolvedWorkspaceRoot, message: 'Update started' }));
     } catch (err) {
+      updateInProgress = false;
       res.writeHead(400, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Invalid request' }));
     }

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -101,6 +101,8 @@ export async function startServer(options: ServerOptions): Promise<void> {
   log('server', `Database: ${effectiveDbPath}`);
   log('server', 'Config path=' + finalConfigPath);
 
+  let httpServer: ReturnType<typeof createHttpServer> | null = null;
+
   // Bind HTTP port early so container CLIs can detect "starting" vs "not running"
   // during the (potentially long) DB integrity check that follows.
   let requestHandler: http.RequestListener = (_req, res) => {
@@ -272,7 +274,6 @@ export async function startServer(options: ServerOptions): Promise<void> {
   };
 
   const streamableSessions = new Map<string, { transport: StreamableHTTPServerTransport; server: McpServer }>();
-  let httpServer: ReturnType<typeof createHttpServer> | null = null;
   let consolidationWorker: ConsolidationWorker | null = null;
 
   const cleanup = async () => {

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -117,6 +117,14 @@ export async function startServer(options: ServerOptions): Promise<void> {
   };
   if (httpPort) {
     httpServer = createHttpServer(httpPort, httpHost, (req, res) => requestHandler(req, res));
+    // Wait for the port to be bound before calling createStore.
+    // createStore runs PRAGMA quick_check synchronously which blocks the event loop,
+    // preventing the async socket binding from completing if we don't wait here first.
+    await new Promise<void>((resolve, reject) => {
+      httpServer!.once('listening', resolve);
+      httpServer!.once('error', reject);
+    });
+    log('server', `Early HTTP binding ready — port ${httpPort} open (status: starting)`);
   }
 
   const store = createStore(effectiveDbPath);

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import * as http from 'http';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -99,6 +100,23 @@ export async function startServer(options: ServerOptions): Promise<void> {
   log('server', 'Database path=' + effectiveDbPath);
   log('server', `Database: ${effectiveDbPath}`);
   log('server', 'Config path=' + finalConfigPath);
+
+  // Bind HTTP port early so container CLIs can detect "starting" vs "not running"
+  // during the (potentially long) DB integrity check that follows.
+  let requestHandler: http.RequestListener = (_req, res) => {
+    const url = _req.url ?? '/';
+    if (_req.method === 'GET' && (url === '/health' || url.startsWith('/health?'))) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'starting', ready: false }));
+      return;
+    }
+    res.writeHead(503, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'server is starting up, please retry in a moment' }));
+  };
+  if (httpPort) {
+    httpServer = createHttpServer(httpPort, httpHost, (req, res) => requestHandler(req, res));
+  }
+
   const store = createStore(effectiveDbPath);
   store.registerWorkspacePrefix(currentProjectHash, resolvedWorkspaceRoot);
   migrateToRelativePaths(store, currentProjectHash, resolvedWorkspaceRoot);
@@ -323,9 +341,12 @@ export async function startServer(options: ServerOptions): Promise<void> {
       eventStore,
     };
 
-    httpServer = createHttpServer(httpPort, httpHost, async (req, res) => {
-      await handleRequest(req, res, httpCtx);
-    });
+    // Swap the early "starting" handler to the full handler now that bootstrap is complete
+    requestHandler = async (req, res) => { await handleRequest(req, res, httpCtx); };
+    if (!httpServer) {
+      // Fallback: HTTP server wasn't started early (shouldn't happen in httpPort mode)
+      httpServer = createHttpServer(httpPort, httpHost, (req, res) => requestHandler(req, res));
+    }
   } else {
     setStdioMode(true);
     const transport = new StdioServerTransport();

--- a/test/cli-proxy.test.ts
+++ b/test/cli-proxy.test.ts
@@ -66,7 +66,7 @@ function mockServerRunning(tagResponse = { tags: [{ tag: 'memory', count: 5 }, {
     if (String(url).includes('/api/v1/tags')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(tagResponse) });
     }
-    if (String(url).includes('/api/update')) {
+    if (String(url).includes('/api/v1/update')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'started', workspace: process.cwd() }) });
     }
     if (String(url).includes('/api/status')) {
@@ -191,9 +191,9 @@ describe('handleUpdate — proxy when server running', () => {
     out.restore();
     cleanup();
 
-    const updateCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('/api/update'));
+    const updateCalls = mockFetch.mock.calls.filter(([url]) => String(url).includes('/api/v1/update'));
     expect(updateCalls.length).toBe(1);
-    expect(mockFetch.mock.calls.find(([url]) => String(url).includes('/api/update'))?.[1]?.method).toBe('POST');
+    expect(mockFetch.mock.calls.find(([url]) => String(url).includes('/api/v1/update'))?.[1]?.method).toBe('POST');
   });
 
   it('shows success message after proxy update', async () => {

--- a/test/cli-proxy.test.ts
+++ b/test/cli-proxy.test.ts
@@ -49,10 +49,19 @@ function captureOutput(): { lines: () => string[]; restore: () => void } {
   };
 }
 
+function mockServerStarting() {
+  mockFetch.mockImplementation((url: string) => {
+    if (String(url).includes('/health')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'starting', ready: false }) });
+    }
+    return Promise.resolve({ ok: false, status: 503, statusText: 'Service Unavailable' });
+  });
+}
+
 function mockServerRunning(tagResponse = { tags: [{ tag: 'memory', count: 5 }, { tag: 'code', count: 3 }] }) {
   mockFetch.mockImplementation((url: string) => {
     if (String(url).includes('/health')) {
-      return Promise.resolve({ ok: true });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'ok', ready: true }) });
     }
     if (String(url).includes('/api/v1/tags')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(tagResponse) });
@@ -235,5 +244,112 @@ describe('handleStatus — container mode, server not running', () => {
 
     exitSpy.mockRestore();
     cleanup();
+  });
+});
+
+// ─── server startup UX ───────────────────────────────────────────────────────
+
+import { assertContainerServer } from '../src/cli/utils.js';
+
+describe('detectRunningServer — ready flag', () => {
+  it('returns true only when /health responds with ready: true', async () => {
+    mockServerRunning();
+    const { detectRunningServer } = await import('../src/cli/utils.js');
+    const result = await detectRunningServer();
+    expect(result).toBe(true);
+  });
+
+  it('returns false when /health responds with ready: false (server starting)', async () => {
+    mockServerStarting();
+    const { detectRunningServer } = await import('../src/cli/utils.js');
+    const result = await detectRunningServer();
+    expect(result).toBe(false);
+  });
+
+  it('returns false when server is completely down', async () => {
+    mockServerDown();
+    const { detectRunningServer } = await import('../src/cli/utils.js');
+    const result = await detectRunningServer();
+    expect(result).toBe(false);
+  });
+});
+
+describe('assertContainerServer — startup hint', () => {
+  it('exits with "starting up" message when server is starting (not "not reachable")', async () => {
+    mockIsInsideContainer.mockReturnValue(true);
+    mockServerStarting();
+
+    const stderrLines: string[] = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((data) => {
+      stderrLines.push(String(data));
+      return true;
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+
+    await expect(assertContainerServer()).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const stderr = stderrLines.join('');
+    expect(stderr).toContain('starting up');
+    expect(stderr).not.toContain('docker start nano-brain');
+
+    exitSpy.mockRestore();
+  });
+
+  it('exits with "not reachable" + docker start hint when server is completely down', async () => {
+    mockIsInsideContainer.mockReturnValue(true);
+    mockServerDown();
+
+    const stderrLines: string[] = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((data) => {
+      stderrLines.push(String(data));
+      return true;
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+
+    await expect(assertContainerServer()).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const stderr = stderrLines.join('');
+    expect(stderr).toContain('docker start nano-brain');
+    expect(stderr).not.toContain('starting up');
+
+    exitSpy.mockRestore();
+  });
+
+  it('returns true and does not exit when server is ready', async () => {
+    mockIsInsideContainer.mockReturnValue(true);
+    mockServerRunning();
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+
+    const result = await assertContainerServer();
+    expect(result).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  it('returns false without exiting when not in container and server is down', async () => {
+    mockIsInsideContainer.mockReturnValue(false);
+    mockServerDown();
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+
+    const result = await assertContainerServer();
+    expect(result).toBe(false);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
   });
 });

--- a/test/sqlite-corruption-fix.test.ts
+++ b/test/sqlite-corruption-fix.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { openDatabase, applyPragmas, createStore, evictCachedStore, getCacheSize, closeAllCachedStores } from '../src/store.js';
-import { checkAndRecoverDB, resetCheckedPaths, getCheckedPaths } from '../src/db/corruption-recovery.js';
+import { checkAndRecoverDB, resetCheckedPaths, getCheckedPaths, clearStamp } from '../src/db/corruption-recovery.js';
 import { createRejectionThreshold } from '../src/server.js';
 
 describe('SQLite Corruption Fix', () => {
@@ -300,6 +300,118 @@ describe('SQLite Corruption Fix', () => {
 
       resetCheckedPaths();
       expect(getCheckedPaths().size).toBe(0);
+    });
+  });
+
+  describe('Stamp file cooldown', () => {
+    beforeEach(() => {
+      resetCheckedPaths();
+      closeAllCachedStores();
+      delete process.env.NANO_BRAIN_CHECK_COOLDOWN_MS;
+    });
+
+    afterEach(() => {
+      resetCheckedPaths();
+      closeAllCachedStores();
+      delete process.env.NANO_BRAIN_CHECK_COOLDOWN_MS;
+    });
+
+    it('stamp file is written after a successful integrity check', () => {
+      const dbPath = path.join(tmpDir, 'stamp-write.db');
+      const result = checkAndRecoverDB(dbPath);
+      result.db.close();
+
+      const stampPath = path.resolve(dbPath) + '.checked';
+      expect(fs.existsSync(stampPath)).toBe(true);
+      const content = fs.readFileSync(stampPath, 'utf-8').trim();
+      expect(Number(content)).toBeGreaterThan(0);
+    });
+
+    it('valid stamp skips PRAGMA quick_check on next process start', () => {
+      const dbPath = path.join(tmpDir, 'stamp-skip.db');
+
+      // First call: creates DB + runs check + writes stamp
+      const r1 = checkAndRecoverDB(dbPath);
+      r1.db.close();
+
+      // Simulate new process: clear in-process dedup set
+      resetCheckedPaths();
+
+      // Spy on logger to detect if check runs again
+      const logMessages: string[] = [];
+      const logger = { log: (_: string, msg: string) => logMessages.push(msg), error: () => {} };
+
+      // Second call: stamp is valid, should skip check
+      const r2 = checkAndRecoverDB(dbPath, { logger });
+      r2.db.close();
+
+      expect(logMessages.some(m => m.includes('Checking database integrity'))).toBe(false);
+      expect(logMessages.some(m => m.includes('stamp') || m.includes('cooldown') || m.includes('Skipping'))).toBe(true);
+    });
+
+    it('stamp is invalidated when cooldown expires', () => {
+      const dbPath = path.join(tmpDir, 'stamp-cooldown.db');
+
+      const r1 = checkAndRecoverDB(dbPath);
+      r1.db.close();
+      resetCheckedPaths();
+
+      // Force zero cooldown: stamp is always expired
+      process.env.NANO_BRAIN_CHECK_COOLDOWN_MS = '0';
+
+      const logMessages: string[] = [];
+      const logger = { log: (_: string, msg: string) => logMessages.push(msg), error: () => {} };
+
+      const r2 = checkAndRecoverDB(dbPath, { logger });
+      r2.db.close();
+
+      expect(logMessages.some(m => m.includes('Checking database integrity'))).toBe(true);
+    });
+
+    it('stamp is written for fresh DB after corruption recovery', () => {
+      const dbPath = path.join(tmpDir, 'stamp-recovery.db');
+
+      // Create a "corrupted" DB (empty file)
+      fs.writeFileSync(dbPath, 'THIS IS NOT SQLITE');
+
+      const result = checkAndRecoverDB(dbPath);
+      result.db.close();
+
+      expect(result.recovered).toBe(true);
+      const stampPath = path.resolve(dbPath) + '.checked';
+      expect(fs.existsSync(stampPath)).toBe(true);
+    });
+
+    it('stamp read failure is non-fatal — falls back to full check', () => {
+      const dbPath = path.join(tmpDir, 'stamp-corrupt.db');
+
+      const r1 = checkAndRecoverDB(dbPath);
+      r1.db.close();
+      resetCheckedPaths();
+
+      // Corrupt the stamp file
+      fs.writeFileSync(path.resolve(dbPath) + '.checked', 'not-a-timestamp\n');
+
+      const logMessages: string[] = [];
+      const logger = { log: (_: string, msg: string) => logMessages.push(msg), error: () => {} };
+
+      // Should not throw, should fall back to full check
+      const r2 = checkAndRecoverDB(dbPath, { logger });
+      r2.db.close();
+
+      expect(logMessages.some(m => m.includes('Checking database integrity'))).toBe(true);
+    });
+
+    it('clearStamp removes the stamp file', () => {
+      const dbPath = path.join(tmpDir, 'stamp-clear.db');
+      const r1 = checkAndRecoverDB(dbPath);
+      r1.db.close();
+
+      const stampPath = path.resolve(dbPath) + '.checked';
+      expect(fs.existsSync(stampPath)).toBe(true);
+
+      clearStamp(dbPath);
+      expect(fs.existsSync(stampPath)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #9. Three improvements discovered during real container testing.

### Changes

**fix: async file read in `/api/update`**
- `fs.readFileSync` inside async IIFE blocked the event loop → `await fs.promises.readFile`

**perf: DB integrity check stamp cooldown** (closes #14)
- `PRAGMA quick_check` ran on every CLI invocation = 7-8s overhead on 10K-doc DB
- Stamp file `{dbPath}.checked` written after each successful check
- Subsequent calls within 30-min cooldown skip check entirely
- Override via `NANO_BRAIN_CHECK_COOLDOWN_MS` env var
- 6 new tests in `test/sqlite-corruption-fix.test.ts`

**ux: distinguish server starting vs not running** (closes #13)
- HTTP port binds at start of `startServer()` before DB integrity check
- During bootstrap: `/health` → `{"status":"starting","ready":false}`, all others → 503
- `detectRunningServer()` now requires `ready:true`
- New `assertContainerServer()` centralises container guard across all 8 CLI commands
- "Server is starting up — please retry" vs "Server not running — docker start nano-brain"
- 5 new tests in `test/cli-proxy.test.ts`

## Test results

- Unit: 116/116 pass (cli-proxy, sqlite-corruption-fix, rest-api, cli)
- Full suite: 1540/1559 — 19 pre-existing failures only
- Real container (beta.3): all proxied commands verified ✅