### PR TITLE
chore: bump version to 2026.8.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.15",
+  "version": "2026.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nano-brain",
-      "version": "2026.8.15",
+      "version": "2026.8.16",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@qdrant/js-client-rest": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.15",
+  "version": "2026.8.16",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `2026.8.15-beta.5` to `2026.8.16` (stable release)
- Reflects all changes shipped in PR #9 and PR #15

## Test plan
- [ ] CI passes (no code changes, version bump only)