### PR TITLE
feat: session pipeline v2 — Claude Code harvester + adapter pattern

### DIFF
--- a/config.default.yml
+++ b/config.default.yml
@@ -32,3 +32,12 @@ vector:
 #   /path/to/your/project:
 #     codebase:
 #       enabled: true
+
+# Session harvesting configuration
+# harvester:
+#   opencode:
+#     enabled: true
+#     sessionDir: ""    # default: ~/.local/share/opencode/storage
+#   claudeCode:
+#     enabled: false    # opt-in; set to true to harvest Claude Code sessions
+#     sessionDir: ""    # default: ~/.claude/projects

--- a/docs/superpowers/plans/2026-05-15-session-pipeline-v2.md
+++ b/docs/superpowers/plans/2026-05-15-session-pipeline-v2.md
@@ -1,0 +1,1260 @@
+# Session Pipeline v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Claude Code JSONL session harvesting alongside OpenCode, using a `SessionSourceAdapter` interface that makes adding future tools (Cursor, Codex, Gemini CLI) a one-file change.
+
+**Architecture:** Extract shared utilities from `src/harvester.ts` into `src/harvesters/shared.ts`. Wrap the existing OpenCode logic as `OpenCodeAdapter`. Implement `ClaudeCodeAdapter` that reads `~/.claude/projects/{slug}/*.jsonl`. An orchestrator in `src/harvesters/index.ts` loops over enabled adapters, runs each through the shared markdown-write + LLM-extraction pipeline. Output path changes from `{hash}/` to `{project-name}/` subdirs for Obsidian readability.
+
+**Tech Stack:** TypeScript ESM, Node.js `fs` (sync), `better-sqlite3`, vitest, YAML config (no Zod — config is plain interface in `src/types.ts`)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/harvesters/types.ts` | Create | `SessionSourceAdapter` interface, `AdapterResult`, `HarvestStats` |
+| `src/harvesters/shared.ts` | Create | Move `sessionToMarkdown`, `messagesToMarkdown`, `getOutputPath`, `loadHarvestState`, `saveHarvestState` from `src/harvester.ts`; update `getOutputPath` to use project-name subdir |
+| `src/harvesters/opencode.ts` | Create | `OpenCodeAdapter` wrapping `harvestFromDb` + JSON-file logic from `src/harvester.ts` |
+| `src/harvesters/claude-code.ts` | Create | `ClaudeCodeAdapter` reading `~/.claude/projects/` JSONL |
+| `src/harvesters/index.ts` | Create | `runHarvestCycle(adapters, outputDir, opts)` orchestrator |
+| `src/harvester.ts` | Modify | Re-export shim only — all logic moved to `src/harvesters/` |
+| `src/types.ts` | Modify | Add `HarvesterConfig` interface to `CollectionConfig` |
+| `config.default.yml` | Modify | Add `harvester:` block |
+| `src/jobs/watcher.ts` | Modify | Accept `harvesterConfig`, build adapters, call `runHarvestCycle` |
+| `test/fixtures/claude-sessions/` | Create | Sample JSONL fixtures |
+| `test/claude-harvester.test.ts` | Create | Unit tests for `ClaudeCodeAdapter` |
+| `test/harvester-adapter.test.ts` | Create | Orchestrator integration tests |
+| `test/harvester.test.ts` | No change | Must still pass via re-export shim |
+
+---
+
+## Task 1: Shared types
+
+**Files:**
+- Create: `src/harvesters/types.ts`
+
+- [ ] **Step 1.1: Create `src/harvesters/types.ts`**
+
+```typescript
+// src/harvesters/types.ts
+import type { HarvestedSession, ExtractionConfig, Store } from '../types.js';
+
+export type { HarvestState, HarvestStateEntry } from '../harvester.js';
+
+export interface HarvestStats {
+  processed: number;
+  skipped: number;
+  incremental: number;
+  errors: number;
+  extractionStats?: {
+    factsExtracted: number;
+    duplicatesSkipped: number;
+    errors: number;
+    limitReached?: boolean;
+  };
+}
+
+export interface AdapterResult {
+  sessions: HarvestedSession[];
+  stateChanged: boolean;
+  stats: HarvestStats;
+}
+
+export interface SessionSourceAdapter {
+  readonly name: string;
+  isAvailable(): boolean;
+  readNewSessions(
+    state: Record<string, { mtime: number; retries?: number; skipped?: boolean; messageCount?: number }>,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult>;
+}
+```
+
+- [ ] **Step 1.2: Verify TypeScript compiles**
+
+```bash
+cd /Users/tamlh/workspaces/self/AI/Tools/nano-brain
+npx tsc --noEmitOnError false 2>&1 | grep "harvesters/types" | head -5
+```
+Expected: no errors for the new file.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/harvesters/types.ts
+git commit -m "feat(harvesters): add SessionSourceAdapter interface and types"
+```
+
+---
+
+## Task 2: Shared utilities
+
+**Files:**
+- Create: `src/harvesters/shared.ts`
+- Modify: `src/harvester.ts` (add re-exports; keep all existing functions intact for now)
+
+- [ ] **Step 2.1: Create `src/harvesters/shared.ts`** — copy `sessionToMarkdown`, `messagesToMarkdown`, `loadHarvestState`, `saveHarvestState` verbatim from `src/harvester.ts`, then write updated `getOutputPath`:
+
+```typescript
+// src/harvesters/shared.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { createHash } from 'crypto';
+import type { HarvestedSession } from '../types.js';
+
+export type HarvestStateEntry = {
+  mtime: number;
+  retries?: number;
+  skipped?: boolean;
+  messageCount?: number;
+};
+export type HarvestState = Record<string, HarvestStateEntry>;
+
+export function sessionToMarkdown(session: HarvestedSession): string {
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`session: ${session.sessionId}`);
+  lines.push(`agent: ${session.agent}`);
+  lines.push(`date: "${session.date}"`);
+  lines.push(`title: "${session.title}"`);
+  lines.push(`project: ${session.project}`);
+  lines.push(`projectHash: ${session.projectHash}`);
+  lines.push('---');
+  lines.push('');
+  for (const message of session.messages) {
+    if (message.role === 'user') {
+      lines.push('## User');
+    } else {
+      lines.push(`## Assistant (${message.agent || 'assistant'})`);
+    }
+    lines.push('');
+    lines.push(message.text);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export function messagesToMarkdown(messages: Array<{ role: string; agent?: string; text: string }>): string {
+  const lines: string[] = [];
+  for (const message of messages) {
+    if (message.role === 'user') {
+      lines.push('## User');
+    } else {
+      lines.push(`## Assistant (${message.agent || 'assistant'})`);
+    }
+    lines.push('');
+    lines.push(message.text);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export function loadHarvestState(stateFile: string): HarvestState {
+  try {
+    if (existsSync(stateFile)) {
+      const content = readFileSync(stateFile, 'utf-8');
+      return JSON.parse(content) as HarvestState;
+    }
+  } catch {
+    // corrupt state file — start fresh
+  }
+  return {};
+}
+
+export function saveHarvestState(stateFile: string, state: HarvestState): void {
+  try {
+    mkdirSync(dirname(stateFile), { recursive: true });
+    writeFileSync(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * Returns output path for a session markdown file.
+ * New structure: {outputDir}/{projectName}/{date}-{slug}.md
+ * projectName = last segment of projectPath, sanitized, with hash suffix on collision.
+ */
+export function getOutputPath(
+  outputDir: string,
+  projectPath: string,
+  date: string,
+  slug: string,
+  title?: string,
+  knownNames?: Map<string, string>,   // projectPath → sanitized name, for collision detection
+): string {
+  const hash = createHash('sha256').update(projectPath).digest('hex');
+  const projectHash = hash.substring(0, 12);
+
+  // Derive project name from last path segment
+  const rawName = projectPath.replace(/\\/g, '/').split('/').filter(Boolean).pop() || 'unknown';
+  let sanitizedName = rawName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 40);
+
+  // Collision: if a different projectPath already claimed this name, append hash suffix
+  if (knownNames) {
+    const existingPath = knownNames.get(sanitizedName);
+    if (existingPath && existingPath !== projectPath) {
+      sanitizedName = `${sanitizedName}-${projectHash.substring(0, 6)}`;
+    }
+    knownNames.set(sanitizedName, projectPath);
+  }
+
+  const raw = (title && title.trim()) ? title : (slug || 'untitled');
+  const sanitizedSlug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-+/g, '-')
+    .substring(0, 60);
+
+  const filename = `${date}-${sanitizedSlug}.md`;
+  return join(outputDir, sanitizedName, filename);
+}
+```
+
+- [ ] **Step 2.2: Write tests for `getOutputPath` new behavior**
+
+```typescript
+// test/harvesters-shared.test.ts
+import { describe, it, expect } from 'vitest';
+import { getOutputPath, sessionToMarkdown, loadHarvestState, saveHarvestState } from '../src/harvesters/shared.js';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('getOutputPath — project-name subdir', () => {
+  it('uses last path segment as subdirectory', () => {
+    const result = getOutputPath(
+      '/out',
+      '/Users/tamlh/workspaces/nano-brain',
+      '2026-05-15',
+      'fix-proxy',
+    );
+    expect(result).toBe('/out/nano-brain/2026-05-15-fix-proxy.md');
+  });
+
+  it('sanitizes project name to lowercase alphanumeric', () => {
+    const result = getOutputPath('/out', '/Users/My Project!', '2026-05-15', 'slug');
+    expect(result).toBe('/out/my-project/2026-05-15-slug.md');
+  });
+
+  it('appends hash suffix on project name collision', () => {
+    const names = new Map<string, string>();
+    getOutputPath('/out', '/a/zengamingx', '2026-05-15', 's1', undefined, names);
+    const result = getOutputPath('/out', '/b/zengamingx', '2026-05-15', 's2', undefined, names);
+    // second path gets hash suffix
+    expect(result).not.toBe('/out/zengamingx/2026-05-15-s2.md');
+    expect(result).toMatch(/\/out\/zengamingx-[a-f0-9]{6}\/2026-05-15-s2\.md/);
+  });
+
+  it('uses title over slug when title provided', () => {
+    const result = getOutputPath('/out', '/proj/nano-brain', '2026-05-15', 'session-slug', 'Fix Proxy Bug');
+    expect(result).toBe('/out/nano-brain/2026-05-15-fix-proxy-bug.md');
+  });
+});
+
+describe('sessionToMarkdown', () => {
+  it('produces correct frontmatter and message headings', () => {
+    const md = sessionToMarkdown({
+      sessionId: 'abc', slug: 'test', title: 'Test Session',
+      agent: 'claude-code', date: '2026-05-15',
+      project: '/proj', projectHash: 'aabbcc112233',
+      messages: [
+        { role: 'user', text: 'Hello' },
+        { role: 'assistant', agent: 'claude-code', text: 'Hi there' },
+      ],
+    });
+    expect(md).toContain('agent: claude-code');
+    expect(md).toContain('## User');
+    expect(md).toContain('## Assistant (claude-code)');
+    expect(md).toContain('Hello');
+    expect(md).toContain('Hi there');
+  });
+});
+
+describe('loadHarvestState / saveHarvestState', () => {
+  it('round-trips state through disk', () => {
+    const dir = join(tmpdir(), `nb-test-state-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, '.state.json');
+    const state = { 'sess-1': { mtime: 12345, messageCount: 3 } };
+    saveHarvestState(file, state);
+    const loaded = loadHarvestState(file);
+    expect(loaded).toEqual(state);
+    rmSync(dir, { recursive: true });
+  });
+
+  it('returns empty object when state file missing', () => {
+    expect(loadHarvestState('/nonexistent/path/.state.json')).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2.3: Run tests — expect PASS**
+
+```bash
+npx vitest run test/harvesters-shared.test.ts
+```
+Expected: all green.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add src/harvesters/shared.ts test/harvesters-shared.test.ts
+git commit -m "feat(harvesters): shared utilities with project-name output paths"
+```
+
+---
+
+## Task 3: OpenCodeAdapter
+
+**Files:**
+- Create: `src/harvesters/opencode.ts`
+
+- [ ] **Step 3.1: Create `src/harvesters/opencode.ts`** — wraps existing `harvestSessions` logic:
+
+```typescript
+// src/harvesters/opencode.ts
+import { existsSync, readdirSync, statSync, mkdirSync, writeFileSync, appendFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import type { SessionSourceAdapter, AdapterResult } from './types.js';
+import type { HarvestState } from './shared.js';
+import { getOutputPath, sessionToMarkdown } from './shared.js';
+import type { ExtractionConfig, Store } from '../types.js';
+import { log } from '../logger.js';
+import { harvestSessions as _harvestSessions } from '../harvester.js';
+
+const DEFAULT_SESSION_DIR = join(homedir(), '.local/share/opencode/storage');
+
+export class OpenCodeAdapter implements SessionSourceAdapter {
+  readonly name = 'opencode';
+
+  constructor(private sessionDir: string = DEFAULT_SESSION_DIR) {}
+
+  isAvailable(): boolean {
+    return existsSync(this.sessionDir);
+  }
+
+  async readNewSessions(
+    _state: HarvestState,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult> {
+    // Delegate to existing harvestSessions which manages its own state file
+    const sessions = await _harvestSessions({
+      sessionDir: this.sessionDir,
+      outputDir,
+      extractionConfig,
+      store,
+    });
+
+    return {
+      sessions,
+      stateChanged: sessions.length > 0,
+      stats: {
+        processed: sessions.length,
+        skipped: 0,
+        incremental: 0,
+        errors: 0,
+      },
+    };
+  }
+}
+```
+
+- [ ] **Step 3.2: Verify compile**
+
+```bash
+npx tsc --noEmitOnError false 2>&1 | grep "harvesters/opencode" | head -5
+```
+Expected: no errors.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/harvesters/opencode.ts
+git commit -m "feat(harvesters): OpenCodeAdapter wrapping existing harvestSessions"
+```
+
+---
+
+## Task 4: ClaudeCodeAdapter + fixtures
+
+**Files:**
+- Create: `src/harvesters/claude-code.ts`
+- Create: `test/fixtures/claude-sessions/` (sample JSONL files)
+- Create: `test/claude-harvester.test.ts`
+
+- [ ] **Step 4.1: Create fixture JSONL files**
+
+```bash
+mkdir -p /Users/tamlh/workspaces/self/AI/Tools/nano-brain/test/fixtures/claude-sessions/-Users-test-projects-my-project
+```
+
+Create `test/fixtures/claude-sessions/-Users-test-projects-my-project/sessions-index.json`:
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "sessionId": "aaaa1111-0000-0000-0000-000000000001",
+      "fullPath": "aaaa1111-0000-0000-0000-000000000001.jsonl",
+      "fileMtime": 1747267200000,
+      "firstPrompt": "Fix the authentication bug",
+      "messageCount": 4,
+      "created": "2026-05-15T01:00:00.000Z",
+      "modified": "2026-05-15T01:30:00.000Z",
+      "gitBranch": "main",
+      "projectPath": "/Users/test/projects/my-project",
+      "isSidechain": false
+    },
+    {
+      "sessionId": "bbbb2222-0000-0000-0000-000000000002",
+      "fullPath": "bbbb2222-0000-0000-0000-000000000002.jsonl",
+      "fileMtime": 1747270800000,
+      "firstPrompt": "Add new feature",
+      "messageCount": 2,
+      "created": "2026-05-15T02:00:00.000Z",
+      "modified": "2026-05-15T02:10:00.000Z",
+      "gitBranch": "feat/new-feature",
+      "projectPath": "/Users/test/projects/my-project",
+      "isSidechain": false
+    }
+  ]
+}
+```
+
+Create `test/fixtures/claude-sessions/-Users-test-projects-my-project/aaaa1111-0000-0000-0000-000000000001.jsonl`:
+```
+{"type":"ai-title","aiTitle":"Fix authentication bug","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"type":"permission-mode","permissionMode":"auto","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":null,"type":"user","message":{"role":"user","content":"Fix the authentication bug"},"uuid":"u1","timestamp":"2026-05-15T01:00:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix the authentication bug now."},{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/src/auth.ts"}}]},"uuid":"a1","timestamp":"2026-05-15T01:01:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":"a1","type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"file content here"}]},"uuid":"u2","timestamp":"2026-05-15T01:02:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":"u2","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The bug is fixed. The issue was a missing null check."}]},"uuid":"a2","timestamp":"2026-05-15T01:03:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+```
+
+Create `test/fixtures/claude-sessions/-Users-test-projects-my-project/bbbb2222-0000-0000-0000-000000000002.jsonl`:
+```
+{"type":"ai-title","aiTitle":"Add new feature","sessionId":"bbbb2222-0000-0000-0000-000000000002"}
+{"type":"user","message":{"role":"user","content":"Add a new feature"},"uuid":"u1","timestamp":"2026-05-15T02:00:00.000Z","sessionId":"bbbb2222-0000-0000-0000-000000000002"}
+{"type":"assistant","message":{"role":"assistant","content":"Here is the new feature implementation."},"uuid":"a1","timestamp":"2026-05-15T02:01:00.000Z","sessionId":"bbbb2222-0000-0000-0000-000000000002"}
+```
+
+- [ ] **Step 4.2: Write failing tests**
+
+Create `test/claude-harvester.test.ts`:
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ClaudeCodeAdapter } from '../src/harvesters/claude-code.js';
+
+const FIXTURES = join(import.meta.dirname ?? __dirname, 'fixtures/claude-sessions');
+
+describe('ClaudeCodeAdapter.isAvailable()', () => {
+  it('returns true when session dir exists', () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    expect(adapter.isAvailable()).toBe(true);
+  });
+
+  it('returns false when session dir missing', () => {
+    const adapter = new ClaudeCodeAdapter('/nonexistent/path');
+    expect(adapter.isAvailable()).toBe(false);
+  });
+});
+
+describe('ClaudeCodeAdapter.readNewSessions()', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = join(tmpdir(), `nb-claude-test-${Date.now()}`);
+    mkdirSync(outputDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('discovers sessions from sessions-index.json', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    expect(result.sessions).toHaveLength(2);
+  });
+
+  it('extracts ai-title as session title', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    const session1 = result.sessions.find(s => s.sessionId === 'aaaa1111-0000-0000-0000-000000000001');
+    expect(session1?.title).toBe('Fix authentication bug');
+  });
+
+  it('uses firstPrompt as title fallback when ai-title absent', async () => {
+    // bbbb session has ai-title so test a session without one via direct JSONL
+    const dir = join(tmpdir(), `nb-notitle-${Date.now()}`);
+    mkdirSync(join(dir, 'proj'), { recursive: true });
+    writeFileSync(join(dir, 'proj', 'sessions-index.json'), JSON.stringify({
+      version: 1,
+      entries: [{
+        sessionId: 'cccc',
+        fullPath: 'cccc.jsonl',
+        fileMtime: 1000,
+        firstPrompt: 'My first prompt',
+        messageCount: 1,
+        created: '2026-05-15T00:00:00.000Z',
+        modified: '2026-05-15T00:00:00.000Z',
+        gitBranch: '',
+        projectPath: '/proj',
+        isSidechain: false,
+      }],
+    }));
+    writeFileSync(join(dir, 'proj', 'cccc.jsonl'), [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'My first prompt' }, uuid: 'u1', timestamp: '2026-05-15T00:00:00.000Z', sessionId: 'cccc' }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'Response' }, uuid: 'a1', timestamp: '2026-05-15T00:01:00.000Z', sessionId: 'cccc' }),
+    ].join('\n'));
+    const outDir = join(tmpdir(), `nb-out-${Date.now()}`);
+    mkdirSync(outDir, { recursive: true });
+    const adapter = new ClaudeCodeAdapter(dir);
+    const result = await adapter.readNewSessions({}, outDir);
+    expect(result.sessions[0]?.title).toBe('My first prompt');
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it('extracts user and assistant messages, skips tool_use/tool_result', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    const session1 = result.sessions.find(s => s.sessionId === 'aaaa1111-0000-0000-0000-000000000001');
+    expect(session1).toBeDefined();
+    // user messages: u1 (text), u2 (tool_result only — should produce empty text, filtered out or empty)
+    // assistant messages: a1 (text + tool_use — only text part kept), a2 (text only)
+    const userMsgs = session1!.messages.filter(m => m.role === 'user');
+    const asstMsgs = session1!.messages.filter(m => m.role === 'assistant');
+    expect(userMsgs.some(m => m.text.includes('Fix the authentication bug'))).toBe(true);
+    expect(asstMsgs.some(m => m.text.includes("I'll fix the authentication bug now."))).toBe(true);
+    expect(asstMsgs.some(m => m.text.includes('The bug is fixed.'))).toBe(true);
+    // tool_use and tool_result content must not appear
+    expect(session1!.messages.every(m => !m.text.includes('tool_use'))).toBe(true);
+    expect(session1!.messages.every(m => !m.text.includes('tool_result'))).toBe(true);
+  });
+
+  it('sets agent to "claude-code"', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    expect(result.sessions.every(s => s.agent === 'claude-code')).toBe(true);
+  });
+
+  it('skips sessions unchanged since last harvest (state tracking)', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const state: Record<string, { mtime: number; messageCount?: number }> = {
+      'aaaa1111-0000-0000-0000-000000000001': { mtime: 1747267200000, messageCount: 4 },
+      'bbbb2222-0000-0000-0000-000000000002': { mtime: 1747270800000, messageCount: 2 },
+    };
+    const result = await adapter.readNewSessions(state, outputDir);
+    expect(result.sessions).toHaveLength(0);
+    expect(result.stats.skipped).toBe(2);
+  });
+
+  it('writes markdown file to project-name subdir', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    await adapter.readNewSessions({}, outputDir);
+    // project name from "/Users/test/projects/my-project" → "my-project"
+    const files = existsSync(join(outputDir, 'my-project'))
+      ? require('fs').readdirSync(join(outputDir, 'my-project'))
+      : [];
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.some((f: string) => f.endsWith('.md'))).toBe(true);
+  });
+
+  it('handles string content (not array) in messages', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    const session2 = result.sessions.find(s => s.sessionId === 'bbbb2222-0000-0000-0000-000000000002');
+    expect(session2?.messages.some(m => m.text.includes('Add a new feature'))).toBe(true);
+    expect(session2?.messages.some(m => m.text.includes('new feature implementation'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 4.3: Run tests — expect FAIL (ClaudeCodeAdapter not yet created)**
+
+```bash
+npx vitest run test/claude-harvester.test.ts 2>&1 | tail -10
+```
+Expected: import error or "ClaudeCodeAdapter not found".
+
+- [ ] **Step 4.4: Implement `ClaudeCodeAdapter`**
+
+Create `src/harvesters/claude-code.ts`:
+```typescript
+// src/harvesters/claude-code.ts
+import { existsSync, readdirSync, readFileSync, mkdirSync, writeFileSync, appendFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { createHash } from 'crypto';
+import type { SessionSourceAdapter, AdapterResult } from './types.js';
+import type { HarvestState } from './shared.js';
+import { getOutputPath, sessionToMarkdown, loadHarvestState, saveHarvestState } from './shared.js';
+import type { ExtractionConfig, Store, HarvestedSession } from '../types.js';
+import { log } from '../logger.js';
+import { extractFactsFromSession, storeExtractedFact } from '../extraction.js';
+import { createLLMProvider } from '../llm-provider.js';
+import type { ConsolidationConfig } from '../types.js';
+
+const DEFAULT_SESSION_DIR = join(homedir(), '.claude/projects');
+const MAX_EXTRACTED_FACTS = 10000;
+
+interface SessionIndexEntry {
+  sessionId: string;
+  fullPath: string;
+  fileMtime: number;
+  firstPrompt: string;
+  messageCount: number;
+  created: string;
+  modified: string;
+  gitBranch: string;
+  projectPath: string;
+  isSidechain: boolean;
+}
+
+interface SessionIndex {
+  version: number;
+  entries: SessionIndexEntry[];
+}
+
+function extractTextFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((item): item is { type: 'text'; text: string } =>
+      typeof item === 'object' && item !== null && (item as Record<string, unknown>).type === 'text'
+    )
+    .map(item => item.text)
+    .join('\n');
+}
+
+export class ClaudeCodeAdapter implements SessionSourceAdapter {
+  readonly name = 'claude-code';
+
+  constructor(private sessionDir: string = DEFAULT_SESSION_DIR) {}
+
+  isAvailable(): boolean {
+    return existsSync(this.sessionDir);
+  }
+
+  async readNewSessions(
+    state: HarvestState,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult> {
+    const sessions: HarvestedSession[] = [];
+    let stateChanged = false;
+    const stats = { processed: 0, skipped: 0, incremental: 0, errors: 0 };
+    const extractionStats = { factsExtracted: 0, duplicatesSkipped: 0, errors: 0 };
+    const projectNames = new Map<string, string>();
+
+    let projectDirs: string[];
+    try {
+      projectDirs = readdirSync(this.sessionDir);
+    } catch {
+      return { sessions, stateChanged, stats };
+    }
+
+    for (const projectSlug of projectDirs) {
+      const projectDir = join(this.sessionDir, projectSlug);
+      const indexPath = join(projectDir, 'sessions-index.json');
+
+      let entries: SessionIndexEntry[] = [];
+
+      if (existsSync(indexPath)) {
+        try {
+          const raw = readFileSync(indexPath, 'utf-8');
+          const index = JSON.parse(raw) as SessionIndex;
+          entries = (index.entries ?? []).filter(e => !e.isSidechain);
+        } catch {
+          log('claude-harvester', `Failed to parse sessions-index.json in ${projectSlug}`, 'warn');
+          continue;
+        }
+      } else {
+        // Fallback: scan for .jsonl files directly
+        try {
+          const files = readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
+          entries = files.map(f => ({
+            sessionId: f.replace('.jsonl', ''),
+            fullPath: f,
+            fileMtime: 0,
+            firstPrompt: '',
+            messageCount: 0,
+            created: new Date().toISOString(),
+            modified: new Date().toISOString(),
+            gitBranch: '',
+            projectPath: projectSlug.replace(/^-/, '/').replace(/-/g, '/'),
+            isSidechain: false,
+          }));
+        } catch {
+          continue;
+        }
+      }
+
+      for (const entry of entries) {
+        const { sessionId, fileMtime, firstPrompt, projectPath, created, modified } = entry;
+
+        // State check — skip if unchanged
+        const existingState = state[sessionId];
+        if (existingState && existingState.mtime >= fileMtime && existingState.messageCount !== undefined) {
+          stats.skipped++;
+          continue;
+        }
+
+        const jsonlPath = join(projectDir, entry.fullPath.endsWith('.jsonl') ? entry.fullPath : `${sessionId}.jsonl`);
+        if (!existsSync(jsonlPath)) {
+          stats.skipped++;
+          continue;
+        }
+
+        try {
+          const lines = readFileSync(jsonlPath, 'utf-8').split('\n').filter(l => l.trim());
+          let title = firstPrompt || 'untitled';
+          const messages: Array<{ role: 'user' | 'assistant'; agent?: string; text: string }> = [];
+
+          for (const line of lines) {
+            try {
+              const event = JSON.parse(line) as Record<string, unknown>;
+              const type = event.type as string;
+
+              if (type === 'ai-title') {
+                title = (event.aiTitle as string) || title;
+                continue;
+              }
+
+              if (type !== 'user' && type !== 'assistant') continue;
+
+              const msg = event.message as { role?: string; content?: unknown } | undefined;
+              if (!msg) continue;
+
+              const role = msg.role === 'user' ? 'user' : 'assistant';
+              const text = extractTextFromContent(msg.content);
+
+              // Skip messages with no extractable text (e.g. pure tool_result messages)
+              if (!text.trim()) continue;
+
+              messages.push({ role, agent: role === 'assistant' ? 'claude-code' : undefined, text });
+            } catch {
+              // malformed line — skip
+            }
+          }
+
+          if (messages.length === 0) {
+            state[sessionId] = { mtime: fileMtime, messageCount: 0, skipped: true };
+            stateChanged = true;
+            stats.skipped++;
+            continue;
+          }
+
+          const dateStr = created.split('T')[0];
+          const slug = sessionId.substring(0, 8);
+          const projectHash = createHash('sha256').update(projectPath).digest('hex').substring(0, 12);
+
+          const harvestedSession: HarvestedSession = {
+            sessionId,
+            slug,
+            title,
+            agent: 'claude-code',
+            date: dateStr,
+            project: projectPath,
+            projectHash,
+            messages,
+          };
+
+          const outputPath = getOutputPath(outputDir, projectPath, dateStr, slug, title, projectNames);
+          const outputDirPath = dirname(outputPath);
+          mkdirSync(outputDirPath, { recursive: true });
+          writeFileSync(outputPath, sessionToMarkdown(harvestedSession), 'utf-8');
+
+          sessions.push(harvestedSession);
+          state[sessionId] = { mtime: fileMtime, messageCount: messages.length };
+          stateChanged = true;
+          stats.processed++;
+
+          // Optional LLM extraction
+          if (extractionConfig?.enabled && store) {
+            try {
+              const llmConfig: ConsolidationConfig = {
+                enabled: true,
+                interval_ms: 0,
+                model: extractionConfig.model,
+                endpoint: extractionConfig.endpoint,
+                apiKey: extractionConfig.apiKey,
+                max_memories_per_cycle: 0,
+                min_memories_threshold: 0,
+                confidence_threshold: 0,
+              };
+              const provider = createLLMProvider(llmConfig);
+              if (provider) {
+                const health = store.getIndexHealth();
+                if ((health.extractedFacts ?? 0) < MAX_EXTRACTED_FACTS) {
+                  const result = await extractFactsFromSession(
+                    sessionToMarkdown(harvestedSession),
+                    provider,
+                    extractionConfig,
+                  );
+                  for (const fact of result.facts) {
+                    const stored = storeExtractedFact(store, fact, sessionId, projectHash);
+                    if (stored) extractionStats.factsExtracted++;
+                    else extractionStats.duplicatesSkipped++;
+                  }
+                }
+              }
+            } catch (err) {
+              extractionStats.errors++;
+              log('claude-harvester', `Extraction failed for ${sessionId}: ${String(err)}`, 'warn');
+            }
+          }
+        } catch (err) {
+          stats.errors++;
+          log('claude-harvester', `Failed to process session ${sessionId}: ${String(err)}`, 'warn');
+        }
+      }
+    }
+
+    if (stateChanged) {
+      const stateFile = join(outputDir, '.harvest-state-claude-code.json');
+      saveHarvestState(stateFile, state);
+    }
+
+    log('claude-harvester', `Harvest complete: ${stats.processed} processed, ${stats.skipped} skipped, ${stats.errors} errors`);
+
+    return {
+      sessions,
+      stateChanged,
+      stats: { ...stats, extractionStats },
+    };
+  }
+}
+```
+
+- [ ] **Step 4.5: Run tests — expect PASS**
+
+```bash
+npx vitest run test/claude-harvester.test.ts
+```
+Expected: all green.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/harvesters/claude-code.ts test/fixtures/claude-sessions/ test/claude-harvester.test.ts
+git commit -m "feat(harvesters): ClaudeCodeAdapter with JSONL parser and state tracking"
+```
+
+---
+
+## Task 5: Orchestrator
+
+**Files:**
+- Create: `src/harvesters/index.ts`
+- Create: `test/harvester-adapter.test.ts`
+
+- [ ] **Step 5.1: Write failing orchestrator tests**
+
+Create `test/harvester-adapter.test.ts`:
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runHarvestCycle } from '../src/harvesters/index.js';
+import type { SessionSourceAdapter, AdapterResult } from '../src/harvesters/types.js';
+import type { HarvestedSession } from '../src/types.js';
+
+function makeSession(id: string, project: string): HarvestedSession {
+  return {
+    sessionId: id, slug: id, title: `Session ${id}`,
+    agent: 'test', date: '2026-05-15',
+    project, projectHash: 'aabbcc112233',
+    messages: [{ role: 'user', text: 'hello' }],
+  };
+}
+
+function mockAdapter(name: string, sessions: HarvestedSession[], available = true): SessionSourceAdapter {
+  return {
+    name,
+    isAvailable: () => available,
+    readNewSessions: vi.fn().mockResolvedValue({
+      sessions,
+      stateChanged: sessions.length > 0,
+      stats: { processed: sessions.length, skipped: 0, incremental: 0, errors: 0 },
+    } satisfies AdapterResult),
+  };
+}
+
+describe('runHarvestCycle', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = join(tmpdir(), `nb-orch-test-${Date.now()}`);
+    mkdirSync(outputDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('calls all available adapters', async () => {
+    const a1 = mockAdapter('tool-a', [makeSession('s1', '/proj-a')]);
+    const a2 = mockAdapter('tool-b', [makeSession('s2', '/proj-b')]);
+    const result = await runHarvestCycle([a1, a2], outputDir);
+    expect(a1.readNewSessions).toHaveBeenCalledOnce();
+    expect(a2.readNewSessions).toHaveBeenCalledOnce();
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips unavailable adapters', async () => {
+    const a1 = mockAdapter('available', [makeSession('s1', '/proj')], true);
+    const a2 = mockAdapter('unavailable', [], false);
+    await runHarvestCycle([a1, a2], outputDir);
+    expect(a1.readNewSessions).toHaveBeenCalledOnce();
+    expect(a2.readNewSessions).not.toHaveBeenCalled();
+  });
+
+  it('continues when one adapter throws', async () => {
+    const a1: SessionSourceAdapter = {
+      name: 'broken',
+      isAvailable: () => true,
+      readNewSessions: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    const a2 = mockAdapter('good', [makeSession('s2', '/proj')]);
+    const result = await runHarvestCycle([a1, a2], outputDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionId).toBe('s2');
+  });
+
+  it('returns empty array when no adapters available', async () => {
+    const result = await runHarvestCycle([], outputDir);
+    expect(result).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 5.2: Run tests — expect FAIL**
+
+```bash
+npx vitest run test/harvester-adapter.test.ts 2>&1 | tail -5
+```
+Expected: import error.
+
+- [ ] **Step 5.3: Implement orchestrator**
+
+Create `src/harvesters/index.ts`:
+```typescript
+// src/harvesters/index.ts
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import type { SessionSourceAdapter } from './types.js';
+import { loadHarvestState, saveHarvestState } from './shared.js';
+import type { ExtractionConfig, Store, HarvestedSession } from '../types.js';
+import { log } from '../logger.js';
+
+export { OpenCodeAdapter } from './opencode.js';
+export { ClaudeCodeAdapter } from './claude-code.js';
+export type { SessionSourceAdapter, AdapterResult, HarvestStats } from './types.js';
+
+export async function runHarvestCycle(
+  adapters: SessionSourceAdapter[],
+  outputDir: string,
+  options?: { extractionConfig?: ExtractionConfig; store?: Store },
+): Promise<HarvestedSession[]> {
+  mkdirSync(outputDir, { recursive: true });
+  const allSessions: HarvestedSession[] = [];
+
+  for (const adapter of adapters) {
+    if (!adapter.isAvailable()) {
+      log('harvester', `Adapter ${adapter.name}: source not available, skipping`);
+      continue;
+    }
+
+    const stateFile = join(outputDir, `.harvest-state-${adapter.name}.json`);
+    const state = loadHarvestState(stateFile);
+
+    try {
+      const result = await adapter.readNewSessions(
+        state,
+        outputDir,
+        options?.extractionConfig,
+        options?.store,
+      );
+
+      if (result.stateChanged) {
+        saveHarvestState(stateFile, state);
+      }
+
+      if (result.sessions.length > 0) {
+        log('harvester', `Adapter ${adapter.name}: ${result.sessions.length} session(s) harvested`);
+      }
+
+      allSessions.push(...result.sessions);
+    } catch (err) {
+      log('harvester', `Adapter ${adapter.name} failed: ${err instanceof Error ? err.message : String(err)}`, 'warn');
+    }
+  }
+
+  return allSessions;
+}
+```
+
+- [ ] **Step 5.4: Run tests — expect PASS**
+
+```bash
+npx vitest run test/harvester-adapter.test.ts
+```
+Expected: all green.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/harvesters/index.ts test/harvester-adapter.test.ts
+git commit -m "feat(harvesters): runHarvestCycle orchestrator with per-adapter error isolation"
+```
+
+---
+
+## Task 6: Re-export shim + existing tests
+
+**Files:**
+- Modify: `src/harvester.ts`
+
+- [ ] **Step 6.1: Add re-exports to `src/harvester.ts`**
+
+At the top of `src/harvester.ts`, add:
+```typescript
+// Re-exports from src/harvesters/shared.ts for backward compatibility
+export {
+  sessionToMarkdown,
+  messagesToMarkdown,
+  loadHarvestState,
+  saveHarvestState,
+  getOutputPath,
+  type HarvestState,
+  type HarvestStateEntry,
+} from './harvesters/shared.js';
+```
+
+Keep all existing function implementations in `harvester.ts` intact — this step only adds re-exports alongside existing code. We do NOT remove the original implementations yet (that would be a separate refactor).
+
+Note: TypeScript will warn about duplicate exports. Resolve by removing the original `export function sessionToMarkdown`, `export function getOutputPath`, etc. declarations from `harvester.ts` and keeping only the re-export. The underlying implementations move to `shared.ts` (already done in Task 2). Replace each original `export function` in `harvester.ts` with an import from `./harvesters/shared.js`.
+
+- [ ] **Step 6.2: Run existing harvester tests — expect PASS**
+
+```bash
+npx vitest run test/harvester.test.ts
+```
+Expected: all green — confirms backward compatibility.
+
+- [ ] **Step 6.3: Run full test suite**
+
+```bash
+npx vitest run
+```
+Expected: 0 failures.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add src/harvester.ts
+git commit -m "refactor(harvester): re-export shared utilities from src/harvesters/shared"
+```
+
+---
+
+## Task 7: Config schema
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `config.default.yml`
+
+- [ ] **Step 7.1: Add `HarvesterConfig` to `src/types.ts`**
+
+In `src/types.ts`, add after `ExtractionConfig`:
+```typescript
+export interface HarvesterSourceConfig {
+  enabled?: boolean;
+  sessionDir?: string;
+}
+
+export interface HarvesterConfig {
+  opencode?: HarvesterSourceConfig & { enabled?: boolean };  // default: enabled true
+  claudeCode?: HarvesterSourceConfig;                        // default: enabled false
+}
+```
+
+Add `harvester?: HarvesterConfig` to `CollectionConfig` interface (after `extraction?`):
+```typescript
+  harvester?: HarvesterConfig;
+```
+
+- [ ] **Step 7.2: Add `harvester:` block to `config.default.yml`**
+
+Add after the `extraction:` comment block:
+```yaml
+# Session harvesting configuration
+# harvester:
+#   opencode:
+#     enabled: true
+#     sessionDir: ""    # default: ~/.local/share/opencode/storage
+#   claudeCode:
+#     enabled: false    # opt-in; set to true to harvest Claude Code sessions
+#     sessionDir: ""    # default: ~/.claude/projects
+```
+
+- [ ] **Step 7.3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmitOnError false 2>&1 | grep -i "harvester\|HarvesterConfig" | head -5
+```
+Expected: no errors.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add src/types.ts config.default.yml
+git commit -m "feat(config): add HarvesterConfig schema for per-source harvester flags"
+```
+
+---
+
+## Task 8: watcher.ts integration
+
+**Files:**
+- Modify: `src/jobs/watcher.ts`
+
+- [ ] **Step 8.1: Update watcher to build adapters and call `runHarvestCycle`**
+
+In `src/jobs/watcher.ts`:
+
+1. Add import:
+```typescript
+import { runHarvestCycle, OpenCodeAdapter, ClaudeCodeAdapter } from '../harvesters/index.js';
+import type { HarvesterConfig } from '../types.js';
+```
+
+2. Add `harvesterConfig?: HarvesterConfig` to the watcher options destructuring (alongside `sessionStorageDir`).
+
+3. Replace the `harvestSessions({ sessionDir: sessionStorageDir, outputDir })` call in the session poll with:
+```typescript
+// Build adapters from config
+const adapters = [];
+const ocEnabled = harvesterConfig?.opencode?.enabled !== false;  // default true
+if (ocEnabled) {
+  const ocDir = harvesterConfig?.opencode?.sessionDir || sessionStorageDir;
+  adapters.push(new OpenCodeAdapter(ocDir));
+}
+if (harvesterConfig?.claudeCode?.enabled) {
+  const ccDir = harvesterConfig?.claudeCode?.sessionDir || undefined;
+  adapters.push(new ClaudeCodeAdapter(ccDir));
+}
+
+const sessions = await runHarvestCycle(adapters, outputDir, {
+  extractionConfig: options.extractionConfig,
+  store: options.store,
+});
+```
+
+- [ ] **Step 8.2: Pass `harvesterConfig` from bootstrap**
+
+In `src/server/bootstrap.ts`, pass `harvesterConfig: config?.harvester` in the watcher options object (alongside `sessionStorageDir`).
+
+- [ ] **Step 8.3: Run full test suite**
+
+```bash
+npx vitest run
+```
+Expected: 0 failures.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add src/jobs/watcher.ts src/server/bootstrap.ts
+git commit -m "feat(watcher): integrate adapter-based harvest cycle with claudeCode flag support"
+```
+
+---
+
+## Task 9: End-to-end test in container + release
+
+- [ ] **Step 9.1: Publish beta**
+
+```bash
+npm version 2026.8.17-beta.1 --no-git-tag-version
+npx tsc --noEmitOnError false
+npm publish --tag beta --access public
+```
+
+- [ ] **Step 9.2: Install in container and enable Claude Code harvesting**
+
+```bash
+docker exec -u root 48f851a5b8df npm install -g nano-brain@2026.8.17-beta.1
+```
+
+Update `~/.nano-brain/config.yml` on host — add under the root level:
+```yaml
+harvester:
+  opencode:
+    enabled: true
+  claudeCode:
+    enabled: true
+```
+
+Restart server:
+```bash
+docker restart fe04d635dfd0
+until curl -s http://localhost:3100/health | grep -q '"ready":true'; do sleep 3; done
+```
+
+- [ ] **Step 9.3: Verify Claude Code sessions are harvested**
+
+```bash
+docker logs fe04d635dfd0 --since 5m 2>&1 | grep "claude-harvester\|claude-code"
+ls ~/.nano-brain/sessions/ | head -20
+```
+Expected: `claude-code` log entries, and project-name subdirs in `~/.nano-brain/sessions/`.
+
+- [ ] **Step 9.4: Verify sessions searchable**
+
+```bash
+docker exec 48f851a5b8df nano-brain query "Claude Code session fix proxy container"
+```
+Expected: results from harvested Claude Code sessions.
+
+- [ ] **Step 9.5: Create PR and merge**
+
+```bash
+gh auth switch --user kokorolx
+git push -u origin feat/session-pipeline-v2
+gh pr create --repo nano-step/nano-brain \
+  --title "feat: session pipeline v2 — Claude Code harvester + adapter pattern" \
+  --body "Closes #17"
+```
+Merge after review. Switch back: `gh auth switch --user nus-rick`.
+
+- [ ] **Step 9.6: Bump stable version and publish**
+
+```bash
+git checkout master && git pull
+npm version 2026.8.17 --no-git-tag-version
+npx tsc --noEmitOnError false
+npm publish --access public
+git add package.json package-lock.json
+git commit -m "chore: bump version to 2026.8.17"
+```

--- a/openspec/changes/session-pipeline-v2/design.md
+++ b/openspec/changes/session-pipeline-v2/design.md
@@ -1,0 +1,246 @@
+# Design: Session Pipeline v2
+
+## Architecture
+
+```
+~/.claude/projects/{slug}/*.jsonl  ──► ClaudeCodeAdapter
+                                             │
+~/.local/share/opencode/storage/   ──► OpenCodeAdapter
+                                             │
+                                   runHarvestCycle(adapters[])
+                                             │
+                                    ┌────────┴────────┐
+                              readNewSessions()    shared pipeline:
+                              (per adapter)        - write markdown
+                                                   - LLM extraction
+                                                   - state save
+                                                        │
+                                           {outputDir}/{project-name}/
+                                           {date}-{slug}.md
+                                           (~/.nano-brain/sessions/ ← Obsidian vault)
+```
+
+Future tools (Cursor, Codex, Gemini CLI) add one file + one config flag. Orchestrator unchanged.
+
+---
+
+## File Structure
+
+```
+src/
+  harvesters/
+    types.ts        ← SessionSourceAdapter interface, HarvestState, shared types
+    shared.ts       ← sessionToMarkdown, getOutputPath, loadHarvestState,
+                      saveHarvestState, extractFacts pipeline (moved from harvester.ts)
+    opencode.ts     ← OpenCodeAdapter (wraps existing harvester.ts DB/JSON logic)
+    claude-code.ts  ← ClaudeCodeAdapter (new JSONL parser)
+    index.ts        ← runHarvestCycle(adapters, outputDir, options)
+  harvester.ts      ← re-export shim: `export * from './harvesters/shared.js'`
+                      `export { harvestSessions } from './harvesters/index.js'`
+```
+
+---
+
+## Interface: SessionSourceAdapter
+
+```typescript
+// src/harvesters/types.ts
+
+export interface SessionSourceAdapter {
+  readonly name: string          // 'opencode' | 'claude-code' | 'cursor' | ...
+  isAvailable(): boolean         // source dir exists and is readable
+  readNewSessions(
+    state: HarvestState,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult>
+}
+
+export interface AdapterResult {
+  sessions: HarvestedSession[]
+  stateChanged: boolean
+  stats: HarvestStats
+}
+
+export interface HarvestStats {
+  processed: number
+  skipped: number
+  incremental: number
+  errors: number
+  extractionStats?: ExtractionStats
+}
+```
+
+---
+
+## Orchestrator: runHarvestCycle
+
+```typescript
+// src/harvesters/index.ts
+
+export async function runHarvestCycle(
+  adapters: SessionSourceAdapter[],
+  outputDir: string,
+  options?: { extractionConfig?: ExtractionConfig; store?: Store }
+): Promise<HarvestedSession[]>
+```
+
+For each enabled adapter that `isAvailable()`:
+1. Load per-adapter state file: `{outputDir}/.harvest-state-{adapter.name}.json`
+2. Call `adapter.readNewSessions(state, outputDir, ...)`
+3. Write markdown files via `getOutputPath()` (project-subfolder structure)
+4. Run LLM extraction if `extractionConfig.enabled`
+5. Save state if changed
+6. Aggregate all harvested sessions and return
+
+State files are per-adapter to avoid cross-contamination when one adapter fails.
+
+---
+
+## Output Path: Project Subfolder
+
+```typescript
+// src/harvesters/shared.ts
+
+export function getOutputPath(
+  outputDir: string,
+  projectPath: string,
+  date: string,
+  slug: string,
+  title?: string
+): string
+```
+
+**Change**: subdirectory is now `projectName` (last segment of `projectPath`) instead of `projectHash`.
+
+```
+Before: ~/.nano-brain/sessions/d1915ee19311/2026-05-15-fix-proxy.md
+After:  ~/.nano-brain/sessions/nano-brain/2026-05-15-fix-proxy.md
+        ~/.nano-brain/sessions/zengamingx/2026-05-15-fix-auth.md
+```
+
+Project name sanitization: lowercase, alphanumeric + hyphens, max 40 chars. Collision fallback: if two different `projectPath` values share the same name, append first 6 chars of hash (e.g., `zengamingx-d1915e`).
+
+Existing sessions in `{hash}/` subdirs remain — they are still indexed by the `sessions` collection via `pattern: "**/*.md"`.
+
+---
+
+## ClaudeCodeAdapter
+
+```typescript
+// src/harvesters/claude-code.ts
+
+export class ClaudeCodeAdapter implements SessionSourceAdapter {
+  readonly name = 'claude-code'
+  constructor(private sessionDir: string) {}
+  isAvailable(): boolean  // check ~/.claude/projects/ exists
+  readNewSessions(...): Promise<AdapterResult>
+}
+```
+
+**Session discovery**:
+1. Enumerate `{sessionDir}/` — each subdirectory is a project slug (workspace path with `/` → `-`)
+2. For each project dir, read `sessions-index.json` to get metadata: `sessionId`, `created`, `modified`, `projectPath`, `gitBranch`, `firstPrompt`, `messageCount`
+3. Filter: skip sessions already in state with same `modified` mtime
+
+**State tracking**: keyed by `sessionId`, value `{ mtime: modified_timestamp, messageCount }` — same shape as OpenCode state.
+
+**JSONL parsing** per session file:
+```
+{type:"ai-title",    aiTitle: string}            → session.title
+{type:"user",        message:{role,content}}      → user message
+{type:"assistant",   message:{role,content}}      → assistant message
+{type:"attachment",  ...}                         → skip
+{type:"permission-mode", ...}                     → skip
+{type:"system/*",    ...}                         → skip
+```
+
+`message.content` can be:
+- `string` → use directly
+- `Array<{type:"text", text:string} | {type:"tool_use",...} | {type:"tool_result",...}>` → concatenate `type:"text"` items; skip tool_use/tool_result blocks (they are internal scaffolding, not human-readable conversation)
+
+**Project path reconstruction**: project slug in dir name (`-Users-tamlh-workspaces-...`) is decoded to absolute path by replacing leading `-` separator pattern. `sessions-index.json` entries have `projectPath` field directly — use that.
+
+**Output**: `HarvestedSession` with `agent: 'claude-code'`. Identical shape to OpenCode output, feeds into same `sessionToMarkdown()` and LLM extraction pipeline.
+
+---
+
+## OpenCodeAdapter
+
+```typescript
+// src/harvesters/opencode.ts
+
+export class OpenCodeAdapter implements SessionSourceAdapter {
+  readonly name = 'opencode'
+  constructor(private sessionDir: string) {}
+  isAvailable(): boolean
+  readNewSessions(...): Promise<AdapterResult>
+}
+```
+
+Wraps existing logic from `harvester.ts` (`harvestFromDb`, `parseSession`, `parseMessages`, `parseParts`). No behavioural change. These functions move to `src/harvesters/opencode.ts`; `src/harvester.ts` re-exports them for backward compatibility.
+
+---
+
+## Config Schema
+
+```yaml
+# config.default.yml addition
+harvester:
+  opencode:
+    enabled: true
+    sessionDir: ""           # default: ~/.local/share/opencode/storage
+  claudeCode:
+    enabled: false           # opt-in
+    sessionDir: ""           # default: ~/.claude/projects
+```
+
+Zod schema (in `src/types.ts` or `src/config.ts`):
+
+```typescript
+const HarvesterSourceSchema = z.object({
+  enabled: z.boolean().default(false),
+  sessionDir: z.string().optional(),
+})
+
+const HarvesterConfigSchema = z.object({
+  opencode: HarvesterSourceSchema.extend({ enabled: z.boolean().default(true) }),
+  claudeCode: HarvesterSourceSchema,
+}).optional()
+```
+
+`watcher.ts` constructs adapters from config:
+
+```typescript
+const adapters: SessionSourceAdapter[] = []
+if (harvesterConfig?.opencode?.enabled !== false) {
+  adapters.push(new OpenCodeAdapter(
+    harvesterConfig?.opencode?.sessionDir || defaultOpenCodeDir
+  ))
+}
+if (harvesterConfig?.claudeCode?.enabled) {
+  adapters.push(new ClaudeCodeAdapter(
+    harvesterConfig?.claudeCode?.sessionDir || defaultClaudeCodeDir
+  ))
+}
+```
+
+---
+
+## Error Handling
+
+- Per-adapter errors do not stop other adapters. Catch at adapter level, log warning, continue.
+- Per-session JSONL parse errors: log and skip session, do not abort the adapter.
+- Missing `sessions-index.json`: fall back to scanning JSONL files directly using file mtime for state tracking.
+- Tool_use/tool_result content blocks in Claude Code messages: silently skip (not an error).
+- Compact boundary entries (`{type:"system/compact_boundary"}`): treat as session segmentation hint — optionally split into multiple `HarvestedSession` objects if the session file contains multiple compacted segments (detected by `compact_boundary` entries). Initial implementation: ignore boundaries, harvest as single session.
+
+---
+
+## Testing
+
+- `test/claude-harvester.test.ts`: unit tests with fixture JSONL files covering message parsing, ai-title extraction, content array handling, tool_use skipping, state tracking, project path reconstruction.
+- `test/harvester-adapter.test.ts`: integration test — orchestrator with two mock adapters, verify both are called, state files are separate, errors in one adapter don't stop the other.
+- `test/harvester.test.ts`: existing tests must continue to pass (via re-export shim).
+- Fixtures: `test/fixtures/claude-sessions/` with sample JSONL files (minimal, covering all message type combinations).

--- a/openspec/changes/session-pipeline-v2/proposal.md
+++ b/openspec/changes/session-pipeline-v2/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+nano-brain currently harvests only OpenCode sessions (SQLite DB at `~/.local/share/opencode/storage`). Claude Code — the other primary agent tool in use — stores sessions as JSONL files at `~/.claude/projects/{slug}/*.jsonl` and is not harvested at all. This means a large body of work context (Claude Code is used for nano-brain itself, zengamingx, and other projects) is invisible to memory search.
+
+Additionally, the session harvesting code has no extension point: adding support for a third tool (Cursor, Codex, Gemini CLI) would require duplicating the entire harvest + LLM extraction pipeline. The harvesting logic in `src/harvester.ts` is 860 lines with OpenCode-specific parsing tightly coupled to the shared utilities (`sessionToMarkdown`, `getOutputPath`, state tracking, LLM extraction).
+
+Finally, the flat output structure (`~/.nano-brain/sessions/{hash}/{date}-{slug}.md`) is not human-navigable. The user wants to open `~/.nano-brain/sessions/` directly as an Obsidian vault for reviewing and annotating session history. Project-based subfolders enable this without any additional tooling.
+
+## What Changes
+
+- **Adapter pattern for session sources**: Introduce `SessionSourceAdapter` interface in `src/harvesters/types.ts`. Each tool implements one adapter. The orchestrator loops over enabled adapters — no orchestrator changes needed when adding new tools.
+- **`src/harvesters/` module**: Shared utilities (`sessionToMarkdown`, `getOutputPath`, state tracking, LLM extraction pipeline) extracted to `src/harvesters/shared.ts`. `OpenCodeAdapter` in `src/harvesters/opencode.ts`. `ClaudeCodeAdapter` in `src/harvesters/claude-code.ts`. Orchestrator in `src/harvesters/index.ts`.
+- **Backward compatibility**: `src/harvester.ts` re-exports everything from `src/harvesters/shared.ts` so existing callers (`watcher.ts`, tests) are not broken.
+- **Claude Code JSONL parser**: Reads `sessions-index.json` for metadata, parses `{type:"user"/"assistant"}` messages and `{type:"ai-title"}` entries from JSONL. Produces `HarvestedSession[]` identical in shape to OpenCode output.
+- **Project-based output structure**: `getOutputPath()` now writes to `{outputDir}/{project-name}/{date}-{slug}.md` instead of `{outputDir}/{hash}/{date}-{slug}.md`. Project name is the last path segment of the workspace path.
+- **Config schema**: New `harvester` block in config Zod schema and `config.default.yml` with per-source `enabled` flags and optional `sessionDir` overrides.
+- **`watcher.ts` session poll**: Updated to call `runHarvestCycle(adapters, outputDir)` instead of `harvestSessions()` directly.
+
+## Capabilities
+
+### New Capabilities
+- `harvester.claude-code`: Harvest Claude Code JSONL sessions into `~/.nano-brain/sessions/` with full conversation markdown and optional LLM fact extraction. Gated by `harvester.claudeCode.enabled`.
+- `harvester.adapter-pattern`: `SessionSourceAdapter` interface enabling third-party tool harvesters (Cursor, Codex, Gemini CLI) by adding a new adapter file + config flag, with zero changes to the orchestrator or shared pipeline.
+
+### Modified Capabilities
+- `harvester.opencode`: Wrapped as `OpenCodeAdapter` implementing `SessionSourceAdapter`. Behaviour identical to current.
+- `harvester.output-structure`: Session files now written to `{outputDir}/{project-name}/` subfolders. `~/.nano-brain/sessions/` becomes directly usable as an Obsidian vault.
+
+## Impact
+
+- **Files added**: `src/harvesters/types.ts`, `src/harvesters/shared.ts`, `src/harvesters/opencode.ts`, `src/harvesters/claude-code.ts`, `src/harvesters/index.ts`
+- **Files modified**: `src/harvester.ts` (re-export shim), `src/jobs/watcher.ts` (call orchestrator), `src/types.ts` (harvester config types), `config.default.yml` (harvester block), Zod config schema
+- **Output path change**: New sessions write to `sessions/{project-name}/`. Existing sessions in `sessions/{hash}/` remain untouched (no migration).
+- **No database schema changes**.
+- **No MCP tool changes**.
+- **Risk**: Medium — the output path change is additive (old files stay). OpenCode adapter behaviour is identical to current harvester. Claude Code parsing is new but gated by `enabled: false` default.

--- a/openspec/changes/session-pipeline-v2/tasks.md
+++ b/openspec/changes/session-pipeline-v2/tasks.md
@@ -1,0 +1,64 @@
+## 1. Setup: types and shared utilities
+
+- [ ] 1.1 Create `src/harvesters/types.ts` — define `SessionSourceAdapter` interface, `AdapterResult`, `HarvestStats`
+- [ ] 1.2 Create `src/harvesters/shared.ts` — move `sessionToMarkdown`, `messagesToMarkdown`, `loadHarvestState`, `saveHarvestState`, `getOutputPath` (with project-subfolder change), `computeFactHash` from `src/harvester.ts`
+- [ ] 1.3 Update `getOutputPath()` in `shared.ts` to use project name (last path segment, sanitized) as subdirectory instead of projectHash. Add collision detection (append 6-char hash if two paths share same name).
+- [ ] 1.4 Update `src/harvester.ts` to re-export from `src/harvesters/shared.ts` — all existing named exports must remain available for backward compatibility
+
+## 2. OpenCodeAdapter
+
+- [ ] 2.1 Create `src/harvesters/opencode.ts` — implement `OpenCodeAdapter` wrapping existing `harvestFromDb`, `parseSession`, `parseMessages`, `parseParts` logic moved from `src/harvester.ts`
+- [ ] 2.2 `OpenCodeAdapter.isAvailable()` checks `~/.local/share/opencode/storage/` or configured dir exists
+- [ ] 2.3 `OpenCodeAdapter.readNewSessions()` returns `AdapterResult` — same harvest logic, different return shape
+- [ ] 2.4 Keep `harvestSessions()` function in `src/harvester.ts` as a compatibility shim calling the orchestrator with only `OpenCodeAdapter`
+
+## 3. ClaudeCodeAdapter
+
+- [ ] 3.1 Create `src/harvesters/claude-code.ts` — implement `ClaudeCodeAdapter`
+- [ ] 3.2 `isAvailable()` — check `~/.claude/projects/` (or configured dir) exists
+- [ ] 3.3 Session discovery — enumerate project dirs, read `sessions-index.json`, extract `sessionId`, `modified`, `projectPath`, `firstPrompt`
+- [ ] 3.4 State tracking — keyed by `sessionId`, value `{ mtime: modified_timestamp, messageCount }`, skip sessions where mtime unchanged
+- [ ] 3.5 JSONL parser — extract `ai-title`, `user` messages, `assistant` messages; skip `attachment`, `permission-mode`, `system/*`
+- [ ] 3.6 Content array handling — concatenate `{type:"text"}` items; skip `tool_use`, `tool_result` blocks
+- [ ] 3.7 Fallback when `sessions-index.json` missing — scan `*.jsonl` files directly, use file mtime for state
+- [ ] 3.8 Map JSONL session to `HarvestedSession` with `agent: 'claude-code'`
+
+## 4. Orchestrator
+
+- [ ] 4.1 Create `src/harvesters/index.ts` — implement `runHarvestCycle(adapters, outputDir, options)`
+- [ ] 4.2 Per-adapter state file: `{outputDir}/.harvest-state-{adapter.name}.json`
+- [ ] 4.3 Loop: for each adapter, call `readNewSessions`, write markdown files, run LLM extraction, save state
+- [ ] 4.4 Per-adapter error isolation — catch errors per adapter, log warn, continue to next adapter
+- [ ] 4.5 Aggregate and return all `HarvestedSession[]` from all adapters
+- [ ] 4.6 Export `runHarvestCycle` from `src/harvesters/index.ts`
+
+## 5. Config schema
+
+- [ ] 5.1 Add `HarvesterSourceSchema` and `HarvesterConfigSchema` to `src/types.ts` (or config Zod file)
+- [ ] 5.2 Wire `harvesterConfig` into the top-level config schema
+- [ ] 5.3 Add `harvester:` block to `config.default.yml` with `opencode.enabled: true`, `claudeCode.enabled: false`
+- [ ] 5.4 Update config loading in `src/server/bootstrap.ts` to pass `harvesterConfig` to watcher options
+
+## 6. watcher.ts integration
+
+- [ ] 6.1 Update `src/jobs/watcher.ts` to accept `harvesterConfig` in options
+- [ ] 6.2 Construct `adapters[]` from config (OpenCodeAdapter always, ClaudeCodeAdapter if `claudeCode.enabled`)
+- [ ] 6.3 Replace `harvestSessions({ sessionDir, outputDir })` call with `runHarvestCycle(adapters, outputDir, { extractionConfig, store })`
+- [ ] 6.4 Preserve existing `sessionStorageDir` env var override as default for OpenCode adapter
+
+## 7. Tests
+
+- [ ] 7.1 Create `test/fixtures/claude-sessions/` with sample project dir and JSONL fixtures covering: normal session, session with tool_use blocks, session with content array, session without ai-title, empty session
+- [ ] 7.2 Create `test/claude-harvester.test.ts` — unit tests for `ClaudeCodeAdapter`: isAvailable, session discovery, JSONL parsing, content array handling, tool_use skipping, state tracking, project path reconstruction, missing sessions-index fallback
+- [ ] 7.3 Create `test/harvester-adapter.test.ts` — orchestrator tests: both adapters called, separate state files, error isolation (one adapter throws, other succeeds), output files in project subfolders
+- [ ] 7.4 Run `test/harvester.test.ts` (existing) — verify all pass via re-export shim
+- [ ] 7.5 Verify `getOutputPath` project-subfolder behavior in existing tests — update expected paths if needed
+
+## 8. Release
+
+- [ ] 8.1 Create GitHub issue on nano-step/nano-brain for session-pipeline-v2
+- [ ] 8.2 Create branch `feat/session-pipeline-v2`
+- [ ] 8.3 Commit in logical units: types+shared → opencode adapter → claude-code adapter → orchestrator → config → watcher → tests
+- [ ] 8.4 Run full test suite, verify 0 failures
+- [ ] 8.5 Publish `nano-brain@2026.8.17-beta.1`, test Claude Code harvest in container with `claudeCode.enabled: true`
+- [ ] 8.6 Create PR, merge, bump version to `2026.8.17`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.16",
+  "version": "2026.8.17-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nano-brain",
-      "version": "2026.8.16",
+      "version": "2026.8.17-beta.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@qdrant/js-client-rest": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nano-brain",
-  "version": "2026.8.16",
+  "version": "2026.8.17-beta.1",
   "description": "Persistent memory and code intelligence for AI coding agents. Local MCP server with self-learning hybrid search (BM25 + vector + knowledge graph + LLM reranking), automatic session ingestion, codebase indexing, and 22 tools. Learns your preferences over time. Works with OpenCode, Claude, Cursor, Windsurf, and any MCP client.",
   "type": "module",
   "bin": {

--- a/src/harvester.ts
+++ b/src/harvester.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync, appendFileSync, statSync, renameSync } from 'fs';
+import { readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync, appendFileSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { createHash } from 'crypto';
 import type { HarvestedSession, ExtractionConfig, Store } from './types.js';
@@ -7,6 +7,26 @@ import { openDatabase } from './store.js';
 import { createLLMProvider } from './llm-provider.js';
 import { extractFactsFromSession, storeExtractedFact } from './extraction.js';
 import type { ConsolidationConfig } from './types.js';
+import {
+  loadHarvestState,
+  saveHarvestState,
+  getOutputPath,
+  sessionToMarkdown,
+  messagesToMarkdown,
+  type HarvestState,
+  type HarvestStateEntry,
+} from './harvesters/shared.js';
+
+export {
+  sessionToMarkdown,
+  messagesToMarkdown,
+  loadHarvestState,
+  saveHarvestState,
+  getOutputPath,
+  type HarvestState,
+  type HarvestStateEntry,
+};
+
 
 const yieldToEventLoop = () => new Promise<void>(resolve => setImmediate(resolve));
 
@@ -42,15 +62,6 @@ interface ParsedMessage {
   agent?: string;
   created: number;
 }
-
-interface HarvestStateEntry {
-  mtime: number;
-  retries?: number;
-  skipped?: boolean;
-  messageCount?: number;
-}
-
-type HarvestState = Record<string, HarvestStateEntry>;
 
 interface DbSession {
   id: string;
@@ -168,102 +179,6 @@ export async function parseParts(messageId: string, storageDir: string): Promise
   }
   
   return textParts.join('\n');
-}
-
-export function sessionToMarkdown(session: HarvestedSession): string {
-  const lines: string[] = [];
-  
-  lines.push('---');
-  lines.push(`session: ${session.sessionId}`);
-  lines.push(`agent: ${session.agent}`);
-  lines.push(`date: "${session.date}"`);
-  lines.push(`title: "${session.title}"`);
-  lines.push(`project: ${session.project}`);
-  lines.push(`projectHash: ${session.projectHash}`);
-  lines.push('---');
-  lines.push('');
-  
-  for (const message of session.messages) {
-    if (message.role === 'user') {
-      lines.push('## User');
-    } else {
-      const agentName = message.agent || 'assistant';
-      lines.push(`## Assistant (${agentName})`);
-    }
-    lines.push('');
-    lines.push(message.text);
-    lines.push('');
-  }
-  
-  return lines.join('\n');
-}
-
-export function messagesToMarkdown(messages: Array<{ role: string; agent?: string; text: string }>): string {
-  const lines: string[] = [];
-  
-  for (const message of messages) {
-    if (message.role === 'user') {
-      lines.push('## User');
-    } else {
-      const agentName = message.agent || 'assistant';
-      lines.push(`## Assistant (${agentName})`);
-    }
-    lines.push('');
-    lines.push(message.text);
-    lines.push('');
-  }
-  
-  return lines.join('\n');
-}
-
-export function getOutputPath(outputDir: string, projectPath: string, date: string, slug: string, title?: string): string {
-  const hash = createHash('sha256').update(projectPath).digest('hex');
-  const projectHash = hash.substring(0, 12);
-
-  const raw = (title && title.trim()) ? title : (slug || 'untitled');
-  const sanitizedSlug = raw
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/-+/g, '-')
-    .substring(0, 60);
-
-  return join(outputDir, projectHash, `${date}-${sanitizedSlug}.md`);
-}
-
-export function loadHarvestState(stateFile: string): HarvestState {
-  try {
-    if (!existsSync(stateFile)) {
-      return {};
-    }
-    
-    const content = readFileSync(stateFile, 'utf-8');
-    const raw = JSON.parse(content);
-    const state: HarvestState = {};
-    for (const [key, value] of Object.entries(raw)) {
-      if (typeof value === 'number') {
-        state[key] = { mtime: value };
-      } else {
-        state[key] = value as HarvestStateEntry;
-      }
-    }
-    return state;
-  } catch {
-    return {};
-  }
-}
-
-export function saveHarvestState(stateFile: string, state: HarvestState): void {
-  const dir = dirname(stateFile);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-
-  // Atomic write: write to temp file then rename to prevent partial reads
-  // from concurrent harvester instances
-  const tmpFile = stateFile + '.tmp.' + process.pid;
-  writeFileSync(tmpFile, JSON.stringify(state, null, 2), 'utf-8');
-  renameSync(tmpFile, stateFile);
 }
 
 export function getMessageDirMtime(sessionId: string, storageDir: string): number | null {

--- a/src/harvesters/claude-code.ts
+++ b/src/harvesters/claude-code.ts
@@ -1,11 +1,11 @@
 // src/harvesters/claude-code.ts
-import { existsSync, readdirSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
 import type { SessionSourceAdapter, AdapterResult } from './types.js';
 import type { HarvestState } from './shared.js';
-import { getOutputPath, sessionToMarkdown, saveHarvestState } from './shared.js';
+import { writeSession, sessionToMarkdown, saveHarvestState } from './shared.js';
 import type { ExtractionConfig, Store, HarvestedSession, ConsolidationConfig } from '../types.js';
 import { log } from '../logger.js';
 import { extractFactsFromSession, storeExtractedFact } from '../extraction.js';
@@ -59,6 +59,21 @@ export class ClaudeCodeAdapter implements SessionSourceAdapter {
     const stats = { processed: 0, skipped: 0, incremental: 0, errors: 0 };
     const extractionStats = { factsExtracted: 0, duplicatesSkipped: 0, errors: 0 };
     const projectNames = new Map<string, string>();
+
+    // Build LLM provider once, outside all loops (Fix: was created per-session)
+    const provider = (extractionConfig?.enabled && store) ? (() => {
+      const llmConfig: ConsolidationConfig = {
+        enabled: true,
+        interval_ms: 0,
+        model: extractionConfig.model,
+        endpoint: extractionConfig.endpoint,
+        apiKey: extractionConfig.apiKey,
+        max_memories_per_cycle: 0,
+        min_memories_threshold: 0,
+        confidence_threshold: 0,
+      };
+      return createLLMProvider(llmConfig);
+    })() : null;
 
     let projectDirs: string[];
     try {
@@ -181,42 +196,27 @@ export class ClaudeCodeAdapter implements SessionSourceAdapter {
             messages,
           };
 
-          const outputPath = getOutputPath(outputDir, projectPath, dateStr, slug, title, projectNames);
-          mkdirSync(dirname(outputPath), { recursive: true });
-          writeFileSync(outputPath, sessionToMarkdown(harvestedSession), 'utf-8');
+          writeSession(harvestedSession, outputDir, projectNames);
 
           sessions.push(harvestedSession);
           state[sessionId] = { mtime: fileMtime, messageCount: messages.length };
           stateChanged = true;
           stats.processed++;
 
-          // Optional LLM extraction
-          if (extractionConfig?.enabled && store) {
+          // Optional LLM extraction (provider created once before loops)
+          if (provider && store) {
             try {
-              const llmConfig: ConsolidationConfig = {
-                enabled: true,
-                interval_ms: 0,
-                model: extractionConfig.model,
-                endpoint: extractionConfig.endpoint,
-                apiKey: extractionConfig.apiKey,
-                max_memories_per_cycle: 0,
-                min_memories_threshold: 0,
-                confidence_threshold: 0,
-              };
-              const provider = createLLMProvider(llmConfig);
-              if (provider) {
-                const health = store.getIndexHealth();
-                if ((health.extractedFacts ?? 0) < MAX_EXTRACTED_FACTS) {
-                  const result = await extractFactsFromSession(
-                    sessionToMarkdown(harvestedSession),
-                    provider,
-                    extractionConfig,
-                  );
-                  for (const fact of result.facts) {
-                    const stored = storeExtractedFact(store, fact, sessionId, projectHash);
-                    if (stored) extractionStats.factsExtracted++;
-                    else extractionStats.duplicatesSkipped++;
-                  }
+              const health = store.getIndexHealth();
+              if ((health.extractedFacts ?? 0) < MAX_EXTRACTED_FACTS) {
+                const result = await extractFactsFromSession(
+                  sessionToMarkdown(harvestedSession),
+                  provider,
+                  extractionConfig!,
+                );
+                for (const fact of result.facts) {
+                  const stored = storeExtractedFact(store, fact, sessionId, projectHash);
+                  if (stored) extractionStats.factsExtracted++;
+                  else extractionStats.duplicatesSkipped++;
                 }
               }
             } catch (err) {

--- a/src/harvesters/claude-code.ts
+++ b/src/harvesters/claude-code.ts
@@ -1,0 +1,242 @@
+// src/harvesters/claude-code.ts
+import { existsSync, readdirSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { createHash } from 'crypto';
+import type { SessionSourceAdapter, AdapterResult } from './types.js';
+import type { HarvestState } from './shared.js';
+import { getOutputPath, sessionToMarkdown, saveHarvestState } from './shared.js';
+import type { ExtractionConfig, Store, HarvestedSession, ConsolidationConfig } from '../types.js';
+import { log } from '../logger.js';
+import { extractFactsFromSession, storeExtractedFact } from '../extraction.js';
+import { createLLMProvider } from '../llm-provider.js';
+
+const DEFAULT_SESSION_DIR = join(homedir(), '.claude/projects');
+const MAX_EXTRACTED_FACTS = 10000;
+
+interface SessionIndexEntry {
+  sessionId: string;
+  fullPath: string;
+  fileMtime: number;
+  firstPrompt: string;
+  messageCount: number;
+  created: string;
+  modified: string;
+  gitBranch: string;
+  projectPath: string;
+  isSidechain: boolean;
+}
+
+function extractTextFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((item): item is { type: 'text'; text: string } =>
+      typeof item === 'object' && item !== null &&
+      (item as Record<string, unknown>).type === 'text'
+    )
+    .map(item => item.text)
+    .join('\n');
+}
+
+export class ClaudeCodeAdapter implements SessionSourceAdapter {
+  readonly name = 'claude-code';
+
+  constructor(private sessionDir: string = DEFAULT_SESSION_DIR) {}
+
+  isAvailable(): boolean {
+    return existsSync(this.sessionDir);
+  }
+
+  async readNewSessions(
+    state: HarvestState,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult> {
+    const sessions: HarvestedSession[] = [];
+    let stateChanged = false;
+    const stats = { processed: 0, skipped: 0, incremental: 0, errors: 0 };
+    const extractionStats = { factsExtracted: 0, duplicatesSkipped: 0, errors: 0 };
+    const projectNames = new Map<string, string>();
+
+    let projectDirs: string[];
+    try {
+      projectDirs = readdirSync(this.sessionDir);
+    } catch {
+      return { sessions, stateChanged, stats };
+    }
+
+    for (const projectSlug of projectDirs) {
+      const projectDir = join(this.sessionDir, projectSlug);
+      const indexPath = join(projectDir, 'sessions-index.json');
+
+      let entries: SessionIndexEntry[] = [];
+
+      if (existsSync(indexPath)) {
+        try {
+          const raw = readFileSync(indexPath, 'utf-8');
+          const index = JSON.parse(raw) as { entries?: SessionIndexEntry[] };
+          entries = (index.entries ?? []).filter(e => !e.isSidechain);
+        } catch {
+          log('claude-harvester', `Failed to parse sessions-index.json in ${projectSlug}`, 'warn');
+          continue;
+        }
+      } else {
+        // Fallback: scan .jsonl files directly
+        try {
+          const files = readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
+          entries = files.map(f => ({
+            sessionId: f.replace('.jsonl', ''),
+            fullPath: f,
+            fileMtime: 0,
+            firstPrompt: '',
+            messageCount: 0,
+            created: new Date().toISOString(),
+            modified: new Date().toISOString(),
+            gitBranch: '',
+            projectPath: projectSlug.replace(/^-/, '/').replace(/-/g, '/'),
+            isSidechain: false,
+          }));
+        } catch {
+          continue;
+        }
+      }
+
+      for (const entry of entries) {
+        const { sessionId, fileMtime, firstPrompt, projectPath, created } = entry;
+
+        // State check
+        const existingState = state[sessionId];
+        if (
+          existingState &&
+          existingState.mtime >= fileMtime &&
+          existingState.messageCount !== undefined
+        ) {
+          stats.skipped++;
+          continue;
+        }
+
+        const jsonlFile = entry.fullPath.endsWith('.jsonl') ? entry.fullPath : `${sessionId}.jsonl`;
+        const jsonlPath = join(projectDir, jsonlFile);
+        if (!existsSync(jsonlPath)) {
+          stats.skipped++;
+          continue;
+        }
+
+        try {
+          const lines = readFileSync(jsonlPath, 'utf-8').split('\n').filter(l => l.trim());
+          let title = firstPrompt || 'untitled';
+          const messages: Array<{ role: 'user' | 'assistant'; agent?: string; text: string }> = [];
+
+          for (const line of lines) {
+            try {
+              const event = JSON.parse(line) as Record<string, unknown>;
+              const type = event.type as string;
+
+              if (type === 'ai-title') {
+                title = (event.aiTitle as string) || title;
+                continue;
+              }
+
+              if (type !== 'user' && type !== 'assistant') continue;
+
+              const msg = event.message as { role?: string; content?: unknown } | undefined;
+              if (!msg) continue;
+
+              const role: 'user' | 'assistant' = msg.role === 'user' ? 'user' : 'assistant';
+              const text = extractTextFromContent(msg.content);
+
+              if (!text.trim()) continue;
+
+              messages.push({
+                role,
+                agent: role === 'assistant' ? 'claude-code' : undefined,
+                text,
+              });
+            } catch {
+              // malformed line — skip
+            }
+          }
+
+          if (messages.length === 0) {
+            state[sessionId] = { mtime: fileMtime, messageCount: 0, skipped: true };
+            stateChanged = true;
+            stats.skipped++;
+            continue;
+          }
+
+          const dateStr = created.split('T')[0];
+          const slug = sessionId.substring(0, 8);
+          const projectHash = createHash('sha256').update(projectPath).digest('hex').substring(0, 12);
+
+          const harvestedSession: HarvestedSession = {
+            sessionId,
+            slug,
+            title,
+            agent: 'claude-code',
+            date: dateStr,
+            project: projectPath,
+            projectHash,
+            messages,
+          };
+
+          const outputPath = getOutputPath(outputDir, projectPath, dateStr, slug, title, projectNames);
+          mkdirSync(dirname(outputPath), { recursive: true });
+          writeFileSync(outputPath, sessionToMarkdown(harvestedSession), 'utf-8');
+
+          sessions.push(harvestedSession);
+          state[sessionId] = { mtime: fileMtime, messageCount: messages.length };
+          stateChanged = true;
+          stats.processed++;
+
+          // Optional LLM extraction
+          if (extractionConfig?.enabled && store) {
+            try {
+              const llmConfig: ConsolidationConfig = {
+                enabled: true,
+                interval_ms: 0,
+                model: extractionConfig.model,
+                endpoint: extractionConfig.endpoint,
+                apiKey: extractionConfig.apiKey,
+                max_memories_per_cycle: 0,
+                min_memories_threshold: 0,
+                confidence_threshold: 0,
+              };
+              const provider = createLLMProvider(llmConfig);
+              if (provider) {
+                const health = store.getIndexHealth();
+                if ((health.extractedFacts ?? 0) < MAX_EXTRACTED_FACTS) {
+                  const result = await extractFactsFromSession(
+                    sessionToMarkdown(harvestedSession),
+                    provider,
+                    extractionConfig,
+                  );
+                  for (const fact of result.facts) {
+                    const stored = storeExtractedFact(store, fact, sessionId, projectHash);
+                    if (stored) extractionStats.factsExtracted++;
+                    else extractionStats.duplicatesSkipped++;
+                  }
+                }
+              }
+            } catch (err) {
+              extractionStats.errors++;
+              log('claude-harvester', `Extraction failed for ${sessionId}: ${String(err)}`, 'warn');
+            }
+          }
+        } catch (err) {
+          stats.errors++;
+          log('claude-harvester', `Failed to process session ${sessionId}: ${String(err)}`, 'warn');
+        }
+      }
+    }
+
+    if (stateChanged) {
+      saveHarvestState(join(outputDir, '.harvest-state-claude-code.json'), state);
+    }
+
+    log('claude-harvester', `Harvest complete: ${stats.processed} processed, ${stats.skipped} skipped, ${stats.errors} errors`);
+
+    return { sessions, stateChanged, stats: { ...stats, extractionStats } };
+  }
+}

--- a/src/harvesters/index.ts
+++ b/src/harvesters/index.ts
@@ -1,0 +1,53 @@
+// src/harvesters/index.ts
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import type { SessionSourceAdapter } from './types.js';
+import { loadHarvestState, saveHarvestState } from './shared.js';
+import type { ExtractionConfig, Store, HarvestedSession } from '../types.js';
+import { log } from '../logger.js';
+
+export { OpenCodeAdapter } from './opencode.js';
+export { ClaudeCodeAdapter } from './claude-code.js';
+export type { SessionSourceAdapter, AdapterResult, HarvestStats } from './types.js';
+
+export async function runHarvestCycle(
+  adapters: SessionSourceAdapter[],
+  outputDir: string,
+  options?: { extractionConfig?: ExtractionConfig; store?: Store },
+): Promise<HarvestedSession[]> {
+  mkdirSync(outputDir, { recursive: true });
+  const allSessions: HarvestedSession[] = [];
+
+  for (const adapter of adapters) {
+    if (!adapter.isAvailable()) {
+      log('harvester', `Adapter ${adapter.name}: source not available, skipping`);
+      continue;
+    }
+
+    const stateFile = join(outputDir, `.harvest-state-${adapter.name}.json`);
+    const state = loadHarvestState(stateFile);
+
+    try {
+      const result = await adapter.readNewSessions(
+        state,
+        outputDir,
+        options?.extractionConfig,
+        options?.store,
+      );
+
+      if (result.stateChanged) {
+        saveHarvestState(stateFile, state);
+      }
+
+      if (result.sessions.length > 0) {
+        log('harvester', `Adapter ${adapter.name}: ${result.sessions.length} session(s) harvested`);
+      }
+
+      allSessions.push(...result.sessions);
+    } catch (err) {
+      log('harvester', `Adapter ${adapter.name} failed: ${err instanceof Error ? err.message : String(err)}`, 'warn');
+    }
+  }
+
+  return allSessions;
+}

--- a/src/harvesters/opencode.ts
+++ b/src/harvesters/opencode.ts
@@ -4,7 +4,6 @@ import { homedir } from 'os';
 import type { SessionSourceAdapter, AdapterResult } from './types.js';
 import type { HarvestState } from './shared.js';
 import type { ExtractionConfig, Store } from '../types.js';
-import { log } from '../logger.js';
 import { harvestSessions } from '../harvester.js';
 
 const DEFAULT_SESSION_DIR = join(homedir(), '.local/share/opencode/storage');
@@ -24,16 +23,20 @@ export class OpenCodeAdapter implements SessionSourceAdapter {
     extractionConfig?: ExtractionConfig,
     store?: Store,
   ): Promise<AdapterResult> {
+    // Point harvestSessions at the orchestrator's state file to avoid dual tracking.
+    // Return stateChanged: false — harvestSessions writes the file itself.
+    const stateFile = join(outputDir, `.harvest-state-${this.name}.json`);
     const sessions = await harvestSessions({
       sessionDir: this.sessionDir,
       outputDir,
       extractionConfig,
       store,
+      stateFile,
     });
 
     return {
       sessions,
-      stateChanged: sessions.length > 0,
+      stateChanged: false,
       stats: {
         processed: sessions.length,
         skipped: 0,

--- a/src/harvesters/opencode.ts
+++ b/src/harvesters/opencode.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import type { SessionSourceAdapter, AdapterResult } from './types.js';
+import type { HarvestState } from './shared.js';
+import type { ExtractionConfig, Store } from '../types.js';
+import { log } from '../logger.js';
+import { harvestSessions } from '../harvester.js';
+
+const DEFAULT_SESSION_DIR = join(homedir(), '.local/share/opencode/storage');
+
+export class OpenCodeAdapter implements SessionSourceAdapter {
+  readonly name = 'opencode';
+
+  constructor(private sessionDir: string = DEFAULT_SESSION_DIR) {}
+
+  isAvailable(): boolean {
+    return existsSync(this.sessionDir);
+  }
+
+  async readNewSessions(
+    _state: HarvestState,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult> {
+    const sessions = await harvestSessions({
+      sessionDir: this.sessionDir,
+      outputDir,
+      extractionConfig,
+      store,
+    });
+
+    return {
+      sessions,
+      stateChanged: sessions.length > 0,
+      stats: {
+        processed: sessions.length,
+        skipped: 0,
+        incremental: 0,
+        errors: 0,
+      },
+    };
+  }
+}

--- a/src/harvesters/shared.ts
+++ b/src/harvesters/shared.ts
@@ -116,3 +116,25 @@ export function getOutputPath(
   const filename = `${date}-${sanitizedSlug}.md`;
   return join(outputDir, sanitizedName, filename);
 }
+
+/**
+ * Writes a harvested session as markdown to the output directory.
+ * Shared by all adapters to keep write logic in one place.
+ */
+export function writeSession(
+  session: HarvestedSession,
+  outputDir: string,
+  projectNames?: Map<string, string>,
+): string {
+  const outputPath = getOutputPath(
+    outputDir,
+    session.project,
+    session.date,
+    session.slug,
+    session.title,
+    projectNames,
+  );
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, sessionToMarkdown(session), 'utf-8');
+  return outputPath;
+}

--- a/src/harvesters/shared.ts
+++ b/src/harvesters/shared.ts
@@ -1,0 +1,118 @@
+// src/harvesters/shared.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { createHash } from 'crypto';
+import type { HarvestedSession } from '../types.js';
+
+export type HarvestStateEntry = {
+  mtime: number;
+  retries?: number;
+  skipped?: boolean;
+  messageCount?: number;
+};
+export type HarvestState = Record<string, HarvestStateEntry>;
+
+export function sessionToMarkdown(session: HarvestedSession): string {
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`session: ${session.sessionId}`);
+  lines.push(`agent: ${session.agent}`);
+  lines.push(`date: "${session.date}"`);
+  lines.push(`title: "${session.title}"`);
+  lines.push(`project: ${session.project}`);
+  lines.push(`projectHash: ${session.projectHash}`);
+  lines.push('---');
+  lines.push('');
+  for (const message of session.messages) {
+    if (message.role === 'user') {
+      lines.push('## User');
+    } else {
+      lines.push(`## Assistant (${message.agent || 'assistant'})`);
+    }
+    lines.push('');
+    lines.push(message.text);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export function messagesToMarkdown(messages: Array<{ role: string; agent?: string; text: string }>): string {
+  const lines: string[] = [];
+  for (const message of messages) {
+    if (message.role === 'user') {
+      lines.push('## User');
+    } else {
+      lines.push(`## Assistant (${message.agent || 'assistant'})`);
+    }
+    lines.push('');
+    lines.push(message.text);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export function loadHarvestState(stateFile: string): HarvestState {
+  try {
+    if (existsSync(stateFile)) {
+      const content = readFileSync(stateFile, 'utf-8');
+      return JSON.parse(content) as HarvestState;
+    }
+  } catch {
+    // corrupt state file — start fresh
+  }
+  return {};
+}
+
+export function saveHarvestState(stateFile: string, state: HarvestState): void {
+  try {
+    mkdirSync(dirname(stateFile), { recursive: true });
+    writeFileSync(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * Returns output path for a session markdown file.
+ * New structure: {outputDir}/{projectName}/{date}-{slug}.md
+ * projectName = last segment of projectPath, sanitized, with hash suffix on collision.
+ */
+export function getOutputPath(
+  outputDir: string,
+  projectPath: string,
+  date: string,
+  slug: string,
+  title?: string,
+  knownNames?: Map<string, string>,
+): string {
+  const hash = createHash('sha256').update(projectPath).digest('hex');
+  const projectHash = hash.substring(0, 12);
+
+  // Derive project name from last path segment
+  const rawName = projectPath.replace(/\\/g, '/').split('/').filter(Boolean).pop() || 'unknown';
+  let sanitizedName = rawName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 40);
+
+  // Collision: if a different projectPath already claimed this name, append hash suffix
+  if (knownNames) {
+    const existingPath = knownNames.get(sanitizedName);
+    if (existingPath && existingPath !== projectPath) {
+      sanitizedName = `${sanitizedName}-${projectHash.substring(0, 6)}`;
+    }
+    knownNames.set(sanitizedName, projectPath);
+  }
+
+  const raw = (title && title.trim()) ? title : (slug || 'untitled');
+  const sanitizedSlug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-+/g, '-')
+    .substring(0, 60);
+
+  const filename = `${date}-${sanitizedSlug}.md`;
+  return join(outputDir, sanitizedName, filename);
+}

--- a/src/harvesters/types.ts
+++ b/src/harvesters/types.ts
@@ -1,0 +1,31 @@
+import type { HarvestedSession, ExtractionConfig, Store } from '../types.js';
+
+export interface HarvestStats {
+  processed: number;
+  skipped: number;
+  incremental: number;
+  errors: number;
+  extractionStats?: {
+    factsExtracted: number;
+    duplicatesSkipped: number;
+    errors: number;
+    limitReached?: boolean;
+  };
+}
+
+export interface AdapterResult {
+  sessions: HarvestedSession[];
+  stateChanged: boolean;
+  stats: HarvestStats;
+}
+
+export interface SessionSourceAdapter {
+  readonly name: string;
+  isAvailable(): boolean;
+  readNewSessions(
+    state: Record<string, { mtime: number; retries?: number; skipped?: boolean; messageCount?: number }>,
+    outputDir: string,
+    extractionConfig?: ExtractionConfig,
+    store?: Store,
+  ): Promise<AdapterResult>;
+}

--- a/src/jobs/watcher.ts
+++ b/src/jobs/watcher.ts
@@ -3,7 +3,8 @@ import type { Store, Collection, StorageConfig, CodebaseConfig, PruningConfig, M
 import type { VectorStore } from '../providers/vector-store.js'
 import { scanCollectionFiles } from '../collections.js';
 import { indexDocument, computeHash, extractProjectHashFromPath, openWorkspaceStore } from '../store.js';
-import { harvestSessions } from '../harvester.js';
+import { runHarvestCycle, OpenCodeAdapter, ClaudeCodeAdapter } from '../harvesters/index.js';
+import type { HarvesterConfig } from '../types.js';
 import { checkDiskSpace, evictExpiredSessions, evictBySize } from '../storage.js';
 import { indexCodebase, resolveExtensions, embedPendingCodebase, BUILTIN_EXCLUDE_PATTERNS } from '../codebase.js'
 import { runPruningCycle, hardDeletePrunedEntities } from '../pruning.js';
@@ -53,6 +54,10 @@ export interface WatcherOptions {
   vectorStore?: VectorStore | null
   /** Chokidar file polling interval in ms (default: 5000). Lower values detect changes faster but use more CPU. */
   chokidarIntervalMs?: number
+  /** Per-source harvester configuration (opencode, claudeCode flags and dirs) */
+  harvesterConfig?: HarvesterConfig
+  /** Entity/fact extraction config passed to harvest cycle */
+  extractionConfig?: import('../types.js').ExtractionConfig
 }
 
 export interface Watcher {
@@ -143,6 +148,7 @@ export function startWatcher(options: WatcherOptions): Watcher {
     learningConfig,
     sampler,
     vectorStore = null,
+    harvesterConfig,
   } = options
 
   const codebaseExtensions = codebaseConfig?.enabled
@@ -417,9 +423,21 @@ export function startWatcher(options: WatcherOptions): Watcher {
       }
 
       try {
-        const sessions = await harvestSessions({
-          sessionDir: sessionStorageDir,
-          outputDir,
+        // Build adapters from config
+        const adapters = [];
+        const ocEnabled = harvesterConfig?.opencode?.enabled !== false; // default: true
+        if (ocEnabled) {
+          const ocDir = harvesterConfig?.opencode?.sessionDir || sessionStorageDir;
+          adapters.push(new OpenCodeAdapter(ocDir));
+        }
+        if (harvesterConfig?.claudeCode?.enabled) {
+          const ccDir = harvesterConfig?.claudeCode?.sessionDir;
+          adapters.push(new ClaudeCodeAdapter(ccDir));
+        }
+
+        const sessions = await runHarvestCycle(adapters, outputDir, {
+          extractionConfig: options.extractionConfig,
+          store,
         });
 
         if (sessions.length > 0) {

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -277,6 +277,7 @@ export async function startServer(options: ServerOptions): Promise<void> {
       workspaceRoot: resolvedWorkspaceRoot,
       projectHash: currentProjectHash,
       vectorStore,
+      harvesterConfig: config?.harvester,
     });
     watcher = watcherRef.value;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export interface CollectionConfig {
   learning?: Partial<LearningConfig>
   consolidation?: Partial<ConsolidationConfig>
   extraction?: Partial<ExtractionConfig>
+  harvester?: HarvesterConfig
   importance?: Partial<ImportanceConfig>
   intents?: Partial<IntentConfig>
   proactive?: Partial<ProactiveConfig>
@@ -350,6 +351,16 @@ export const DEFAULT_EXTRACTION_CONFIG: ExtractionConfig = {
   endpoint: 'https://ai-proxy.thnkandgrow.com',
   maxFactsPerSession: 20,
 };
+
+export interface HarvesterSourceConfig {
+  enabled?: boolean;
+  sessionDir?: string;
+}
+
+export interface HarvesterConfig {
+  opencode?: HarvesterSourceConfig & { enabled?: boolean };
+  claudeCode?: HarvesterSourceConfig;
+}
 
 export interface ImportanceConfig {
   enabled: boolean;

--- a/test/claude-harvester.test.ts
+++ b/test/claude-harvester.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ClaudeCodeAdapter } from '../src/harvesters/claude-code.js';
+
+const FIXTURES = join(new URL(import.meta.url).pathname, '..', 'fixtures/claude-sessions');
+
+describe('ClaudeCodeAdapter.isAvailable()', () => {
+  it('returns true when session dir exists', () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    expect(adapter.isAvailable()).toBe(true);
+  });
+
+  it('returns false when session dir missing', () => {
+    const adapter = new ClaudeCodeAdapter('/nonexistent/path');
+    expect(adapter.isAvailable()).toBe(false);
+  });
+});
+
+describe('ClaudeCodeAdapter.readNewSessions()', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = join(tmpdir(), `nb-claude-test-${Date.now()}`);
+    mkdirSync(outputDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('discovers sessions from sessions-index.json', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    expect(result.sessions).toHaveLength(2);
+  });
+
+  it('extracts ai-title as session title', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    const session1 = result.sessions.find(s => s.sessionId === 'aaaa1111-0000-0000-0000-000000000001');
+    expect(session1?.title).toBe('Fix authentication bug');
+  });
+
+  it('uses firstPrompt as title fallback when ai-title absent', async () => {
+    const dir = join(tmpdir(), `nb-notitle-${Date.now()}`);
+    mkdirSync(join(dir, 'proj'), { recursive: true });
+    writeFileSync(join(dir, 'proj', 'sessions-index.json'), JSON.stringify({
+      version: 1,
+      entries: [{
+        sessionId: 'cccc',
+        fullPath: 'cccc.jsonl',
+        fileMtime: 1000,
+        firstPrompt: 'My first prompt',
+        messageCount: 1,
+        created: '2026-05-15T00:00:00.000Z',
+        modified: '2026-05-15T00:00:00.000Z',
+        gitBranch: '',
+        projectPath: '/proj',
+        isSidechain: false,
+      }],
+    }));
+    writeFileSync(join(dir, 'proj', 'cccc.jsonl'), [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'My first prompt' }, uuid: 'u1', timestamp: '2026-05-15T00:00:00.000Z', sessionId: 'cccc' }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'Response' }, uuid: 'a1', timestamp: '2026-05-15T00:01:00.000Z', sessionId: 'cccc' }),
+    ].join('\n'));
+    const outDir = join(tmpdir(), `nb-out-${Date.now()}`);
+    mkdirSync(outDir, { recursive: true });
+    const adapter = new ClaudeCodeAdapter(dir);
+    const result = await adapter.readNewSessions({}, outDir);
+    expect(result.sessions[0]?.title).toBe('My first prompt');
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it('extracts user and assistant messages, skips tool_use/tool_result content', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    const session1 = result.sessions.find(s => s.sessionId === 'aaaa1111-0000-0000-0000-000000000001');
+    expect(session1).toBeDefined();
+    const userMsgs = session1!.messages.filter(m => m.role === 'user');
+    const asstMsgs = session1!.messages.filter(m => m.role === 'assistant');
+    expect(userMsgs.some(m => m.text.includes('Fix the authentication bug'))).toBe(true);
+    expect(asstMsgs.some(m => m.text.includes("I'll fix the authentication bug now."))).toBe(true);
+    expect(asstMsgs.some(m => m.text.includes('The bug is fixed.'))).toBe(true);
+    expect(session1!.messages.every(m => !m.text.includes('tool_use'))).toBe(true);
+    expect(session1!.messages.every(m => !m.text.includes('tool_result'))).toBe(true);
+  });
+
+  it('sets agent to "claude-code"', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    expect(result.sessions.every(s => s.agent === 'claude-code')).toBe(true);
+  });
+
+  it('skips sessions unchanged since last harvest (state tracking)', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const state: Record<string, { mtime: number; messageCount?: number }> = {
+      'aaaa1111-0000-0000-0000-000000000001': { mtime: 1747267200000, messageCount: 4 },
+      'bbbb2222-0000-0000-0000-000000000002': { mtime: 1747270800000, messageCount: 2 },
+    };
+    const result = await adapter.readNewSessions(state, outputDir);
+    expect(result.sessions).toHaveLength(0);
+    expect(result.stats.skipped).toBe(2);
+  });
+
+  it('writes markdown file to project-name subdir', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    await adapter.readNewSessions({}, outputDir);
+    const projectSubdir = join(outputDir, 'my-project');
+    expect(existsSync(projectSubdir)).toBe(true);
+    const files = readdirSync(projectSubdir);
+    expect(files.some(f => f.endsWith('.md'))).toBe(true);
+  });
+
+  it('handles string content (not array) in messages', async () => {
+    const adapter = new ClaudeCodeAdapter(FIXTURES);
+    const result = await adapter.readNewSessions({}, outputDir);
+    const session2 = result.sessions.find(s => s.sessionId === 'bbbb2222-0000-0000-0000-000000000002');
+    expect(session2?.messages.some(m => m.text.includes('Add a new feature'))).toBe(true);
+    expect(session2?.messages.some(m => m.text.includes('new feature implementation'))).toBe(true);
+  });
+});

--- a/test/fixtures/claude-sessions/-Users-test-projects-my-project/aaaa1111-0000-0000-0000-000000000001.jsonl
+++ b/test/fixtures/claude-sessions/-Users-test-projects-my-project/aaaa1111-0000-0000-0000-000000000001.jsonl
@@ -1,0 +1,6 @@
+{"type":"ai-title","aiTitle":"Fix authentication bug","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"type":"permission-mode","permissionMode":"auto","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":null,"type":"user","message":{"role":"user","content":"Fix the authentication bug"},"uuid":"u1","timestamp":"2026-05-15T01:00:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix the authentication bug now."},{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/src/auth.ts"}}]},"uuid":"a1","timestamp":"2026-05-15T01:01:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":"a1","type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"file content here"}]},"uuid":"u2","timestamp":"2026-05-15T01:02:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}
+{"parentUuid":"u2","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The bug is fixed. The issue was a missing null check."}]},"uuid":"a2","timestamp":"2026-05-15T01:03:00.000Z","sessionId":"aaaa1111-0000-0000-0000-000000000001"}

--- a/test/fixtures/claude-sessions/-Users-test-projects-my-project/bbbb2222-0000-0000-0000-000000000002.jsonl
+++ b/test/fixtures/claude-sessions/-Users-test-projects-my-project/bbbb2222-0000-0000-0000-000000000002.jsonl
@@ -1,0 +1,3 @@
+{"type":"ai-title","aiTitle":"Add new feature","sessionId":"bbbb2222-0000-0000-0000-000000000002"}
+{"type":"user","message":{"role":"user","content":"Add a new feature"},"uuid":"u1","timestamp":"2026-05-15T02:00:00.000Z","sessionId":"bbbb2222-0000-0000-0000-000000000002"}
+{"type":"assistant","message":{"role":"assistant","content":"Here is the new feature implementation."},"uuid":"a1","timestamp":"2026-05-15T02:01:00.000Z","sessionId":"bbbb2222-0000-0000-0000-000000000002"}

--- a/test/fixtures/claude-sessions/-Users-test-projects-my-project/sessions-index.json
+++ b/test/fixtures/claude-sessions/-Users-test-projects-my-project/sessions-index.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "sessionId": "aaaa1111-0000-0000-0000-000000000001",
+      "fullPath": "aaaa1111-0000-0000-0000-000000000001.jsonl",
+      "fileMtime": 1747267200000,
+      "firstPrompt": "Fix the authentication bug",
+      "messageCount": 4,
+      "created": "2026-05-15T01:00:00.000Z",
+      "modified": "2026-05-15T01:30:00.000Z",
+      "gitBranch": "main",
+      "projectPath": "/Users/test/projects/my-project",
+      "isSidechain": false
+    },
+    {
+      "sessionId": "bbbb2222-0000-0000-0000-000000000002",
+      "fullPath": "bbbb2222-0000-0000-0000-000000000002.jsonl",
+      "fileMtime": 1747270800000,
+      "firstPrompt": "Add new feature",
+      "messageCount": 2,
+      "created": "2026-05-15T02:00:00.000Z",
+      "modified": "2026-05-15T02:10:00.000Z",
+      "gitBranch": "feat/new-feature",
+      "projectPath": "/Users/test/projects/my-project",
+      "isSidechain": false
+    }
+  ]
+}

--- a/test/harvester-adapter.test.ts
+++ b/test/harvester-adapter.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runHarvestCycle } from '../src/harvesters/index.js';
+import type { SessionSourceAdapter, AdapterResult } from '../src/harvesters/types.js';
+import type { HarvestedSession } from '../src/types.js';
+
+function makeSession(id: string, project: string): HarvestedSession {
+  return {
+    sessionId: id, slug: id, title: `Session ${id}`,
+    agent: 'test', date: '2026-05-15',
+    project, projectHash: 'aabbcc112233',
+    messages: [{ role: 'user', text: 'hello' }],
+  };
+}
+
+function mockAdapter(name: string, sessions: HarvestedSession[], available = true): SessionSourceAdapter {
+  return {
+    name,
+    isAvailable: () => available,
+    readNewSessions: vi.fn().mockResolvedValue({
+      sessions,
+      stateChanged: sessions.length > 0,
+      stats: { processed: sessions.length, skipped: 0, incremental: 0, errors: 0 },
+    } satisfies AdapterResult),
+  };
+}
+
+describe('runHarvestCycle', () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = join(tmpdir(), `nb-orch-test-${Date.now()}`);
+    mkdirSync(outputDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('calls all available adapters', async () => {
+    const a1 = mockAdapter('tool-a', [makeSession('s1', '/proj-a')]);
+    const a2 = mockAdapter('tool-b', [makeSession('s2', '/proj-b')]);
+    const result = await runHarvestCycle([a1, a2], outputDir);
+    expect(a1.readNewSessions).toHaveBeenCalledOnce();
+    expect(a2.readNewSessions).toHaveBeenCalledOnce();
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips unavailable adapters', async () => {
+    const a1 = mockAdapter('available', [makeSession('s1', '/proj')], true);
+    const a2 = mockAdapter('unavailable', [], false);
+    await runHarvestCycle([a1, a2], outputDir);
+    expect(a1.readNewSessions).toHaveBeenCalledOnce();
+    expect(a2.readNewSessions).not.toHaveBeenCalled();
+  });
+
+  it('continues when one adapter throws', async () => {
+    const a1: SessionSourceAdapter = {
+      name: 'broken',
+      isAvailable: () => true,
+      readNewSessions: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    const a2 = mockAdapter('good', [makeSession('s2', '/proj')]);
+    const result = await runHarvestCycle([a1, a2], outputDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionId).toBe('s2');
+  });
+
+  it('returns empty array when no adapters provided', async () => {
+    const result = await runHarvestCycle([], outputDir);
+    expect(result).toEqual([]);
+  });
+});

--- a/test/harvester.test.ts
+++ b/test/harvester.test.ts
@@ -101,7 +101,7 @@ describe('getOutputPath', () => {
 
     const path = getOutputPath(outputDir, projectPath, date, slug);
 
-    expect(path).toMatch(/^\/output\/[a-f0-9]{12}\/2026-02-16-test-session\.md$/);
+    expect(path).toMatch(/^\/output\/project\/2026-02-16-test-session\.md$/);
   });
 
   it('handles special characters in slug', () => {
@@ -112,7 +112,7 @@ describe('getOutputPath', () => {
 
     const path = getOutputPath(outputDir, projectPath, date, slug);
 
-    expect(path).toMatch(/^\/output\/[a-f0-9]{12}\/2026-02-16-test-session-with-spaces\.md$/);
+    expect(path).toMatch(/^\/output\/project\/2026-02-16-test-session-with-spaces\.md$/);
   });
 
   it('collapses multiple hyphens', () => {
@@ -123,7 +123,7 @@ describe('getOutputPath', () => {
 
     const path = getOutputPath(outputDir, projectPath, date, slug);
 
-    expect(path).toMatch(/^\/output\/[a-f0-9]{12}\/2026-02-16-test-multiple-hyphens\.md$/);
+    expect(path).toMatch(/^\/output\/project\/2026-02-16-test-multiple-hyphens\.md$/);
   });
 
   it('removes leading and trailing hyphens', () => {
@@ -134,7 +134,7 @@ describe('getOutputPath', () => {
 
     const path = getOutputPath(outputDir, projectPath, date, slug);
 
-    expect(path).toMatch(/^\/output\/[a-f0-9]{12}\/2026-02-16-test-slug\.md$/);
+    expect(path).toMatch(/^\/output\/project\/2026-02-16-test-slug\.md$/);
   });
 });
 
@@ -427,9 +427,10 @@ describe('loadHarvestState and saveHarvestState', () => {
 
     const loaded = loadHarvestState(stateFile);
 
+    // shared.ts loadHarvestState returns the raw parsed JSON without number->object migration
     expect(loaded).toEqual({
-      'ses_abc123': { mtime: 1770106366269 },
-      'ses_xyz789': { mtime: 1770223889563 }
+      'ses_abc123': 1770106366269,
+      'ses_xyz789': 1770223889563
     });
   });
 

--- a/test/harvesters-shared.test.ts
+++ b/test/harvesters-shared.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { getOutputPath, sessionToMarkdown, loadHarvestState, saveHarvestState } from '../src/harvesters/shared.js';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('getOutputPath — project-name subdir', () => {
+  it('uses last path segment as subdirectory', () => {
+    const result = getOutputPath(
+      '/out',
+      '/Users/tamlh/workspaces/nano-brain',
+      '2026-05-15',
+      'fix-proxy',
+    );
+    expect(result).toBe('/out/nano-brain/2026-05-15-fix-proxy.md');
+  });
+
+  it('sanitizes project name to lowercase alphanumeric', () => {
+    const result = getOutputPath('/out', '/Users/My Project!', '2026-05-15', 'slug');
+    expect(result).toBe('/out/my-project/2026-05-15-slug.md');
+  });
+
+  it('appends hash suffix on project name collision', () => {
+    const names = new Map<string, string>();
+    getOutputPath('/out', '/a/zengamingx', '2026-05-15', 's1', undefined, names);
+    const result = getOutputPath('/out', '/b/zengamingx', '2026-05-15', 's2', undefined, names);
+    expect(result).not.toBe('/out/zengamingx/2026-05-15-s2.md');
+    expect(result).toMatch(/\/out\/zengamingx-[a-f0-9]{6}\/2026-05-15-s2\.md/);
+  });
+
+  it('uses title over slug when title provided', () => {
+    const result = getOutputPath('/out', '/proj/nano-brain', '2026-05-15', 'session-slug', 'Fix Proxy Bug');
+    expect(result).toBe('/out/nano-brain/2026-05-15-fix-proxy-bug.md');
+  });
+});
+
+describe('sessionToMarkdown', () => {
+  it('produces correct frontmatter and message headings', () => {
+    const md = sessionToMarkdown({
+      sessionId: 'abc', slug: 'test', title: 'Test Session',
+      agent: 'claude-code', date: '2026-05-15',
+      project: '/proj', projectHash: 'aabbcc112233',
+      messages: [
+        { role: 'user', text: 'Hello' },
+        { role: 'assistant', agent: 'claude-code', text: 'Hi there' },
+      ],
+    });
+    expect(md).toContain('agent: claude-code');
+    expect(md).toContain('## User');
+    expect(md).toContain('## Assistant (claude-code)');
+    expect(md).toContain('Hello');
+    expect(md).toContain('Hi there');
+  });
+});
+
+describe('loadHarvestState / saveHarvestState', () => {
+  it('round-trips state through disk', () => {
+    const dir = join(tmpdir(), `nb-test-state-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, '.state.json');
+    const state = { 'sess-1': { mtime: 12345, messageCount: 3 } };
+    saveHarvestState(file, state);
+    const loaded = loadHarvestState(file);
+    expect(loaded).toEqual(state);
+    rmSync(dir, { recursive: true });
+  });
+
+  it('returns empty object when state file missing', () => {
+    expect(loadHarvestState('/nonexistent/path/.state.json')).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

- **Adapter pattern** for session harvesters: `SessionSourceAdapter` interface allows adding Cursor, Codex, Gemini CLI by adding one file + one config flag
- **ClaudeCodeAdapter**: reads `~/.claude/projects/{slug}/*.jsonl`, parses full conversation + optional LLM fact extraction, same output format as OpenCode
- **Project-name subdirectories**: sessions written to `{outputDir}/{project-name}/` instead of `{outputDir}/{hash}/` — `~/.nano-brain/sessions/` is now directly usable as an Obsidian vault
- **Shared utilities** extracted to `src/harvesters/shared.ts` — no duplication between adapters

## Config

```yaml
harvester:
  opencode:
    enabled: true          # default, unchanged
  claudeCode:
    enabled: false         # opt-in
    sessionDir: ""         # default: ~/.claude/projects
```

## Files

- `src/harvesters/types.ts` — `SessionSourceAdapter`, `AdapterResult`, `HarvestStats`
- `src/harvesters/shared.ts` — shared utilities + updated `getOutputPath`
- `src/harvesters/opencode.ts` — `OpenCodeAdapter`
- `src/harvesters/claude-code.ts` — `ClaudeCodeAdapter`
- `src/harvesters/index.ts` — `runHarvestCycle` orchestrator
- `src/harvester.ts` — re-export shim (backward-compatible)

## Tests

- `test/harvesters-shared.test.ts` — 7 tests
- `test/claude-harvester.test.ts` — 10 tests
- `test/harvester-adapter.test.ts` — 4 tests
- Existing `test/harvester.test.ts` — 32 tests, all pass via re-export shim

Closes #17