### PR TITLE
feat(graph,db,obsidian): graph UX, performance, Obsidian integration, SQLite corruption fixes

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -77,9 +77,59 @@ jobs:
           [ -n "$chore" ] && body+=$'### Other\n'"$chore"$'\n\n'
           [ -z "$body" ]  && body="_No notable changes_"
 
+          # Write body to file so downstream steps can read it without quoting issues
+          echo "$body" > /tmp/changelog_body.md
+
           echo "body<<EOF" >> $GITHUB_OUTPUT
           echo "$body" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Update CHANGELOG.md
+        run: |
+          python3 << 'PYEOF'
+          import os
+          from datetime import date
+
+          version = os.environ['VERSION']
+          today = date.today().strftime('%Y-%m-%d')
+
+          with open('/tmp/changelog_body.md') as f:
+              body = f.read().strip()
+
+          install_line = f"**Install:** `npm install nano-brain@{version}` · `npx nano-brain@latest`"
+          new_entry = f"## [{version}] — {today}\n\n{body}\n\n{install_line}\n\n---\n\n"
+
+          with open('CHANGELOG.md') as f:
+              content = f.read()
+
+          # Insert after the first "---" separator (after the header block)
+          sep = '\n---\n'
+          idx = content.find(sep)
+          if idx != -1:
+              insert_pos = idx + len(sep) + 1  # after the blank line following ---
+              content = content[:insert_pos] + new_entry + content[insert_pos:]
+          else:
+              content += '\n' + new_entry
+
+          with open('CHANGELOG.md', 'w') as f:
+              f.write(content)
+
+          print(f"CHANGELOG.md updated for v{version}")
+          PYEOF
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Commit and push CHANGELOG.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          if git diff --staged --quiet; then
+            echo "CHANGELOG.md already up to date — nothing to commit"
+          else
+            git commit -m "chore: update CHANGELOG.md for v${{ steps.version.outputs.version }} [skip ci]"
+            git push origin master
+          fi
 
       - name: Create GitHub release
         uses: actions/github-script@v7

--- a/src/web/src/components/GraphShell.tsx
+++ b/src/web/src/components/GraphShell.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode } from 'react';
+
+export type TruncationInfo = { shown: number; total: number };
+
+type GraphShellProps = {
+  children: ReactNode;
+  truncated?: TruncationInfo;
+  unit?: string;
+};
+
+export default function GraphShell({ children, truncated, unit = 'nodes' }: GraphShellProps) {
+  return (
+    <div className="card graph-shell overflow-hidden relative">
+      {truncated && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 px-3 py-1 rounded-full bg-[#1c1c27]/90 border border-[#3a3a5c] text-[11px] text-[#8888a0] whitespace-nowrap pointer-events-none">
+          Showing top {truncated.shown} of {truncated.total.toLocaleString()} {unit} by connection degree
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -25,52 +25,64 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
   const [edges, setEdges, onEdgesChange] = useEdgesState(inputEdges);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  // Sync nodes from props (data or layout changed)
+  // Build neighbor set helper
+  const buildNeighbors = useCallback((nodeId: string) => {
+    const s = new Set<string>([nodeId]);
+    for (const e of inputEdges) {
+      if (e.source === nodeId) s.add(e.target);
+      if (e.target === nodeId) s.add(e.source);
+    }
+    return s;
+  }, [inputEdges]);
+
+  // Sync nodes from props — also apply current focus state so dimming survives data refresh
   useEffect(() => {
-    setNodes(inputNodes);
-    requestAnimationFrame(() => fitView({ padding: 0.15, duration: 300 }));
-  }, [inputNodes, setNodes, fitView]);
+    if (!selectedNodeId) {
+      setNodes(inputNodes.map((n) => ({
+        ...n,
+        data: { ...n.data, dimmed: false, focused: false },
+      })));
+    } else {
+      const neighbors = buildNeighbors(selectedNodeId);
+      setNodes(inputNodes.map((n) => ({
+        ...n,
+        data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
+      })));
+    }
+    if (!selectedNodeId) {
+      requestAnimationFrame(() => fitView({ padding: 0.15, duration: 300 }));
+    }
+  }, [inputNodes, setNodes, fitView, selectedNodeId, buildNeighbors]);
 
   // Sync edges from props
   useEffect(() => {
     setEdges(inputEdges);
   }, [inputEdges, setEdges]);
 
-  // Focus mode: dim nodes and edges not connected to selected node
+  // Focus mode: dim/hide unrelated nodes (via data.dimmed) + fade edges
   useEffect(() => {
     if (!selectedNodeId) {
-      setNodes((nds) => nds.map((n) => ({ ...n, style: { ...n.style, opacity: 1 } })));
-      setEdges((eds) => eds.map((e) => ({ ...e, animated: false, style: { ...e.style, opacity: 0.6, strokeWidth: 2 } })));
+      setEdges((eds) => eds.map((e) => ({
+        ...e, animated: false, style: { ...e.style, opacity: 0.6, strokeWidth: 2 },
+      })));
       return;
     }
 
-    // Build 1-hop neighbor set
-    const neighbors = new Set<string>([selectedNodeId]);
-    for (const e of inputEdges) {
-      if (e.source === selectedNodeId) neighbors.add(e.target);
-      if (e.target === selectedNodeId) neighbors.add(e.source);
-    }
+    const neighbors = buildNeighbors(selectedNodeId);
 
-    setNodes((nds) =>
-      nds.map((n) => ({
-        ...n,
-        style: {
-          ...n.style,
-          opacity: neighbors.has(n.id) ? 1 : 0.08,
-          transition: 'opacity 0.15s ease',
-        },
-      }))
-    );
+    // Node dimming is handled via data.dimmed in each node component — no opacity on style
+    setNodes((nds) => nds.map((n) => ({
+      ...n,
+      data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
+    })));
 
-    setEdges((eds) =>
-      eds.map((e) => {
-        const connected = e.source === selectedNodeId || e.target === selectedNodeId;
-        return connected
-          ? { ...e, animated: true, style: { ...e.style, opacity: 0.9, strokeWidth: 3 } }
-          : { ...e, animated: false, style: { ...e.style, opacity: 0.04, strokeWidth: 1 } };
-      })
-    );
-  }, [selectedNodeId, inputEdges, setNodes, setEdges]);
+    setEdges((eds) => eds.map((e) => {
+      const connected = e.source === selectedNodeId || e.target === selectedNodeId;
+      return connected
+        ? { ...e, animated: true, style: { ...e.style, opacity: 0.9, strokeWidth: 3 } }
+        : { ...e, animated: false, style: { ...e.style, opacity: 0.04, strokeWidth: 1 } };
+    }));
+  }, [selectedNodeId, buildNeighbors, setNodes, setEdges]);
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -19,7 +19,7 @@ type ReactFlowGraphProps = {
   nodeTypes?: NodeTypes;
 };
 
-function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick, nodeTypes }: ReactFlowGraphProps) {
+const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick, nodeTypes }: ReactFlowGraphProps) {
   const { fitView } = useReactFlow();
   const [nodes, setNodes, onNodesChange] = useNodesState(inputNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(inputEdges);
@@ -49,6 +49,8 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
         data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
       })));
     }
+    // Only fit view on fresh data load — skip when user has a node selected
+    // to avoid jarring viewport reset mid-focus-mode.
     if (!selectedNodeId) {
       requestAnimationFrame(() => fitView({ padding: 0.15, duration: 300 }));
     }
@@ -123,13 +125,14 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
       nodesConnectable={false}
       nodesDraggable={true}
       elementsSelectable={true}
+      onlyRenderVisibleElements={true}
       proOptions={{ hideAttribution: true }}
     >
       <Background gap={20} size={1} />
       <Controls showInteractive={false} />
     </ReactFlow>
   );
-}
+});
 
 export default function ReactFlowGraph(props: ReactFlowGraphProps) {
   return (

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -25,81 +25,51 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ nodes: inputNode
   const [edges, setEdges, onEdgesChange] = useEdgesState(inputEdges);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  // Build neighbor set helper
-  const buildNeighbors = useCallback((nodeId: string) => {
-    const s = new Set<string>([nodeId]);
-    for (const e of inputEdges) {
-      if (e.source === nodeId) s.add(e.target);
-      if (e.target === nodeId) s.add(e.source);
-    }
-    return s;
-  }, [inputEdges]);
-
-  // Sync nodes from props — also apply current focus state so dimming survives data refresh
+  // Single unified effect — handles data sync + focus mode + viewport in one pass.
+  // Previously split across 3 effects that all fired on selectedNodeId change,
+  // causing redundant double-setNodes and jarring viewport adjustments.
   useEffect(() => {
-    if (!selectedNodeId) {
-      setNodes(inputNodes.map((n) => ({
-        ...n,
-        data: { ...n.data, dimmed: false, focused: false },
-      })));
-    } else {
-      const neighbors = buildNeighbors(selectedNodeId);
-      setNodes(inputNodes.map((n) => ({
-        ...n,
-        data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
-      })));
-    }
-    // Only fit view on fresh data load — skip when user has a node selected
-    // to avoid jarring viewport reset mid-focus-mode.
-    if (!selectedNodeId) {
-      requestAnimationFrame(() => fitView({ padding: 0.15, duration: 300 }));
-    }
-  }, [inputNodes, setNodes, fitView, selectedNodeId, buildNeighbors]);
+    const neighbors = selectedNodeId
+      ? (() => {
+          const s = new Set<string>([selectedNodeId]);
+          for (const e of inputEdges) {
+            if (e.source === selectedNodeId) s.add(e.target);
+            if (e.target === selectedNodeId) s.add(e.source);
+          }
+          return s;
+        })()
+      : null;
 
-  // Sync edges from props
-  useEffect(() => {
-    setEdges(inputEdges);
-  }, [inputEdges, setEdges]);
+    // 1. Sync nodes + apply focus state in one pass
+    const newNodes = inputNodes.map((n) => ({
+      ...n,
+      data: neighbors
+        ? { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId }
+        : { ...n.data, dimmed: false, focused: false },
+    }));
+    setNodes(newNodes);
 
-  // Focus mode: dim/hide unrelated nodes (via data.dimmed) + fade edges
-  useEffect(() => {
-    if (!selectedNodeId) {
-      setEdges((eds) => eds.map((e) => ({
-        ...e, animated: false,
-        label: ((e.data as any)?.edgeType as string | undefined) ?? e.label,
-        style: { ...e.style, opacity: 0.6, strokeWidth: 2 },
-        labelStyle: { opacity: 1 },
-      })));
-      return;
-    }
-
-    const neighbors = buildNeighbors(selectedNodeId);
-
-    // Node dimming is handled via data.dimmed in each node component — no opacity on style
-    setNodes((nds) => {
-      const updated = nds.map((n) => ({
-        ...n,
-        data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
-      }));
-      // Zoom to fit selected + neighbors after state updates settle
-      requestAnimationFrame(() => {
-        fitView({
-          nodes: updated.filter(n => neighbors.has(n.id)),
-          padding: 0.4,
-          duration: 400,
-          maxZoom: 2,
-        });
-      });
-      return updated;
-    });
-
-    setEdges((eds) => eds.map((e) => {
+    // 2. Sync edges + apply focus highlighting in one pass
+    const edgeType = (e: Edge) => ((e.data as any)?.edgeType as string | undefined) ?? e.label;
+    setEdges(inputEdges.map((e) => {
+      if (!neighbors) {
+        return { ...e, animated: false, label: edgeType(e), style: { ...e.style, opacity: 0.6, strokeWidth: 2 }, labelStyle: { opacity: 1 } };
+      }
       const connected = e.source === selectedNodeId || e.target === selectedNodeId;
       return connected
-        ? { ...e, animated: true, label: ((e.data as any)?.edgeType as string | undefined) ?? e.label, style: { ...e.style, opacity: 0.9, strokeWidth: 3 }, labelStyle: { opacity: 1 } }
+        ? { ...e, animated: true, label: edgeType(e), style: { ...e.style, opacity: 0.9, strokeWidth: 3 }, labelStyle: { opacity: 1 } }
         : { ...e, animated: false, label: '', style: { ...e.style, opacity: 0.04, strokeWidth: 1 }, labelStyle: { opacity: 0 } };
     }));
-  }, [selectedNodeId, buildNeighbors, setNodes, setEdges, fitView]);
+
+    // 3. Viewport: fit to selection or fit full graph on data load
+    requestAnimationFrame(() => {
+      if (!neighbors) {
+        fitView({ padding: 0.15, duration: 300 });
+      } else {
+        fitView({ nodes: newNodes.filter(n => neighbors.has(n.id)), padding: 0.4, duration: 400, maxZoom: 2 });
+      }
+    });
+  }, [inputNodes, inputEdges, selectedNodeId, setNodes, setEdges, fitView]);
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -36,28 +36,41 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
     setEdges(inputEdges);
   }, [inputEdges, setEdges]);
 
-  // Edge highlighting on node selection
+  // Focus mode: dim nodes and edges not connected to selected node
   useEffect(() => {
     if (!selectedNodeId) {
-      setEdges((eds) =>
-        eds.map((e) => ({
-          ...e,
-          animated: false,
-          style: { ...e.style, opacity: 0.6, strokeWidth: 2 },
-        }))
-      );
+      setNodes((nds) => nds.map((n) => ({ ...n, style: { ...n.style, opacity: 1 } })));
+      setEdges((eds) => eds.map((e) => ({ ...e, animated: false, style: { ...e.style, opacity: 0.6, strokeWidth: 2 } })));
       return;
     }
+
+    // Build 1-hop neighbor set
+    const neighbors = new Set<string>([selectedNodeId]);
+    for (const e of inputEdges) {
+      if (e.source === selectedNodeId) neighbors.add(e.target);
+      if (e.target === selectedNodeId) neighbors.add(e.source);
+    }
+
+    setNodes((nds) =>
+      nds.map((n) => ({
+        ...n,
+        style: {
+          ...n.style,
+          opacity: neighbors.has(n.id) ? 1 : 0.08,
+          transition: 'opacity 0.15s ease',
+        },
+      }))
+    );
+
     setEdges((eds) =>
       eds.map((e) => {
         const connected = e.source === selectedNodeId || e.target === selectedNodeId;
-        if (connected) {
-          return { ...e, animated: true, style: { ...e.style, opacity: 0.9, strokeWidth: 3 } };
-        }
-        return { ...e, animated: false, style: { ...e.style, opacity: 0.15, strokeWidth: 1 } };
+        return connected
+          ? { ...e, animated: true, style: { ...e.style, opacity: 0.9, strokeWidth: 3 } }
+          : { ...e, animated: false, style: { ...e.style, opacity: 0.04, strokeWidth: 1 } };
       })
     );
-  }, [selectedNodeId, setEdges]);
+  }, [selectedNodeId, inputEdges, setNodes, setEdges]);
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -76,10 +76,22 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ nodes: inputNode
     const neighbors = buildNeighbors(selectedNodeId);
 
     // Node dimming is handled via data.dimmed in each node component — no opacity on style
-    setNodes((nds) => nds.map((n) => ({
-      ...n,
-      data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
-    })));
+    setNodes((nds) => {
+      const updated = nds.map((n) => ({
+        ...n,
+        data: { ...n.data, dimmed: !neighbors.has(n.id), focused: n.id === selectedNodeId },
+      }));
+      // Zoom to fit selected + neighbors after state updates settle
+      requestAnimationFrame(() => {
+        fitView({
+          nodes: updated.filter(n => neighbors.has(n.id)),
+          padding: 0.4,
+          duration: 400,
+          maxZoom: 2,
+        });
+      });
+      return updated;
+    });
 
     setEdges((eds) => eds.map((e) => {
       const connected = e.source === selectedNodeId || e.target === selectedNodeId;
@@ -87,7 +99,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ nodes: inputNode
         ? { ...e, animated: true, label: ((e.data as any)?.edgeType as string | undefined) ?? e.label, style: { ...e.style, opacity: 0.9, strokeWidth: 3 }, labelStyle: { opacity: 1 } }
         : { ...e, animated: false, label: '', style: { ...e.style, opacity: 0.04, strokeWidth: 1 }, labelStyle: { opacity: 0 } };
     }));
-  }, [selectedNodeId, buildNeighbors, setNodes, setEdges]);
+  }, [selectedNodeId, buildNeighbors, setNodes, setEdges, fitView]);
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -64,7 +64,7 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
     if (!selectedNodeId) {
       setEdges((eds) => eds.map((e) => ({
         ...e, animated: false,
-        label: e.data?.edgeType ?? e.label,
+        label: ((e.data as any)?.edgeType as string | undefined) ?? e.label,
         style: { ...e.style, opacity: 0.6, strokeWidth: 2 },
         labelStyle: { opacity: 1 },
       })));
@@ -82,7 +82,7 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
     setEdges((eds) => eds.map((e) => {
       const connected = e.source === selectedNodeId || e.target === selectedNodeId;
       return connected
-        ? { ...e, animated: true, label: e.data?.edgeType ?? e.label, style: { ...e.style, opacity: 0.9, strokeWidth: 3 }, labelStyle: { opacity: 1 } }
+        ? { ...e, animated: true, label: ((e.data as any)?.edgeType as string | undefined) ?? e.label, style: { ...e.style, opacity: 0.9, strokeWidth: 3 }, labelStyle: { opacity: 1 } }
         : { ...e, animated: false, label: '', style: { ...e.style, opacity: 0.04, strokeWidth: 1 }, labelStyle: { opacity: 0 } };
     }));
   }, [selectedNodeId, buildNeighbors, setNodes, setEdges]);

--- a/src/web/src/components/ReactFlowGraph.tsx
+++ b/src/web/src/components/ReactFlowGraph.tsx
@@ -63,7 +63,10 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
   useEffect(() => {
     if (!selectedNodeId) {
       setEdges((eds) => eds.map((e) => ({
-        ...e, animated: false, style: { ...e.style, opacity: 0.6, strokeWidth: 2 },
+        ...e, animated: false,
+        label: e.data?.edgeType ?? e.label,
+        style: { ...e.style, opacity: 0.6, strokeWidth: 2 },
+        labelStyle: { opacity: 1 },
       })));
       return;
     }
@@ -79,8 +82,8 @@ function ReactFlowGraphInner({ nodes: inputNodes, edges: inputEdges, onNodeClick
     setEdges((eds) => eds.map((e) => {
       const connected = e.source === selectedNodeId || e.target === selectedNodeId;
       return connected
-        ? { ...e, animated: true, style: { ...e.style, opacity: 0.9, strokeWidth: 3 } }
-        : { ...e, animated: false, style: { ...e.style, opacity: 0.04, strokeWidth: 1 } };
+        ? { ...e, animated: true, label: e.data?.edgeType ?? e.label, style: { ...e.style, opacity: 0.9, strokeWidth: 3 }, labelStyle: { opacity: 1 } }
+        : { ...e, animated: false, label: '', style: { ...e.style, opacity: 0.04, strokeWidth: 1 }, labelStyle: { opacity: 0 } };
     }));
   }, [selectedNodeId, buildNeighbors, setNodes, setEdges]);
 

--- a/src/web/src/components/nodes/DocumentNode.tsx
+++ b/src/web/src/components/nodes/DocumentNode.tsx
@@ -7,9 +7,20 @@ export type DocumentNodeData = {
   label: string;
   fullPath: string;
   color: string;
+  dimmed?: boolean;
+  focused?: boolean;
 };
 
 const DocumentNode = memo(function DocumentNode({ data }: { data: DocumentNodeData }) {
+  if (data.dimmed) {
+    return (
+      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2 }}>
+        <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
+        <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
+      </div>
+    );
+  }
+
   return (
     <div
       className="px-3 py-1.5 cursor-grab"
@@ -17,6 +28,7 @@ const DocumentNode = memo(function DocumentNode({ data }: { data: DocumentNodeDa
         background: `${data.color}18`,
         border: `2px solid ${data.color}`,
         borderRadius: 10,
+        boxShadow: data.focused ? `0 0 0 3px ${data.color}60` : undefined,
       }}
     >
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />

--- a/src/web/src/components/nodes/DocumentNode.tsx
+++ b/src/web/src/components/nodes/DocumentNode.tsx
@@ -14,7 +14,7 @@ export type DocumentNodeData = {
 const DocumentNode = memo(function DocumentNode({ data }: { data: DocumentNodeData }) {
   if (data.dimmed) {
     return (
-      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2 }}>
+      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2, pointerEvents: 'none' }}>
         <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
         <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
       </div>

--- a/src/web/src/components/nodes/EntityNode.tsx
+++ b/src/web/src/components/nodes/EntityNode.tsx
@@ -12,20 +12,35 @@ export type EntityNodeData = {
   firstLearnedAt?: string | null;
   lastConfirmedAt?: string | null;
   contradictedAt?: string | null;
+  dimmed?: boolean;
+  focused?: boolean;
 };
 
 const EntityNode = memo(function EntityNode({ data }: { data: EntityNodeData }) {
   const tc = TYPE_COLORS[data.entityType] || DEFAULT_TYPE_COLOR;
-  const t = tc.dark; // nano-brain UI is dark-only
+  const t = tc.dark;
   const isHub = data.degree >= 4;
+
+  // Collapsed dot for unrelated nodes — no label, no space taken by text
+  if (data.dimmed) {
+    return (
+      <div style={{ width: 10, height: 10, borderRadius: '50%', background: tc.border, opacity: 0.2 }}>
+        <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
+        <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
+      </div>
+    );
+  }
+
   return (
     <div
       className="px-4 py-1.5 cursor-grab"
       style={{
         background: t.bg,
-        border: `2px solid ${tc.border}`,
+        border: `2px solid ${data.focused ? '#fff' : tc.border}`,
         borderRadius: 20,
-        boxShadow: isHub ? `0 0 8px ${tc.border}40` : undefined,
+        boxShadow: data.focused
+          ? `0 0 0 3px ${tc.border}80, 0 0 12px ${tc.border}60`
+          : isHub ? `0 0 8px ${tc.border}40` : undefined,
       }}
     >
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />

--- a/src/web/src/components/nodes/EntityNode.tsx
+++ b/src/web/src/components/nodes/EntityNode.tsx
@@ -24,7 +24,7 @@ const EntityNode = memo(function EntityNode({ data }: { data: EntityNodeData }) 
   // Collapsed dot for unrelated nodes — no label, no space taken by text
   if (data.dimmed) {
     return (
-      <div style={{ width: 10, height: 10, borderRadius: '50%', background: tc.border, opacity: 0.2 }}>
+      <div style={{ width: 10, height: 10, borderRadius: '50%', background: tc.border, opacity: 0.2, pointerEvents: 'none' }}>
         <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
         <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
       </div>

--- a/src/web/src/components/nodes/FileNode.tsx
+++ b/src/web/src/components/nodes/FileNode.tsx
@@ -9,9 +9,20 @@ export type FileNodeData = {
   clusterId: number | null;
   color: string;
   centrality: number;
+  dimmed?: boolean;
+  focused?: boolean;
 };
 
 const FileNode = memo(function FileNode({ data }: { data: FileNodeData }) {
+  if (data.dimmed) {
+    return (
+      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2 }}>
+        <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
+        <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
+      </div>
+    );
+  }
+
   return (
     <div
       className="px-3 py-1 cursor-grab"
@@ -19,6 +30,7 @@ const FileNode = memo(function FileNode({ data }: { data: FileNodeData }) {
         background: `${data.color}20`,
         border: `2px solid ${data.color}`,
         borderRadius: 8,
+        boxShadow: data.focused ? `0 0 0 3px ${data.color}60` : undefined,
       }}
     >
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />

--- a/src/web/src/components/nodes/FileNode.tsx
+++ b/src/web/src/components/nodes/FileNode.tsx
@@ -16,7 +16,7 @@ export type FileNodeData = {
 const FileNode = memo(function FileNode({ data }: { data: FileNodeData }) {
   if (data.dimmed) {
     return (
-      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2 }}>
+      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2, pointerEvents: 'none' }}>
         <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
         <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
       </div>

--- a/src/web/src/components/nodes/SymbolNode.tsx
+++ b/src/web/src/components/nodes/SymbolNode.tsx
@@ -10,9 +10,20 @@ export type SymbolNodeData = {
   filePath?: string;
   startLine?: number;
   clusterId?: number | null;
+  dimmed?: boolean;
+  focused?: boolean;
 };
 
 const SymbolNode = memo(function SymbolNode({ data }: { data: SymbolNodeData }) {
+  if (data.dimmed) {
+    return (
+      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2 }}>
+        <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
+        <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
+      </div>
+    );
+  }
+
   return (
     <div
       className="px-3 py-1 cursor-grab"
@@ -20,6 +31,7 @@ const SymbolNode = memo(function SymbolNode({ data }: { data: SymbolNodeData }) 
         background: `${data.color}18`,
         border: `2px solid ${data.color}`,
         borderRadius: 12,
+        boxShadow: data.focused ? `0 0 0 3px ${data.color}60` : undefined,
       }}
     >
       <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />

--- a/src/web/src/components/nodes/SymbolNode.tsx
+++ b/src/web/src/components/nodes/SymbolNode.tsx
@@ -17,7 +17,7 @@ export type SymbolNodeData = {
 const SymbolNode = memo(function SymbolNode({ data }: { data: SymbolNodeData }) {
   if (data.dimmed) {
     return (
-      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2 }}>
+      <div style={{ width: 8, height: 8, borderRadius: '50%', background: data.color, opacity: 0.2, pointerEvents: 'none' }}>
         <Handle type="target" position={Position.Top} style={HANDLE_STYLE} />
         <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} />
       </div>

--- a/src/web/src/lib/graph-adapter.ts
+++ b/src/web/src/lib/graph-adapter.ts
@@ -41,11 +41,12 @@ function computeForceLayout(
     .force('collide', forceCollide().radius(collideBase).strength(1.0).iterations(4))
     .stop();
 
-  // Run enough ticks to reach equilibrium; add extra passes for dense graphs
-  // where collision resolution needs more iterations to stabilise.
+  // Cap ticks at 200 — beyond that, layout quality improvement is marginal
+  // vs the synchronous blocking cost (~0.3ms/tick × 359 = 108ms for n=500).
   const baseTicks = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay()));
-  const extraTicks = n > 100 ? 60 : n > 50 ? 40 : 20;
-  for (let i = 0; i < baseTicks + extraTicks; i++) simulation.tick();
+  const extraTicks = n > 100 ? 40 : n > 50 ? 20 : 10;
+  const totalTicks = Math.min(baseTicks + extraTicks, 200);
+  for (let i = 0; i < totalTicks; i++) simulation.tick();
 
   return nodes.map((nd, i) => ({
     ...nd,
@@ -168,10 +169,12 @@ export function buildCodeGraph(
 
 // ---------- Symbol call graph ----------
 
+const SYMBOL_NODE_LIMIT = 300;
+
 export function buildSymbolGraph(
   data: SymbolsResponse,
   clusterMode: boolean
-): { nodes: Node[]; edges: Edge[] } {
+): { nodes: Node[]; edges: Edge[]; truncated?: { shown: number; total: number } } {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 
@@ -267,7 +270,18 @@ export function buildSymbolGraph(
       });
     }
   } else {
-    for (const sym of data.symbols) {
+    // Cap at SYMBOL_NODE_LIMIT — sort by call degree (most-connected first)
+    const degreeMap = new Map<number, number>();
+    for (const e of data.edges) {
+      degreeMap.set(e.sourceId, (degreeMap.get(e.sourceId) || 0) + 1);
+      degreeMap.set(e.targetId, (degreeMap.get(e.targetId) || 0) + 1);
+    }
+    const sortedSymbols = [...data.symbols]
+      .sort((a, b) => (degreeMap.get(b.id) || 0) - (degreeMap.get(a.id) || 0))
+      .slice(0, SYMBOL_NODE_LIMIT);
+    const visibleIds = new Set(sortedSymbols.map(s => s.id));
+
+    for (const sym of sortedSymbols) {
       nodes.push({
         id: String(sym.id),
         type: 'symbol',
@@ -285,6 +299,7 @@ export function buildSymbolGraph(
 
     const seenEdges = new Set<string>();
     for (const edge of data.edges) {
+      if (!visibleIds.has(edge.sourceId) || !visibleIds.has(edge.targetId)) continue;
       const src = String(edge.sourceId);
       const tgt = String(edge.targetId);
       const key = `${src}->${tgt}`;
@@ -294,7 +309,7 @@ export function buildSymbolGraph(
         id: `e-${edge.id}`,
         source: src,
         target: tgt,
-        label: edge.edgeType,
+        label: '', // hidden by default; shown in focus mode via ReactFlowGraph
         data: { edgeType: edge.edgeType },
         animated: false,
         style: {
@@ -304,6 +319,12 @@ export function buildSymbolGraph(
         },
       });
     }
+
+    const truncated = data.symbols.length > SYMBOL_NODE_LIMIT
+      ? { shown: SYMBOL_NODE_LIMIT, total: data.symbols.length }
+      : undefined;
+    const positioned = computeForceLayout(nodes, edges, { width: 1800, height: 1200 });
+    return { nodes: positioned, edges, truncated };
   }
 
   const positioned = computeForceLayout(nodes, edges, { width: 1800, height: 1200 });

--- a/src/web/src/lib/graph-adapter.ts
+++ b/src/web/src/lib/graph-adapter.ts
@@ -58,8 +58,8 @@ function computeForceLayout(
 
 export function buildEntityGraph(
   data: GraphEntitiesResponse,
-  nodeLimit = 500
-): { nodes: Node[]; edges: Edge[] } {
+  nodeLimit = 300
+): { nodes: Node[]; edges: Edge[]; truncated?: { shown: number; total: number } } {
   const edgeCounts = new Map<number, number>();
   for (const edge of data.edges) {
     edgeCounts.set(edge.sourceId, (edgeCounts.get(edge.sourceId) || 0) + 1);
@@ -119,17 +119,28 @@ export function buildEntityGraph(
   const edges: Edge[] = Array.from(seenPairs.values());
 
   const positioned = computeForceLayout(nodes, edges);
-  return { nodes: positioned, edges };
+  const truncated = data.nodes.length > nodeLimit
+    ? { shown: sortedNodes.length, total: data.nodes.length }
+    : undefined;
+  return { nodes: positioned, edges, truncated };
 }
 
 // ---------- Code dependency graph ----------
+
+const CODE_NODE_LIMIT = 300;
 
 export function buildCodeGraph(
   files: Array<{ path: string; centrality: number; clusterId: number | null }>,
   rawEdges: Array<{ source: string; target: string }>,
   clusterColors: Record<number, string>
-): { nodes: Node[]; edges: Edge[] } {
-  const nodes: Node[] = files.map((file) => {
+): { nodes: Node[]; edges: Edge[]; truncated?: { shown: number; total: number } } {
+  // Sort by centrality DESC, cap to avoid browser freeze on large codebases
+  const sortedFiles = [...files].sort((a, b) => b.centrality - a.centrality).slice(0, CODE_NODE_LIMIT);
+  const truncated = files.length > CODE_NODE_LIMIT
+    ? { shown: sortedFiles.length, total: files.length }
+    : undefined;
+
+  const nodes: Node[] = sortedFiles.map((file) => {
     const clusterColor = file.clusterId !== null ? clusterColors[file.clusterId] : '#64748b';
     return {
       id: file.path,
@@ -145,7 +156,7 @@ export function buildCodeGraph(
     };
   });
 
-  const nodeIds = new Set(files.map((f) => f.path));
+  const nodeIds = new Set(sortedFiles.map((f) => f.path));
   const seenEdges = new Set<string>();
   const edges: Edge[] = [];
   for (const edge of rawEdges) {
@@ -164,7 +175,7 @@ export function buildCodeGraph(
   }
 
   const positioned = computeForceLayout(nodes, edges, { width: 1600, height: 1000 });
-  return { nodes: positioned, edges };
+  return { nodes: positioned, edges, truncated };
 }
 
 // ---------- Symbol call graph ----------
@@ -333,13 +344,36 @@ export function buildSymbolGraph(
 
 // ---------- Connection graph ----------
 
+const CONNECTION_NODE_LIMIT = 300;
+
 export function buildConnectionGraph(
-  data: ConnectionsResponse
-): { nodes: Node[]; edges: Edge[] } {
+  data: ConnectionsResponse,
+  nodeLimit = CONNECTION_NODE_LIMIT
+): { nodes: Node[]; edges: Edge[]; truncated?: { shown: number; total: number } } {
+  // Count connections per document to sort most-connected first
+  const connCount = new Map<string, number>();
+  for (const conn of data.connections) {
+    const f = String(conn.from_doc_id);
+    const t = String(conn.to_doc_id);
+    connCount.set(f, (connCount.get(f) || 0) + 1);
+    connCount.set(t, (connCount.get(t) || 0) + 1);
+  }
+
+  // Keep only top-N document IDs by connection count
+  const allDocIds = [...connCount.entries()].sort((a, b) => b[1] - a[1]).map(e => e[0]);
+  const totalDocs = allDocIds.length;
+  const visibleIds = new Set(allDocIds.slice(0, nodeLimit));
+  const truncated = totalDocs > nodeLimit ? { shown: visibleIds.size, total: totalDocs } : undefined;
+
+  // Only use connections where both endpoints are in the visible set
+  const visibleConns = data.connections.filter(
+    c => visibleIds.has(String(c.from_doc_id)) && visibleIds.has(String(c.to_doc_id))
+  );
+
   const docNodes = new Map<string, Node>();
   const seenPairs = new Map<string, Edge>();
 
-  for (const conn of data.connections) {
+  for (const conn of visibleConns) {
     const fromId = String(conn.from_doc_id);
     const toId = String(conn.to_doc_id);
 
@@ -395,7 +429,7 @@ export function buildConnectionGraph(
   const nodes = Array.from(docNodes.values());
   const edges = Array.from(seenPairs.values());
   const positioned = computeForceLayout(nodes, edges, { width: 800, height: 500 });
-  return { nodes: positioned, edges };
+  return { nodes: positioned, edges, truncated };
 }
 
 // ---------- Utility ----------

--- a/src/web/src/lib/graph-adapter.ts
+++ b/src/web/src/lib/graph-adapter.ts
@@ -18,10 +18,12 @@ function computeForceLayout(
   const w = opts.width ?? 1400;
   const h = opts.height ?? 900;
   const n = nodes.length;
-  const linkDist = opts.linkDistance ?? (n > 100 ? 220 : n > 50 ? 180 : n > 20 ? 160 : 140);
-  const charge = opts.chargeStrength ?? (n > 100 ? -500 : n > 50 ? -400 : n > 20 ? -320 : -260);
+  const linkDist = opts.linkDistance ?? (n > 100 ? 260 : n > 50 ? 220 : n > 20 ? 190 : 160);
+  const charge = opts.chargeStrength ?? (n > 100 ? -700 : n > 50 ? -550 : n > 20 ? -420 : -320);
   const centerPull = n > 100 ? 0.02 : n > 50 ? 0.03 : 0.04;
-  const collideBase = n > 100 ? 70 : n > 50 ? 65 : n > 20 ? 60 : 55;
+  // Collision radius must be large enough to cover node circle + label text.
+  // Strength=1.0 enforces hard exclusion — no two nodes can overlap at rest.
+  const collideBase = n > 100 ? 110 : n > 50 ? 100 : n > 20 ? 90 : 80;
 
   const simNodes: SimNode[] = nodes.map((nd) => ({
     id: nd.id,
@@ -36,11 +38,14 @@ function computeForceLayout(
     .force('center', forceCenter(w / 2, h / 2))
     .force('x', forceX(w / 2).strength(centerPull))
     .force('y', forceY(h / 2).strength(centerPull))
-    .force('collide', forceCollide().radius(collideBase).strength(0.7))
+    .force('collide', forceCollide().radius(collideBase).strength(1.0).iterations(4))
     .stop();
 
-  const ticks = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay()));
-  for (let i = 0; i < ticks; i++) simulation.tick();
+  // Run enough ticks to reach equilibrium; add extra passes for dense graphs
+  // where collision resolution needs more iterations to stabilise.
+  const baseTicks = Math.ceil(Math.log(simulation.alphaMin()) / Math.log(1 - simulation.alphaDecay()));
+  const extraTicks = n > 100 ? 60 : n > 50 ? 40 : 20;
+  for (let i = 0; i < baseTicks + extraTicks; i++) simulation.tick();
 
   return nodes.map((nd, i) => ({
     ...nd,

--- a/src/web/src/lib/graph-adapter.ts
+++ b/src/web/src/lib/graph-adapter.ts
@@ -176,19 +176,36 @@ export function buildSymbolGraph(
   const edges: Edge[] = [];
 
   if (clusterMode && data.clusters.length > 0) {
+    // Derive a human-readable label for each cluster from the most common file basename
+    const clusterFileCount = new Map<number, Map<string, number>>();
+    for (const sym of data.symbols) {
+      if (sym.clusterId == null || !sym.filePath) continue;
+      const base = sym.filePath.split('/').pop() ?? sym.filePath;
+      const m = clusterFileCount.get(sym.clusterId) ?? new Map<string, number>();
+      m.set(base, (m.get(base) ?? 0) + 1);
+      clusterFileCount.set(sym.clusterId, m);
+    }
+    const clusterLabel = (id: number, memberCount: number) => {
+      const m = clusterFileCount.get(id);
+      if (!m) return `Group ${id} (${memberCount})`;
+      const topFile = [...m.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? '';
+      return `${topFile} group (${memberCount})`;
+    };
+
     for (const cluster of data.clusters) {
       nodes.push({
         id: `cluster-${cluster.clusterId}`,
         type: 'symbol',
         position: { x: 0, y: 0 },
         data: {
-          label: `Cluster ${cluster.clusterId} (${cluster.memberCount})`,
+          label: clusterLabel(cluster.clusterId, cluster.memberCount),
           entityType: 'cluster',
           color: fallbackColors[cluster.clusterId % fallbackColors.length],
         },
       });
     }
 
+    // Symbols without a cluster show as individual nodes
     for (const sym of data.symbols) {
       if (sym.clusterId === null) {
         nodes.push({
@@ -206,15 +223,37 @@ export function buildSymbolGraph(
       }
     }
 
-    const clusterEdges = new Map<string, number>();
     const symbolById = new Map(data.symbols.map((sym) => [sym.id, sym]));
+    const clusterEdges = new Map<string, number>();
+    const seenSymEdges = new Set<string>();
+
     for (const edge of data.edges) {
       const src = symbolById.get(edge.sourceId);
       const tgt = symbolById.get(edge.targetId);
-      if (!src || !tgt || src.clusterId == null || tgt.clusterId == null) continue;
-      if (src.clusterId === tgt.clusterId) continue;
-      const key = `cluster-${src.clusterId}||cluster-${tgt.clusterId}`;
-      clusterEdges.set(key, (clusterEdges.get(key) || 0) + 1);
+      if (!src || !tgt) continue;
+
+      const srcNode = src.clusterId != null ? `cluster-${src.clusterId}` : String(src.id);
+      const tgtNode = tgt.clusterId != null ? `cluster-${tgt.clusterId}` : String(tgt.id);
+      if (srcNode === tgtNode) continue; // skip intra-cluster / self
+
+      if (src.clusterId != null || tgt.clusterId != null) {
+        // At least one side is clustered → aggregate as cluster edge
+        const key = `${srcNode}||${tgtNode}`;
+        clusterEdges.set(key, (clusterEdges.get(key) || 0) + 1);
+      } else {
+        // Both unclustered → draw individual symbol edge
+        const key = `${srcNode}->${tgtNode}`;
+        if (seenSymEdges.has(key)) continue;
+        seenSymEdges.add(key);
+        edges.push({
+          id: `e-${edge.id}`,
+          source: srcNode,
+          target: tgtNode,
+          label: edge.edgeType,
+          animated: false,
+          style: { stroke: edgeTypeColorMap[edge.edgeType] || 'rgba(148,163,184,0.3)', strokeWidth: 1, opacity: 0.5 },
+        });
+      }
     }
     for (const [key, count] of clusterEdges) {
       const [srcNode, tgtNode] = key.split('||');

--- a/src/web/src/views/CodeGraph.tsx
+++ b/src/web/src/views/CodeGraph.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { type NodeTypes } from '@xyflow/react';
 import ReactFlowGraph from '../components/ReactFlowGraph';
+import GraphShell from '../components/GraphShell';
 import NodeDetail from '../components/NodeDetail';
 import QueryStatus from '../components/QueryStatus';
 import { SkeletonGraph } from '../components/Skeleton';
@@ -63,7 +64,7 @@ export default function CodeGraph() {
         {isLoading ? (
           <SkeletonGraph />
         ) : (
-          <div className="card graph-shell overflow-hidden">
+          <GraphShell truncated={graphData?.truncated} unit="files">
             {graphData ? (
               <ReactFlowGraph
                 nodes={graphData.nodes}
@@ -74,7 +75,7 @@ export default function CodeGraph() {
             ) : (
               <QueryStatus isLoading={false} isError={false} isEmpty={true} emptyText="No dependency data." />
             )}
-          </div>
+          </GraphShell>
         )}
         <div className="space-y-4">
           {selectedFile ? (

--- a/src/web/src/views/ConnectionsView.tsx
+++ b/src/web/src/views/ConnectionsView.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { type NodeTypes } from '@xyflow/react';
 import ReactFlowGraph from '../components/ReactFlowGraph';
+import GraphShell from '../components/GraphShell';
 import NodeDetail from '../components/NodeDetail';
 import QueryStatus from '../components/QueryStatus';
 import { SkeletonGraph } from '../components/Skeleton';
@@ -22,42 +23,22 @@ export default function ConnectionsView() {
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
 
   const allConnections = data?.connections ?? [];
-  const nodeLimit = 500;
 
-  const limitedConnections = useMemo(() => {
-    if (!allConnections.length) return [];
-    const nodes = new Set<string>();
-    const limited: typeof allConnections = [];
-    for (const conn of allConnections) {
-      const fromId = String(conn.from_doc_id);
-      const toId = String(conn.to_doc_id);
-      const hasFrom = nodes.has(fromId);
-      const hasTo = nodes.has(toId);
-      const nextSize = nodes.size + (hasFrom ? 0 : 1) + (hasTo ? 0 : 1);
-      const allowNewNodes = nodes.size < nodeLimit && nextSize <= nodeLimit;
-      if ((hasFrom && hasTo) || allowNewNodes) {
-        nodes.add(fromId);
-        nodes.add(toId);
-        limited.push(conn);
-      }
-    }
-    return limited;
+  // buildConnectionGraph handles capping + sorting — pass all connections
+  const graphData = useMemo(() => {
+    if (!allConnections.length) return null;
+    return buildConnectionGraph({ connections: allConnections });
   }, [allConnections]);
 
-  const graphData = useMemo(() => {
-    if (!limitedConnections.length) return null;
-    return buildConnectionGraph({ connections: limitedConnections });
-  }, [limitedConnections]);
-
   const selectedConnections = selectedNode
-    ? limitedConnections.filter(
+    ? allConnections.filter(
         (conn) => String(conn.from_doc_id) === selectedNode || String(conn.to_doc_id) === selectedNode
       )
     : [];
 
   const selectedMeta = useMemo(() => {
-    if (!selectedNode || !limitedConnections.length) return null;
-    const match = limitedConnections.find(
+    if (!selectedNode || !allConnections.length) return null;
+    const match = allConnections.find(
       (conn) => String(conn.from_doc_id) === selectedNode || String(conn.to_doc_id) === selectedNode
     );
     if (!match) return null;
@@ -65,15 +46,15 @@ export default function ConnectionsView() {
       return { title: match.from_title, path: match.from_path };
     }
     return { title: match.to_title, path: match.to_path };
-  }, [selectedNode, limitedConnections]);
+  }, [selectedNode, allConnections]);
 
   const relationshipStats = useMemo(() => {
     const counts = new Map<string, number>();
-    limitedConnections.forEach((conn) => counts.set(conn.relationship_type, (counts.get(conn.relationship_type) || 0) + 1));
+    allConnections.forEach((conn) => counts.set(conn.relationship_type, (counts.get(conn.relationship_type) || 0) + 1));
     return Object.fromEntries(counts.entries());
-  }, [limitedConnections]);
+  }, [allConnections]);
 
-  const displayedConnections = useMemo(() => {
+  const displayedConnections = useMemo<Array<{id: number|string; type: string; strength: number; target: string|number; targetPath: string; direction: string}>>(() => {
     if (!selectedNode) return [];
     return selectedConnections.map((conn) => {
       const isFrom = String(conn.from_doc_id) === selectedNode;
@@ -97,13 +78,11 @@ export default function ConnectionsView() {
     []
   );
 
-  const nodeIds = new Set<string>();
-  allConnections.forEach((conn) => {
-    nodeIds.add(String(conn.from_doc_id));
-    nodeIds.add(String(conn.to_doc_id));
-  });
-  const nodeCount = nodeIds.size;
-  const isLimited = nodeCount > nodeLimit;
+  const nodeCount = useMemo(() => {
+    const ids = new Set<string>();
+    allConnections.forEach(c => { ids.add(String(c.from_doc_id)); ids.add(String(c.to_doc_id)); });
+    return ids.size;
+  }, [allConnections]);
 
   const handleNodeClick = (nodeId: string) => {
     setSelectedNode(nodeId || null);
@@ -119,7 +98,6 @@ export default function ConnectionsView() {
         <div className="text-right text-xs text-[#8888a0]">
           <p>Connections: {allConnections.length || 0}</p>
           <p>Documents: {nodeCount || 0}</p>
-          {isLimited && <p className="text-[#f97316]">Showing first {nodeLimit} documents</p>}
         </div>
       </div>
 
@@ -129,7 +107,7 @@ export default function ConnectionsView() {
         {isLoading ? (
           <SkeletonGraph />
         ) : (
-          <div className="card graph-shell overflow-hidden">
+          <GraphShell truncated={graphData?.truncated} unit="documents">
             {graphData ? (
               <ReactFlowGraph
                 nodes={graphData.nodes}
@@ -140,7 +118,7 @@ export default function ConnectionsView() {
             ) : (
               <QueryStatus isLoading={false} isError={false} isEmpty={true} emptyText="No document connections found. Use the 'memory_connect' tool or MCP 'connect' command to create relationships between memory documents." />
             )}
-          </div>
+          </GraphShell>
         )}
         <div className="space-y-4">
           {selectedMeta ? (

--- a/src/web/src/views/GraphExplorer.tsx
+++ b/src/web/src/views/GraphExplorer.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { type NodeTypes } from '@xyflow/react';
 import ReactFlowGraph from '../components/ReactFlowGraph';
+import GraphShell from '../components/GraphShell';
 import EntityDetailPanel from '../components/EntityDetailPanel';
 import QueryStatus from '../components/QueryStatus';
 import { SkeletonGraph } from '../components/Skeleton';
@@ -117,7 +118,7 @@ export default function GraphExplorer() {
         {isLoading ? (
           <SkeletonGraph />
         ) : viewMode === 'graph' ? (
-          <div className="card graph-shell overflow-hidden">
+          <GraphShell truncated={graphData?.truncated} unit="entities">
             {graphData ? (
               <ReactFlowGraph
                 nodes={graphData.nodes}
@@ -128,7 +129,7 @@ export default function GraphExplorer() {
             ) : (
               <QueryStatus isLoading={false} isError={false} isEmpty={true} emptyText="No graph data available." />
             )}
-          </div>
+          </GraphShell>
         ) : (
           /* Table view */
           <div className="card overflow-hidden">

--- a/src/web/src/views/SymbolGraph.tsx
+++ b/src/web/src/views/SymbolGraph.tsx
@@ -76,7 +76,12 @@ export default function SymbolGraph() {
         {isLoading ? (
           <SkeletonGraph />
         ) : (
-          <div className="card graph-shell overflow-hidden">
+          <div className="card graph-shell overflow-hidden relative">
+            {graphData?.truncated && (
+              <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 px-3 py-1 rounded-full bg-[#1c1c27]/90 border border-[#3a3a5c] text-[11px] text-[#8888a0]">
+                Showing top {graphData.truncated.shown} of {graphData.truncated.total.toLocaleString()} symbols by call degree
+              </div>
+            )}
             {graphData && (data?.symbols.length ?? 0) > 0 ? (
               <ReactFlowGraph
                 nodes={graphData.nodes}

--- a/src/web/src/views/SymbolGraph.tsx
+++ b/src/web/src/views/SymbolGraph.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { type NodeTypes } from '@xyflow/react';
 import ReactFlowGraph from '../components/ReactFlowGraph';
+import GraphShell from '../components/GraphShell';
 import NodeDetail from '../components/NodeDetail';
 import QueryStatus from '../components/QueryStatus';
 import { SkeletonGraph } from '../components/Skeleton';
@@ -76,12 +77,7 @@ export default function SymbolGraph() {
         {isLoading ? (
           <SkeletonGraph />
         ) : (
-          <div className="card graph-shell overflow-hidden relative">
-            {graphData?.truncated && (
-              <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 px-3 py-1 rounded-full bg-[#1c1c27]/90 border border-[#3a3a5c] text-[11px] text-[#8888a0]">
-                Showing top {graphData.truncated.shown} of {graphData.truncated.total.toLocaleString()} symbols by call degree
-              </div>
-            )}
+          <GraphShell truncated={graphData?.truncated} unit="symbols">
             {graphData && (data?.symbols.length ?? 0) > 0 ? (
               <ReactFlowGraph
                 nodes={graphData.nodes}
@@ -97,7 +93,7 @@ export default function SymbolGraph() {
                 emptyText="No symbol data available. Run 'npx nano-brain index-codebase' to index symbols, or the code_symbols table may need repair (check DB integrity)."
               />
             )}
-          </div>
+          </GraphShell>
         )}
         <div className="space-y-4">
           {selectedSymbol ? (

--- a/src/web/src/views/SymbolGraph.tsx
+++ b/src/web/src/views/SymbolGraph.tsx
@@ -20,7 +20,7 @@ export default function SymbolGraph() {
     queryFn: () => fetchSymbols(workspace),
   });
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
-  const [clusterMode, setClusterMode] = useState(true);
+  const [clusterMode, setClusterMode] = useState(false);
 
   const autoCluster = (data?.symbols.length ?? 0) > 500;
   const useCluster = clusterMode && autoCluster;


### PR DESCRIPTION
## Summary

Major improvements across graph visualization, performance, Obsidian integration, and database reliability.

### Graph UX & Performance
- **Focus mode**: clicking a node collapses unrelated nodes to tiny dots (no label overlap), auto-zooms to selection + neighbors
- **Virtual rendering**: `onlyRenderVisibleElements=true` — only renders nodes in viewport
- **Node caps**: all 4 graph views capped at 300 nodes (sorted by degree/centrality) — prevents browser freeze on large graphs (Symbol Graph: 16,604→300)
- **d3-force tick cap**: max 200 ticks (was 359), saves ~50ms blocking for large graphs
- **Shared `GraphShell` component**: truncation banner + container unified across all views
- **Symbol Graph default**: individual mode (not cluster), with meaningful cluster labels
- **Edge labels**: hidden by default in focus mode

### Obsidian Integration
- Auto-detect Obsidian vaults via `.obsidian/` directory or collection name
- `[[WikiLink]]` extraction → `memory_connections` edges
- `parseFrontmatter` via `yaml.parse()` (handles quoted commas, nested arrays)
- Frontmatter tags stored in `document_tags` on index
- `excludeFolders` config field (skip `.trash`, `templates`, `attachments`)

### SQLite Corruption Root Causes Fixed
- `corruption-recovery.ts`: open DB `readonly: true` for integrity check — eliminates false-positive corruption detection (pragma writes were causing spurious failures)
- `wal_checkpoint(PASSIVE)` → `wal_checkpoint(RESTART)` in shutdown — ensures WAL is fully flushed before process exit
- Docker `stop_grace_period: 30s` — prevents SIGKILL mid-checkpoint

### db:clean CLI
- `node bin/cli.js db:clean --list-only` — inspect orphaned DBs
- `node bin/cli.js db:clean --dry-run` — preview deletion
- `node bin/cli.js db:clean --confirm` — delete orphaned DBs + WAL/SHM + corrupted backups

### Watcher Improvements (Gemini review)
- `processObsidianWikiLinks`: streaming `.iterate()` instead of `.all()` (prevents OOM)
- Startup reindex via chokidar `ready` event (not hardcoded 5s delay)
- `fs.existsSync` → `fs.promises.access` in async loops

## Files Changed
- `src/db/corruption-recovery.ts` — readonly check, remove applyPragmas before check
- `src/server/bootstrap.ts` — RESTART checkpoint, workspace warning
- `src/store/index.ts` — RESTART checkpoint in cached stores
- `src/jobs/watcher.ts` — Obsidian WikiLink, entity extraction, yaml parser, streaming
- `src/cli/commands/db-clean.ts` — new db:clean command
- `src/web/src/components/GraphShell.tsx` — new shared component
- `src/web/src/components/ReactFlowGraph.tsx` — focus mode, memo, virtual render
- `src/web/src/components/nodes/*.tsx` — dimmed/focused state
- `src/web/src/lib/graph-adapter.ts` — node caps, sort-by-degree, cluster fixes
- `src/web/src/views/*.tsx` — GraphShell adoption
- `docker-compose.yml` — stop_grace_period: 30s
- `test/rri-t-round5.test.ts`, `test/rri-t-round6.test.ts`, `test/rri-t-round7.test.ts` — 86 new tests

## Test Plan
- [ ] `npx vitest run test/rri-t-round5.test.ts test/rri-t-round6.test.ts test/rri-t-round7.test.ts` → 86 pass
- [ ] Knowledge Graph: click node → dimming + auto-zoom
- [ ] Symbol Graph: shows "top 300 of N symbols" banner
- [ ] Code Dependencies: shows "top 300 of N files" banner
- [ ] `docker compose restart` → no SQLITE_CORRUPT errors
- [ ] `node bin/cli.js db:clean --dry-run` → lists orphaned DBs