### PR TITLE
feat: Story 2.2 — API middleware (workspace validation, content-type)

### DIFF
--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrWorkspaceRequired is returned when a workspace is required but not provided.
 var ErrWorkspaceRequired = errors.New("workspace is required")
+
+// ErrUnsupportedMediaType is returned when the request Content-Type is not application/json.
+var ErrUnsupportedMediaType = errors.New("Content-Type must be application/json")

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,8 +1,12 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 )
@@ -18,6 +22,69 @@ func versionHeaderMiddleware(version string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			c.Response().Header().Set(versionHeader, version)
+			return next(c)
+		}
+	}
+}
+
+func workspaceMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var workspace string
+
+			method := c.Request().Method
+			if method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch {
+				body, err := io.ReadAll(c.Request().Body)
+				if err != nil {
+					return echo.NewHTTPError(http.StatusBadRequest, "failed to read request body")
+				}
+				c.Request().Body = io.NopCloser(bytes.NewReader(body))
+
+				var req struct {
+					Workspace string `json:"workspace"`
+				}
+				_ = json.Unmarshal(body, &req)
+				workspace = req.Workspace
+			} else {
+				workspace = c.QueryParam("workspace")
+			}
+
+			if workspace == "" {
+				return c.JSON(http.StatusBadRequest, map[string]string{
+					"error":   "workspace_required",
+					"message": "A workspace identifier is required. Pass workspace in request body (POST) or query string (GET). Use 'all' for cross-workspace queries.",
+				})
+			}
+
+			c.Set("workspace", workspace)
+			return next(c)
+		}
+	}
+}
+
+func contentTypeMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			method := c.Request().Method
+			if method != http.MethodPost && method != http.MethodPut && method != http.MethodPatch {
+				return next(c)
+			}
+
+			r := c.Request()
+			hasBody := r.ContentLength > 0 ||
+				strings.EqualFold(r.Header.Get("Transfer-Encoding"), "chunked")
+			if !hasBody {
+				return next(c)
+			}
+
+			ct := r.Header.Get(echo.HeaderContentType)
+			if !strings.HasPrefix(ct, "application/json") {
+				return c.JSON(http.StatusUnsupportedMediaType, map[string]string{
+					"error":   "unsupported_media_type",
+					"message": ErrUnsupportedMediaType.Error(),
+				})
+			}
+
 			return next(c)
 		}
 	}
@@ -45,6 +112,10 @@ func httpErrorHandler(s *Server) echo.HTTPErrorHandler {
 		case errors.Is(err, ErrWorkspaceRequired):
 			code = http.StatusBadRequest
 			errType = "workspace_required"
+			msg = err.Error()
+		case errors.Is(err, ErrUnsupportedMediaType):
+			code = http.StatusUnsupportedMediaType
+			errType = "unsupported_media_type"
 			msg = err.Error()
 		}
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func noopHandler(c echo.Context) error {
+	return c.String(http.StatusOK, "ok")
+}
+
+func applyMiddleware(mw echo.MiddlewareFunc, req *http.Request) *httptest.ResponseRecorder {
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = mw(noopHandler)(c)
+	return rec
+}
+
+func TestWorkspaceMiddleware_POST_WithWorkspace(t *testing.T) {
+	mw := workspaceMiddleware()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"workspace":"abc"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var captured string
+	handler := mw(func(c echo.Context) error {
+		captured = c.Get("workspace").(string)
+		return c.String(http.StatusOK, "ok")
+	})
+	if err := handler(c); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if captured != "abc" {
+		t.Errorf("expected workspace=abc, got %q", captured)
+	}
+}
+
+func TestWorkspaceMiddleware_POST_MissingWorkspace(t *testing.T) {
+	mw := workspaceMiddleware()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["error"] != "workspace_required" {
+		t.Errorf("expected error=workspace_required, got %q", body["error"])
+	}
+}
+
+func TestWorkspaceMiddleware_GET_WithQueryParam(t *testing.T) {
+	mw := workspaceMiddleware()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/?workspace=myws", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var captured string
+	handler := mw(func(c echo.Context) error {
+		captured = c.Get("workspace").(string)
+		return c.String(http.StatusOK, "ok")
+	})
+	if err := handler(c); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if captured != "myws" {
+		t.Errorf("expected workspace=myws, got %q", captured)
+	}
+}
+
+func TestWorkspaceMiddleware_GET_MissingQueryParam(t *testing.T) {
+	mw := workspaceMiddleware()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["error"] != "workspace_required" {
+		t.Errorf("expected error=workspace_required, got %q", body["error"])
+	}
+}
+
+func TestWorkspaceMiddleware_AllValue(t *testing.T) {
+	mw := workspaceMiddleware()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"workspace":"all"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var captured string
+	handler := mw(func(c echo.Context) error {
+		captured = c.Get("workspace").(string)
+		return c.String(http.StatusOK, "ok")
+	})
+	if err := handler(c); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if captured != "all" {
+		t.Errorf("expected workspace=all, got %q", captured)
+	}
+}
+
+func TestContentType_JSON(t *testing.T) {
+	mw := contentTypeMiddleware()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, "application/json")
+	req.ContentLength = int64(len(`{}`))
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestContentType_PlainText(t *testing.T) {
+	mw := contentTypeMiddleware()
+	body := "hello"
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, "text/plain")
+	req.ContentLength = int64(len(body))
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("expected 415, got %d", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["error"] != "unsupported_media_type" {
+		t.Errorf("expected error=unsupported_media_type, got %q", resp["error"])
+	}
+}
+
+func TestContentType_GET_NoBody(t *testing.T) {
+	mw := contentTypeMiddleware()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestContentType_POST_NoBody(t *testing.T) {
+	mw := contentTypeMiddleware()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.ContentLength = 0
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -10,7 +10,10 @@ func registerRoutes(s *Server) {
 	s.echo.GET("/health", h.Health)
 	s.echo.GET("/api/status", h.Status)
 
-	api := s.echo.Group("/api/v1")
+	api := s.echo.Group("/api/v1", contentTypeMiddleware())
 	api.POST("/init", handlers.InitWorkspace(s.queries, s.db, s.logger))
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
+
+	data := api.Group("", workspaceMiddleware())
+	_ = data
 }


### PR DESCRIPTION
## Story 2.2: API Middleware Layer

Closes #46

### Changes
- `workspaceMiddleware()`: extracts workspace from POST body / GET query, HTTP 400 if missing
- `contentTypeMiddleware()`: HTTP 415 on non-JSON for POST/PUT/PATCH
- Updated error handler for `ErrUnsupportedMediaType`
- Wired to `/api/v1` group with data sub-group
- 9 unit tests

### Verification
- `go build ./...` ✅
- `go test -race -short ./...` ✅