### PR TITLE
feat(collections): collection management CLI + live watcher attach

### DIFF
--- a/cmd/nano-brain/collection.go
+++ b/cmd/nano-brain/collection.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func collectionUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: nano-brain collection <add|remove|list|rename> [flags]")
+	os.Exit(1)
+}
+
+func collectionBaseURL() string {
+	host := os.Getenv("NANO_BRAIN_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := os.Getenv("NANO_BRAIN_PORT")
+	if port == "" {
+		port = "3100"
+	}
+	return fmt.Sprintf("http://%s:%s", host, port)
+}
+
+func runCollectionCmd(args []string) {
+	if len(args) == 0 {
+		collectionUsage()
+	}
+
+	switch args[0] {
+	case "add":
+		runCollectionAdd(args[1:])
+	case "remove":
+		runCollectionRemove(args[1:])
+	case "list":
+		runCollectionList(args[1:])
+	case "rename":
+		runCollectionRename(args[1:])
+	default:
+		collectionUsage()
+	}
+}
+
+func runCollectionAdd(args []string) {
+	var name, path, workspace, glob string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--name":
+			i++
+			name = args[i]
+		case "--path":
+			i++
+			path = args[i]
+		case "--workspace":
+			i++
+			workspace = args[i]
+		case "--glob":
+			i++
+			glob = args[i]
+		}
+	}
+	if name == "" || path == "" || workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain collection add --name <name> --path <path> --workspace <hash> [--glob <pattern>]")
+		os.Exit(1)
+	}
+
+	body := map[string]string{
+		"workspace":    workspace,
+		"name":         name,
+		"path":         path,
+		"glob_pattern": glob,
+	}
+	data, _ := json.Marshal(body)
+
+	resp, err := http.Post(collectionBaseURL()+"/api/v1/collections", "application/json", bytes.NewReader(data))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	io.Copy(os.Stdout, resp.Body)
+	fmt.Println()
+}
+
+func runCollectionRemove(args []string) {
+	var name, workspace string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--name":
+			i++
+			name = args[i]
+		case "--workspace":
+			i++
+			workspace = args[i]
+		}
+	}
+	if name == "" || workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain collection remove --name <name> --workspace <hash>")
+		os.Exit(1)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/collections/%s?workspace=%s", collectionBaseURL(), name, workspace)
+	req, _ := http.NewRequest(http.MethodDelete, url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		fmt.Println("collection removed")
+		return
+	}
+	io.Copy(os.Stdout, resp.Body)
+	fmt.Println()
+}
+
+func runCollectionList(args []string) {
+	var workspace string
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--workspace" {
+			i++
+			workspace = args[i]
+		}
+	}
+	if workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain collection list --workspace <hash>")
+		os.Exit(1)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/collections?workspace=%s", collectionBaseURL(), workspace)
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	io.Copy(os.Stdout, resp.Body)
+	fmt.Println()
+}
+
+func runCollectionRename(args []string) {
+	var oldName, newName, workspace string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--old":
+			i++
+			oldName = args[i]
+		case "--new":
+			i++
+			newName = args[i]
+		case "--workspace":
+			i++
+			workspace = args[i]
+		}
+	}
+	if oldName == "" || newName == "" || workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain collection rename --old <old> --new <new> --workspace <hash>")
+		os.Exit(1)
+	}
+
+	body := map[string]string{
+		"workspace": workspace,
+		"new_name":  newName,
+	}
+	data, _ := json.Marshal(body)
+
+	url := fmt.Sprintf("%s/api/v1/collections/%s", collectionBaseURL(), oldName)
+	req, _ := http.NewRequest(http.MethodPut, url, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	io.Copy(os.Stdout, resp.Body)
+	fmt.Println()
+}

--- a/cmd/nano-brain/collection.go
+++ b/cmd/nano-brain/collection.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 )
 
@@ -50,15 +51,31 @@ func runCollectionAdd(args []string) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--name":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			name = args[i]
 		case "--path":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			path = args[i]
 		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			workspace = args[i]
 		case "--glob":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			glob = args[i]
 		}
@@ -91,9 +108,17 @@ func runCollectionRemove(args []string) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--name":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			name = args[i]
 		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			workspace = args[i]
 		}
@@ -103,8 +128,8 @@ func runCollectionRemove(args []string) {
 		os.Exit(1)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/collections/%s?workspace=%s", collectionBaseURL(), name, workspace)
-	req, _ := http.NewRequest(http.MethodDelete, url, nil)
+	reqURL := fmt.Sprintf("%s/api/v1/collections/%s?workspace=%s", collectionBaseURL(), url.PathEscape(name), url.QueryEscape(workspace))
+	req, _ := http.NewRequest(http.MethodDelete, reqURL, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -124,6 +149,10 @@ func runCollectionList(args []string) {
 	var workspace string
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--workspace" {
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			workspace = args[i]
 		}
@@ -133,8 +162,8 @@ func runCollectionList(args []string) {
 		os.Exit(1)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/collections?workspace=%s", collectionBaseURL(), workspace)
-	resp, err := http.Get(url)
+	reqURL := fmt.Sprintf("%s/api/v1/collections?workspace=%s", collectionBaseURL(), url.QueryEscape(workspace))
+	resp, err := http.Get(reqURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -149,12 +178,24 @@ func runCollectionRename(args []string) {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--old":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			oldName = args[i]
 		case "--new":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			newName = args[i]
 		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "%s requires a value\n", args[i])
+				os.Exit(1)
+			}
 			i++
 			workspace = args[i]
 		}
@@ -170,8 +211,8 @@ func runCollectionRename(args []string) {
 	}
 	data, _ := json.Marshal(body)
 
-	url := fmt.Sprintf("%s/api/v1/collections/%s", collectionBaseURL(), oldName)
-	req, _ := http.NewRequest(http.MethodPut, url, bytes.NewReader(data))
+	reqURL := fmt.Sprintf("%s/api/v1/collections/%s", collectionBaseURL(), url.PathEscape(oldName))
+	req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewReader(data))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/cmd/nano-brain/collection.go
+++ b/cmd/nano-brain/collection.go
@@ -91,7 +91,11 @@ func runCollectionAdd(args []string) {
 		"path":         path,
 		"glob_pattern": glob,
 	}
-	data, _ := json.Marshal(body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to marshal request: %v\n", err)
+		os.Exit(1)
+	}
 
 	resp, err := http.Post(collectionBaseURL()+"/api/v1/collections", "application/json", bytes.NewReader(data))
 	if err != nil {
@@ -209,7 +213,11 @@ func runCollectionRename(args []string) {
 		"workspace": workspace,
 		"new_name":  newName,
 	}
-	data, _ := json.Marshal(body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to marshal request: %v\n", err)
+		os.Exit(1)
+	}
 
 	reqURL := fmt.Sprintf("%s/api/v1/collections/%s", collectionBaseURL(), url.PathEscape(oldName))
 	req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewReader(data))

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -27,6 +27,11 @@ func main() {
 	flag.StringVar(&configPath, "config", "", "path to config file (default: ~/.nano-brain/config.yml)")
 	flag.Parse()
 
+	if args := flag.Args(); len(args) > 0 && args[0] == "collection" {
+		runCollectionCmd(args[1:])
+		return
+	}
+
 	if configPath == "" {
 		configPath = config.DefaultConfigPath()
 	}
@@ -62,9 +67,10 @@ func main() {
 	db := stdlib.OpenDBFromPool(pool)
 	queries := sqlc.New(db)
 
-	srv := server.New(cfg.Server, pool, db, queries, logger, Version)
-
 	fw := watcher.New(db, queries, logger, *cfg)
+
+	srv := server.New(cfg.Server, pool, db, queries, fw, logger, Version)
+
 	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {
 			collections, err := queries.ListCollections(ctx, ws.Hash)

--- a/docs/evidence/self-review-story-2.7.md
+++ b/docs/evidence/self-review-story-2.7.md
@@ -1,0 +1,15 @@
+# Story 2.7 Self-Review Evidence
+
+## Oracle Review
+- **2 Critical**: CLI panic on trailing flag (fixed bounds check), Rename not updating watcher (fixed: pass watcher + call Watch)
+- **4 Major**: CLI URL-encoding (fixed: url.PathEscape/QueryEscape), Rename 500→404 (fixed: sql.ErrNoRows check), Name validation (fixed: regex), N+1 query (fixed: ListCollectionsWithDocCount JOIN)
+- **3 Minor**: CLI status code check, watcher test coverage, glob validation — deferred (low risk)
+
+## Gemini Review (PR #55)
+- **1 Critical**: Rename doesn't update documents table (fixed: UpdateDocumentsCollection query)
+- **3 High**: Watcher rename, N+1, CLI panic — already fixed by Oracle findings
+- **1 Medium**: json.Marshal error ignored (fixed: error handling added)
+
+## Verification
+- `go build ./...` ✅
+- `go test -race -short ./...` ✅ (7 packages pass)

--- a/docs/harness-state.json
+++ b/docs/harness-state.json
@@ -2,9 +2,9 @@
   "updated": "2026-05-23",
   "position": {
     "epic": 2,
-    "story": "2.5",
-    "branch": "story/2.5-chunker-integration",
-    "base_commit": "c7a31d3"
+    "story": "2.7",
+    "branch": null,
+    "base_commit": "8188c50"
   },
   "debt": [
     {
@@ -21,8 +21,8 @@
     "2.2": { "status": "done", "pr": 47, "issue": 46, "review": "missing", "pr_comments": "not_checked" },
     "2.3": { "status": "done", "pr": 49, "issue": 48, "review": "oracle", "pr_comments": "6M:3fixed,3deferred" },
     "2.4": { "status": "done", "pr": 45, "review": "oracle", "pr_comments": "n/a" },
-    "2.5": { "status": "in_progress", "issue": 50, "review": null, "pr_comments": null },
-    "2.6": { "status": "pending" },
+    "2.5": { "status": "done", "pr": 51, "issue": 50, "review": "oracle", "pr_comments": "none" },
+    "2.6": { "status": "done", "pr": 53, "issue": 52, "review": "oracle", "pr_comments": "1C+2H+3M:all_fixed_or_deferred" },
     "2.7": { "status": "pending" },
     "2.8": { "status": "pending" }
   }

--- a/internal/server/handlers/collection.go
+++ b/internal/server/handlers/collection.go
@@ -24,6 +24,7 @@ type CollectionQuerier interface {
 	RenameCollection(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
 	DeleteCollection(ctx context.Context, arg sqlc.DeleteCollectionParams) error
 	CountDocumentsByCollection(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error)
+	UpdateDocumentsCollection(ctx context.Context, arg sqlc.UpdateDocumentsCollectionParams) error
 }
 
 type AddCollectionRequest struct {
@@ -169,22 +170,31 @@ func RenameCollectionHandler(q CollectionQuerier, fw *watcher.Watcher, logger ze
 		if req.NewName == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "new_name is required")
 		}
-		if !validCollectionName.MatchString(req.NewName) {
-			return echo.NewHTTPError(http.StatusBadRequest, "new_name must be 1-128 characters: letters, digits, underscores, hyphens only")
-		}
+	if !validCollectionName.MatchString(req.NewName) {
+		return echo.NewHTTPError(http.StatusBadRequest, "new_name must be 1-128 characters: letters, digits, underscores, hyphens only")
+	}
 
-		col, err := q.RenameCollection(c.Request().Context(), sqlc.RenameCollectionParams{
-			Name:          name,
-			Name_2:        req.NewName,
-			WorkspaceHash: workspace,
-		})
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return echo.NewHTTPError(http.StatusNotFound, "collection not found")
-			}
-			logger.Error().Err(err).Str("old", name).Str("new", req.NewName).Msg("rename collection failed")
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to rename collection")
+	if err := q.UpdateDocumentsCollection(c.Request().Context(), sqlc.UpdateDocumentsCollectionParams{
+		Collection:    name,
+		Collection_2:  req.NewName,
+		WorkspaceHash: workspace,
+	}); err != nil {
+		logger.Error().Err(err).Str("old", name).Str("new", req.NewName).Msg("update documents collection failed")
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update documents for rename")
+	}
+
+	col, err := q.RenameCollection(c.Request().Context(), sqlc.RenameCollectionParams{
+		Name:          name,
+		Name_2:        req.NewName,
+		WorkspaceHash: workspace,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusNotFound, "collection not found")
 		}
+		logger.Error().Err(err).Str("old", name).Str("new", req.NewName).Msg("rename collection failed")
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to rename collection")
+	}
 
 		if fw != nil {
 			if err := fw.Watch(col.Name, col.Path, col.WorkspaceHash, col.GlobPattern); err != nil {

--- a/internal/server/handlers/collection.go
+++ b/internal/server/handlers/collection.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/watcher"
+	"github.com/rs/zerolog"
+)
+
+type CollectionQuerier interface {
+	UpsertCollection(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
+	ListCollections(ctx context.Context, workspaceHash string) ([]sqlc.Collection, error)
+	GetCollectionByName(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error)
+	RenameCollection(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
+	DeleteCollection(ctx context.Context, arg sqlc.DeleteCollectionParams) error
+	CountDocumentsByCollection(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error)
+}
+
+type AddCollectionRequest struct {
+	Workspace   string `json:"workspace"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	GlobPattern string `json:"glob_pattern"`
+}
+
+type RenameCollectionRequest struct {
+	Workspace string `json:"workspace"`
+	NewName   string `json:"new_name"`
+}
+
+type CollectionResponse struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Path          string `json:"path"`
+	GlobPattern   string `json:"glob_pattern"`
+	UpdateMode    string `json:"update_mode"`
+	DocumentCount int64  `json:"document_count"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+}
+
+func toCollectionResponse(col sqlc.Collection, docCount int64) CollectionResponse {
+	return CollectionResponse{
+		ID:            col.ID.String(),
+		Name:          col.Name,
+		Path:          col.Path,
+		GlobPattern:   col.GlobPattern,
+		UpdateMode:    col.UpdateMode,
+		DocumentCount: docCount,
+		CreatedAt:     col.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:     col.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func AddCollection(q CollectionQuerier, fw *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req AddCollectionRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+
+		workspace, _ := c.Get("workspace").(string)
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+
+		if req.Name == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+		}
+		if req.Path == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "path is required")
+		}
+
+		if _, err := os.Stat(req.Path); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "path does not exist on filesystem")
+		}
+
+		globPattern := req.GlobPattern
+		if globPattern == "" {
+			globPattern = "**/*"
+		}
+
+		col, err := q.UpsertCollection(c.Request().Context(), sqlc.UpsertCollectionParams{
+			WorkspaceHash: workspace,
+			Name:          req.Name,
+			Path:          req.Path,
+			GlobPattern:   globPattern,
+			UpdateMode:    "auto",
+		})
+		if err != nil {
+			logger.Error().Err(err).Str("name", req.Name).Msg("upsert collection failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to add collection")
+		}
+
+		if fw != nil {
+			if err := fw.Watch(col.Name, col.Path, col.WorkspaceHash, col.GlobPattern); err != nil {
+				logger.Warn().Err(err).Str("name", col.Name).Msg("failed to attach watcher")
+			}
+		}
+
+		return c.JSON(http.StatusCreated, toCollectionResponse(col, 0))
+	}
+}
+
+func ListCollectionsHandler(q CollectionQuerier, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		workspace := c.QueryParam("workspace")
+		if workspace == "" {
+			workspace, _ = c.Get("workspace").(string)
+		}
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+
+		cols, err := q.ListCollections(c.Request().Context(), workspace)
+		if err != nil {
+			logger.Error().Err(err).Str("workspace", workspace).Msg("list collections failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to list collections")
+		}
+
+		items := make([]CollectionResponse, 0, len(cols))
+		for _, col := range cols {
+			count, err := q.CountDocumentsByCollection(c.Request().Context(), sqlc.CountDocumentsByCollectionParams{
+				Collection:    col.Name,
+				WorkspaceHash: workspace,
+			})
+			if err != nil {
+				logger.Error().Err(err).Str("collection", col.Name).Msg("count documents failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to count documents")
+			}
+			items = append(items, toCollectionResponse(col, count))
+		}
+
+		return c.JSON(http.StatusOK, items)
+	}
+}
+
+func RenameCollectionHandler(q CollectionQuerier, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		name := c.Param("name")
+		if name == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "collection name is required")
+		}
+
+		var req RenameCollectionRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+
+		workspace, _ := c.Get("workspace").(string)
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+
+		if req.NewName == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "new_name is required")
+		}
+
+		col, err := q.RenameCollection(c.Request().Context(), sqlc.RenameCollectionParams{
+			Name:          name,
+			Name_2:        req.NewName,
+			WorkspaceHash: workspace,
+		})
+		if err != nil {
+			logger.Error().Err(err).Str("old", name).Str("new", req.NewName).Msg("rename collection failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to rename collection")
+		}
+
+		return c.JSON(http.StatusOK, toCollectionResponse(col, 0))
+	}
+}
+
+func RemoveCollection(q CollectionQuerier, fw *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		name := c.Param("name")
+		if name == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "collection name is required")
+		}
+
+		workspace, _ := c.Get("workspace").(string)
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+
+		col, err := q.GetCollectionByName(c.Request().Context(), sqlc.GetCollectionByNameParams{
+			Name:          name,
+			WorkspaceHash: workspace,
+		})
+		if err != nil {
+			logger.Error().Err(err).Str("name", name).Msg("get collection failed")
+			return echo.NewHTTPError(http.StatusNotFound, "collection not found")
+		}
+
+		if err := q.DeleteCollection(c.Request().Context(), sqlc.DeleteCollectionParams{
+			Name:          name,
+			WorkspaceHash: workspace,
+		}); err != nil {
+			logger.Error().Err(err).Str("name", name).Msg("delete collection failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to remove collection")
+		}
+
+		if fw != nil {
+			if err := fw.Unwatch(col.Path); err != nil {
+				logger.Warn().Err(err).Str("path", col.Path).Msg("failed to detach watcher")
+			}
+		}
+
+		return c.NoContent(http.StatusNoContent)
+	}
+}

--- a/internal/server/handlers/collection.go
+++ b/internal/server/handlers/collection.go
@@ -2,8 +2,11 @@ package handlers
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"net/http"
 	"os"
+	"regexp"
 
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
@@ -11,9 +14,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var validCollectionName = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
+
 type CollectionQuerier interface {
 	UpsertCollection(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
 	ListCollections(ctx context.Context, workspaceHash string) ([]sqlc.Collection, error)
+	ListCollectionsWithDocCount(ctx context.Context, workspaceHash string) ([]sqlc.ListCollectionsWithDocCountRow, error)
 	GetCollectionByName(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error)
 	RenameCollection(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
 	DeleteCollection(ctx context.Context, arg sqlc.DeleteCollectionParams) error
@@ -71,6 +77,9 @@ func AddCollection(q CollectionQuerier, fw *watcher.Watcher, logger zerolog.Logg
 		if req.Name == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "name is required")
 		}
+		if !validCollectionName.MatchString(req.Name) {
+			return echo.NewHTTPError(http.StatusBadRequest, "name must be 1-128 characters: letters, digits, underscores, hyphens only")
+		}
 		if req.Path == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "path is required")
 		}
@@ -116,7 +125,7 @@ func ListCollectionsHandler(q CollectionQuerier, logger zerolog.Logger) echo.Han
 			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
 		}
 
-		cols, err := q.ListCollections(c.Request().Context(), workspace)
+		cols, err := q.ListCollectionsWithDocCount(c.Request().Context(), workspace)
 		if err != nil {
 			logger.Error().Err(err).Str("workspace", workspace).Msg("list collections failed")
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to list collections")
@@ -124,22 +133,23 @@ func ListCollectionsHandler(q CollectionQuerier, logger zerolog.Logger) echo.Han
 
 		items := make([]CollectionResponse, 0, len(cols))
 		for _, col := range cols {
-			count, err := q.CountDocumentsByCollection(c.Request().Context(), sqlc.CountDocumentsByCollectionParams{
-				Collection:    col.Name,
-				WorkspaceHash: workspace,
+			items = append(items, CollectionResponse{
+				ID:            col.ID.String(),
+				Name:          col.Name,
+				Path:          col.Path,
+				GlobPattern:   col.GlobPattern,
+				UpdateMode:    col.UpdateMode,
+				DocumentCount: col.DocumentCount,
+				CreatedAt:     col.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+				UpdatedAt:     col.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 			})
-			if err != nil {
-				logger.Error().Err(err).Str("collection", col.Name).Msg("count documents failed")
-				return echo.NewHTTPError(http.StatusInternalServerError, "failed to count documents")
-			}
-			items = append(items, toCollectionResponse(col, count))
 		}
 
 		return c.JSON(http.StatusOK, items)
 	}
 }
 
-func RenameCollectionHandler(q CollectionQuerier, logger zerolog.Logger) echo.HandlerFunc {
+func RenameCollectionHandler(q CollectionQuerier, fw *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		name := c.Param("name")
 		if name == "" {
@@ -159,6 +169,9 @@ func RenameCollectionHandler(q CollectionQuerier, logger zerolog.Logger) echo.Ha
 		if req.NewName == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "new_name is required")
 		}
+		if !validCollectionName.MatchString(req.NewName) {
+			return echo.NewHTTPError(http.StatusBadRequest, "new_name must be 1-128 characters: letters, digits, underscores, hyphens only")
+		}
 
 		col, err := q.RenameCollection(c.Request().Context(), sqlc.RenameCollectionParams{
 			Name:          name,
@@ -166,8 +179,17 @@ func RenameCollectionHandler(q CollectionQuerier, logger zerolog.Logger) echo.Ha
 			WorkspaceHash: workspace,
 		})
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return echo.NewHTTPError(http.StatusNotFound, "collection not found")
+			}
 			logger.Error().Err(err).Str("old", name).Str("new", req.NewName).Msg("rename collection failed")
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to rename collection")
+		}
+
+		if fw != nil {
+			if err := fw.Watch(col.Name, col.Path, col.WorkspaceHash, col.GlobPattern); err != nil {
+				logger.Warn().Err(err).Str("name", col.Name).Msg("failed to update watcher after rename")
+			}
 		}
 
 		return c.JSON(http.StatusOK, toCollectionResponse(col, 0))

--- a/internal/server/handlers/collection_test.go
+++ b/internal/server/handlers/collection_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 type mockCollectionQuerier struct {
-	upsertFn      func(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
-	listFn        func(ctx context.Context, ws string) ([]sqlc.Collection, error)
-	getFn         func(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error)
-	renameFn      func(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
-	deleteFn      func(ctx context.Context, arg sqlc.DeleteCollectionParams) error
-	countDocsFn   func(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error)
+	upsertFn            func(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
+	listFn              func(ctx context.Context, ws string) ([]sqlc.Collection, error)
+	listWithDocCountFn  func(ctx context.Context, ws string) ([]sqlc.ListCollectionsWithDocCountRow, error)
+	getFn               func(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error)
+	renameFn            func(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
+	deleteFn            func(ctx context.Context, arg sqlc.DeleteCollectionParams) error
+	countDocsFn         func(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error)
 }
 
 func (m *mockCollectionQuerier) UpsertCollection(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error) {
@@ -31,6 +32,9 @@ func (m *mockCollectionQuerier) UpsertCollection(ctx context.Context, arg sqlc.U
 }
 func (m *mockCollectionQuerier) ListCollections(ctx context.Context, ws string) ([]sqlc.Collection, error) {
 	return m.listFn(ctx, ws)
+}
+func (m *mockCollectionQuerier) ListCollectionsWithDocCount(ctx context.Context, ws string) ([]sqlc.ListCollectionsWithDocCountRow, error) {
+	return m.listWithDocCountFn(ctx, ws)
 }
 func (m *mockCollectionQuerier) GetCollectionByName(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error) {
 	return m.getFn(ctx, arg)
@@ -143,12 +147,20 @@ func TestAddCollection_MissingName(t *testing.T) {
 }
 
 func TestListCollections_Success(t *testing.T) {
+	col := fixedCollection("codebase", "/tmp")
 	q := &mockCollectionQuerier{
-		listFn: func(_ context.Context, _ string) ([]sqlc.Collection, error) {
-			return []sqlc.Collection{fixedCollection("codebase", "/tmp")}, nil
-		},
-		countDocsFn: func(_ context.Context, _ sqlc.CountDocumentsByCollectionParams) (int64, error) {
-			return 42, nil
+		listWithDocCountFn: func(_ context.Context, _ string) ([]sqlc.ListCollectionsWithDocCountRow, error) {
+			return []sqlc.ListCollectionsWithDocCountRow{{
+				ID:            col.ID,
+				WorkspaceHash: col.WorkspaceHash,
+				Name:          col.Name,
+				Path:          col.Path,
+				GlobPattern:   col.GlobPattern,
+				UpdateMode:    col.UpdateMode,
+				CreatedAt:     col.CreatedAt,
+				UpdatedAt:     col.UpdatedAt,
+				DocumentCount: 42,
+			}}, nil
 		},
 	}
 
@@ -188,7 +200,7 @@ func TestRenameCollection_Success(t *testing.T) {
 	c.SetParamNames("name")
 	c.SetParamValues("old-name")
 
-	h := handlers.RenameCollectionHandler(q, zerolog.Nop())
+	h := handlers.RenameCollectionHandler(q, nil, zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}

--- a/internal/server/handlers/collection_test.go
+++ b/internal/server/handlers/collection_test.go
@@ -1,0 +1,256 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockCollectionQuerier struct {
+	upsertFn      func(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
+	listFn        func(ctx context.Context, ws string) ([]sqlc.Collection, error)
+	getFn         func(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error)
+	renameFn      func(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
+	deleteFn      func(ctx context.Context, arg sqlc.DeleteCollectionParams) error
+	countDocsFn   func(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error)
+}
+
+func (m *mockCollectionQuerier) UpsertCollection(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error) {
+	return m.upsertFn(ctx, arg)
+}
+func (m *mockCollectionQuerier) ListCollections(ctx context.Context, ws string) ([]sqlc.Collection, error) {
+	return m.listFn(ctx, ws)
+}
+func (m *mockCollectionQuerier) GetCollectionByName(ctx context.Context, arg sqlc.GetCollectionByNameParams) (sqlc.Collection, error) {
+	return m.getFn(ctx, arg)
+}
+func (m *mockCollectionQuerier) RenameCollection(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error) {
+	return m.renameFn(ctx, arg)
+}
+func (m *mockCollectionQuerier) DeleteCollection(ctx context.Context, arg sqlc.DeleteCollectionParams) error {
+	return m.deleteFn(ctx, arg)
+}
+func (m *mockCollectionQuerier) CountDocumentsByCollection(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error) {
+	return m.countDocsFn(ctx, arg)
+}
+
+func newCollectionContext(e *echo.Echo, method, target, body, workspace string) (echo.Context, *httptest.ResponseRecorder) {
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	} else {
+		req = httptest.NewRequest(method, target, nil)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if workspace != "" {
+		c.Set("workspace", workspace)
+	}
+	return c, rec
+}
+
+func fixedCollection(name, path string) sqlc.Collection {
+	return sqlc.Collection{
+		ID:            uuid.New(),
+		WorkspaceHash: "ws-test",
+		Name:          name,
+		Path:          path,
+		GlobPattern:   "**/*",
+		UpdateMode:    "auto",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+}
+
+func TestAddCollection_Success(t *testing.T) {
+	q := &mockCollectionQuerier{
+		upsertFn: func(_ context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error) {
+			return fixedCollection(arg.Name, arg.Path), nil
+		},
+	}
+
+	e := echo.New()
+	body := `{"workspace":"ws-test","name":"codebase","path":"/tmp","glob_pattern":"**/*.go"}`
+	c, rec := newCollectionContext(e, http.MethodPost, "/api/v1/collections", body, "ws-test")
+
+	h := handlers.AddCollection(q, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp handlers.CollectionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Name != "codebase" {
+		t.Errorf("expected name=codebase, got %s", resp.Name)
+	}
+}
+
+func TestAddCollection_InvalidPath(t *testing.T) {
+	q := &mockCollectionQuerier{}
+	e := echo.New()
+	body := `{"workspace":"ws-test","name":"bad","path":"/nonexistent-path-xyz-12345"}`
+	c, _ := newCollectionContext(e, http.MethodPost, "/api/v1/collections", body, "ws-test")
+
+	h := handlers.AddCollection(q, nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestAddCollection_MissingName(t *testing.T) {
+	q := &mockCollectionQuerier{}
+	e := echo.New()
+	body := `{"workspace":"ws-test","path":"/tmp"}`
+	c, _ := newCollectionContext(e, http.MethodPost, "/api/v1/collections", body, "ws-test")
+
+	h := handlers.AddCollection(q, nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestListCollections_Success(t *testing.T) {
+	q := &mockCollectionQuerier{
+		listFn: func(_ context.Context, _ string) ([]sqlc.Collection, error) {
+			return []sqlc.Collection{fixedCollection("codebase", "/tmp")}, nil
+		},
+		countDocsFn: func(_ context.Context, _ sqlc.CountDocumentsByCollectionParams) (int64, error) {
+			return 42, nil
+		},
+	}
+
+	e := echo.New()
+	c, rec := newCollectionContext(e, http.MethodGet, "/api/v1/collections?workspace=ws-test", "", "ws-test")
+
+	h := handlers.ListCollectionsHandler(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var items []handlers.CollectionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].DocumentCount != 42 {
+		t.Errorf("expected document_count=42, got %d", items[0].DocumentCount)
+	}
+}
+
+func TestRenameCollection_Success(t *testing.T) {
+	q := &mockCollectionQuerier{
+		renameFn: func(_ context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error) {
+			return fixedCollection(arg.Name_2, "/tmp"), nil
+		},
+	}
+
+	e := echo.New()
+	body := `{"workspace":"ws-test","new_name":"renamed"}`
+	c, rec := newCollectionContext(e, http.MethodPut, "/api/v1/collections/old-name", body, "ws-test")
+	c.SetParamNames("name")
+	c.SetParamValues("old-name")
+
+	h := handlers.RenameCollectionHandler(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp handlers.CollectionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Name != "renamed" {
+		t.Errorf("expected name=renamed, got %s", resp.Name)
+	}
+}
+
+func TestRemoveCollection_Success(t *testing.T) {
+	q := &mockCollectionQuerier{
+		getFn: func(_ context.Context, _ sqlc.GetCollectionByNameParams) (sqlc.Collection, error) {
+			return fixedCollection("doomed", "/tmp"), nil
+		},
+		deleteFn: func(_ context.Context, _ sqlc.DeleteCollectionParams) error {
+			return nil
+		},
+	}
+
+	e := echo.New()
+	c, rec := newCollectionContext(e, http.MethodDelete, "/api/v1/collections/doomed?workspace=ws-test", "", "ws-test")
+	c.SetParamNames("name")
+	c.SetParamValues("doomed")
+
+	h := handlers.RemoveCollection(q, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRemoveCollection_NotFound(t *testing.T) {
+	q := &mockCollectionQuerier{
+		getFn: func(_ context.Context, _ sqlc.GetCollectionByNameParams) (sqlc.Collection, error) {
+			return sqlc.Collection{}, errors.New("sql: no rows in result set")
+		},
+	}
+
+	e := echo.New()
+	c, _ := newCollectionContext(e, http.MethodDelete, "/api/v1/collections/missing?workspace=ws-test", "", "ws-test")
+	c.SetParamNames("name")
+	c.SetParamValues("missing")
+
+	h := handlers.RemoveCollection(q, nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing collection")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", he.Code)
+	}
+}

--- a/internal/server/handlers/collection_test.go
+++ b/internal/server/handlers/collection_test.go
@@ -25,6 +25,7 @@ type mockCollectionQuerier struct {
 	renameFn            func(ctx context.Context, arg sqlc.RenameCollectionParams) (sqlc.Collection, error)
 	deleteFn            func(ctx context.Context, arg sqlc.DeleteCollectionParams) error
 	countDocsFn         func(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error)
+	updateDocsFn        func(ctx context.Context, arg sqlc.UpdateDocumentsCollectionParams) error
 }
 
 func (m *mockCollectionQuerier) UpsertCollection(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error) {
@@ -47,6 +48,12 @@ func (m *mockCollectionQuerier) DeleteCollection(ctx context.Context, arg sqlc.D
 }
 func (m *mockCollectionQuerier) CountDocumentsByCollection(ctx context.Context, arg sqlc.CountDocumentsByCollectionParams) (int64, error) {
 	return m.countDocsFn(ctx, arg)
+}
+func (m *mockCollectionQuerier) UpdateDocumentsCollection(ctx context.Context, arg sqlc.UpdateDocumentsCollectionParams) error {
+	if m.updateDocsFn == nil {
+		return nil
+	}
+	return m.updateDocsFn(ctx, arg)
 }
 
 func newCollectionContext(e *echo.Echo, method, target, body, workspace string) (echo.Context, *httptest.ResponseRecorder) {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -19,7 +19,7 @@ func registerRoutes(s *Server) {
 
 	data.POST("/collections", handlers.AddCollection(s.queries, s.watcher, s.logger))
 	data.GET("/collections", handlers.ListCollectionsHandler(s.queries, s.logger))
-	data.PUT("/collections/:name", handlers.RenameCollectionHandler(s.queries, s.logger))
+	data.PUT("/collections/:name", handlers.RenameCollectionHandler(s.queries, s.watcher, s.logger))
 	data.DELETE("/collections/:name", handlers.RemoveCollection(s.queries, s.watcher, s.logger))
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -16,6 +16,11 @@ func registerRoutes(s *Server) {
 
 	data := api.Group("", workspaceMiddleware())
 	data.POST("/write", handlers.WriteDocument(s.queries, s.db, s.logger, defaultMaxFileSize))
+
+	data.POST("/collections", handlers.AddCollection(s.queries, s.watcher, s.logger))
+	data.GET("/collections", handlers.ListCollectionsHandler(s.queries, s.logger))
+	data.PUT("/collections/:name", handlers.RenameCollectionHandler(s.queries, s.logger))
+	data.DELETE("/collections/:name", handlers.RemoveCollection(s.queries, s.watcher, s.logger))
 }
 
 const defaultMaxFileSize int64 = 307200

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
 )
 
@@ -25,6 +26,7 @@ type Server struct {
 	pool      PoolChecker
 	db        *sql.DB
 	queries   *sqlc.Queries
+	watcher   *watcher.Watcher
 	logger    zerolog.Logger
 	cfg       config.ServerConfig
 	version   string
@@ -32,7 +34,7 @@ type Server struct {
 }
 
 // New creates a new Server with all routes and middleware registered.
-func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, logger zerolog.Logger, version string) *Server {
+func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, logger zerolog.Logger, version string) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -42,6 +44,7 @@ func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Qu
 		pool:      pool,
 		db:        db,
 		queries:   queries,
+		watcher:   fw,
 		logger:    logger,
 		cfg:       cfg,
 		version:   version,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,7 @@ func (m *mockPool) Ping(_ context.Context) error {
 func newTestServer(pool *mockPool) *server.Server {
 	cfg := config.ServerConfig{Host: "127.0.0.1", Port: 3100}
 	logger := zerolog.Nop()
-	return server.New(cfg, pool, nil, nil, logger, "test-v1")
+	return server.New(cfg, pool, nil, nil, nil, logger, "test-v1")
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {
@@ -155,7 +155,7 @@ func TestRouteRegistration(t *testing.T) {
 		paths[r.Path] = true
 	}
 
-	for _, path := range []string{"/health", "/api/status", "/api/v1/init", "/api/v1/workspaces"} {
+	for _, path := range []string{"/health", "/api/status", "/api/v1/init", "/api/v1/workspaces", "/api/v1/collections", "/api/v1/collections/:name"} {
 		if !paths[path] {
 			t.Errorf("route %s not registered", path)
 		}

--- a/internal/storage/queries/collections.sql
+++ b/internal/storage/queries/collections.sql
@@ -10,3 +10,17 @@ RETURNING *;
 
 -- name: ListCollections :many
 SELECT * FROM collections WHERE workspace_hash = $1 ORDER BY name;
+
+-- name: GetCollectionByName :one
+SELECT * FROM collections WHERE name = $1 AND workspace_hash = $2;
+
+-- name: RenameCollection :one
+UPDATE collections SET name = $2, updated_at = now()
+WHERE name = $1 AND workspace_hash = $3
+RETURNING *;
+
+-- name: DeleteCollection :exec
+DELETE FROM collections WHERE name = $1 AND workspace_hash = $2;
+
+-- name: CountDocumentsByCollection :one
+SELECT count(*) FROM documents WHERE collection = $1 AND workspace_hash = $2;

--- a/internal/storage/queries/collections.sql
+++ b/internal/storage/queries/collections.sql
@@ -24,3 +24,14 @@ DELETE FROM collections WHERE name = $1 AND workspace_hash = $2;
 
 -- name: CountDocumentsByCollection :one
 SELECT count(*) FROM documents WHERE collection = $1 AND workspace_hash = $2;
+
+-- name: ListCollectionsWithDocCount :many
+SELECT c.id, c.workspace_hash, c.name, c.path, c.glob_pattern, c.update_mode, c.exclude_patterns, c.created_at, c.updated_at, COALESCE(d.cnt, 0)::bigint AS document_count
+FROM collections c
+LEFT JOIN (
+    SELECT collection, workspace_hash, count(*) AS cnt
+    FROM documents
+    GROUP BY collection, workspace_hash
+) d ON c.name = d.collection AND c.workspace_hash = d.workspace_hash
+WHERE c.workspace_hash = $1
+ORDER BY c.name;

--- a/internal/storage/queries/documents.sql
+++ b/internal/storage/queries/documents.sql
@@ -33,3 +33,6 @@ SELECT id, content_hash FROM documents WHERE source_path = $1 AND workspace_hash
 -- name: ListDocumentsByWorkspace :many
 SELECT id, workspace_hash, content_hash, title, source_path, collection, tags, created_at, updated_at
 FROM documents WHERE workspace_hash = $1 ORDER BY updated_at DESC;
+
+-- name: UpdateDocumentsCollection :exec
+UPDATE documents SET collection = $2 WHERE collection = $1 AND workspace_hash = $3;

--- a/internal/storage/sqlc/collections.sql.go
+++ b/internal/storage/sqlc/collections.sql.go
@@ -7,7 +7,9 @@ package sqlc
 
 import (
 	"context"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
 
@@ -90,6 +92,65 @@ func (q *Queries) ListCollections(ctx context.Context, workspaceHash string) ([]
 			pq.Array(&i.ExcludePatterns),
 			&i.CreatedAt,
 			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCollectionsWithDocCount = `-- name: ListCollectionsWithDocCount :many
+SELECT c.id, c.workspace_hash, c.name, c.path, c.glob_pattern, c.update_mode, c.exclude_patterns, c.created_at, c.updated_at, COALESCE(d.cnt, 0)::bigint AS document_count
+FROM collections c
+LEFT JOIN (
+    SELECT collection, workspace_hash, count(*) AS cnt
+    FROM documents
+    GROUP BY collection, workspace_hash
+) d ON c.name = d.collection AND c.workspace_hash = d.workspace_hash
+WHERE c.workspace_hash = $1
+ORDER BY c.name
+`
+
+type ListCollectionsWithDocCountRow struct {
+	ID              uuid.UUID
+	WorkspaceHash   string
+	Name            string
+	Path            string
+	GlobPattern     string
+	UpdateMode      string
+	ExcludePatterns []string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	DocumentCount   int64
+}
+
+func (q *Queries) ListCollectionsWithDocCount(ctx context.Context, workspaceHash string) ([]ListCollectionsWithDocCountRow, error) {
+	rows, err := q.db.QueryContext(ctx, listCollectionsWithDocCount, workspaceHash)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCollectionsWithDocCountRow
+	for rows.Next() {
+		var i ListCollectionsWithDocCountRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceHash,
+			&i.Name,
+			&i.Path,
+			&i.GlobPattern,
+			&i.UpdateMode,
+			pq.Array(&i.ExcludePatterns),
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DocumentCount,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/storage/sqlc/collections.sql.go
+++ b/internal/storage/sqlc/collections.sql.go
@@ -11,6 +11,62 @@ import (
 	"github.com/lib/pq"
 )
 
+const countDocumentsByCollection = `-- name: CountDocumentsByCollection :one
+SELECT count(*) FROM documents WHERE collection = $1 AND workspace_hash = $2
+`
+
+type CountDocumentsByCollectionParams struct {
+	Collection    string
+	WorkspaceHash string
+}
+
+func (q *Queries) CountDocumentsByCollection(ctx context.Context, arg CountDocumentsByCollectionParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countDocumentsByCollection, arg.Collection, arg.WorkspaceHash)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const deleteCollection = `-- name: DeleteCollection :exec
+DELETE FROM collections WHERE name = $1 AND workspace_hash = $2
+`
+
+type DeleteCollectionParams struct {
+	Name          string
+	WorkspaceHash string
+}
+
+func (q *Queries) DeleteCollection(ctx context.Context, arg DeleteCollectionParams) error {
+	_, err := q.db.ExecContext(ctx, deleteCollection, arg.Name, arg.WorkspaceHash)
+	return err
+}
+
+const getCollectionByName = `-- name: GetCollectionByName :one
+SELECT id, workspace_hash, name, path, glob_pattern, update_mode, exclude_patterns, created_at, updated_at FROM collections WHERE name = $1 AND workspace_hash = $2
+`
+
+type GetCollectionByNameParams struct {
+	Name          string
+	WorkspaceHash string
+}
+
+func (q *Queries) GetCollectionByName(ctx context.Context, arg GetCollectionByNameParams) (Collection, error) {
+	row := q.db.QueryRowContext(ctx, getCollectionByName, arg.Name, arg.WorkspaceHash)
+	var i Collection
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceHash,
+		&i.Name,
+		&i.Path,
+		&i.GlobPattern,
+		&i.UpdateMode,
+		pq.Array(&i.ExcludePatterns),
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listCollections = `-- name: ListCollections :many
 SELECT id, workspace_hash, name, path, glob_pattern, update_mode, exclude_patterns, created_at, updated_at FROM collections WHERE workspace_hash = $1 ORDER BY name
 `
@@ -46,6 +102,35 @@ func (q *Queries) ListCollections(ctx context.Context, workspaceHash string) ([]
 		return nil, err
 	}
 	return items, nil
+}
+
+const renameCollection = `-- name: RenameCollection :one
+UPDATE collections SET name = $2, updated_at = now()
+WHERE name = $1 AND workspace_hash = $3
+RETURNING id, workspace_hash, name, path, glob_pattern, update_mode, exclude_patterns, created_at, updated_at
+`
+
+type RenameCollectionParams struct {
+	Name          string
+	Name_2        string
+	WorkspaceHash string
+}
+
+func (q *Queries) RenameCollection(ctx context.Context, arg RenameCollectionParams) (Collection, error) {
+	row := q.db.QueryRowContext(ctx, renameCollection, arg.Name, arg.Name_2, arg.WorkspaceHash)
+	var i Collection
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceHash,
+		&i.Name,
+		&i.Path,
+		&i.GlobPattern,
+		&i.UpdateMode,
+		pq.Array(&i.ExcludePatterns),
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const upsertCollection = `-- name: UpsertCollection :one

--- a/internal/storage/sqlc/documents.sql.go
+++ b/internal/storage/sqlc/documents.sql.go
@@ -113,6 +113,21 @@ func (q *Queries) ListDocumentsByWorkspace(ctx context.Context, workspaceHash st
 	return items, nil
 }
 
+const updateDocumentsCollection = `-- name: UpdateDocumentsCollection :exec
+UPDATE documents SET collection = $2 WHERE collection = $1 AND workspace_hash = $3
+`
+
+type UpdateDocumentsCollectionParams struct {
+	Collection    string
+	Collection_2  string
+	WorkspaceHash string
+}
+
+func (q *Queries) UpdateDocumentsCollection(ctx context.Context, arg UpdateDocumentsCollectionParams) error {
+	_, err := q.db.ExecContext(ctx, updateDocumentsCollection, arg.Collection, arg.Collection_2, arg.WorkspaceHash)
+	return err
+}
+
 const upsertDocument = `-- name: UpsertDocument :one
 INSERT INTO documents (workspace_hash, content_hash, title, content, source_path, collection, tags, metadata)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)


### PR DESCRIPTION
## Story 2.7: Collection Management

Collection CRUD with live watcher integration.

### Changes
- **API**: POST/GET /collections, PUT/DELETE /collections/:name
- **CLI**: `nano-brain collection add|remove|list|rename` via HTTP API calls
- **Watcher**: Live Watch/Unwatch on collection add/remove
- **SQL**: 4 new queries (GetCollectionByName, RenameCollection, DeleteCollection, CountDocumentsByCollection)
- **Server**: Updated to hold watcher reference for handler access
- **Tests**: 7 unit tests for all handler paths

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅

Closes #54