### PR TITLE
feat(embed): embedding provider interface + Ollama/VoyageAI implementations

### DIFF
--- a/docs/evidence/self-review-story-3.1.md
+++ b/docs/evidence/self-review-story-3.1.md
@@ -1,0 +1,14 @@
+# Story 3.1 Self-Review Evidence
+
+## Oracle Review
+- **0 Critical**
+- **2 Major**: Hardcoded dimensions (fixed: configurable via EmbeddingConfig.Dimension), deprecated Ollama /api/embeddings (fixed: migrated to /api/embed)
+- **4 Minor**: Bounded error reads (fixed: io.LimitReader 4096), batch embedding (deferred to queue story), VoyageAI configurable URL (fixed), missing edge tests (noted)
+
+## Gemini Review (PR #61)
+- **2 High**: Hardcoded dimensions — already fixed by Oracle review
+- **3 Medium**: io.ReadAll unbounded (fixed by Oracle), redundant VOYAGE_API_KEY env fallback in factory (fixed)
+
+## Verification
+- `go build ./...` ✅
+- `go test -race -short ./...` ✅ (15 embed tests)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type EmbeddingConfig struct {
 	Provider     string `koanf:"provider"`
 	URL          string `koanf:"url"`
 	Model        string `koanf:"model"`
+	Dimension    int    `koanf:"dimension"`
 	Concurrency  int    `koanf:"concurrency"`
 	VoyageAPIKey string `koanf:"voyage_api_key"`
 }

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -1,2 +1,12 @@
 // Package embed handles vector embedding generation.
 package embed
+
+import "context"
+
+// Embedder generates vector embeddings from text.
+type Embedder interface {
+	// Embed returns a float32 vector for the given text.
+	Embed(ctx context.Context, text string) ([]float32, error)
+	// Dimension returns the expected vector dimension.
+	Dimension() int
+}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -81,25 +81,28 @@ func TestOllamaEmbedder_Embed(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %s, want POST", r.Method)
 		}
-		if r.URL.Path != "/api/embeddings" {
-			t.Errorf("path = %s, want /api/embeddings", r.URL.Path)
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("path = %s, want /api/embed", r.URL.Path)
 		}
-		var req map[string]string
+		var req struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Fatalf("decode request: %v", err)
 		}
-		if req["model"] != "test-model" {
-			t.Errorf("model = %q, want %q", req["model"], "test-model")
+		if req.Model != "test-model" {
+			t.Errorf("model = %q, want %q", req.Model, "test-model")
 		}
-		if req["prompt"] != "hello world" {
-			t.Errorf("prompt = %q, want %q", req["prompt"], "hello world")
+		if len(req.Input) != 1 || req.Input[0] != "hello world" {
+			t.Errorf("input = %v, want [hello world]", req.Input)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string][]float32{"embedding": want})
+		json.NewEncoder(w).Encode(map[string][][]float32{"embeddings": {want}})
 	}))
 	defer srv.Close()
 
-	e := NewOllamaEmbedder(srv.URL, "test-model")
+	e := NewOllamaEmbedder(srv.URL, "test-model", 0)
 	got, err := e.Embed(context.Background(), "hello world")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -115,9 +118,16 @@ func TestOllamaEmbedder_Embed(t *testing.T) {
 }
 
 func TestOllamaEmbedder_Dimension(t *testing.T) {
-	e := NewOllamaEmbedder("http://localhost:11434", "test")
+	e := NewOllamaEmbedder("http://localhost:11434", "test", 0)
 	if d := e.Dimension(); d != 768 {
 		t.Errorf("Dimension() = %d, want 768", d)
+	}
+}
+
+func TestOllamaEmbedder_CustomDimension(t *testing.T) {
+	e := NewOllamaEmbedder("http://localhost:11434", "test", 384)
+	if d := e.Dimension(); d != 384 {
+		t.Errorf("Dimension() = %d, want 384", d)
 	}
 }
 
@@ -128,7 +138,7 @@ func TestOllamaEmbedder_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOllamaEmbedder(srv.URL, "test-model")
+	e := NewOllamaEmbedder(srv.URL, "test-model", 0)
 	_, err := e.Embed(context.Background(), "hello")
 	if err == nil {
 		t.Fatal("expected error for 500 response")
@@ -168,17 +178,10 @@ func TestVoyageAIEmbedder_Embed(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ve := &VoyageAIEmbedder{
-		apiKey:     "test-key",
-		model:      "voyage-3",
-		httpClient: srv.Client(),
+	ve, err := NewVoyageAIEmbedder("test-key", "voyage-3", srv.URL, 0)
+	if err != nil {
+		t.Fatalf("unexpected error creating embedder: %v", err)
 	}
-	ve.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		r.URL.Scheme = "http"
-		r.URL.Host = srv.Listener.Addr().String()
-		return http.DefaultTransport.RoundTrip(r)
-	})
-
 	got, err := ve.Embed(context.Background(), "hello world")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -193,21 +196,29 @@ func TestVoyageAIEmbedder_Embed(t *testing.T) {
 	}
 }
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
-	return f(r)
-}
-
 func TestVoyageAIEmbedder_Dimension(t *testing.T) {
-	e, _ := NewVoyageAIEmbedder("key", "model")
+	e, _ := NewVoyageAIEmbedder("key", "model", "", 0)
 	if d := e.Dimension(); d != 1024 {
 		t.Errorf("Dimension() = %d, want 1024", d)
 	}
 }
 
+func TestVoyageAIEmbedder_CustomDimension(t *testing.T) {
+	e, _ := NewVoyageAIEmbedder("key", "model", "", 512)
+	if d := e.Dimension(); d != 512 {
+		t.Errorf("Dimension() = %d, want 512", d)
+	}
+}
+
+func TestVoyageAIEmbedder_DefaultURL(t *testing.T) {
+	e, _ := NewVoyageAIEmbedder("key", "model", "", 0)
+	if e.url != defaultVoyageAIURL {
+		t.Errorf("url = %q, want %q", e.url, defaultVoyageAIURL)
+	}
+}
+
 func TestVoyageAIEmbedder_MissingKey(t *testing.T) {
-	_, err := NewVoyageAIEmbedder("", "voyage-3")
+	_, err := NewVoyageAIEmbedder("", "voyage-3", "", 0)
 	if err == nil {
 		t.Fatal("expected error for empty API key")
 	}
@@ -220,18 +231,11 @@ func TestVoyageAIEmbedder_Unauthorized(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ve := &VoyageAIEmbedder{
-		apiKey:     "bad-key",
-		model:      "voyage-3",
-		httpClient: srv.Client(),
+	ve, err := NewVoyageAIEmbedder("bad-key", "voyage-3", srv.URL, 0)
+	if err != nil {
+		t.Fatalf("unexpected error creating embedder: %v", err)
 	}
-	ve.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		r.URL.Scheme = "http"
-		r.URL.Host = srv.Listener.Addr().String()
-		return http.DefaultTransport.RoundTrip(r)
-	})
-
-	_, err := ve.Embed(context.Background(), "hello")
+	_, err = ve.Embed(context.Background(), "hello")
 	if err == nil {
 		t.Fatal("expected error for 401 response")
 	}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -59,7 +59,6 @@ func TestNewFromConfig_VoyageAI(t *testing.T) {
 }
 
 func TestNewFromConfig_VoyageAI_MissingKey(t *testing.T) {
-	t.Setenv("VOYAGE_API_KEY", "")
 	cfg := config.EmbeddingConfig{Provider: "voyageai"}
 	_, err := NewFromConfig(cfg)
 	if err == nil {

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -1,0 +1,238 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+)
+
+func TestNewFromConfig_Ollama(t *testing.T) {
+	cfg := config.EmbeddingConfig{Provider: "ollama", URL: "http://myhost:11434", Model: "test-model"}
+	e, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	oe, ok := e.(*OllamaEmbedder)
+	if !ok {
+		t.Fatalf("expected *OllamaEmbedder, got %T", e)
+	}
+	if oe.url != "http://myhost:11434" {
+		t.Errorf("url = %q, want %q", oe.url, "http://myhost:11434")
+	}
+	if oe.model != "test-model" {
+		t.Errorf("model = %q, want %q", oe.model, "test-model")
+	}
+}
+
+func TestNewFromConfig_Ollama_Defaults(t *testing.T) {
+	cfg := config.EmbeddingConfig{Provider: "ollama"}
+	e, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	oe := e.(*OllamaEmbedder)
+	if oe.url != "http://localhost:11434" {
+		t.Errorf("url = %q, want default", oe.url)
+	}
+	if oe.model != "nomic-embed-text" {
+		t.Errorf("model = %q, want default", oe.model)
+	}
+}
+
+func TestNewFromConfig_VoyageAI(t *testing.T) {
+	cfg := config.EmbeddingConfig{Provider: "voyageai", VoyageAPIKey: "test-key", Model: "voyage-3"}
+	e, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ve, ok := e.(*VoyageAIEmbedder)
+	if !ok {
+		t.Fatalf("expected *VoyageAIEmbedder, got %T", e)
+	}
+	if ve.apiKey != "test-key" {
+		t.Errorf("apiKey = %q, want %q", ve.apiKey, "test-key")
+	}
+}
+
+func TestNewFromConfig_VoyageAI_MissingKey(t *testing.T) {
+	t.Setenv("VOYAGE_API_KEY", "")
+	cfg := config.EmbeddingConfig{Provider: "voyageai"}
+	_, err := NewFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+}
+
+func TestNewFromConfig_UnknownProvider(t *testing.T) {
+	cfg := config.EmbeddingConfig{Provider: "unknown"}
+	_, err := NewFromConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestOllamaEmbedder_Embed(t *testing.T) {
+	want := []float32{0.1, 0.2, 0.3}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/embeddings" {
+			t.Errorf("path = %s, want /api/embeddings", r.URL.Path)
+		}
+		var req map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req["model"] != "test-model" {
+			t.Errorf("model = %q, want %q", req["model"], "test-model")
+		}
+		if req["prompt"] != "hello world" {
+			t.Errorf("prompt = %q, want %q", req["prompt"], "hello world")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string][]float32{"embedding": want})
+	}))
+	defer srv.Close()
+
+	e := NewOllamaEmbedder(srv.URL, "test-model")
+	got, err := e.Embed(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %f, want %f", i, got[i], want[i])
+		}
+	}
+}
+
+func TestOllamaEmbedder_Dimension(t *testing.T) {
+	e := NewOllamaEmbedder("http://localhost:11434", "test")
+	if d := e.Dimension(); d != 768 {
+		t.Errorf("Dimension() = %d, want 768", d)
+	}
+}
+
+func TestOllamaEmbedder_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	e := NewOllamaEmbedder(srv.URL, "test-model")
+	_, err := e.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestVoyageAIEmbedder_Embed(t *testing.T) {
+	want := []float32{0.4, 0.5, 0.6}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want %q", auth, "Bearer test-key")
+		}
+		var req struct {
+			Model string   `json:"model"`
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Model != "voyage-3" {
+			t.Errorf("model = %q, want %q", req.Model, "voyage-3")
+		}
+		if len(req.Input) != 1 || req.Input[0] != "hello world" {
+			t.Errorf("input = %v, want [hello world]", req.Input)
+		}
+		resp := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{"embedding": want},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	ve := &VoyageAIEmbedder{
+		apiKey:     "test-key",
+		model:      "voyage-3",
+		httpClient: srv.Client(),
+	}
+	ve.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		r.URL.Scheme = "http"
+		r.URL.Host = srv.Listener.Addr().String()
+		return http.DefaultTransport.RoundTrip(r)
+	})
+
+	got, err := ve.Embed(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %f, want %f", i, got[i], want[i])
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestVoyageAIEmbedder_Dimension(t *testing.T) {
+	e, _ := NewVoyageAIEmbedder("key", "model")
+	if d := e.Dimension(); d != 1024 {
+		t.Errorf("Dimension() = %d, want 1024", d)
+	}
+}
+
+func TestVoyageAIEmbedder_MissingKey(t *testing.T) {
+	_, err := NewVoyageAIEmbedder("", "voyage-3")
+	if err == nil {
+		t.Fatal("expected error for empty API key")
+	}
+}
+
+func TestVoyageAIEmbedder_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid api key"}`))
+	}))
+	defer srv.Close()
+
+	ve := &VoyageAIEmbedder{
+		apiKey:     "bad-key",
+		model:      "voyage-3",
+		httpClient: srv.Client(),
+	}
+	ve.httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		r.URL.Scheme = "http"
+		r.URL.Host = srv.Listener.Addr().String()
+		return http.DefaultTransport.RoundTrip(r)
+	})
+
+	_, err := ve.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}

--- a/internal/embed/factory.go
+++ b/internal/embed/factory.go
@@ -2,7 +2,6 @@ package embed
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/nano-brain/nano-brain/internal/config"
 )
@@ -22,9 +21,6 @@ func NewFromConfig(cfg config.EmbeddingConfig) (Embedder, error) {
 
 	case "voyageai":
 		apiKey := cfg.VoyageAPIKey
-		if apiKey == "" {
-			apiKey = os.Getenv("VOYAGE_API_KEY")
-		}
 		model := cfg.Model
 		if model == "" {
 			model = "voyage-3"

--- a/internal/embed/factory.go
+++ b/internal/embed/factory.go
@@ -18,7 +18,7 @@ func NewFromConfig(cfg config.EmbeddingConfig) (Embedder, error) {
 		if model == "" {
 			model = "nomic-embed-text"
 		}
-		return NewOllamaEmbedder(url, model), nil
+		return NewOllamaEmbedder(url, model, cfg.Dimension), nil
 
 	case "voyageai":
 		apiKey := cfg.VoyageAPIKey
@@ -29,7 +29,7 @@ func NewFromConfig(cfg config.EmbeddingConfig) (Embedder, error) {
 		if model == "" {
 			model = "voyage-3"
 		}
-		return NewVoyageAIEmbedder(apiKey, model)
+		return NewVoyageAIEmbedder(apiKey, model, cfg.URL, cfg.Dimension)
 
 	default:
 		return nil, fmt.Errorf("unknown embedding provider: %q (supported: ollama, voyageai)", cfg.Provider)

--- a/internal/embed/factory.go
+++ b/internal/embed/factory.go
@@ -1,0 +1,37 @@
+package embed
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+)
+
+func NewFromConfig(cfg config.EmbeddingConfig) (Embedder, error) {
+	switch cfg.Provider {
+	case "ollama":
+		url := cfg.URL
+		if url == "" {
+			url = "http://localhost:11434"
+		}
+		model := cfg.Model
+		if model == "" {
+			model = "nomic-embed-text"
+		}
+		return NewOllamaEmbedder(url, model), nil
+
+	case "voyageai":
+		apiKey := cfg.VoyageAPIKey
+		if apiKey == "" {
+			apiKey = os.Getenv("VOYAGE_API_KEY")
+		}
+		model := cfg.Model
+		if model == "" {
+			model = "voyage-3"
+		}
+		return NewVoyageAIEmbedder(apiKey, model)
+
+	default:
+		return nil, fmt.Errorf("unknown embedding provider: %q (supported: ollama, voyageai)", cfg.Provider)
+	}
+}

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -10,18 +10,23 @@ import (
 	"time"
 )
 
-const ollamaDimension = 768
+const defaultOllamaDimension = 768
 
 type OllamaEmbedder struct {
 	url        string
 	model      string
+	dimension  int
 	httpClient *http.Client
 }
 
-func NewOllamaEmbedder(url, model string) *OllamaEmbedder {
+func NewOllamaEmbedder(url, model string, dimension int) *OllamaEmbedder {
+	if dimension <= 0 {
+		dimension = defaultOllamaDimension
+	}
 	return &OllamaEmbedder{
-		url:   url,
-		model: model,
+		url:       url,
+		model:     model,
+		dimension: dimension,
 		httpClient: &http.Client{
 			Timeout: 60 * time.Second,
 		},
@@ -29,15 +34,20 @@ func NewOllamaEmbedder(url, model string) *OllamaEmbedder {
 }
 
 func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	body, err := json.Marshal(map[string]string{
-		"model":  o.model,
-		"prompt": text,
-	})
+	reqBody := struct {
+		Model string   `json:"model"`
+		Input []string `json:"input"`
+	}{
+		Model: o.model,
+		Input: []string{text},
+	}
+
+	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("ollama: marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.url+"/api/embeddings", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.url+"/api/embed", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("ollama: create request: %w", err)
 	}
@@ -50,24 +60,24 @@ func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("ollama: unexpected status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var result struct {
-		Embedding []float32 `json:"embedding"`
+		Embeddings [][]float32 `json:"embeddings"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("ollama: decode response: %w", err)
 	}
 
-	if len(result.Embedding) == 0 {
+	if len(result.Embeddings) == 0 || len(result.Embeddings[0]) == 0 {
 		return nil, fmt.Errorf("ollama: empty embedding returned")
 	}
 
-	return result.Embedding, nil
+	return result.Embeddings[0], nil
 }
 
 func (o *OllamaEmbedder) Dimension() int {
-	return ollamaDimension
+	return o.dimension
 }

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -1,0 +1,73 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const ollamaDimension = 768
+
+type OllamaEmbedder struct {
+	url        string
+	model      string
+	httpClient *http.Client
+}
+
+func NewOllamaEmbedder(url, model string) *OllamaEmbedder {
+	return &OllamaEmbedder{
+		url:   url,
+		model: model,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	body, err := json.Marshal(map[string]string{
+		"model":  o.model,
+		"prompt": text,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ollama: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.url+"/api/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ollama: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("ollama: unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Embedding []float32 `json:"embedding"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("ollama: decode response: %w", err)
+	}
+
+	if len(result.Embedding) == 0 {
+		return nil, fmt.Errorf("ollama: empty embedding returned")
+	}
+
+	return result.Embedding, nil
+}
+
+func (o *OllamaEmbedder) Dimension() int {
+	return ollamaDimension
+}

--- a/internal/embed/voyageai.go
+++ b/internal/embed/voyageai.go
@@ -1,0 +1,87 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	voyageAPIDimension = 1024
+	voyageAPIURL       = "https://api.voyageai.com/v1/embeddings"
+)
+
+type VoyageAIEmbedder struct {
+	apiKey     string
+	model      string
+	httpClient *http.Client
+}
+
+func NewVoyageAIEmbedder(apiKey, model string) (*VoyageAIEmbedder, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("voyageai: api key is required")
+	}
+	return &VoyageAIEmbedder{
+		apiKey: apiKey,
+		model:  model,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}, nil
+}
+
+func (v *VoyageAIEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	reqBody := struct {
+		Model string   `json:"model"`
+		Input []string `json:"input"`
+	}{
+		Model: v.model,
+		Input: []string{text},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("voyageai: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, voyageAPIURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("voyageai: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+v.apiKey)
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("voyageai: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("voyageai: unexpected status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("voyageai: decode response: %w", err)
+	}
+
+	if len(result.Data) == 0 || len(result.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("voyageai: empty embedding returned")
+	}
+
+	return result.Data[0].Embedding, nil
+}
+
+func (v *VoyageAIEmbedder) Dimension() int {
+	return voyageAPIDimension
+}

--- a/internal/embed/voyageai.go
+++ b/internal/embed/voyageai.go
@@ -11,23 +11,33 @@ import (
 )
 
 const (
-	voyageAPIDimension = 1024
-	voyageAPIURL       = "https://api.voyageai.com/v1/embeddings"
+	defaultVoyageAIDimension = 1024
+	defaultVoyageAIURL       = "https://api.voyageai.com/v1/embeddings"
 )
 
 type VoyageAIEmbedder struct {
+	url        string
 	apiKey     string
 	model      string
+	dimension  int
 	httpClient *http.Client
 }
 
-func NewVoyageAIEmbedder(apiKey, model string) (*VoyageAIEmbedder, error) {
+func NewVoyageAIEmbedder(apiKey, model, url string, dimension int) (*VoyageAIEmbedder, error) {
 	if apiKey == "" {
 		return nil, fmt.Errorf("voyageai: api key is required")
 	}
+	if url == "" {
+		url = defaultVoyageAIURL
+	}
+	if dimension <= 0 {
+		dimension = defaultVoyageAIDimension
+	}
 	return &VoyageAIEmbedder{
-		apiKey: apiKey,
-		model:  model,
+		url:       url,
+		apiKey:    apiKey,
+		model:     model,
+		dimension: dimension,
 		httpClient: &http.Client{
 			Timeout: 60 * time.Second,
 		},
@@ -48,7 +58,7 @@ func (v *VoyageAIEmbedder) Embed(ctx context.Context, text string) ([]float32, e
 		return nil, fmt.Errorf("voyageai: marshal request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, voyageAPIURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("voyageai: create request: %w", err)
 	}
@@ -62,7 +72,7 @@ func (v *VoyageAIEmbedder) Embed(ctx context.Context, text string) ([]float32, e
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("voyageai: unexpected status %d: %s", resp.StatusCode, string(respBody))
 	}
 
@@ -83,5 +93,5 @@ func (v *VoyageAIEmbedder) Embed(ctx context.Context, text string) ([]float32, e
 }
 
 func (v *VoyageAIEmbedder) Dimension() int {
-	return voyageAPIDimension
+	return v.dimension
 }


### PR DESCRIPTION
## Story 3.1: Embedding Provider Interface and Implementations

### Changes
- **Interface**: `Embedder` with `Embed(ctx, text) → []float32` and `Dimension()`
- **Ollama**: POST /api/embeddings, 768-dim default, 60s timeout
- **VoyageAI**: Bearer auth, 1024-dim default, validates API key
- **Factory**: `NewFromConfig` with defaults + VOYAGE_API_KEY env fallback
- **Tests**: 12 unit tests with httptest mocks

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅ (12 embed tests pass)

Closes #60