### PR TITLE
feat(embed): async embedding queue with backoff + concurrency

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/embed"
 	"github.com/nano-brain/nano-brain/internal/health"
 	"github.com/nano-brain/nano-brain/internal/server"
 	"github.com/nano-brain/nano-brain/internal/storage"
@@ -87,7 +88,17 @@ func main() {
 
 	fw := watcher.New(db, queries, logger, *cfg)
 
-	srv := server.New(cfg.Server, pool, db, queries, fw, logger, Version)
+	var eq *embed.Queue
+	if cfg.Embedding.Provider != "" {
+		embedder, embedErr := embed.NewFromConfig(cfg.Embedding)
+		if embedErr != nil {
+			logger.Warn().Err(embedErr).Msg("embedding disabled — provider not configured")
+		} else {
+			eq = embed.NewQueue(embedder, queries, logger, cfg.Embedding.Provider, cfg.Embedding.Model, cfg.Embedding.Concurrency)
+		}
+	}
+
+	srv := server.New(cfg.Server, pool, db, queries, fw, eq, logger, Version)
 
 	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {
@@ -116,6 +127,12 @@ func main() {
 	g.Go(func() error {
 		return fw.Run(gctx)
 	})
+
+	if eq != nil {
+		g.Go(func() error {
+			return eq.Run(gctx)
+		})
+	}
 
 	g.Go(func() error {
 		<-gctx.Done()

--- a/docs/evidence/self-review-story-3.2.md
+++ b/docs/evidence/self-review-story-3.2.md
@@ -1,0 +1,14 @@
+# Story 3.2 Self-Review Evidence
+
+## Oracle Review
+- **0 Critical**
+- **3 Major**: M1 shutdown drain (fixed: sync.WaitGroup), M2 failed chunks dropped (deferred to Story 3.3 by design), M3 enqueuer test gap (fixed: mockEnqueuer test)
+- **3 Minor**: m1 thundering herd jitter (fixed), m2 dropped enqueue logging (fixed), m3 embedding type (noted, low priority)
+
+## Gemini Review (PR #63)
+- **1 High**: Failed chunks dropped — deferred to Story 3.3 (retry counting + embed_failed)
+- **2 Medium**: Startup scan limit (fixed: paginated + periodic 5min rescan), no per-request timeout (fixed: 2min context timeout on Embed)
+
+## Verification
+- `go build ./...` ✅
+- `go test -race -short ./...` ✅

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -1,0 +1,178 @@
+package embed
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	pgvector "github.com/pgvector/pgvector-go"
+	"github.com/rs/zerolog"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+const (
+	channelCapacity     = 10000
+	defaultConcurrency  = 4
+	startupScanLimit    = 1000
+	backoffBase         = 60 * time.Second
+	backoffMultiplier   = 1.5
+	backoffMax          = 300 * time.Second
+)
+
+type QueueQuerier interface {
+	GetChunkByID(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error)
+	GetAllPendingChunks(ctx context.Context, limit int32) ([]uuid.UUID, error)
+	InsertEmbedding(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
+	MarkChunkEmbedded(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
+}
+
+type Queue struct {
+	ch          chan uuid.UUID
+	embedder    Embedder
+	queries     QueueQuerier
+	logger      zerolog.Logger
+	provider    string
+	model       string
+	concurrency int
+	backoff     backoffState
+	mu          sync.Mutex
+}
+
+type backoffState struct {
+	current time.Duration
+}
+
+func NewQueue(embedder Embedder, queries QueueQuerier, logger zerolog.Logger, provider, model string, concurrency int) *Queue {
+	if concurrency <= 0 {
+		concurrency = defaultConcurrency
+	}
+	return &Queue{
+		ch:          make(chan uuid.UUID, channelCapacity),
+		embedder:    embedder,
+		queries:     queries,
+		logger:      logger.With().Str("component", "embed-queue").Logger(),
+		provider:    provider,
+		model:       model,
+		concurrency: concurrency,
+		backoff:     backoffState{current: 0},
+	}
+}
+
+func (q *Queue) Enqueue(chunkID uuid.UUID) bool {
+	select {
+	case q.ch <- chunkID:
+		q.logger.Debug().Str("chunk_id", chunkID.String()).Msg("chunk enqueued")
+		return true
+	default:
+		q.logger.Warn().Str("chunk_id", chunkID.String()).Msg("queue full, chunk dropped")
+		return false
+	}
+}
+
+func (q *Queue) Run(ctx context.Context) error {
+	q.scanPending(ctx)
+
+	sem := make(chan struct{}, q.concurrency)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case chunkID := <-q.ch:
+			sem <- struct{}{}
+			go func(id uuid.UUID) {
+				defer func() { <-sem }()
+				q.processChunk(ctx, id)
+			}(chunkID)
+		}
+	}
+}
+
+func (q *Queue) scanPending(ctx context.Context) {
+	ids, err := q.queries.GetAllPendingChunks(ctx, startupScanLimit)
+	if err != nil {
+		q.logger.Error().Err(err).Msg("startup scan failed")
+		return
+	}
+	enqueued := 0
+	for _, id := range ids {
+		if q.Enqueue(id) {
+			enqueued++
+		}
+	}
+	q.logger.Info().Int("count", enqueued).Msg("startup scan: re-queued pending chunks")
+}
+
+func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	q.mu.Lock()
+	delay := q.backoff.current
+	q.mu.Unlock()
+
+	if delay > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+	}
+
+	chunk, err := q.queries.GetChunkByID(ctx, chunkID)
+	if err != nil {
+		q.logger.Error().Err(err).Str("chunk_id", chunkID.String()).Msg("failed to fetch chunk")
+		return
+	}
+
+	vec, err := q.embedder.Embed(ctx, chunk.Content)
+	if err != nil {
+		q.logger.Error().Err(err).Str("chunk_id", chunkID.String()).Msg("embedding failed")
+		q.increaseBackoff()
+		return
+	}
+
+	_, err = q.queries.InsertEmbedding(ctx, sqlc.InsertEmbeddingParams{
+		ChunkID:       chunkID,
+		WorkspaceHash: chunk.WorkspaceHash,
+		Provider:      q.provider,
+		Model:         q.model,
+		Embedding:     pgvector.NewVector(vec),
+	})
+	if err != nil {
+		q.logger.Error().Err(err).Str("chunk_id", chunkID.String()).Msg("insert embedding failed")
+		return
+	}
+
+	if err := q.queries.MarkChunkEmbedded(ctx, sqlc.MarkChunkEmbeddedParams{
+		ID:            chunkID,
+		WorkspaceHash: chunk.WorkspaceHash,
+	}); err != nil {
+		q.logger.Error().Err(err).Str("chunk_id", chunkID.String()).Msg("mark embedded failed")
+		return
+	}
+
+	q.resetBackoff()
+	q.logger.Debug().Str("chunk_id", chunkID.String()).Msg("chunk embedded")
+}
+
+func (q *Queue) increaseBackoff() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.backoff.current == 0 {
+		q.backoff.current = backoffBase
+	} else {
+		q.backoff.current = time.Duration(float64(q.backoff.current) * backoffMultiplier)
+	}
+	if q.backoff.current > backoffMax {
+		q.backoff.current = backoffMax
+	}
+}
+
+func (q *Queue) resetBackoff() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.backoff.current = 0
+}

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -14,12 +14,14 @@ import (
 )
 
 const (
-	channelCapacity     = 10000
-	defaultConcurrency  = 4
-	startupScanLimit    = 1000
-	backoffBase         = 60 * time.Second
-	backoffMultiplier   = 1.5
-	backoffMax          = 300 * time.Second
+	channelCapacity    = 10000
+	defaultConcurrency = 4
+	scanBatchSize      = 1000
+	rescanInterval     = 5 * time.Minute
+	embedTimeout       = 2 * time.Minute
+	backoffBase        = 60 * time.Second
+	backoffMultiplier  = 1.5
+	backoffMax         = 300 * time.Second
 )
 
 type QueueQuerier interface {
@@ -75,6 +77,9 @@ func (q *Queue) Enqueue(chunkID uuid.UUID) bool {
 func (q *Queue) Run(ctx context.Context) error {
 	q.scanPending(ctx)
 
+	rescanTicker := time.NewTicker(rescanInterval)
+	defer rescanTicker.Stop()
+
 	sem := make(chan struct{}, q.concurrency)
 	var wg sync.WaitGroup
 	for {
@@ -82,6 +87,8 @@ func (q *Queue) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			wg.Wait()
 			return nil
+		case <-rescanTicker.C:
+			q.scanPending(ctx)
 		case chunkID := <-q.ch:
 			sem <- struct{}{}
 			wg.Add(1)
@@ -95,18 +102,25 @@ func (q *Queue) Run(ctx context.Context) error {
 }
 
 func (q *Queue) scanPending(ctx context.Context) {
-	ids, err := q.queries.GetAllPendingChunks(ctx, startupScanLimit)
-	if err != nil {
-		q.logger.Error().Err(err).Msg("startup scan failed")
-		return
-	}
-	enqueued := 0
-	for _, id := range ids {
-		if q.Enqueue(id) {
-			enqueued++
+	total := 0
+	for {
+		ids, err := q.queries.GetAllPendingChunks(ctx, scanBatchSize)
+		if err != nil {
+			q.logger.Error().Err(err).Msg("failed to scan pending chunks")
+			return
+		}
+		for _, id := range ids {
+			if !q.Enqueue(id) {
+				q.logger.Info().Int("total", total).Msg("scan complete (queue full)")
+				return
+			}
+			total++
+		}
+		if len(ids) < scanBatchSize {
+			break
 		}
 	}
-	q.logger.Info().Int("count", enqueued).Msg("startup scan: re-queued pending chunks")
+	q.logger.Info().Int("total", total).Msg("scan complete")
 }
 
 func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
@@ -134,7 +148,9 @@ func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
 		return
 	}
 
-	vec, err := q.embedder.Embed(ctx, chunk.Content)
+	embedCtx, cancel := context.WithTimeout(ctx, embedTimeout)
+	defer cancel()
+	vec, err := q.embedder.Embed(embedCtx, chunk.Content)
 	if err != nil {
 		q.logger.Error().Err(err).Str("chunk_id", chunkID.String()).Msg("embedding failed")
 		q.increaseBackoff()

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -2,6 +2,7 @@ package embed
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -75,13 +76,17 @@ func (q *Queue) Run(ctx context.Context) error {
 	q.scanPending(ctx)
 
 	sem := make(chan struct{}, q.concurrency)
+	var wg sync.WaitGroup
 	for {
 		select {
 		case <-ctx.Done():
+			wg.Wait()
 			return nil
 		case chunkID := <-q.ch:
 			sem <- struct{}{}
+			wg.Add(1)
 			go func(id uuid.UUID) {
+				defer wg.Done()
 				defer func() { <-sem }()
 				q.processChunk(ctx, id)
 			}(chunkID)
@@ -114,6 +119,8 @@ func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
 	q.mu.Unlock()
 
 	if delay > 0 {
+		jitter := time.Duration(rand.Int63n(int64(delay / 4)))
+		delay += jitter
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -1,0 +1,246 @@
+package embed
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockEmbedder struct {
+	mu       sync.Mutex
+	embedFn  func(ctx context.Context, text string) ([]float32, error)
+	calls    int
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+	if m.embedFn != nil {
+		return m.embedFn(ctx, text)
+	}
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+
+func (m *mockEmbedder) Dimension() int { return 3 }
+
+func (m *mockEmbedder) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+type mockQuerier struct {
+	mu                     sync.Mutex
+	getChunkByIDFn         func(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error)
+	getAllPendingChunksFn   func(ctx context.Context, limit int32) ([]uuid.UUID, error)
+	insertEmbeddingFn      func(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
+	markChunkEmbeddedFn    func(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
+	insertEmbeddingCalls   int
+	markChunkEmbeddedCalls int
+}
+
+func (m *mockQuerier) GetChunkByID(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error) {
+	if m.getChunkByIDFn != nil {
+		return m.getChunkByIDFn(ctx, id)
+	}
+	return sqlc.GetChunkByIDRow{
+		ID:            id,
+		WorkspaceHash: "ws1",
+		Content:       "test content",
+	}, nil
+}
+
+func (m *mockQuerier) GetAllPendingChunks(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+	if m.getAllPendingChunksFn != nil {
+		return m.getAllPendingChunksFn(ctx, limit)
+	}
+	return nil, nil
+}
+
+func (m *mockQuerier) InsertEmbedding(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error) {
+	m.mu.Lock()
+	m.insertEmbeddingCalls++
+	m.mu.Unlock()
+	if m.insertEmbeddingFn != nil {
+		return m.insertEmbeddingFn(ctx, arg)
+	}
+	return sqlc.Embedding{}, nil
+}
+
+func (m *mockQuerier) MarkChunkEmbedded(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error {
+	m.mu.Lock()
+	m.markChunkEmbeddedCalls++
+	m.mu.Unlock()
+	if m.markChunkEmbeddedFn != nil {
+		return m.markChunkEmbeddedFn(ctx, arg)
+	}
+	return nil
+}
+
+func newTestQueue(e Embedder, q QueueQuerier) *Queue {
+	return NewQueue(e, q, zerolog.Nop(), "test-provider", "test-model", 2)
+}
+
+func TestQueue_Enqueue(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	id := uuid.New()
+	if !eq.Enqueue(id) {
+		t.Fatal("expected Enqueue to return true")
+	}
+	select {
+	case got := <-eq.ch:
+		if got != id {
+			t.Errorf("got %s, want %s", got, id)
+		}
+	default:
+		t.Fatal("channel should have one item")
+	}
+}
+
+func TestQueue_EnqueueFull(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	for i := 0; i < channelCapacity; i++ {
+		if !eq.Enqueue(uuid.New()) {
+			t.Fatalf("enqueue failed at %d", i)
+		}
+	}
+	if eq.Enqueue(uuid.New()) {
+		t.Fatal("expected Enqueue to return false when channel is full")
+	}
+}
+
+func TestQueue_ProcessChunk_Success(t *testing.T) {
+	chunkID := uuid.New()
+	me := &mockEmbedder{}
+	mq := &mockQuerier{}
+
+	eq := newTestQueue(me, mq)
+	eq.processChunk(context.Background(), chunkID)
+
+	if me.callCount() != 1 {
+		t.Errorf("embed calls = %d, want 1", me.callCount())
+	}
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	if mq.insertEmbeddingCalls != 1 {
+		t.Errorf("insertEmbedding calls = %d, want 1", mq.insertEmbeddingCalls)
+	}
+	if mq.markChunkEmbeddedCalls != 1 {
+		t.Errorf("markChunkEmbedded calls = %d, want 1", mq.markChunkEmbeddedCalls)
+	}
+}
+
+func TestQueue_ProcessChunk_EmbedFailure(t *testing.T) {
+	chunkID := uuid.New()
+	me := &mockEmbedder{
+		embedFn: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, fmt.Errorf("provider down")
+		},
+	}
+	mq := &mockQuerier{}
+
+	eq := newTestQueue(me, mq)
+	eq.processChunk(context.Background(), chunkID)
+
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	if mq.insertEmbeddingCalls != 0 {
+		t.Errorf("insertEmbedding calls = %d, want 0", mq.insertEmbeddingCalls)
+	}
+	if mq.markChunkEmbeddedCalls != 0 {
+		t.Errorf("markChunkEmbedded calls = %d, want 0", mq.markChunkEmbeddedCalls)
+	}
+}
+
+func TestQueue_Backoff(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+
+	if eq.backoff.current != 0 {
+		t.Fatalf("initial backoff = %v, want 0", eq.backoff.current)
+	}
+
+	eq.increaseBackoff()
+	if eq.backoff.current != backoffBase {
+		t.Errorf("after first failure = %v, want %v", eq.backoff.current, backoffBase)
+	}
+
+	eq.increaseBackoff()
+	want := time.Duration(float64(backoffBase) * backoffMultiplier)
+	if eq.backoff.current != want {
+		t.Errorf("after second failure = %v, want %v", eq.backoff.current, want)
+	}
+
+	eq.resetBackoff()
+	if eq.backoff.current != 0 {
+		t.Errorf("after reset = %v, want 0", eq.backoff.current)
+	}
+}
+
+func TestQueue_BackoffMax(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+
+	for i := 0; i < 100; i++ {
+		eq.increaseBackoff()
+	}
+	if eq.backoff.current > backoffMax {
+		t.Errorf("backoff %v exceeds max %v", eq.backoff.current, backoffMax)
+	}
+}
+
+func TestQueue_RunStartupScan(t *testing.T) {
+	pending := []uuid.UUID{uuid.New(), uuid.New()}
+	mq := &mockQuerier{
+		getAllPendingChunksFn: func(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+			return pending, nil
+		},
+	}
+
+	eq := newTestQueue(&mockEmbedder{}, mq)
+	eq.scanPending(context.Background())
+
+	if len(eq.ch) != 2 {
+		t.Errorf("channel len = %d, want 2", len(eq.ch))
+	}
+}
+
+func TestQueue_RunContextCancellation(t *testing.T) {
+	mq := &mockQuerier{}
+	eq := newTestQueue(&mockEmbedder{}, mq)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- eq.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run() = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+func TestNewQueue_DefaultConcurrency(t *testing.T) {
+	eq := NewQueue(&mockEmbedder{}, &mockQuerier{}, zerolog.Nop(), "p", "m", 0)
+	if eq.concurrency != defaultConcurrency {
+		t.Errorf("concurrency = %d, want %d", eq.concurrency, defaultConcurrency)
+	}
+}
+
+func TestNewQueue_NegativeConcurrency(t *testing.T) {
+	eq := NewQueue(&mockEmbedder{}, &mockQuerier{}, zerolog.Nop(), "p", "m", -1)
+	if eq.concurrency != defaultConcurrency {
+		t.Errorf("concurrency = %d, want %d", eq.concurrency, defaultConcurrency)
+	}
+}

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -195,7 +195,7 @@ func TestQueue_BackoffMax(t *testing.T) {
 	}
 }
 
-func TestQueue_RunStartupScan(t *testing.T) {
+func TestQueue_ScanPendingSingleBatch(t *testing.T) {
 	pending := []uuid.UUID{uuid.New(), uuid.New()}
 	mq := &mockQuerier{
 		getAllPendingChunksFn: func(ctx context.Context, limit int32) ([]uuid.UUID, error) {
@@ -208,6 +208,58 @@ func TestQueue_RunStartupScan(t *testing.T) {
 
 	if len(eq.ch) != 2 {
 		t.Errorf("channel len = %d, want 2", len(eq.ch))
+	}
+}
+
+func TestQueue_ScanPendingMultiBatch(t *testing.T) {
+	callCount := 0
+	mq := &mockQuerier{
+		getAllPendingChunksFn: func(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+			callCount++
+			if callCount == 1 {
+				ids := make([]uuid.UUID, scanBatchSize)
+				for i := range ids {
+					ids[i] = uuid.New()
+				}
+				return ids, nil
+			}
+			return []uuid.UUID{uuid.New(), uuid.New()}, nil
+		},
+	}
+
+	eq := newTestQueue(&mockEmbedder{}, mq)
+	eq.scanPending(context.Background())
+
+	if callCount != 2 {
+		t.Errorf("GetAllPendingChunks called %d times, want 2", callCount)
+	}
+	if len(eq.ch) != scanBatchSize+2 {
+		t.Errorf("channel len = %d, want %d", len(eq.ch), scanBatchSize+2)
+	}
+}
+
+func TestQueue_ScanPendingStopsWhenQueueFull(t *testing.T) {
+	mq := &mockQuerier{
+		getAllPendingChunksFn: func(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+			ids := make([]uuid.UUID, scanBatchSize)
+			for i := range ids {
+				ids[i] = uuid.New()
+			}
+			return ids, nil
+		},
+	}
+
+	eq := newTestQueue(&mockEmbedder{}, mq)
+
+	prefill := channelCapacity - 5
+	for i := 0; i < prefill; i++ {
+		eq.ch <- uuid.New()
+	}
+
+	eq.scanPending(context.Background())
+
+	if len(eq.ch) != channelCapacity {
+		t.Errorf("channel len = %d, want %d (full)", len(eq.ch), channelCapacity)
 	}
 }
 
@@ -228,6 +280,30 @@ func TestQueue_RunContextCancellation(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return after context cancellation")
+	}
+}
+
+func TestQueue_ProcessChunk_EmbedHasDeadline(t *testing.T) {
+	chunkID := uuid.New()
+	var capturedDeadline time.Time
+	var hasDeadline bool
+	me := &mockEmbedder{
+		embedFn: func(ctx context.Context, text string) ([]float32, error) {
+			capturedDeadline, hasDeadline = ctx.Deadline()
+			return []float32{0.1, 0.2, 0.3}, nil
+		},
+	}
+	mq := &mockQuerier{}
+
+	eq := newTestQueue(me, mq)
+	eq.processChunk(context.Background(), chunkID)
+
+	if !hasDeadline {
+		t.Fatal("embed context should have a deadline")
+	}
+	remaining := time.Until(capturedDeadline)
+	if remaining > embedTimeout || remaining < 0 {
+		t.Errorf("deadline remaining = %v, expected within (0, %v]", remaining, embedTimeout)
 	}
 }
 

--- a/internal/server/handlers/document.go
+++ b/internal/server/handlers/document.go
@@ -163,7 +163,9 @@ func WriteDocument(q DocumentQuerier, db *sql.DB, enqueuer ChunkEnqueuer, logger
 
 		if enqueuer != nil {
 			for _, id := range chunkIDs {
-				enqueuer.Enqueue(id)
+				if !enqueuer.Enqueue(id) {
+					logger.Warn().Str("chunk_id", id.String()).Msg("embedding queue full, chunk will be picked up on next scan")
+				}
 			}
 		}
 

--- a/internal/server/handlers/document.go
+++ b/internal/server/handlers/document.go
@@ -22,6 +22,10 @@ type DocumentQuerier interface {
 	UpsertChunk(ctx context.Context, arg sqlc.UpsertChunkParams) (uuid.UUID, error)
 }
 
+type ChunkEnqueuer interface {
+	Enqueue(chunkID uuid.UUID) bool
+}
+
 type WriteRequest struct {
 	Content    string          `json:"content"`
 	Tags       []string        `json:"tags"`
@@ -39,15 +43,16 @@ type WriteResponse struct {
 	ChunkCount    int    `json:"chunk_count"`
 }
 
-func writeChunks(ctx context.Context, q DocumentQuerier, docID uuid.UUID, workspace string, chunks []chunk.Chunk, meta pqtype.NullRawMessage) error {
+func writeChunks(ctx context.Context, q DocumentQuerier, docID uuid.UUID, workspace string, chunks []chunk.Chunk, meta pqtype.NullRawMessage) ([]uuid.UUID, error) {
 	if err := q.DeleteChunksByDocumentID(ctx, sqlc.DeleteChunksByDocumentIDParams{
 		DocumentID:    docID,
 		WorkspaceHash: workspace,
 	}); err != nil {
-		return err
+		return nil, err
 	}
+	ids := make([]uuid.UUID, 0, len(chunks))
 	for _, ch := range chunks {
-		if _, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+		id, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{
 			DocumentID:    docID,
 			WorkspaceHash: workspace,
 			ContentHash:   ch.Hash,
@@ -56,14 +61,16 @@ func writeChunks(ctx context.Context, q DocumentQuerier, docID uuid.UUID, worksp
 			StartLine:     sql.NullInt32{Int32: int32(ch.StartLine), Valid: true},
 			EndLine:       sql.NullInt32{Int32: int32(ch.EndLine), Valid: true},
 			Metadata:      meta,
-		}); err != nil {
-			return err
+		})
+		if err != nil {
+			return nil, err
 		}
+		ids = append(ids, id)
 	}
-	return nil
+	return ids, nil
 }
 
-func WriteDocument(q DocumentQuerier, db *sql.DB, logger zerolog.Logger, maxFileSize int64) echo.HandlerFunc {
+func WriteDocument(q DocumentQuerier, db *sql.DB, enqueuer ChunkEnqueuer, logger zerolog.Logger, maxFileSize int64) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var req WriteRequest
 		if err := c.Bind(&req); err != nil {
@@ -116,6 +123,7 @@ func WriteDocument(q DocumentQuerier, db *sql.DB, logger zerolog.Logger, maxFile
 		chunkMeta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
 
 		var row sqlc.UpsertDocumentRow
+		var chunkIDs []uuid.UUID
 		if db != nil {
 			tx, err := db.BeginTx(c.Request().Context(), nil)
 			if err != nil {
@@ -129,7 +137,8 @@ func WriteDocument(q DocumentQuerier, db *sql.DB, logger zerolog.Logger, maxFile
 				logger.Error().Err(err).Str("workspace", workspace).Str("hash", contentHash).Msg("upsert document failed")
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to write document")
 			}
-			if err := writeChunks(c.Request().Context(), tq, row.ID, workspace, chunks, chunkMeta); err != nil {
+			chunkIDs, err = writeChunks(c.Request().Context(), tq, row.ID, workspace, chunks, chunkMeta)
+			if err != nil {
 				_ = tx.Rollback()
 				logger.Error().Err(err).Msg("write chunks failed")
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to write document")
@@ -139,17 +148,22 @@ func WriteDocument(q DocumentQuerier, db *sql.DB, logger zerolog.Logger, maxFile
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to write document")
 			}
 		} else {
-			// no-tx path: used in tests where db is nil. Not used in production.
-			// Lacks atomicity — acceptable for unit tests with mock queriers.
 			var err error
 			row, err = q.UpsertDocument(c.Request().Context(), params)
 			if err != nil {
 				logger.Error().Err(err).Str("workspace", workspace).Str("hash", contentHash).Msg("upsert document failed")
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to write document")
 			}
-			if err := writeChunks(c.Request().Context(), q, row.ID, workspace, chunks, chunkMeta); err != nil {
+			chunkIDs, err = writeChunks(c.Request().Context(), q, row.ID, workspace, chunks, chunkMeta)
+			if err != nil {
 				logger.Error().Err(err).Msg("write chunks failed")
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to write document")
+			}
+		}
+
+		if enqueuer != nil {
+			for _, id := range chunkIDs {
+				enqueuer.Enqueue(id)
 			}
 		}
 

--- a/internal/server/handlers/document_test.go
+++ b/internal/server/handlers/document_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -275,5 +276,65 @@ func TestWriteDocument_HashVerification(t *testing.T) {
 
 	if capturedHash != expectedHash {
 		t.Errorf("expected hash %s, got %s", expectedHash, capturedHash)
+	}
+}
+
+type mockEnqueuer struct {
+	mu       sync.Mutex
+	enqueued []uuid.UUID
+}
+
+func (m *mockEnqueuer) Enqueue(id uuid.UUID) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.enqueued = append(m.enqueued, id)
+	return true
+}
+
+func TestWriteDocument_EnqueuesChunks(t *testing.T) {
+	var chunkIDs []uuid.UUID
+	q := &mockDocumentQuerier{
+		upsertDocumentFn: func(_ context.Context, arg sqlc.UpsertDocumentParams) (sqlc.UpsertDocumentRow, error) {
+			return sqlc.UpsertDocumentRow{
+				ID:            uuid.New(),
+				ContentHash:   arg.ContentHash,
+				Collection:    arg.Collection,
+				WorkspaceHash: arg.WorkspaceHash,
+			}, nil
+		},
+		upsertChunkFn: func(_ context.Context, arg sqlc.UpsertChunkParams) (uuid.UUID, error) {
+			id := uuid.New()
+			chunkIDs = append(chunkIDs, id)
+			return id, nil
+		},
+	}
+
+	enq := &mockEnqueuer{}
+
+	e := echo.New()
+	body := `{"content":"hello world","workspace":"ws1"}`
+	c, rec := newWriteContext(e, body, "ws1")
+
+	h := handlers.WriteDocument(q, nil, enq, zerolog.Nop(), testMaxFileSize)
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+
+	enq.mu.Lock()
+	defer enq.mu.Unlock()
+
+	if len(enq.enqueued) == 0 {
+		t.Fatal("expected enqueuer to be called at least once")
+	}
+	if len(enq.enqueued) != len(chunkIDs) {
+		t.Errorf("enqueued %d chunks, want %d", len(enq.enqueued), len(chunkIDs))
+	}
+	for i, id := range enq.enqueued {
+		if id != chunkIDs[i] {
+			t.Errorf("enqueued[%d] = %s, want %s", i, id, chunkIDs[i])
+		}
 	}
 }

--- a/internal/server/handlers/document_test.go
+++ b/internal/server/handlers/document_test.go
@@ -70,7 +70,7 @@ func TestWriteDocument_Success(t *testing.T) {
 	body := `{"content":"hello world","workspace":"ws1"}`
 	c, rec := newWriteContext(e, body, "ws1")
 
-	h := handlers.WriteDocument(q, nil, zerolog.Nop(), testMaxFileSize)
+	h := handlers.WriteDocument(q, nil, nil, zerolog.Nop(), testMaxFileSize)
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestWriteDocument_ChunksCreated(t *testing.T) {
 	body := `{"content":"hello world","workspace":"ws1"}`
 	c, rec := newWriteContext(e, body, "ws1")
 
-	h := handlers.WriteDocument(q, nil, zerolog.Nop(), testMaxFileSize)
+	h := handlers.WriteDocument(q, nil, nil, zerolog.Nop(), testMaxFileSize)
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestWriteDocument_EmptyContent(t *testing.T) {
 	body := `{"content":"","workspace":"ws1"}`
 	c, _ := newWriteContext(e, body, "ws1")
 
-	h := handlers.WriteDocument(q, nil, zerolog.Nop(), testMaxFileSize)
+	h := handlers.WriteDocument(q, nil, nil, zerolog.Nop(), testMaxFileSize)
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for empty content")
@@ -205,7 +205,7 @@ func TestWriteDocument_ContentTooLarge(t *testing.T) {
 	body := `{"content":"` + large + `","workspace":"ws1"}`
 	c, _ := newWriteContext(e, body, "ws1")
 
-	h := handlers.WriteDocument(q, nil, zerolog.Nop(), testMaxFileSize)
+	h := handlers.WriteDocument(q, nil, nil, zerolog.Nop(), testMaxFileSize)
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for oversized content")
@@ -237,7 +237,7 @@ func TestWriteDocument_DefaultCollection(t *testing.T) {
 	body := `{"content":"hello","workspace":"ws1"}`
 	c, _ := newWriteContext(e, body, "ws1")
 
-	h := handlers.WriteDocument(q, nil, zerolog.Nop(), testMaxFileSize)
+	h := handlers.WriteDocument(q, nil, nil, zerolog.Nop(), testMaxFileSize)
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestWriteDocument_HashVerification(t *testing.T) {
 	body := `{"content":"` + content + `"}`
 	c, _ := newWriteContext(e, body, "ws1")
 
-	h := handlers.WriteDocument(q, nil, zerolog.Nop(), testMaxFileSize)
+	h := handlers.WriteDocument(q, nil, nil, zerolog.Nop(), testMaxFileSize)
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -15,7 +15,7 @@ func registerRoutes(s *Server) {
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
 
 	data := api.Group("", workspaceMiddleware())
-	data.POST("/write", handlers.WriteDocument(s.queries, s.db, s.logger, defaultMaxFileSize))
+	data.POST("/write", handlers.WriteDocument(s.queries, s.db, s.embedQueue, s.logger, defaultMaxFileSize))
 
 	data.POST("/collections", handlers.AddCollection(s.queries, s.watcher, s.logger))
 	data.GET("/collections", handlers.ListCollectionsHandler(s.queries, s.logger))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/embed"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
@@ -22,33 +23,35 @@ type PoolChecker interface {
 
 // Server wraps Echo and holds dependencies.
 type Server struct {
-	echo      *echo.Echo
-	pool      PoolChecker
-	db        *sql.DB
-	queries   *sqlc.Queries
-	watcher   *watcher.Watcher
-	logger    zerolog.Logger
-	cfg       config.ServerConfig
-	version   string
-	startTime time.Time
+	echo       *echo.Echo
+	pool       PoolChecker
+	db         *sql.DB
+	queries    *sqlc.Queries
+	watcher    *watcher.Watcher
+	embedQueue *embed.Queue
+	logger     zerolog.Logger
+	cfg        config.ServerConfig
+	version    string
+	startTime  time.Time
 }
 
 // New creates a new Server with all routes and middleware registered.
-func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, logger zerolog.Logger, version string) *Server {
+func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, logger zerolog.Logger, version string) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
 
 	s := &Server{
-		echo:      e,
-		pool:      pool,
-		db:        db,
-		queries:   queries,
-		watcher:   fw,
-		logger:    logger,
-		cfg:       cfg,
-		version:   version,
-		startTime: time.Now(),
+		echo:       e,
+		pool:       pool,
+		db:         db,
+		queries:    queries,
+		watcher:    fw,
+		embedQueue: eq,
+		logger:     logger,
+		cfg:        cfg,
+		version:    version,
+		startTime:  time.Now(),
 	}
 
 	registerMiddleware(s)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,7 @@ func (m *mockPool) Ping(_ context.Context) error {
 func newTestServer(pool *mockPool) *server.Server {
 	cfg := config.ServerConfig{Host: "127.0.0.1", Port: 3100}
 	logger := zerolog.Nop()
-	return server.New(cfg, pool, nil, nil, nil, logger, "test-v1")
+	return server.New(cfg, pool, nil, nil, nil, nil, logger, "test-v1")
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {

--- a/internal/storage/queries/chunks.sql
+++ b/internal/storage/queries/chunks.sql
@@ -16,6 +16,10 @@ DELETE FROM chunks WHERE document_id = $1 AND workspace_hash = $2;
 -- name: CountChunksByDocumentID :one
 SELECT count(*) FROM chunks WHERE document_id = $1 AND workspace_hash = $2;
 
+-- name: GetChunkByID :one
+SELECT id, document_id, workspace_hash, content_hash, content, chunk_index, start_line, end_line, metadata, embed_status, created_at
+FROM chunks WHERE id = $1;
+
 -- name: ListChunksByDocumentID :many
 SELECT id, document_id, workspace_hash, content_hash, content, chunk_index, start_line, end_line, metadata, created_at
 FROM chunks WHERE document_id = $1 AND workspace_hash = $2 ORDER BY chunk_index;

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -30,6 +30,12 @@ SELECT count(*) FROM chunks WHERE workspace_hash = $1 AND embed_status = 'embed_
 -- name: ResetEmbedStatus :exec
 UPDATE chunks SET embed_status = 'pending' WHERE workspace_hash = $1;
 
+-- name: GetAllPendingChunks :many
+SELECT id FROM chunks
+WHERE embed_status = 'pending'
+ORDER BY created_at ASC
+LIMIT $1;
+
 -- name: VectorSearch :many
 SELECT e.id, e.chunk_id, e.workspace_hash,
        c.content, c.metadata, c.document_id,

--- a/internal/storage/sqlc/chunks.sql.go
+++ b/internal/storage/sqlc/chunks.sql.go
@@ -44,6 +44,44 @@ func (q *Queries) DeleteChunksByDocumentID(ctx context.Context, arg DeleteChunks
 	return err
 }
 
+const getChunkByID = `-- name: GetChunkByID :one
+SELECT id, document_id, workspace_hash, content_hash, content, chunk_index, start_line, end_line, metadata, embed_status, created_at
+FROM chunks WHERE id = $1
+`
+
+type GetChunkByIDRow struct {
+	ID            uuid.UUID
+	DocumentID    uuid.UUID
+	WorkspaceHash string
+	ContentHash   string
+	Content       string
+	ChunkIndex    int32
+	StartLine     sql.NullInt32
+	EndLine       sql.NullInt32
+	Metadata      pqtype.NullRawMessage
+	EmbedStatus   string
+	CreatedAt     time.Time
+}
+
+func (q *Queries) GetChunkByID(ctx context.Context, id uuid.UUID) (GetChunkByIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getChunkByID, id)
+	var i GetChunkByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.DocumentID,
+		&i.WorkspaceHash,
+		&i.ContentHash,
+		&i.Content,
+		&i.ChunkIndex,
+		&i.StartLine,
+		&i.EndLine,
+		&i.Metadata,
+		&i.EmbedStatus,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const listChunksByDocumentID = `-- name: ListChunksByDocumentID :many
 SELECT id, document_id, workspace_hash, content_hash, content, chunk_index, start_line, end_line, metadata, created_at
 FROM chunks WHERE document_id = $1 AND workspace_hash = $2 ORDER BY chunk_index

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -36,6 +36,36 @@ func (q *Queries) CountPendingChunks(ctx context.Context, workspaceHash string) 
 	return count, err
 }
 
+const getAllPendingChunks = `-- name: GetAllPendingChunks :many
+SELECT id FROM chunks
+WHERE embed_status = 'pending'
+ORDER BY created_at ASC
+LIMIT $1
+`
+
+func (q *Queries) GetAllPendingChunks(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+	rows, err := q.db.QueryContext(ctx, getAllPendingChunks, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getPendingChunks = `-- name: GetPendingChunks :many
 SELECT c.id, c.document_id, c.workspace_hash, c.content_hash, c.content, c.chunk_index, c.start_line, c.end_line, c.metadata, c.created_at, c.embed_status FROM chunks c
 WHERE c.workspace_hash = $1


### PR DESCRIPTION
## Story 3.2: Async Embedding Queue

### Changes
- **Queue**: `chan uuid.UUID` (cap 10000) with semaphore-based concurrency limiting
- **Run goroutine**: Startup scan for un-embedded chunks + main drain loop
- **Backoff**: 60s base, 1.5x multiplier, 300s cap, reset on success, context-interruptible
- **Integration**: Wired into errgroup in main.go; WriteDocument enqueues via ChunkEnqueuer interface
- **Queries**: Added GetChunkByID + GetAllPendingChunks
- **Tests**: 10 unit tests (enqueue, full-channel, process success/failure, backoff, scan, ctx cancel)

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅

Closes #62