### PR TITLE
feat(search): POST /api/v1/vsearch vector search endpoint

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -89,16 +89,18 @@ func main() {
 	fw := watcher.New(db, queries, logger, *cfg)
 
 	var eq *embed.Queue
+	var embedder embed.Embedder
 	if cfg.Embedding.Provider != "" {
-		embedder, embedErr := embed.NewFromConfig(cfg.Embedding)
+		e, embedErr := embed.NewFromConfig(cfg.Embedding)
 		if embedErr != nil {
 			logger.Warn().Err(embedErr).Msg("embedding disabled — provider not configured")
 		} else {
+			embedder = e
 			eq = embed.NewQueue(embedder, queries, logger, cfg.Embedding.Provider, cfg.Embedding.Model, cfg.Embedding.Concurrency)
 		}
 	}
 
-	srv := server.New(cfg.Server, pool, db, queries, fw, eq, logger, Version)
+	srv := server.New(cfg.Server, pool, db, queries, fw, eq, embedder, logger, Version)
 
 	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {

--- a/docs/evidence/self-review-story-3.4.md
+++ b/docs/evidence/self-review-story-3.4.md
@@ -1,0 +1,20 @@
+# Story 3.4 Self-Review Evidence
+
+## Oracle Review (0C, 3M, 3m)
+- **M1**: Collection field accepted but silently ignored → removed from VSearchRequest
+- **M2**: Missing DB error test → added TestVSearch_DBError
+- **M3**: No timeout on embed call → added 10s context.WithTimeout
+- **m1**: Dead Workspace field → removed (middleware authoritative)
+- **m2**: Dead ChunkIndex field → removed (not in VectorSearchRow)
+- **m3**: Duplicate Embedder interface → acceptable (consumer-defined)
+
+## Gemini Review (5M, 0H, 0C)
+- G1: Add strings import → fixed (paired with G4)
+- G2: Remove unused Workspace/Collection → already fixed by Oracle M1/m1
+- G3: Remove ChunkIndex → already fixed by Oracle m2
+- G4: Use strings.Join instead of joinTags → fixed
+- G5: Remove joinTags helper → fixed (paired with G4)
+
+## Verification
+- `go build ./...` ✅
+- `go test -race -short ./internal/server/handlers/...` ✅ (9 tests)

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -94,17 +95,13 @@ func VectorSearch(q VSearchQuerier, embedder Embedder, logger zerolog.Logger) ec
 
 		results := make([]SearchResult, 0, len(rows))
 		for _, r := range rows {
-			tags := ""
-			if len(r.Tags) > 0 {
-				tags = joinTags(r.Tags)
-			}
 			results = append(results, SearchResult{
 				ID:            r.ID.String(),
 				Content:       r.Content,
 				Score:         r.Score,
 				SourcePath:    r.SourcePath,
 				Collection:    r.Collection,
-				Tags:          tags,
+				Tags:          strings.Join(r.Tags, ","),
 				WorkspaceHash: r.WorkspaceHash,
 				DocumentID:    r.DocumentID.String(),
 			})
@@ -116,15 +113,4 @@ func VectorSearch(q VSearchQuerier, embedder Embedder, logger zerolog.Logger) ec
 			QueryMs: time.Since(start).Milliseconds(),
 		})
 	}
-}
-
-func joinTags(tags []string) string {
-	if len(tags) == 0 {
-		return ""
-	}
-	result := tags[0]
-	for _, t := range tags[1:] {
-		result += "," + t
-	}
-	return result
 }

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+	pgvector_go "github.com/pgvector/pgvector-go"
+)
+
+// Embedder generates vector embeddings from text.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	Dimension() int
+}
+
+// VSearchQuerier is the database interface for vector search.
+type VSearchQuerier interface {
+	VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error)
+}
+
+type VSearchRequest struct {
+	Query      string `json:"query"`
+	Workspace  string `json:"workspace"`
+	MaxResults int    `json:"max_results,omitempty"`
+	Collection string `json:"collection,omitempty"`
+}
+
+type SearchResult struct {
+	ID            string  `json:"id"`
+	Content       string  `json:"content"`
+	Score         float64 `json:"score"`
+	SourcePath    string  `json:"source_path"`
+	Collection    string  `json:"collection"`
+	Tags          string  `json:"tags,omitempty"`
+	WorkspaceHash string  `json:"workspace_hash"`
+	DocumentID    string  `json:"document_id"`
+	ChunkIndex    int32   `json:"chunk_index,omitempty"`
+}
+
+type SearchResponse struct {
+	Results []SearchResult `json:"results"`
+	Total   int            `json:"total"`
+	QueryMs int64          `json:"query_ms"`
+}
+
+func VectorSearch(q VSearchQuerier, embedder Embedder, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if embedder == nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "vector search requires embedding provider")
+		}
+
+		var req VSearchRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+		if req.Query == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "query is required")
+		}
+
+		maxResults := req.MaxResults
+		if maxResults <= 0 {
+			maxResults = 10
+		}
+		if maxResults > 100 {
+			maxResults = 100
+		}
+
+		workspace, _ := c.Get("workspace").(string)
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+
+		start := time.Now()
+
+		vec, err := embedder.Embed(c.Request().Context(), req.Query)
+		if err != nil {
+			logger.Error().Err(err).Msg("embedding query failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to embed query")
+		}
+
+		rows, err := q.VectorSearch(c.Request().Context(), sqlc.VectorSearchParams{
+			QueryEmbedding: pgvector_go.NewVector(vec),
+			WorkspaceHash:  workspace,
+			MaxResults:     int32(maxResults),
+		})
+		if err != nil {
+			logger.Error().Err(err).Str("workspace", workspace).Msg("vector search failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "vector search failed")
+		}
+
+		results := make([]SearchResult, 0, len(rows))
+		for _, r := range rows {
+			tags := ""
+			if len(r.Tags) > 0 {
+				tags = joinTags(r.Tags)
+			}
+			results = append(results, SearchResult{
+				ID:            r.ID.String(),
+				Content:       r.Content,
+				Score:         r.Score,
+				SourcePath:    r.SourcePath,
+				Collection:    r.Collection,
+				Tags:          tags,
+				WorkspaceHash: r.WorkspaceHash,
+				DocumentID:    r.DocumentID.String(),
+			})
+		}
+
+		return c.JSON(http.StatusOK, SearchResponse{
+			Results: results,
+			Total:   len(results),
+			QueryMs: time.Since(start).Milliseconds(),
+		})
+	}
+}
+
+func joinTags(tags []string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	result := tags[0]
+	for _, t := range tags[1:] {
+		result += "," + t
+	}
+	return result
+}

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -24,9 +24,7 @@ type VSearchQuerier interface {
 
 type VSearchRequest struct {
 	Query      string `json:"query"`
-	Workspace  string `json:"workspace"`
 	MaxResults int    `json:"max_results,omitempty"`
-	Collection string `json:"collection,omitempty"`
 }
 
 type SearchResult struct {
@@ -38,7 +36,6 @@ type SearchResult struct {
 	Tags          string  `json:"tags,omitempty"`
 	WorkspaceHash string  `json:"workspace_hash"`
 	DocumentID    string  `json:"document_id"`
-	ChunkIndex    int32   `json:"chunk_index,omitempty"`
 }
 
 type SearchResponse struct {
@@ -76,7 +73,10 @@ func VectorSearch(q VSearchQuerier, embedder Embedder, logger zerolog.Logger) ec
 
 		start := time.Now()
 
-		vec, err := embedder.Embed(c.Request().Context(), req.Query)
+		embedCtx, cancel := context.WithTimeout(c.Request().Context(), 10*time.Second)
+		defer cancel()
+
+		vec, err := embedder.Embed(embedCtx, req.Query)
 		if err != nil {
 			logger.Error().Err(err).Msg("embedding query failed")
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to embed query")

--- a/internal/server/handlers/search_test.go
+++ b/internal/server/handlers/search_test.go
@@ -1,0 +1,302 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockEmbedder struct {
+	embedFn    func(ctx context.Context, text string) ([]float32, error)
+	dimension  int
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	return m.embedFn(ctx, text)
+}
+
+func (m *mockEmbedder) Dimension() int { return m.dimension }
+
+type mockVSearchQuerier struct {
+	vectorSearchFn func(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error)
+}
+
+func (m *mockVSearchQuerier) VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+	return m.vectorSearchFn(ctx, arg)
+}
+
+func newVSearchContext(e *echo.Echo, body string, workspace string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/vsearch", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if workspace != "" {
+		c.Set("workspace", workspace)
+	}
+	return c, rec
+}
+
+func testVector() []float32 { return []float32{0.1, 0.2, 0.3} }
+
+func TestVSearch_Success(t *testing.T) {
+	docID := uuid.New()
+	embID := uuid.New()
+
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{
+		vectorSearchFn: func(_ context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+			if arg.WorkspaceHash != "ws1" {
+				t.Errorf("expected workspace ws1, got %q", arg.WorkspaceHash)
+			}
+			if arg.MaxResults != 10 {
+				t.Errorf("expected max_results 10, got %d", arg.MaxResults)
+			}
+			return []sqlc.VectorSearchRow{
+				{
+					ID:            embID,
+					ChunkID:       uuid.New(),
+					WorkspaceHash: "ws1",
+					Content:       "test content",
+					DocumentID:    docID,
+					SourcePath:    "/test.md",
+					Collection:    "memory",
+					Tags:          []string{"tag1", "tag2"},
+					Score:         0.95,
+				},
+			}, nil
+		},
+	}
+
+	e := echo.New()
+	body := `{"query":"hello","workspace":"ws1"}`
+	c, rec := newVSearchContext(e, body, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp handlers.SearchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Total)
+	}
+	if resp.Results[0].ID != embID.String() {
+		t.Errorf("expected id=%s, got %s", embID, resp.Results[0].ID)
+	}
+	if resp.Results[0].Score != 0.95 {
+		t.Errorf("expected score=0.95, got %f", resp.Results[0].Score)
+	}
+	if resp.Results[0].Tags != "tag1,tag2" {
+		t.Errorf("expected tags=tag1,tag2, got %q", resp.Results[0].Tags)
+	}
+	if resp.Results[0].DocumentID != docID.String() {
+		t.Errorf("expected document_id=%s, got %s", docID, resp.Results[0].DocumentID)
+	}
+	if resp.QueryMs < 0 {
+		t.Error("expected non-negative query_ms")
+	}
+}
+
+func TestVSearch_EmptyResults(t *testing.T) {
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{
+		vectorSearchFn: func(_ context.Context, _ sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+			return []sqlc.VectorSearchRow{}, nil
+		},
+	}
+
+	e := echo.New()
+	c, rec := newVSearchContext(e, `{"query":"nothing","workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.SearchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != 0 {
+		t.Errorf("expected total=0, got %d", resp.Total)
+	}
+	if resp.Results == nil {
+		t.Error("expected non-nil results array")
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("expected empty results, got %d", len(resp.Results))
+	}
+}
+
+func TestVSearch_NilResults(t *testing.T) {
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{
+		vectorSearchFn: func(_ context.Context, _ sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+			return nil, nil
+		},
+	}
+
+	e := echo.New()
+	c, rec := newVSearchContext(e, `{"query":"nothing","workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	var resp handlers.SearchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Results == nil {
+		t.Error("expected non-nil results even when DB returns nil")
+	}
+}
+
+func TestVSearch_MissingQuery(t *testing.T) {
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{}
+
+	e := echo.New()
+	c, _ := newVSearchContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestVSearch_NoEmbedder(t *testing.T) {
+	q := &mockVSearchQuerier{}
+
+	e := echo.New()
+	c, _ := newVSearchContext(e, `{"query":"hello","workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for nil embedder")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestVSearch_DefaultMaxResults(t *testing.T) {
+	var capturedMax int32
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{
+		vectorSearchFn: func(_ context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+			capturedMax = arg.MaxResults
+			return nil, nil
+		},
+	}
+
+	e := echo.New()
+	c, _ := newVSearchContext(e, `{"query":"test","workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if capturedMax != 10 {
+		t.Errorf("expected default max_results=10, got %d", capturedMax)
+	}
+}
+
+func TestVSearch_MaxResultsCapped(t *testing.T) {
+	var capturedMax int32
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{
+		vectorSearchFn: func(_ context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+			capturedMax = arg.MaxResults
+			return nil, nil
+		},
+	}
+
+	e := echo.New()
+	c, _ := newVSearchContext(e, `{"query":"test","max_results":200,"workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if capturedMax != 100 {
+		t.Errorf("expected capped max_results=100, got %d", capturedMax)
+	}
+}
+
+func TestVSearch_EmbedError(t *testing.T) {
+	emb := &mockEmbedder{
+		embedFn: func(_ context.Context, _ string) ([]float32, error) {
+			return nil, errors.New("embed failed")
+		},
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{}
+
+	e := echo.New()
+	c, _ := newVSearchContext(e, `{"query":"test","workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for embed failure")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", he.Code)
+	}
+}

--- a/internal/server/handlers/search_test.go
+++ b/internal/server/handlers/search_test.go
@@ -300,3 +300,31 @@ func TestVSearch_EmbedError(t *testing.T) {
 		t.Errorf("expected 500, got %d", he.Code)
 	}
 }
+
+func TestVSearch_DBError(t *testing.T) {
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	q := &mockVSearchQuerier{
+		vectorSearchFn: func(_ context.Context, _ sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+			return nil, errors.New("db down")
+		},
+	}
+
+	e := echo.New()
+	c, _ := newVSearchContext(e, `{"query":"test","workspace":"ws1"}`, "ws1")
+
+	h := handlers.VectorSearch(q, emb, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for DB failure")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", he.Code)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -21,6 +21,8 @@ func registerRoutes(s *Server) {
 	data.GET("/collections", handlers.ListCollectionsHandler(s.queries, s.logger))
 	data.PUT("/collections/:name", handlers.RenameCollectionHandler(s.queries, s.watcher, s.logger))
 	data.DELETE("/collections/:name", handlers.RemoveCollection(s.queries, s.watcher, s.logger))
+
+	data.POST("/vsearch", handlers.VectorSearch(s.queries, s.embedder, s.logger))
 }
 
 const defaultMaxFileSize int64 = 307200

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	queries    *sqlc.Queries
 	watcher    *watcher.Watcher
 	embedQueue *embed.Queue
+	embedder   embed.Embedder
 	logger     zerolog.Logger
 	cfg        config.ServerConfig
 	version    string
@@ -36,7 +37,7 @@ type Server struct {
 }
 
 // New creates a new Server with all routes and middleware registered.
-func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, logger zerolog.Logger, version string) *Server {
+func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -48,6 +49,7 @@ func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Qu
 		queries:    queries,
 		watcher:    fw,
 		embedQueue: eq,
+		embedder:   embedder,
 		logger:     logger,
 		cfg:        cfg,
 		version:    version,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,7 @@ func (m *mockPool) Ping(_ context.Context) error {
 func newTestServer(pool *mockPool) *server.Server {
 	cfg := config.ServerConfig{Host: "127.0.0.1", Port: 3100}
 	logger := zerolog.Nop()
-	return server.New(cfg, pool, nil, nil, nil, nil, logger, "test-v1")
+	return server.New(cfg, pool, nil, nil, nil, nil, nil, logger, "test-v1")
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {


### PR DESCRIPTION
## Story 3.4: Vector Search Endpoint

### Changes
- **Handler**: POST /api/v1/vsearch — embed query via Embedder, cosine similarity via pgvector HNSW
- **Response**: FR-10 schema (id, content, score, source_path, collection, tags, workspace_hash)
- **Edge cases**: Empty results = `[]` not error; nil embedder = 400; max_results default 10 capped 100
- **Server**: Embedder field added for vsearch use
- **Tests**: 8 unit tests (success, empty, nil, missing query, no embedder, defaults, cap, embed error)

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅

Closes #66