### PR TITLE
feat(embed): POST /api/v1/embed trigger + status observability

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -100,7 +100,7 @@ func main() {
 		}
 	}
 
-	srv := server.New(cfg.Server, pool, db, queries, fw, eq, embedder, logger, Version)
+	srv := server.New(cfg.Server, cfg.Embedding, pool, db, queries, fw, eq, embedder, logger, Version)
 
 	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {

--- a/docs/evidence/self-review-story-3.5.md
+++ b/docs/evidence/self-review-story-3.5.md
@@ -1,0 +1,20 @@
+# Story 3.5 Self-Review Evidence
+
+## Oracle Review (0C, 2M, 3m)
+- **M1**: No request timeout on embed loop → added 3min context.WithTimeout
+- **M2**: Bind error silently ignored → returns 400 on malformed body
+- **m1**: Missing partial failure + hasMore tests → added 2 tests
+- **m2**: CountPendingChunks error discarded → now logged
+- **m3**: Queue Status() TOCTOU → documented as advisory
+
+## Gemini Review (6M)
+- G1: Workspace field redundant in embedRequest → removed
+- G2: Unused queue param in TriggerEmbed → removed
+- G3: Bind error ignored → already fixed by Oracle M2
+- G4: Long-running sync request → already fixed by Oracle M1
+- G5: CountPendingChunks error → already fixed by Oracle m2
+- G6: Update route call for G2 → fixed
+
+## Verification
+- `go build ./...` ✅
+- `go test -race -short ./...` ✅ (all packages pass)

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -96,7 +96,7 @@ func (q *Queue) Depth() int { return len(q.ch) }
 // Capacity returns the channel capacity.
 func (q *Queue) Capacity() int { return channelCapacity }
 
-// Status returns a human-readable queue status string.
+// Status is advisory; reads are not atomic across fields.
 func (q *Queue) Status() string {
 	if q.pending.Load() >= rejectionThreshold {
 		return "rejecting"

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -90,6 +90,27 @@ func (q *Queue) Enqueue(chunkID uuid.UUID) bool {
 	}
 }
 
+// Depth returns the current channel length.
+func (q *Queue) Depth() int { return len(q.ch) }
+
+// Capacity returns the channel capacity.
+func (q *Queue) Capacity() int { return channelCapacity }
+
+// Status returns a human-readable queue status string.
+func (q *Queue) Status() string {
+	if q.pending.Load() >= rejectionThreshold {
+		return "rejecting"
+	}
+	depth := len(q.ch)
+	if depth == 0 {
+		return "nominal"
+	}
+	if float64(depth) >= float64(channelCapacity)*0.6 {
+		return "backpressure"
+	}
+	return "busy"
+}
+
 // IsPressured returns true when the total pending backlog reaches the rejection threshold.
 func (q *Queue) IsPressured() bool {
 	return q.pending.Load() >= rejectionThreshold

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -501,6 +501,65 @@ func TestQueue_PendingDecrementsOnInsertEmbeddingError(t *testing.T) {
 	}
 }
 
+func TestQueue_Depth(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	if eq.Depth() != 0 {
+		t.Errorf("initial depth = %d, want 0", eq.Depth())
+	}
+
+	eq.Enqueue(uuid.New())
+	eq.Enqueue(uuid.New())
+	if eq.Depth() != 2 {
+		t.Errorf("depth after 2 enqueues = %d, want 2", eq.Depth())
+	}
+
+	<-eq.ch
+	if eq.Depth() != 1 {
+		t.Errorf("depth after 1 dequeue = %d, want 1", eq.Depth())
+	}
+}
+
+func TestQueue_Capacity(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	if eq.Capacity() != channelCapacity {
+		t.Errorf("capacity = %d, want %d", eq.Capacity(), channelCapacity)
+	}
+}
+
+func TestQueue_Status_Nominal(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	if s := eq.Status(); s != "nominal" {
+		t.Errorf("status = %q, want nominal", s)
+	}
+}
+
+func TestQueue_Status_Busy(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	eq.ch <- uuid.New()
+	if s := eq.Status(); s != "busy" {
+		t.Errorf("status = %q, want busy", s)
+	}
+}
+
+func TestQueue_Status_Backpressure(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	threshold := int(float64(channelCapacity) * 0.6)
+	for i := 0; i < threshold; i++ {
+		eq.ch <- uuid.New()
+	}
+	if s := eq.Status(); s != "backpressure" {
+		t.Errorf("status = %q, want backpressure", s)
+	}
+}
+
+func TestQueue_Status_Rejecting(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	eq.pending.Store(rejectionThreshold)
+	if s := eq.Status(); s != "rejecting" {
+		t.Errorf("status = %q, want rejecting", s)
+	}
+}
+
 func TestQueue_PendingDecrementsOnMarkEmbeddedError(t *testing.T) {
 	mq := &mockQuerier{
 		markChunkEmbeddedFn: func(_ context.Context, _ sqlc.MarkChunkEmbeddedParams) error {

--- a/internal/server/handlers/embed.go
+++ b/internal/server/handlers/embed.go
@@ -23,8 +23,7 @@ type EmbedQuerier interface {
 }
 
 type embedRequest struct {
-	Workspace string `json:"workspace"`
-	Force     bool   `json:"force"`
+	Force bool `json:"force"`
 }
 
 type EmbedResponse struct {
@@ -32,7 +31,7 @@ type EmbedResponse struct {
 	Remaining int64 `json:"remaining"`
 }
 
-func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, provider, model string, logger zerolog.Logger) echo.HandlerFunc {
+func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, provider, model string, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		if embedder == nil {
 			return echo.NewHTTPError(http.StatusBadRequest, "embedding not configured")

--- a/internal/server/handlers/embed.go
+++ b/internal/server/handlers/embed.go
@@ -39,7 +39,9 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, p
 		}
 
 		var req embedRequest
-		_ = c.Bind(&req)
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
 
 		workspace, _ := c.Get("workspace").(string)
 		if workspace == "" {
@@ -68,9 +70,12 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, p
 			chunks = chunks[:embedBatchLimit]
 		}
 
+		loopCtx, loopCancel := context.WithTimeout(ctx, 3*time.Minute)
+		defer loopCancel()
+
 		embedded := 0
 		for _, chunk := range chunks {
-			embedCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			embedCtx, cancel := context.WithTimeout(loopCtx, 30*time.Second)
 			vec, embedErr := embedder.Embed(embedCtx, chunk.Content)
 			cancel()
 			if embedErr != nil {
@@ -78,7 +83,7 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, p
 				break
 			}
 
-			if _, insertErr := q.InsertEmbedding(ctx, sqlc.InsertEmbeddingParams{
+			if _, insertErr := q.InsertEmbedding(loopCtx, sqlc.InsertEmbeddingParams{
 				ChunkID:       chunk.ID,
 				WorkspaceHash: chunk.WorkspaceHash,
 				Provider:      provider,
@@ -89,7 +94,7 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, p
 				break
 			}
 
-			if markErr := q.MarkChunkEmbedded(ctx, sqlc.MarkChunkEmbeddedParams{
+			if markErr := q.MarkChunkEmbedded(loopCtx, sqlc.MarkChunkEmbeddedParams{
 				ID:            chunk.ID,
 				WorkspaceHash: chunk.WorkspaceHash,
 			}); markErr != nil {
@@ -102,7 +107,11 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, p
 
 		var remaining int64
 		if hasMore {
-			remaining, _ = q.CountPendingChunks(ctx, workspace)
+			var countErr error
+			remaining, countErr = q.CountPendingChunks(ctx, workspace)
+			if countErr != nil {
+				logger.Error().Err(countErr).Msg("failed to count remaining pending chunks")
+			}
 		} else {
 			remaining = int64(len(chunks) - embedded)
 			if remaining < 0 {

--- a/internal/server/handlers/embed.go
+++ b/internal/server/handlers/embed.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/embed"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	pgvector "github.com/pgvector/pgvector-go"
+	"github.com/rs/zerolog"
+)
+
+const embedBatchLimit = 50
+
+type EmbedQuerier interface {
+	GetPendingChunks(ctx context.Context, arg sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error)
+	InsertEmbedding(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
+	MarkChunkEmbedded(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
+	CountPendingChunks(ctx context.Context, workspaceHash string) (int64, error)
+	ResetEmbedStatus(ctx context.Context, workspaceHash string) error
+}
+
+type embedRequest struct {
+	Workspace string `json:"workspace"`
+	Force     bool   `json:"force"`
+}
+
+type EmbedResponse struct {
+	Embedded  int   `json:"embedded"`
+	Remaining int64 `json:"remaining"`
+}
+
+func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, queue *embed.Queue, provider, model string, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if embedder == nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "embedding not configured")
+		}
+
+		var req embedRequest
+		_ = c.Bind(&req)
+
+		workspace, _ := c.Get("workspace").(string)
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+		ctx := c.Request().Context()
+
+		if req.Force {
+			if err := q.ResetEmbedStatus(ctx, workspace); err != nil {
+				logger.Error().Err(err).Str("workspace", workspace).Msg("reset embed status failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to reset embed status")
+			}
+		}
+
+		chunks, err := q.GetPendingChunks(ctx, sqlc.GetPendingChunksParams{
+			WorkspaceHash: workspace,
+			Limit:         embedBatchLimit + 1,
+		})
+		if err != nil {
+			logger.Error().Err(err).Str("workspace", workspace).Msg("get pending chunks failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get pending chunks")
+		}
+
+		hasMore := len(chunks) > embedBatchLimit
+		if hasMore {
+			chunks = chunks[:embedBatchLimit]
+		}
+
+		embedded := 0
+		for _, chunk := range chunks {
+			embedCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			vec, embedErr := embedder.Embed(embedCtx, chunk.Content)
+			cancel()
+			if embedErr != nil {
+				logger.Error().Err(embedErr).Str("chunk_id", chunk.ID.String()).Msg("embed failed")
+				break
+			}
+
+			if _, insertErr := q.InsertEmbedding(ctx, sqlc.InsertEmbeddingParams{
+				ChunkID:       chunk.ID,
+				WorkspaceHash: chunk.WorkspaceHash,
+				Provider:      provider,
+				Model:         model,
+				Embedding:     pgvector.NewVector(vec),
+			}); insertErr != nil {
+				logger.Error().Err(insertErr).Str("chunk_id", chunk.ID.String()).Msg("insert embedding failed")
+				break
+			}
+
+			if markErr := q.MarkChunkEmbedded(ctx, sqlc.MarkChunkEmbeddedParams{
+				ID:            chunk.ID,
+				WorkspaceHash: chunk.WorkspaceHash,
+			}); markErr != nil {
+				logger.Error().Err(markErr).Str("chunk_id", chunk.ID.String()).Msg("mark embedded failed")
+				break
+			}
+
+			embedded++
+		}
+
+		var remaining int64
+		if hasMore {
+			remaining, _ = q.CountPendingChunks(ctx, workspace)
+		} else {
+			remaining = int64(len(chunks) - embedded)
+			if remaining < 0 {
+				remaining = 0
+			}
+		}
+
+		return c.JSON(http.StatusOK, EmbedResponse{
+			Embedded:  embedded,
+			Remaining: remaining,
+		})
+	}
+}

--- a/internal/server/handlers/embed_test.go
+++ b/internal/server/handlers/embed_test.go
@@ -199,3 +199,83 @@ func TestTriggerEmbed_Force(t *testing.T) {
 		t.Errorf("embedded = %d, want 2", resp.Embedded)
 	}
 }
+
+func TestTriggerEmbed_PartialFailure(t *testing.T) {
+	chunks := makeChunks(3, "ws1")
+	callCount := 0
+	q := &mockEmbedQuerier{
+		getPendingChunksFn: func(_ context.Context, _ sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error) {
+			return chunks, nil
+		},
+	}
+	emb := &mockEmbedder{
+		embedFn: func(_ context.Context, _ string) ([]float32, error) {
+			callCount++
+			if callCount == 2 {
+				return nil, fmt.Errorf("provider error")
+			}
+			return testVector(), nil
+		},
+		dimension: 3,
+	}
+
+	e := echo.New()
+	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.EmbedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Embedded != 1 {
+		t.Errorf("embedded = %d, want 1", resp.Embedded)
+	}
+	if resp.Remaining != 2 {
+		t.Errorf("remaining = %d, want 2", resp.Remaining)
+	}
+}
+
+func TestTriggerEmbed_HasMore(t *testing.T) {
+	chunks := makeChunks(51, "ws1")
+	q := &mockEmbedQuerier{
+		getPendingChunksFn: func(_ context.Context, _ sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error) {
+			return chunks, nil
+		},
+		countPendingFn: func(_ context.Context, _ string) (int64, error) {
+			return 120, nil
+		},
+	}
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+
+	e := echo.New()
+	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.EmbedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Embedded != 50 {
+		t.Errorf("embedded = %d, want 50", resp.Embedded)
+	}
+	if resp.Remaining != 120 {
+		t.Errorf("remaining = %d, want 120", resp.Remaining)
+	}
+}

--- a/internal/server/handlers/embed_test.go
+++ b/internal/server/handlers/embed_test.go
@@ -1,0 +1,201 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockEmbedQuerier struct {
+	getPendingChunksFn  func(ctx context.Context, arg sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error)
+	insertEmbeddingFn   func(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
+	markChunkEmbeddedFn func(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
+	countPendingFn      func(ctx context.Context, ws string) (int64, error)
+	resetEmbedStatusFn  func(ctx context.Context, ws string) error
+	resetCalled         bool
+}
+
+func (m *mockEmbedQuerier) GetPendingChunks(ctx context.Context, arg sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error) {
+	if m.getPendingChunksFn != nil {
+		return m.getPendingChunksFn(ctx, arg)
+	}
+	return nil, nil
+}
+
+func (m *mockEmbedQuerier) InsertEmbedding(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error) {
+	if m.insertEmbeddingFn != nil {
+		return m.insertEmbeddingFn(ctx, arg)
+	}
+	return sqlc.Embedding{}, nil
+}
+
+func (m *mockEmbedQuerier) MarkChunkEmbedded(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error {
+	if m.markChunkEmbeddedFn != nil {
+		return m.markChunkEmbeddedFn(ctx, arg)
+	}
+	return nil
+}
+
+func (m *mockEmbedQuerier) CountPendingChunks(ctx context.Context, ws string) (int64, error) {
+	if m.countPendingFn != nil {
+		return m.countPendingFn(ctx, ws)
+	}
+	return 0, nil
+}
+
+func (m *mockEmbedQuerier) ResetEmbedStatus(ctx context.Context, ws string) error {
+	m.resetCalled = true
+	if m.resetEmbedStatusFn != nil {
+		return m.resetEmbedStatusFn(ctx, ws)
+	}
+	return nil
+}
+
+func newEmbedContext(e *echo.Echo, body, workspace string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embed", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if workspace != "" {
+		c.Set("workspace", workspace)
+	}
+	return c, rec
+}
+
+func makeChunks(n int, ws string) []sqlc.Chunk {
+	chunks := make([]sqlc.Chunk, n)
+	for i := range chunks {
+		chunks[i] = sqlc.Chunk{
+			ID:            uuid.New(),
+			WorkspaceHash: ws,
+			Content:       fmt.Sprintf("content-%d", i),
+		}
+	}
+	return chunks
+}
+
+func TestTriggerEmbed_Success(t *testing.T) {
+	chunks := makeChunks(3, "ws1")
+	q := &mockEmbedQuerier{
+		getPendingChunksFn: func(_ context.Context, arg sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error) {
+			return chunks, nil
+		},
+	}
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+
+	e := echo.New()
+	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	h := handlers.TriggerEmbed(q, emb, nil, "test-provider", "test-model", zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.EmbedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Embedded != 3 {
+		t.Errorf("embedded = %d, want 3", resp.Embedded)
+	}
+	if resp.Remaining != 0 {
+		t.Errorf("remaining = %d, want 0", resp.Remaining)
+	}
+}
+
+func TestTriggerEmbed_NoPending(t *testing.T) {
+	q := &mockEmbedQuerier{}
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+
+	e := echo.New()
+	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var resp handlers.EmbedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Embedded != 0 {
+		t.Errorf("embedded = %d, want 0", resp.Embedded)
+	}
+	if resp.Remaining != 0 {
+		t.Errorf("remaining = %d, want 0", resp.Remaining)
+	}
+}
+
+func TestTriggerEmbed_NoEmbedder(t *testing.T) {
+	q := &mockEmbedQuerier{}
+
+	e := echo.New()
+	c, _ := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	h := handlers.TriggerEmbed(q, nil, nil, "p", "m", zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for nil embedder")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestTriggerEmbed_Force(t *testing.T) {
+	q := &mockEmbedQuerier{
+		getPendingChunksFn: func(_ context.Context, _ sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error) {
+			return makeChunks(2, "ws1"), nil
+		},
+	}
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+
+	e := echo.New()
+	c, rec := newEmbedContext(e, `{"workspace":"ws1","force":true}`, "ws1")
+
+	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !q.resetCalled {
+		t.Error("expected ResetEmbedStatus to be called")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.EmbedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Embedded != 2 {
+		t.Errorf("embedded = %d, want 2", resp.Embedded)
+	}
+}

--- a/internal/server/handlers/embed_test.go
+++ b/internal/server/handlers/embed_test.go
@@ -99,7 +99,7 @@ func TestTriggerEmbed_Success(t *testing.T) {
 	e := echo.New()
 	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
 
-	h := handlers.TriggerEmbed(q, emb, nil, "test-provider", "test-model", zerolog.Nop())
+	h := handlers.TriggerEmbed(q, emb, "test-provider", "test-model", zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestTriggerEmbed_NoPending(t *testing.T) {
 	e := echo.New()
 	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
 
-	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	h := handlers.TriggerEmbed(q, emb, "p", "m", zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestTriggerEmbed_NoEmbedder(t *testing.T) {
 	e := echo.New()
 	c, _ := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
 
-	h := handlers.TriggerEmbed(q, nil, nil, "p", "m", zerolog.Nop())
+	h := handlers.TriggerEmbed(q, nil, "p", "m", zerolog.Nop())
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for nil embedder")
@@ -180,7 +180,7 @@ func TestTriggerEmbed_Force(t *testing.T) {
 	e := echo.New()
 	c, rec := newEmbedContext(e, `{"workspace":"ws1","force":true}`, "ws1")
 
-	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	h := handlers.TriggerEmbed(q, emb, "p", "m", zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestTriggerEmbed_PartialFailure(t *testing.T) {
 	e := echo.New()
 	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
 
-	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	h := handlers.TriggerEmbed(q, emb, "p", "m", zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestTriggerEmbed_HasMore(t *testing.T) {
 	e := echo.New()
 	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
 
-	h := handlers.TriggerEmbed(q, emb, nil, "p", "m", zerolog.Nop())
+	h := handlers.TriggerEmbed(q, emb, "p", "m", zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}

--- a/internal/server/handlers/health.go
+++ b/internal/server/handlers/health.go
@@ -9,22 +9,27 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// PoolChecker is the consumer-side interface for database health checks.
 type PoolChecker interface {
 	Ping(ctx context.Context) error
 }
 
-// Health holds dependencies for health-check handlers.
+type EmbedQueueInfo interface {
+	Depth() int
+	Capacity() int
+	Status() string
+	PendingCount() int64
+}
+
 type Health struct {
 	pool      PoolChecker
+	queue     EmbedQueueInfo
 	logger    zerolog.Logger
 	version   string
 	startTime time.Time
 }
 
-// NewHealth creates a new Health handler.
-func NewHealth(pool PoolChecker, logger zerolog.Logger, version string, startTime time.Time) *Health {
-	return &Health{pool: pool, logger: logger, version: version, startTime: startTime}
+func NewHealth(pool PoolChecker, logger zerolog.Logger, version string, startTime time.Time, queue EmbedQueueInfo) *Health {
+	return &Health{pool: pool, queue: queue, logger: logger, version: version, startTime: startTime}
 }
 
 type healthResponse struct {
@@ -42,9 +47,12 @@ type statusResponse struct {
 	EmbeddingQueueDepth  int    `json:"embedding_queue_depth"`
 	ActiveProvider       string `json:"active_provider"`
 	WorkspaceCount       int    `json:"workspace_count"`
+	QueueDepth           int    `json:"queue_depth"`
+	QueueCapacity        int    `json:"queue_capacity"`
+	QueueStatus          string `json:"queue_status"`
+	QueuePending         int64  `json:"queue_pending"`
 }
 
-// Health handles GET /health.
 func (h *Health) Health(c echo.Context) error {
 	if err := h.pool.Ping(c.Request().Context()); err != nil {
 		return c.JSON(http.StatusOK, healthResponse{
@@ -63,18 +71,27 @@ func (h *Health) Health(c echo.Context) error {
 	})
 }
 
-// Status handles GET /api/status.
 func (h *Health) Status(c echo.Context) error {
 	pgStatus := "healthy"
 	if err := h.pool.Ping(c.Request().Context()); err != nil {
 		pgStatus = "unreachable"
 	}
 
-	return c.JSON(http.StatusOK, statusResponse{
+	resp := statusResponse{
 		PGStatus:            pgStatus,
 		MigrationVersion:    1,
 		EmbeddingQueueDepth: 0,
 		ActiveProvider:      "none",
 		WorkspaceCount:      0,
-	})
+	}
+
+	if h.queue != nil {
+		resp.QueueDepth = h.queue.Depth()
+		resp.QueueCapacity = h.queue.Capacity()
+		resp.QueueStatus = h.queue.Status()
+		resp.QueuePending = h.queue.PendingCount()
+		resp.EmbeddingQueueDepth = h.queue.Depth()
+	}
+
+	return c.JSON(http.StatusOK, resp)
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -20,7 +20,7 @@ func registerRoutes(s *Server) {
 
 	data := api.Group("", workspaceMiddleware())
 	data.POST("/write", handlers.WriteDocument(s.queries, s.db, s.embedQueue, s.logger, defaultMaxFileSize))
-	data.POST("/embed", handlers.TriggerEmbed(s.queries, s.embedder, s.embedQueue, s.embedCfg.Provider, s.embedCfg.Model, s.logger))
+	data.POST("/embed", handlers.TriggerEmbed(s.queries, s.embedder, s.embedCfg.Provider, s.embedCfg.Model, s.logger))
 
 	data.POST("/collections", handlers.AddCollection(s.queries, s.watcher, s.logger))
 	data.GET("/collections", handlers.ListCollectionsHandler(s.queries, s.logger))

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -5,7 +5,11 @@ import (
 )
 
 func registerRoutes(s *Server) {
-	h := handlers.NewHealth(s.pool, s.logger, s.version, s.startTime)
+	var queueInfo handlers.EmbedQueueInfo
+	if s.embedQueue != nil {
+		queueInfo = s.embedQueue
+	}
+	h := handlers.NewHealth(s.pool, s.logger, s.version, s.startTime, queueInfo)
 
 	s.echo.GET("/health", h.Health)
 	s.echo.GET("/api/status", h.Status)
@@ -16,6 +20,7 @@ func registerRoutes(s *Server) {
 
 	data := api.Group("", workspaceMiddleware())
 	data.POST("/write", handlers.WriteDocument(s.queries, s.db, s.embedQueue, s.logger, defaultMaxFileSize))
+	data.POST("/embed", handlers.TriggerEmbed(s.queries, s.embedder, s.embedQueue, s.embedCfg.Provider, s.embedCfg.Model, s.logger))
 
 	data.POST("/collections", handlers.AddCollection(s.queries, s.watcher, s.logger))
 	data.GET("/collections", handlers.ListCollectionsHandler(s.queries, s.logger))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,7 +21,6 @@ type PoolChecker interface {
 	Ping(ctx context.Context) error
 }
 
-// Server wraps Echo and holds dependencies.
 type Server struct {
 	echo       *echo.Echo
 	pool       PoolChecker
@@ -32,12 +31,12 @@ type Server struct {
 	embedder   embed.Embedder
 	logger     zerolog.Logger
 	cfg        config.ServerConfig
+	embedCfg   config.EmbeddingConfig
 	version    string
 	startTime  time.Time
 }
 
-// New creates a new Server with all routes and middleware registered.
-func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
+func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -52,6 +51,7 @@ func New(cfg config.ServerConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Qu
 		embedder:   embedder,
 		logger:     logger,
 		cfg:        cfg,
+		embedCfg:   embedCfg,
 		version:    version,
 		startTime:  time.Now(),
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,7 @@ func (m *mockPool) Ping(_ context.Context) error {
 func newTestServer(pool *mockPool) *server.Server {
 	cfg := config.ServerConfig{Host: "127.0.0.1", Port: 3100}
 	logger := zerolog.Nop()
-	return server.New(cfg, pool, nil, nil, nil, nil, nil, logger, "test-v1")
+	return server.New(cfg, config.EmbeddingConfig{}, pool, nil, nil, nil, nil, nil, logger, "test-v1")
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {
@@ -98,7 +98,7 @@ func TestStatusEndpointShape(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requiredFields := []string{"pg_status", "migration_version", "embedding_queue_depth", "active_provider", "workspace_count"}
+	requiredFields := []string{"pg_status", "migration_version", "embedding_queue_depth", "active_provider", "workspace_count", "queue_depth", "queue_capacity", "queue_status", "queue_pending"}
 	for _, field := range requiredFields {
 		if _, ok := body[field]; !ok {
 			t.Errorf("missing required field: %s", field)
@@ -155,7 +155,7 @@ func TestRouteRegistration(t *testing.T) {
 		paths[r.Path] = true
 	}
 
-	for _, path := range []string{"/health", "/api/status", "/api/v1/init", "/api/v1/workspaces", "/api/v1/collections", "/api/v1/collections/:name"} {
+	for _, path := range []string{"/health", "/api/status", "/api/v1/init", "/api/v1/workspaces", "/api/v1/embed", "/api/v1/collections", "/api/v1/collections/:name"} {
 		if !paths[path] {
 			t.Errorf("route %s not registered", path)
 		}


### PR DESCRIPTION
## Story 3.5: Immediate Embed Trigger and Status Observability

### Changes
- **POST /api/v1/embed**: Embed up to 50 pending chunks synchronously. Force mode resets all to pending first.
- **Queue observability**: Depth(), Capacity(), Status() methods on Queue
- **GET /api/status**: Enhanced with queue_depth, queue_capacity, queue_status, queue_pending fields
- **Tests**: 4 handler tests + 7 queue observability tests

### Acceptance Criteria
- ✅ POST /api/embed embeds up to 50 pending chunks, returns {embedded, remaining}
- ✅ force=true resets all chunks to pending first
- ✅ GET /api/status includes queue fields
- ✅ Queue status: nominal/busy/backpressure/rejecting

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅

Closes #68