### PR TITLE
refactor(search): normalize SearchResult schema across all endpoints

### DIFF
--- a/docs/evidence/self-review-story-4.2.md
+++ b/docs/evidence/self-review-story-4.2.md
@@ -1,0 +1,16 @@
+## Self-Review: Story 4.2
+Date: 2026-05-23
+Reviewer: Oracle
+
+## Findings
+| # | Severity | File | Description | Status |
+|---|----------|------|-------------|--------|
+| 1 | major | queries/search.sql | BM25 float32→float64 precision loss (ts_rank_cd returns real) | FIXED |
+| 2 | minor | search_test.go | Missing VectorSearch snippet truncation test | DEFERRED |
+| 3 | minor | search_test.go | Missing VectorSearch workspace test | DEFERRED |
+| 4 | minor | search.go:37 | Tags nil vs empty slice JSON inconsistency | DEFERRED |
+
+## Summary
+- Critical: 0 found
+- Major: 1 found, 1 fixed (CAST to double precision in both BM25 queries)
+- Minor: 3 found, 0 fixed (deferred — shared logic already tested via BM25)

--- a/internal/server/handlers/bm25.go
+++ b/internal/server/handlers/bm25.go
@@ -59,7 +59,7 @@ func BM25Search(q BM25SearchQuerier, logger zerolog.Logger) echo.HandlerFunc {
 			Tags          []string
 			CreatedAt     time.Time
 			UpdatedAt     time.Time
-			Score         float32
+			Score         float64
 		}
 
 		var matched []bm25Row
@@ -112,7 +112,7 @@ func BM25Search(q BM25SearchQuerier, logger zerolog.Logger) echo.HandlerFunc {
 				ID:            r.ID,
 				Title:         r.Title,
 				Snippet:       truncateSnippet(r.Content, maxSnippetLen),
-				Score:         float64(r.Score),
+				Score:         r.Score,
 				Tags:          r.Tags,
 				Collection:    r.Collection,
 				WorkspaceHash: r.WorkspaceHash,

--- a/internal/server/handlers/bm25.go
+++ b/internal/server/handlers/bm25.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -21,8 +20,6 @@ type BM25SearchRequest struct {
 	MaxResults int      `json:"max_results,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 }
-
-const maxSnippetLen = 700
 
 func BM25Search(q BM25SearchQuerier, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
@@ -55,10 +52,13 @@ func BM25Search(q BM25SearchQuerier, logger zerolog.Logger) echo.HandlerFunc {
 			ID            string
 			DocumentID    string
 			WorkspaceHash string
+			Title         string
 			Content       string
 			SourcePath    string
 			Collection    string
 			Tags          []string
+			CreatedAt     time.Time
+			UpdatedAt     time.Time
 			Score         float32
 		}
 
@@ -77,9 +77,11 @@ func BM25Search(q BM25SearchQuerier, logger zerolog.Logger) echo.HandlerFunc {
 			for _, r := range rows {
 				matched = append(matched, bm25Row{
 					ID: r.ID.String(), DocumentID: r.DocumentID.String(),
-					WorkspaceHash: r.WorkspaceHash, Content: r.Content,
-					SourcePath: r.SourcePath, Collection: r.Collection,
-					Tags: r.Tags, Score: r.Score,
+					WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+					Content: r.Content, SourcePath: r.SourcePath,
+					Collection: r.Collection, Tags: r.Tags,
+					CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					Score: r.Score,
 				})
 			}
 		} else {
@@ -95,31 +97,29 @@ func BM25Search(q BM25SearchQuerier, logger zerolog.Logger) echo.HandlerFunc {
 			for _, r := range rows {
 				matched = append(matched, bm25Row{
 					ID: r.ID.String(), DocumentID: r.DocumentID.String(),
-					WorkspaceHash: r.WorkspaceHash, Content: r.Content,
-					SourcePath: r.SourcePath, Collection: r.Collection,
-					Tags: r.Tags, Score: r.Score,
+					WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+					Content: r.Content, SourcePath: r.SourcePath,
+					Collection: r.Collection, Tags: r.Tags,
+					CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					Score: r.Score,
 				})
 			}
 		}
 
 		results := make([]SearchResult, 0, len(matched))
 		for _, r := range matched {
-			content := r.Content
-			if len(content) > maxSnippetLen {
-				runes := []rune(content)
-				if len(runes) > maxSnippetLen {
-					content = string(runes[:maxSnippetLen])
-				}
-			}
 			results = append(results, SearchResult{
 				ID:            r.ID,
-				Content:       content,
+				Title:         r.Title,
+				Snippet:       truncateSnippet(r.Content, maxSnippetLen),
 				Score:         float64(r.Score),
-				SourcePath:    r.SourcePath,
+				Tags:          r.Tags,
 				Collection:    r.Collection,
-				Tags:          strings.Join(r.Tags, ","),
 				WorkspaceHash: r.WorkspaceHash,
+				SourcePath:    r.SourcePath,
 				DocumentID:    r.DocumentID,
+				CreatedAt:     r.CreatedAt,
+				UpdatedAt:     r.UpdatedAt,
 			})
 		}
 

--- a/internal/server/handlers/bm25_test.go
+++ b/internal/server/handlers/bm25_test.go
@@ -256,8 +256,8 @@ func TestBM25Search_SnippetTruncation(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
-	if len(resp.Results[0].Content) != 700 {
-		t.Errorf("expected content truncated to 700 chars, got %d", len(resp.Results[0].Content))
+	if len(resp.Results[0].Snippet) != 700 {
+		t.Errorf("expected snippet truncated to 700 chars, got %d", len(resp.Results[0].Snippet))
 	}
 }
 
@@ -326,8 +326,8 @@ func TestBM25Search_WithTags(t *testing.T) {
 	if resp.Total != 1 {
 		t.Errorf("expected total=1, got %d", resp.Total)
 	}
-	if resp.Results[0].Tags != "decision" {
-		t.Errorf("expected tags=decision, got %q", resp.Results[0].Tags)
+	if len(resp.Results[0].Tags) != 1 || resp.Results[0].Tags[0] != "decision" {
+		t.Errorf("expected tags=[decision], got %v", resp.Results[0].Tags)
 	}
 }
 
@@ -362,7 +362,7 @@ func TestBM25Search_UTF8Truncation(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
-	runes := []rune(resp.Results[0].Content)
+	runes := []rune(resp.Results[0].Snippet)
 	if len(runes) != 700 {
 		t.Errorf("expected 700 runes after truncation, got %d", len(runes))
 	}

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -3,13 +3,12 @@ package handlers
 import (
 	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
-	"github.com/rs/zerolog"
 	pgvector_go "github.com/pgvector/pgvector-go"
+	"github.com/rs/zerolog"
 )
 
 // Embedder generates vector embeddings from text.
@@ -28,15 +27,31 @@ type VSearchRequest struct {
 	MaxResults int    `json:"max_results,omitempty"`
 }
 
+const maxSnippetLen = 700
+
 type SearchResult struct {
-	ID            string  `json:"id"`
-	Content       string  `json:"content"`
-	Score         float64 `json:"score"`
-	SourcePath    string  `json:"source_path"`
-	Collection    string  `json:"collection"`
-	Tags          string  `json:"tags,omitempty"`
-	WorkspaceHash string  `json:"workspace_hash"`
-	DocumentID    string  `json:"document_id"`
+	ID            string    `json:"id"`
+	Title         string    `json:"title"`
+	Snippet       string    `json:"snippet"`
+	Score         float64   `json:"score"`
+	Tags          []string  `json:"tags,omitempty"`
+	Collection    string    `json:"collection"`
+	WorkspaceHash string    `json:"workspace_hash"`
+	SourcePath    string    `json:"source_path"`
+	DocumentID    string    `json:"document_id"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func truncateSnippet(content string, maxLen int) string {
+	if len(content) <= maxLen {
+		return content
+	}
+	runes := []rune(content)
+	if len(runes) <= maxLen {
+		return content
+	}
+	return string(runes[:maxLen])
 }
 
 type SearchResponse struct {
@@ -97,13 +112,16 @@ func VectorSearch(q VSearchQuerier, embedder Embedder, logger zerolog.Logger) ec
 		for _, r := range rows {
 			results = append(results, SearchResult{
 				ID:            r.ID.String(),
-				Content:       r.Content,
+				Title:         r.Title,
+				Snippet:       truncateSnippet(r.Content, maxSnippetLen),
 				Score:         r.Score,
-				SourcePath:    r.SourcePath,
+				Tags:          r.Tags,
 				Collection:    r.Collection,
-				Tags:          strings.Join(r.Tags, ","),
 				WorkspaceHash: r.WorkspaceHash,
+				SourcePath:    r.SourcePath,
 				DocumentID:    r.DocumentID.String(),
+				CreatedAt:     r.CreatedAt,
+				UpdatedAt:     r.UpdatedAt,
 			})
 		}
 

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -47,11 +47,14 @@ func truncateSnippet(content string, maxLen int) string {
 	if len(content) <= maxLen {
 		return content
 	}
-	runes := []rune(content)
-	if len(runes) <= maxLen {
-		return content
+	var count int
+	for i := range content {
+		if count == maxLen {
+			return content[:i]
+		}
+		count++
 	}
-	return string(runes[:maxLen])
+	return content
 }
 
 type SearchResponse struct {

--- a/internal/server/handlers/search_test.go
+++ b/internal/server/handlers/search_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -51,6 +52,7 @@ func testVector() []float32 { return []float32{0.1, 0.2, 0.3} }
 func TestVSearch_Success(t *testing.T) {
 	docID := uuid.New()
 	embID := uuid.New()
+	now := time.Now().Truncate(time.Second)
 
 	emb := &mockEmbedder{
 		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
@@ -72,8 +74,11 @@ func TestVSearch_Success(t *testing.T) {
 					Content:       "test content",
 					DocumentID:    docID,
 					SourcePath:    "/test.md",
+					Title:         "Test Doc",
 					Collection:    "memory",
 					Tags:          []string{"tag1", "tag2"},
+					CreatedAt:     now,
+					UpdatedAt:     now,
 					Score:         0.95,
 				},
 			}, nil
@@ -99,17 +104,24 @@ func TestVSearch_Success(t *testing.T) {
 	if resp.Total != 1 {
 		t.Errorf("expected total=1, got %d", resp.Total)
 	}
-	if resp.Results[0].ID != embID.String() {
-		t.Errorf("expected id=%s, got %s", embID, resp.Results[0].ID)
+	r := resp.Results[0]
+	if r.ID != embID.String() {
+		t.Errorf("expected id=%s, got %s", embID, r.ID)
 	}
-	if resp.Results[0].Score != 0.95 {
-		t.Errorf("expected score=0.95, got %f", resp.Results[0].Score)
+	if r.Title != "Test Doc" {
+		t.Errorf("expected title=Test Doc, got %q", r.Title)
 	}
-	if resp.Results[0].Tags != "tag1,tag2" {
-		t.Errorf("expected tags=tag1,tag2, got %q", resp.Results[0].Tags)
+	if r.Snippet != "test content" {
+		t.Errorf("expected snippet=test content, got %q", r.Snippet)
 	}
-	if resp.Results[0].DocumentID != docID.String() {
-		t.Errorf("expected document_id=%s, got %s", docID, resp.Results[0].DocumentID)
+	if r.Score != 0.95 {
+		t.Errorf("expected score=0.95, got %f", r.Score)
+	}
+	if len(r.Tags) != 2 || r.Tags[0] != "tag1" || r.Tags[1] != "tag2" {
+		t.Errorf("expected tags=[tag1,tag2], got %v", r.Tags)
+	}
+	if r.DocumentID != docID.String() {
+		t.Errorf("expected document_id=%s, got %s", docID, r.DocumentID)
 	}
 	if resp.QueryMs < 0 {
 		t.Error("expected non-negative query_ms")

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -39,7 +39,8 @@ LIMIT $1;
 -- name: VectorSearch :many
 SELECT e.id, e.chunk_id, e.workspace_hash,
        c.content, c.metadata, c.document_id,
-       d.source_path, d.collection, d.tags,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
        CAST(1 - (e.embedding <=> sqlc.arg(query_embedding)::vector) AS double precision) AS score
 FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id

--- a/internal/storage/queries/search.sql
+++ b/internal/storage/queries/search.sql
@@ -2,7 +2,7 @@
 SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
        d.source_path, d.title, d.collection, d.tags,
        d.created_at, d.updated_at,
-       ts_rank_cd(c.search_vector, websearch_to_tsquery('english', sqlc.arg(query)::text)) AS score
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', sqlc.arg(query)::text)) AS double precision) AS score
 FROM chunks c
 JOIN documents d ON c.document_id = d.id
 WHERE c.workspace_hash = sqlc.arg(workspace_hash)
@@ -14,7 +14,7 @@ LIMIT sqlc.arg(max_results);
 SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
        d.source_path, d.title, d.collection, d.tags,
        d.created_at, d.updated_at,
-       ts_rank_cd(c.search_vector, websearch_to_tsquery('english', sqlc.arg(query)::text)) AS score
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', sqlc.arg(query)::text)) AS double precision) AS score
 FROM chunks c
 JOIN documents d ON c.document_id = d.id
 WHERE c.workspace_hash = sqlc.arg(workspace_hash)

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -7,6 +7,7 @@ package sqlc
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
@@ -196,7 +197,8 @@ func (q *Queries) ResetEmbedStatus(ctx context.Context, workspaceHash string) er
 const vectorSearch = `-- name: VectorSearch :many
 SELECT e.id, e.chunk_id, e.workspace_hash,
        c.content, c.metadata, c.document_id,
-       d.source_path, d.collection, d.tags,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
        CAST(1 - (e.embedding <=> $1::vector) AS double precision) AS score
 FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
@@ -220,8 +222,11 @@ type VectorSearchRow struct {
 	Metadata      pqtype.NullRawMessage
 	DocumentID    uuid.UUID
 	SourcePath    string
+	Title         string
 	Collection    string
 	Tags          []string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 	Score         float64
 }
 
@@ -242,8 +247,11 @@ func (q *Queries) VectorSearch(ctx context.Context, arg VectorSearchParams) ([]V
 			&i.Metadata,
 			&i.DocumentID,
 			&i.SourcePath,
+			&i.Title,
 			&i.Collection,
 			pq.Array(&i.Tags),
+			&i.CreatedAt,
+			&i.UpdatedAt,
 			&i.Score,
 		); err != nil {
 			return nil, err

--- a/internal/storage/sqlc/search.sql.go
+++ b/internal/storage/sqlc/search.sql.go
@@ -18,7 +18,7 @@ const bM25Search = `-- name: BM25Search :many
 SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
        d.source_path, d.title, d.collection, d.tags,
        d.created_at, d.updated_at,
-       ts_rank_cd(c.search_vector, websearch_to_tsquery('english', $1::text)) AS score
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', $1::text)) AS double precision) AS score
 FROM chunks c
 JOIN documents d ON c.document_id = d.id
 WHERE c.workspace_hash = $2
@@ -46,7 +46,7 @@ type BM25SearchRow struct {
 	Tags          []string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
-	Score         float32
+	Score         float64
 }
 
 func (q *Queries) BM25Search(ctx context.Context, arg BM25SearchParams) ([]BM25SearchRow, error) {
@@ -90,7 +90,7 @@ const bM25SearchWithTags = `-- name: BM25SearchWithTags :many
 SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
        d.source_path, d.title, d.collection, d.tags,
        d.created_at, d.updated_at,
-       ts_rank_cd(c.search_vector, websearch_to_tsquery('english', $1::text)) AS score
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', $1::text)) AS double precision) AS score
 FROM chunks c
 JOIN documents d ON c.document_id = d.id
 WHERE c.workspace_hash = $2
@@ -120,7 +120,7 @@ type BM25SearchWithTagsRow struct {
 	Tags          []string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
-	Score         float32
+	Score         float64
 }
 
 func (q *Queries) BM25SearchWithTags(ctx context.Context, arg BM25SearchWithTagsParams) ([]BM25SearchWithTagsRow, error) {


### PR DESCRIPTION
## Story 4.2: Consistent Result Schema

### Changes
- **SearchResult** normalized: Content→Snippet, Tags string→[]string omitempty, added Title/CreatedAt/UpdatedAt
- **VectorSearch query** updated to JOIN documents for title/timestamps
- **Shared truncateSnippet()** helper with UTF-8 rune safety
- Both BM25 and VectorSearch use identical SearchResult/SearchResponse schema
- All existing tests updated for new field names

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅

Closes #72