### PR TITLE
feat(search): POST /api/query hybrid search pipeline

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -100,7 +100,7 @@ func main() {
 		}
 	}
 
-	srv := server.New(cfg.Server, cfg.Embedding, pool, db, queries, fw, eq, embedder, logger, Version)
+	srv := server.New(cfg.Server, cfg.Embedding, cfg.Search, pool, db, queries, fw, eq, embedder, logger, Version)
 
 	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {

--- a/internal/search/recency.go
+++ b/internal/search/recency.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// ApplyRecencyBoost blends RRF scores with an exponential-decay recency signal.
+// final = (1 - weight) * score + weight * exp(-ln2 * ageDays / halfLife)
+func ApplyRecencyBoost(results []Result, weight float64, halfLifeDays int, now time.Time) []Result {
+	if weight == 0 || len(results) == 0 {
+		return results
+	}
+
+	halfLife := float64(halfLifeDays)
+	ln2 := math.Ln2
+
+	for i := range results {
+		ageDays := now.Sub(results[i].UpdatedAt).Hours() / 24
+		if ageDays < 0 {
+			ageDays = 0
+		}
+		multiplier := math.Exp(-ln2 * ageDays / halfLife)
+		results[i].Score = (1-weight)*results[i].Score + weight*multiplier
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	return results
+}

--- a/internal/search/recency.go
+++ b/internal/search/recency.go
@@ -7,27 +7,43 @@ import (
 )
 
 // ApplyRecencyBoost blends RRF scores with an exponential-decay recency signal.
-// final = (1 - weight) * score + weight * exp(-ln2 * ageDays / halfLife)
+// Scores are normalized to [0,1] before blending so recency doesn't dominate.
+// final = (1 - weight) * normalized_score + weight * exp(-ln2 * ageDays / halfLife)
 func ApplyRecencyBoost(results []Result, weight float64, halfLifeDays int, now time.Time) []Result {
-	if weight == 0 || len(results) == 0 {
+	if len(results) == 0 || weight <= 0 || halfLifeDays <= 0 {
 		return results
 	}
 
-	halfLife := float64(halfLifeDays)
-	ln2 := math.Ln2
+	maxScore := 0.0
+	for _, r := range results {
+		if r.Score > maxScore {
+			maxScore = r.Score
+		}
+	}
 
-	for i := range results {
-		ageDays := now.Sub(results[i].UpdatedAt).Hours() / 24
+	halfLife := float64(halfLifeDays)
+	boosted := make([]Result, len(results))
+
+	for i, r := range results {
+		boosted[i] = r
+
+		normalized := 0.0
+		if maxScore > 0 {
+			normalized = r.Score / maxScore
+		}
+
+		ageDays := now.Sub(r.UpdatedAt).Hours() / 24
 		if ageDays < 0 {
 			ageDays = 0
 		}
-		multiplier := math.Exp(-ln2 * ageDays / halfLife)
-		results[i].Score = (1-weight)*results[i].Score + weight*multiplier
+		multiplier := math.Exp(-math.Ln2 * ageDays / halfLife)
+
+		boosted[i].Score = (1-weight)*normalized + weight*multiplier
 	}
 
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Score > results[j].Score
+	sort.Slice(boosted, func(i, j int) bool {
+		return boosted[i].Score > boosted[j].Score
 	})
 
-	return results
+	return boosted
 }

--- a/internal/search/recency_test.go
+++ b/internal/search/recency_test.go
@@ -48,6 +48,31 @@ func TestRecencyBoost_TodayDoc(t *testing.T) {
 	}
 }
 
+func TestRecencyBoost_Normalization(t *testing.T) {
+	now := time.Now()
+	results := []Result{
+		{ID: "high", Score: 0.03, UpdatedAt: now.Add(-200 * 24 * time.Hour)},
+		{ID: "low", Score: 0.01, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+	}
+
+	boosted := ApplyRecencyBoost(results, 0.3, 180, now)
+	if boosted[0].ID != "high" {
+		t.Errorf("higher-scoring doc should still rank first after normalization, got %s first", boosted[0].ID)
+	}
+	if boosted[0].Score <= 0 || boosted[0].Score > 1.0 {
+		t.Errorf("boosted score should be in (0,1], got %f", boosted[0].Score)
+	}
+}
+
+func TestRecencyBoost_ZeroHalfLife(t *testing.T) {
+	now := time.Now()
+	results := []Result{{ID: "1", Score: 0.5, UpdatedAt: now}}
+	boosted := ApplyRecencyBoost(results, 0.3, 0, now)
+	if !approxEqual(boosted[0].Score, 0.5, 1e-9) {
+		t.Errorf("halfLifeDays=0 should return unchanged, got %f", boosted[0].Score)
+	}
+}
+
 func TestRecencyBoost_VeryOldDoc(t *testing.T) {
 	now := time.Now()
 	results := []Result{

--- a/internal/search/recency_test.go
+++ b/internal/search/recency_test.go
@@ -1,0 +1,66 @@
+package search
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestRecencyBoost_NewerHigher(t *testing.T) {
+	now := time.Now()
+	results := []Result{
+		{ID: "old", Score: 0.5, UpdatedAt: now.Add(-200 * 24 * time.Hour)},
+		{ID: "new", Score: 0.5, UpdatedAt: now.Add(-10 * 24 * time.Hour)},
+	}
+
+	boosted := ApplyRecencyBoost(results, 0.3, 180, now)
+	if boosted[0].ID != "new" {
+		t.Errorf("newer doc should rank first, got %s", boosted[0].ID)
+	}
+	if boosted[0].Score <= boosted[1].Score {
+		t.Error("newer doc should have higher score")
+	}
+}
+
+func TestRecencyBoost_ZeroWeight(t *testing.T) {
+	now := time.Now()
+	results := []Result{
+		{ID: "a", Score: 0.8, UpdatedAt: now.Add(-100 * 24 * time.Hour)},
+		{ID: "b", Score: 0.5, UpdatedAt: now},
+	}
+
+	boosted := ApplyRecencyBoost(results, 0, 180, now)
+	if boosted[0].ID != "a" || !approxEqual(boosted[0].Score, 0.8, 1e-9) {
+		t.Error("zero weight should preserve original scores and order")
+	}
+}
+
+func TestRecencyBoost_TodayDoc(t *testing.T) {
+	now := time.Now()
+	results := []Result{
+		{ID: "today", Score: 1.0, UpdatedAt: now},
+	}
+
+	boosted := ApplyRecencyBoost(results, 0.5, 180, now)
+	want := 0.5*1.0 + 0.5*1.0 // multiplier = exp(0) = 1.0
+	if !approxEqual(boosted[0].Score, want, 1e-9) {
+		t.Errorf("today doc score = %f, want %f", boosted[0].Score, want)
+	}
+}
+
+func TestRecencyBoost_VeryOldDoc(t *testing.T) {
+	now := time.Now()
+	results := []Result{
+		{ID: "ancient", Score: 1.0, UpdatedAt: now.Add(-1000 * 24 * time.Hour)},
+	}
+
+	boosted := ApplyRecencyBoost(results, 0.5, 180, now)
+	multiplier := math.Exp(-math.Ln2 * 1000 / 180)
+	want := 0.5*1.0 + 0.5*multiplier
+	if !approxEqual(boosted[0].Score, want, 1e-9) {
+		t.Errorf("very old doc score = %f, want %f", boosted[0].Score, want)
+	}
+	if multiplier > 0.05 {
+		t.Errorf("1000-day multiplier should be near zero, got %f", multiplier)
+	}
+}

--- a/internal/search/rrf.go
+++ b/internal/search/rrf.go
@@ -4,6 +4,8 @@ import "sort"
 
 // RRFMerge merges two ranked result lists using Reciprocal Rank Fusion.
 // score = Σ 1/(k + rank + 1) for each list the result appears in.
+// When a chunk appears in both lists, metadata is kept from the first occurrence (BM25).
+// Both queries return identical metadata for the same chunk ID so the choice is safe.
 func RRFMerge(bm25Results, vectorResults []Result, k float64) []Result {
 	type entry struct {
 		result Result

--- a/internal/search/rrf.go
+++ b/internal/search/rrf.go
@@ -1,0 +1,43 @@
+package search
+
+import "sort"
+
+// RRFMerge merges two ranked result lists using Reciprocal Rank Fusion.
+// score = Σ 1/(k + rank + 1) for each list the result appears in.
+func RRFMerge(bm25Results, vectorResults []Result, k float64) []Result {
+	type entry struct {
+		result Result
+		score  float64
+	}
+	merged := make(map[string]*entry)
+
+	for rank, r := range bm25Results {
+		s := 1.0 / (k + float64(rank) + 1)
+		if e, ok := merged[r.ID]; ok {
+			e.score += s
+		} else {
+			merged[r.ID] = &entry{result: r, score: s}
+		}
+	}
+
+	for rank, r := range vectorResults {
+		s := 1.0 / (k + float64(rank) + 1)
+		if e, ok := merged[r.ID]; ok {
+			e.score += s
+		} else {
+			merged[r.ID] = &entry{result: r, score: s}
+		}
+	}
+
+	out := make([]Result, 0, len(merged))
+	for _, e := range merged {
+		e.result.Score = e.score
+		out = append(out, e.result)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Score > out[j].Score
+	})
+
+	return out
+}

--- a/internal/search/rrf_test.go
+++ b/internal/search/rrf_test.go
@@ -1,0 +1,73 @@
+package search
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRRFMerge_BasicFusion(t *testing.T) {
+	bm25 := []Result{{ID: "a"}, {ID: "b"}}
+	vec := []Result{{ID: "c"}, {ID: "d"}}
+	k := 60.0
+
+	got := RRFMerge(bm25, vec, k)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(got))
+	}
+
+	wantFirst := 1.0 / (k + 0 + 1)
+	if !approxEqual(got[0].Score, wantFirst, 1e-9) {
+		t.Errorf("rank-0 score = %f, want %f", got[0].Score, wantFirst)
+	}
+	if got[0].Score < got[1].Score {
+		t.Error("results not sorted descending")
+	}
+}
+
+func TestRRFMerge_Deduplication(t *testing.T) {
+	bm25 := []Result{{ID: "dup", Title: "bm25-title"}}
+	vec := []Result{{ID: "dup", Title: "vec-title"}}
+	k := 60.0
+
+	got := RRFMerge(bm25, vec, k)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 deduplicated result, got %d", len(got))
+	}
+
+	wantScore := 2 * (1.0 / (k + 0 + 1))
+	if !approxEqual(got[0].Score, wantScore, 1e-9) {
+		t.Errorf("dedup score = %f, want %f (sum of both)", got[0].Score, wantScore)
+	}
+}
+
+func TestRRFMerge_SingleList(t *testing.T) {
+	bm25 := []Result{{ID: "a"}, {ID: "b"}}
+	got := RRFMerge(bm25, nil, 60)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(got))
+	}
+}
+
+func TestRRFMerge_EmptyBoth(t *testing.T) {
+	got := RRFMerge(nil, nil, 60)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(got))
+	}
+}
+
+func TestRRFMerge_CustomK(t *testing.T) {
+	list := []Result{{ID: "x"}}
+	k30 := RRFMerge(list, nil, 30)
+	k60 := RRFMerge(list, nil, 60)
+
+	if approxEqual(k30[0].Score, k60[0].Score, 1e-12) {
+		t.Error("k=30 and k=60 should produce different scores")
+	}
+	if k30[0].Score <= k60[0].Score {
+		t.Error("smaller k should produce higher scores")
+	}
+}
+
+func approxEqual(a, b, epsilon float64) bool {
+	return math.Abs(a-b) < epsilon
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,2 +1,20 @@
 // Package search handles semantic and keyword search queries.
 package search
+
+import "time"
+
+// Result represents a single search result from any search method.
+type Result struct {
+	ID            string
+	DocumentID    string
+	WorkspaceHash string
+	Title         string
+	Snippet       string
+	Content       string
+	Score         float64
+	Tags          []string
+	Collection    string
+	SourcePath    string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -1,0 +1,126 @@
+package search
+
+import (
+	"context"
+	"time"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	pgvector_go "github.com/pgvector/pgvector-go"
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/errgroup"
+)
+
+type Querier interface {
+	BM25Search(ctx context.Context, arg sqlc.BM25SearchParams) ([]sqlc.BM25SearchRow, error)
+	VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error)
+}
+
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	Dimension() int
+}
+
+type SearchService struct {
+	queries  Querier
+	embedder Embedder
+	config   config.SearchConfig
+	logger   zerolog.Logger
+}
+
+func NewSearchService(queries Querier, embedder Embedder, cfg config.SearchConfig, logger zerolog.Logger) *SearchService {
+	return &SearchService{queries: queries, embedder: embedder, config: cfg, logger: logger}
+}
+
+func (s *SearchService) HybridSearch(ctx context.Context, query string, workspace string, maxResults int) ([]Result, error) {
+	fetchLimit := int32(maxResults * 3)
+	if fetchLimit < 30 {
+		fetchLimit = 30
+	}
+
+	var (
+		bm25Results   []Result
+		vectorResults []Result
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		rows, err := s.queries.BM25Search(gctx, sqlc.BM25SearchParams{
+			Query:         query,
+			WorkspaceHash: workspace,
+			MaxResults:    fetchLimit,
+		})
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("bm25 leg failed, continuing with vector only")
+			return nil
+		}
+		bm25Results = make([]Result, 0, len(rows))
+		for _, r := range rows {
+			bm25Results = append(bm25Results, Result{
+				ID:            r.ID.String(),
+				DocumentID:    r.DocumentID.String(),
+				WorkspaceHash: r.WorkspaceHash,
+				Title:         r.Title,
+				Content:       r.Content,
+				Score:         r.Score,
+				Tags:          r.Tags,
+				Collection:    r.Collection,
+				SourcePath:    r.SourcePath,
+				CreatedAt:     r.CreatedAt,
+				UpdatedAt:     r.UpdatedAt,
+			})
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		if s.embedder == nil {
+			s.logger.Warn().Msg("no embedder configured, skipping vector leg")
+			return nil
+		}
+		vec, err := s.embedder.Embed(gctx, query)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("embed failed, continuing with bm25 only")
+			return nil
+		}
+		rows, err := s.queries.VectorSearch(gctx, sqlc.VectorSearchParams{
+			QueryEmbedding: pgvector_go.NewVector(vec),
+			WorkspaceHash:  workspace,
+			MaxResults:     fetchLimit,
+		})
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("vector search leg failed, continuing with bm25 only")
+			return nil
+		}
+		vectorResults = make([]Result, 0, len(rows))
+		for _, r := range rows {
+			vectorResults = append(vectorResults, Result{
+				ID:            r.ChunkID.String(),
+				DocumentID:    r.DocumentID.String(),
+				WorkspaceHash: r.WorkspaceHash,
+				Title:         r.Title,
+				Content:       r.Content,
+				Score:         r.Score,
+				Tags:          r.Tags,
+				Collection:    r.Collection,
+				SourcePath:    r.SourcePath,
+				CreatedAt:     r.CreatedAt,
+				UpdatedAt:     r.UpdatedAt,
+			})
+		}
+		return nil
+	})
+
+	_ = g.Wait()
+
+	merged := RRFMerge(bm25Results, vectorResults, s.config.RrfK)
+
+	boosted := ApplyRecencyBoost(merged, s.config.RecencyWeight, s.config.RecencyHalfLifeDays, time.Now())
+
+	if len(boosted) > maxResults {
+		boosted = boosted[:maxResults]
+	}
+
+	return boosted, nil
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/nano-brain/nano-brain/internal/config"
@@ -41,6 +42,8 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 	var (
 		bm25Results   []Result
 		vectorResults []Result
+		bm25Err       error
+		vectorErr     error
 	)
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -52,7 +55,8 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 			MaxResults:    fetchLimit,
 		})
 		if err != nil {
-			s.logger.Warn().Err(err).Msg("bm25 leg failed, continuing with vector only")
+			bm25Err = err
+			s.logger.Warn().Err(err).Msg("bm25 leg failed, degrading")
 			return nil
 		}
 		bm25Results = make([]Result, 0, len(rows))
@@ -76,12 +80,12 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 
 	g.Go(func() error {
 		if s.embedder == nil {
-			s.logger.Warn().Msg("no embedder configured, skipping vector leg")
 			return nil
 		}
 		vec, err := s.embedder.Embed(gctx, query)
 		if err != nil {
-			s.logger.Warn().Err(err).Msg("embed failed, continuing with bm25 only")
+			vectorErr = err
+			s.logger.Warn().Err(err).Msg("embed failed, degrading")
 			return nil
 		}
 		rows, err := s.queries.VectorSearch(gctx, sqlc.VectorSearchParams{
@@ -90,7 +94,8 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 			MaxResults:     fetchLimit,
 		})
 		if err != nil {
-			s.logger.Warn().Err(err).Msg("vector search leg failed, continuing with bm25 only")
+			vectorErr = err
+			s.logger.Warn().Err(err).Msg("vector search leg failed, degrading")
 			return nil
 		}
 		vectorResults = make([]Result, 0, len(rows))
@@ -113,6 +118,10 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 	})
 
 	_ = g.Wait()
+
+	if bm25Err != nil && vectorErr != nil {
+		return nil, fmt.Errorf("all search legs failed: bm25: %v, vector: %v", bm25Err, vectorErr)
+	}
 
 	merged := RRFMerge(bm25Results, vectorResults, s.config.RrfK)
 

--- a/internal/server/handlers/query.go
+++ b/internal/server/handlers/query.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/rs/zerolog"
+)
+
+type HybridSearcher interface {
+	HybridSearch(ctx context.Context, query string, workspace string, maxResults int) ([]search.Result, error)
+}
+
+type QueryRequest struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results,omitempty"`
+}
+
+func Query(searcher HybridSearcher, defaultLimit int, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req QueryRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+		if req.Query == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "query is required")
+		}
+
+		maxResults := req.MaxResults
+		if maxResults <= 0 {
+			maxResults = defaultLimit
+		}
+		if maxResults > 100 {
+			maxResults = 100
+		}
+
+		workspace, _ := c.Get("workspace").(string)
+		if workspace == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace is required")
+		}
+
+		start := time.Now()
+
+		results, err := searcher.HybridSearch(c.Request().Context(), req.Query, workspace, maxResults)
+		if err != nil {
+			logger.Error().Err(err).Str("workspace", workspace).Msg("hybrid search failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "search failed")
+		}
+
+		out := make([]SearchResult, 0, len(results))
+		for _, r := range results {
+			out = append(out, SearchResult{
+				ID:            r.ID,
+				Title:         r.Title,
+				Snippet:       truncateSnippet(r.Content, maxSnippetLen),
+				Score:         r.Score,
+				Tags:          r.Tags,
+				Collection:    r.Collection,
+				WorkspaceHash: r.WorkspaceHash,
+				SourcePath:    r.SourcePath,
+				DocumentID:    r.DocumentID,
+				CreatedAt:     r.CreatedAt,
+				UpdatedAt:     r.UpdatedAt,
+			})
+		}
+
+		return c.JSON(http.StatusOK, SearchResponse{
+			Results: out,
+			Total:   len(out),
+			QueryMs: time.Since(start).Milliseconds(),
+		})
+	}
+}

--- a/internal/server/handlers/query_test.go
+++ b/internal/server/handlers/query_test.go
@@ -88,22 +88,23 @@ func TestQuery_MissingWorkspace(t *testing.T) {
 }
 
 func TestQuery_DefaultMaxResults(t *testing.T) {
-	var capturedMax int
-	ms := &mockSearcher{}
-	original := handlers.Query(ms, 20, zerolog.Nop())
-
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/query",
-		strings.NewReader(`{"query":"test"}`))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("workspace", "ws1")
-
-	_ = original(c)
-
-	_ = capturedMax
+	h := handlers.Query(&mockSearcher{}, 20, zerolog.Nop())
+	rec, c := queryRequest(`{"query":"test"}`, "ws1")
+	if err := h(c); err != nil {
+		t.Fatal(err)
+	}
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestQuery_MaxResultsCapping(t *testing.T) {
+	h := handlers.Query(&mockSearcher{}, 20, zerolog.Nop())
+	rec, c := queryRequest(`{"query":"test","max_results":500}`, "ws1")
+	if err := h(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 even with oversized max_results, got %d", rec.Code)
 	}
 }

--- a/internal/server/handlers/query_test.go
+++ b/internal/server/handlers/query_test.go
@@ -1,0 +1,109 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/rs/zerolog"
+)
+
+type mockSearcher struct {
+	results []search.Result
+	err     error
+}
+
+func (m *mockSearcher) HybridSearch(_ context.Context, _ string, _ string, _ int) ([]search.Result, error) {
+	return m.results, m.err
+}
+
+func queryRequest(body string, workspace string) (*httptest.ResponseRecorder, echo.Context) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/query", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if workspace != "" {
+		c.Set("workspace", workspace)
+	}
+	return rec, c
+}
+
+func TestQuery_Success(t *testing.T) {
+	ms := &mockSearcher{results: []search.Result{
+		{ID: "r1", Title: "Result One", Content: "snippet", Score: 0.9},
+	}}
+	h := handlers.Query(ms, 20, zerolog.Nop())
+
+	rec, c := queryRequest(`{"query":"test"}`, "ws1")
+	if err := h(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.SearchResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("expected total=1, got %d", resp.Total)
+	}
+	if resp.Results[0].ID != "r1" {
+		t.Errorf("expected ID=r1, got %s", resp.Results[0].ID)
+	}
+}
+
+func TestQuery_EmptyQuery(t *testing.T) {
+	h := handlers.Query(&mockSearcher{}, 20, zerolog.Nop())
+	_, c := queryRequest(`{"query":""}`, "ws1")
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for empty query")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %v", err)
+	}
+}
+
+func TestQuery_MissingWorkspace(t *testing.T) {
+	h := handlers.Query(&mockSearcher{}, 20, zerolog.Nop())
+	_, c := queryRequest(`{"query":"test"}`, "")
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing workspace")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %v", err)
+	}
+}
+
+func TestQuery_DefaultMaxResults(t *testing.T) {
+	var capturedMax int
+	ms := &mockSearcher{}
+	original := handlers.Query(ms, 20, zerolog.Nop())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/query",
+		strings.NewReader(`{"query":"test"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws1")
+
+	_ = original(c)
+
+	_ = capturedMax
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -29,6 +29,10 @@ func registerRoutes(s *Server) {
 
 	data.POST("/vsearch", handlers.VectorSearch(s.queries, s.embedder, s.logger))
 	data.POST("/search", handlers.BM25Search(s.queries, s.logger))
+
+	if s.searchService != nil {
+		data.POST("/query", handlers.Query(s.searchService, s.searchCfg.Limit, s.logger))
+	}
 }
 
 const defaultMaxFileSize int64 = 307200

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/embed"
+	"github.com/nano-brain/nano-brain/internal/search"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
@@ -22,38 +23,47 @@ type PoolChecker interface {
 }
 
 type Server struct {
-	echo       *echo.Echo
-	pool       PoolChecker
-	db         *sql.DB
-	queries    *sqlc.Queries
-	watcher    *watcher.Watcher
-	embedQueue *embed.Queue
-	embedder   embed.Embedder
-	logger     zerolog.Logger
-	cfg        config.ServerConfig
-	embedCfg   config.EmbeddingConfig
-	version    string
-	startTime  time.Time
+	echo          *echo.Echo
+	pool          PoolChecker
+	db            *sql.DB
+	queries       *sqlc.Queries
+	watcher       *watcher.Watcher
+	embedQueue    *embed.Queue
+	embedder      embed.Embedder
+	searchService *search.SearchService
+	logger        zerolog.Logger
+	cfg           config.ServerConfig
+	embedCfg      config.EmbeddingConfig
+	searchCfg     config.SearchConfig
+	version       string
+	startTime     time.Time
 }
 
-func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
+func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, searchCfg config.SearchConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
 
+	var ss *search.SearchService
+	if queries != nil {
+		ss = search.NewSearchService(queries, embedder, searchCfg, logger)
+	}
+
 	s := &Server{
-		echo:       e,
-		pool:       pool,
-		db:         db,
-		queries:    queries,
-		watcher:    fw,
-		embedQueue: eq,
-		embedder:   embedder,
-		logger:     logger,
-		cfg:        cfg,
-		embedCfg:   embedCfg,
-		version:    version,
-		startTime:  time.Now(),
+		echo:          e,
+		pool:          pool,
+		db:            db,
+		queries:       queries,
+		watcher:       fw,
+		embedQueue:    eq,
+		embedder:      embedder,
+		searchService: ss,
+		logger:        logger,
+		cfg:           cfg,
+		embedCfg:      embedCfg,
+		searchCfg:     searchCfg,
+		version:       version,
+		startTime:     time.Now(),
 	}
 
 	registerMiddleware(s)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,7 +25,7 @@ func (m *mockPool) Ping(_ context.Context) error {
 func newTestServer(pool *mockPool) *server.Server {
 	cfg := config.ServerConfig{Host: "127.0.0.1", Port: 3100}
 	logger := zerolog.Nop()
-	return server.New(cfg, config.EmbeddingConfig{}, pool, nil, nil, nil, nil, nil, logger, "test-v1")
+	return server.New(cfg, config.EmbeddingConfig{}, config.SearchConfig{RrfK: 60, Limit: 20}, pool, nil, nil, nil, nil, nil, logger, "test-v1")
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {


### PR DESCRIPTION
## Story 4.3: 7-Stage Hybrid Search Pipeline

### Changes
- **SearchService**: 7-stage pipeline — validate, parallel BM25+vector, RRF merge, recency boost, top-K
- **RRF fusion**: Configurable k (default 60), deduplication by chunk ID, equal weight per leg
- **Recency boost**: Exponential decay with configurable weight (0.3) and half-life (180 days)
- **POST /api/v1/query**: Handler wired with HybridSearcher interface
- **Graceful degradation**: If one search leg fails, other results still returned
- **Over-fetch**: 3x max_results per leg for better RRF candidate pool
- **Tests**: 5 RRF + 4 recency + 4 handler = 13 unit tests

### Design
- `internal/search/` package: service.go, rrf.go, recency.go
- `internal/server/handlers/query.go`: thin handler delegating to SearchService
- Server.New() updated to accept SearchConfig and create SearchService

### Testing
- `go build ./...` ✅
- `go test -race -short ./...` ✅

Closes #74