### PR TITLE
feat(search): thread-safe config updates + validation tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,15 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Search.RrfK != 60 {
 		t.Errorf("expected Search.RrfK=60, got %v", cfg.Search.RrfK)
 	}
+	if cfg.Search.RecencyWeight != 0.3 {
+		t.Errorf("expected Search.RecencyWeight=0.3, got %v", cfg.Search.RecencyWeight)
+	}
+	if cfg.Search.RecencyHalfLifeDays != 180 {
+		t.Errorf("expected Search.RecencyHalfLifeDays=180, got %d", cfg.Search.RecencyHalfLifeDays)
+	}
+	if cfg.Search.Limit != 20 {
+		t.Errorf("expected Search.Limit=20, got %d", cfg.Search.Limit)
+	}
 	if cfg.Storage.MaxFileSize != 314572800 {
 		t.Errorf("expected Storage.MaxFileSize=314572800, got %d", cfg.Storage.MaxFileSize)
 	}
@@ -174,6 +183,16 @@ func TestInvalidRangeRejectsStartup(t *testing.T) {
 			name:    "invalid_recency_weight_too_high",
 			envVars: map[string]string{"NANO_BRAIN_SEARCH_RECENCY_WEIGHT": "1.5"},
 			errMsg:  "search.recency_weight must be between 0 and 1",
+		},
+		{
+			name:    "invalid_recency_half_life_days_zero",
+			envVars: map[string]string{"NANO_BRAIN_SEARCH_RECENCY_HALF_LIFE_DAYS": "0"},
+			errMsg:  "search.recency_half_life_days must be >= 1",
+		},
+		{
+			name:    "invalid_recency_half_life_days_negative",
+			envVars: map[string]string{"NANO_BRAIN_SEARCH_RECENCY_HALF_LIFE_DAYS": "-1"},
+			errMsg:  "search.recency_half_life_days must be >= 1",
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -194,6 +195,11 @@ func TestInvalidRangeRejectsStartup(t *testing.T) {
 			envVars: map[string]string{"NANO_BRAIN_SEARCH_RECENCY_HALF_LIFE_DAYS": "-1"},
 			errMsg:  "search.recency_half_life_days must be >= 1",
 		},
+		{
+			name:    "invalid_search_limit_zero",
+			envVars: map[string]string{"NANO_BRAIN_SEARCH_LIMIT": "0"},
+			errMsg:  "search.limit must be >= 1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -243,6 +249,44 @@ func TestGeneratesDefaultConfigFile(t *testing.T) {
 
 	if cfg.Server.Port != 3100 {
 		t.Errorf("generated config has unexpected port: %d", cfg.Server.Port)
+	}
+}
+
+func TestRecencyWeightBoundaryValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "recency_weight_zero",
+			value: "0.0",
+		},
+		{
+			name:  "recency_weight_one",
+			value: "1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "nonexistent.yml")
+
+			t.Setenv("NANO_BRAIN_SEARCH_RECENCY_WEIGHT", tt.value)
+
+			cfg, err := Load(configPath)
+			if err != nil {
+				t.Errorf("expected no error for recency_weight=%s, got: %v", tt.value, err)
+			}
+
+			weight, err := strconv.ParseFloat(tt.value, 64)
+			if err != nil {
+				t.Fatalf("test setup error: %v", err)
+			}
+			if cfg.Search.RecencyWeight != weight {
+				t.Errorf("expected Search.RecencyWeight=%v, got %v", weight, cfg.Search.RecencyWeight)
+			}
+		})
 	}
 }
 

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -36,6 +36,8 @@ func NewSearchService(queries Querier, embedder Embedder, cfg config.SearchConfi
 }
 
 // UpdateConfig updates the search configuration with thread-safe locking.
+// TODO(story-8.2): validate cfg before accepting — callers must ensure
+// RrfK >= 1, RecencyWeight in [0,1], RecencyHalfLifeDays >= 1, Limit >= 1.
 func (s *SearchService) UpdateConfig(cfg config.SearchConfig) {
 	s.configMutex.Lock()
 	defer s.configMutex.Unlock()

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/nano-brain/nano-brain/internal/config"
@@ -23,17 +24,32 @@ type Embedder interface {
 }
 
 type SearchService struct {
-	queries  Querier
-	embedder Embedder
-	config   config.SearchConfig
-	logger   zerolog.Logger
+	queries     Querier
+	embedder    Embedder
+	config      config.SearchConfig
+	configMutex sync.RWMutex
+	logger      zerolog.Logger
 }
 
 func NewSearchService(queries Querier, embedder Embedder, cfg config.SearchConfig, logger zerolog.Logger) *SearchService {
 	return &SearchService{queries: queries, embedder: embedder, config: cfg, logger: logger}
 }
 
+// UpdateConfig updates the search configuration with thread-safe locking.
+func (s *SearchService) UpdateConfig(cfg config.SearchConfig) {
+	s.configMutex.Lock()
+	defer s.configMutex.Unlock()
+	s.config = cfg
+}
+
 func (s *SearchService) HybridSearch(ctx context.Context, query string, workspace string, maxResults int) ([]Result, error) {
+	// Read config under lock at the start, then release before I/O
+	s.configMutex.RLock()
+	rrfK := s.config.RrfK
+	recencyWeight := s.config.RecencyWeight
+	recencyHalfLifeDays := s.config.RecencyHalfLifeDays
+	s.configMutex.RUnlock()
+
 	fetchLimit := int32(maxResults * 3)
 	if fetchLimit < 30 {
 		fetchLimit = 30
@@ -123,9 +139,9 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 		return nil, fmt.Errorf("all search legs failed: bm25: %v, vector: %v", bm25Err, vectorErr)
 	}
 
-	merged := RRFMerge(bm25Results, vectorResults, s.config.RrfK)
+	merged := RRFMerge(bm25Results, vectorResults, rrfK)
 
-	boosted := ApplyRecencyBoost(merged, s.config.RecencyWeight, s.config.RecencyHalfLifeDays, time.Now())
+	boosted := ApplyRecencyBoost(merged, recencyWeight, recencyHalfLifeDays, time.Now())
 
 	if len(boosted) > maxResults {
 		boosted = boosted[:maxResults]

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/nano-brain/nano-brain/internal/config"
@@ -70,7 +71,7 @@ func TestUpdateConfig_ChangesAppliedToSubsequentSearches(t *testing.T) {
 	service.configMutex.RUnlock()
 }
 
-func TestUpdateConfig_ThreadSafe(t *testing.T) {
+func TestUpdateConfig_ConcurrentReadersAndWriters(t *testing.T) {
 	logger := zerolog.Nop()
 	initialCfg := config.SearchConfig{
 		RrfK:                60,
@@ -80,20 +81,40 @@ func TestUpdateConfig_ThreadSafe(t *testing.T) {
 	}
 
 	service := NewSearchService(&mockQuerier{}, &mockEmbedder{}, initialCfg, logger)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errors := make(chan error, 20)
 
 	for i := 0; i < 10; i++ {
-		newCfg := config.SearchConfig{
-			RrfK:                float64(50 + i),
-			RecencyWeight:       0.3,
-			RecencyHalfLifeDays: 180,
-			Limit:               20,
-		}
-		service.UpdateConfig(newCfg)
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			newCfg := config.SearchConfig{
+				RrfK:                float64(50 + idx),
+				RecencyWeight:       0.3,
+				RecencyHalfLifeDays: 180,
+				Limit:               20,
+			}
+			service.UpdateConfig(newCfg)
+		}(i)
 	}
 
-	service.configMutex.RLock()
-	defer service.configMutex.RUnlock()
-	if service.config.RrfK != 59 {
-		t.Errorf("final RrfK should be 59, got %v", service.config.RrfK)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := service.HybridSearch(ctx, "test", "workspace", 10)
+			if err != nil {
+				errors <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("concurrent operation failed: %v", err)
 	}
 }

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -1,0 +1,99 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockQuerier struct{}
+
+func (m *mockQuerier) BM25Search(ctx context.Context, arg sqlc.BM25SearchParams) ([]sqlc.BM25SearchRow, error) {
+	return []sqlc.BM25SearchRow{}, nil
+}
+
+func (m *mockQuerier) VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+	return []sqlc.VectorSearchRow{}, nil
+}
+
+type mockEmbedder struct{}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	return make([]float32, 1536), nil
+}
+
+func (m *mockEmbedder) Dimension() int {
+	return 1536
+}
+
+func TestUpdateConfig_ChangesAppliedToSubsequentSearches(t *testing.T) {
+	logger := zerolog.Nop()
+	initialCfg := config.SearchConfig{
+		RrfK:                60,
+		RecencyWeight:       0.3,
+		RecencyHalfLifeDays: 180,
+		Limit:               20,
+	}
+
+	service := NewSearchService(&mockQuerier{}, &mockEmbedder{}, initialCfg, logger)
+
+	service.configMutex.RLock()
+	if service.config.RrfK != 60 {
+		t.Errorf("initial RrfK should be 60, got %v", service.config.RrfK)
+	}
+	service.configMutex.RUnlock()
+
+	newCfg := config.SearchConfig{
+		RrfK:                45,
+		RecencyWeight:       0.5,
+		RecencyHalfLifeDays: 90,
+		Limit:               15,
+	}
+	service.UpdateConfig(newCfg)
+
+	service.configMutex.RLock()
+	if service.config.RrfK != 45 {
+		t.Errorf("updated RrfK should be 45, got %v", service.config.RrfK)
+	}
+	if service.config.RecencyWeight != 0.5 {
+		t.Errorf("updated RecencyWeight should be 0.5, got %v", service.config.RecencyWeight)
+	}
+	if service.config.RecencyHalfLifeDays != 90 {
+		t.Errorf("updated RecencyHalfLifeDays should be 90, got %d", service.config.RecencyHalfLifeDays)
+	}
+	if service.config.Limit != 15 {
+		t.Errorf("updated Limit should be 15, got %d", service.config.Limit)
+	}
+	service.configMutex.RUnlock()
+}
+
+func TestUpdateConfig_ThreadSafe(t *testing.T) {
+	logger := zerolog.Nop()
+	initialCfg := config.SearchConfig{
+		RrfK:                60,
+		RecencyWeight:       0.3,
+		RecencyHalfLifeDays: 180,
+		Limit:               20,
+	}
+
+	service := NewSearchService(&mockQuerier{}, &mockEmbedder{}, initialCfg, logger)
+
+	for i := 0; i < 10; i++ {
+		newCfg := config.SearchConfig{
+			RrfK:                float64(50 + i),
+			RecencyWeight:       0.3,
+			RecencyHalfLifeDays: 180,
+			Limit:               20,
+		}
+		service.UpdateConfig(newCfg)
+	}
+
+	service.configMutex.RLock()
+	defer service.configMutex.RUnlock()
+	if service.config.RrfK != 59 {
+		t.Errorf("final RrfK should be 59, got %v", service.config.RrfK)
+	}
+}


### PR DESCRIPTION
## Story 4.5: Configurable RRF and Recency Parameters

### Changes
- Added `sync.RWMutex` to `SearchService` for thread-safe config updates
- Added `UpdateConfig(cfg)` method — enables hot-reload (prep for Story 8.2)
- `HybridSearch` reads config under `RLock`, releases before I/O
- Added missing config default assertions: RecencyWeight=0.3, HalfLifeDays=180, Limit=20
- Added validation tests: half_life_days=0 and negative values rejected
- Added UpdateConfig unit tests with race detection

### Validation
- `go build ./...` ✅
- `go test -race -count=1 ./internal/search/... ./internal/config/...` ✅

Closes #77