### PR TITLE
fix: prevent nil pointer panic in WriteDocument when embedding disabled

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,8 +18,13 @@ func registerRoutes(s *Server) {
 	api.POST("/init", handlers.InitWorkspace(s.queries, s.db, s.logger))
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
 
+	var enqueuer handlers.ChunkEnqueuer
+	if s.embedQueue != nil {
+		enqueuer = s.embedQueue
+	}
+
 	data := api.Group("", workspaceMiddleware())
-	data.POST("/write", handlers.WriteDocument(s.queries, s.db, s.embedQueue, s.logger, defaultMaxFileSize))
+	data.POST("/write", handlers.WriteDocument(s.queries, s.db, enqueuer, s.logger, defaultMaxFileSize))
 	data.POST("/embed", handlers.TriggerEmbed(s.queries, s.embedder, s.embedCfg.Provider, s.embedCfg.Model, s.logger))
 
 	data.POST("/collections", handlers.AddCollection(s.queries, s.watcher, s.logger))


### PR DESCRIPTION
## Bug Fix: POST /api/v1/write panics without embedding provider

### Problem
When no embedding provider is configured, `s.embedQueue` is `nil (*embed.Queue)`. Passing this as `ChunkEnqueuer` interface to `WriteDocument()` creates a non-nil interface wrapping a nil pointer. The `enqueuer != nil` check in document.go:167 passes, then `enqueuer.IsPressured()` panics.

### Root Cause
Go interface semantics: `(*embed.Queue)(nil)` cast to `ChunkEnqueuer` is a non-nil interface.

### Fix
Apply the same nil-guard pattern already used for `EmbedQueueInfo` (lines 8-11 of routes.go):
```go
var enqueuer handlers.ChunkEnqueuer
if s.embedQueue != nil {
    enqueuer = s.embedQueue
}
```

### Found During
E2E smoke test — build binary, start server without embedding provider, POST /api/v1/write.

### Validation
- `go build ./...` ✅
- `go test -race -short ./...` ✅
- Manual E2E: POST /api/v1/write returns 201 ✅

Closes #81