### PR TITLE
feat: mount MCP SSE and Streamable HTTP transports (Story 5.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/knadh/koanf/v2 v2.3.4
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/lib/pq v1.12.3
+	github.com/modelcontextprotocol/go-sdk v0.8.0
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pgvector/pgvector-go v0.2.2
 	github.com/pressly/goose/v3 v3.22.1
@@ -25,6 +26,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -39,6 +41,7 @@ require (
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.3 // indirect
 	golang.org/x/crypto v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,10 @@ github.com/go-pg/zerochecker v0.2.0 h1:pp7f72c3DobMWOb2ErtZsnrPaSvHd2W4o9//8HtF4
 github.com/go-pg/zerochecker v0.2.0/go.mod h1:NJZ4wKL0NmTtz0GKCoJ8kym6Xn/EQzXRl2OnAe7MmDo=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
@@ -65,6 +69,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/modelcontextprotocol/go-sdk v0.8.0 h1:jdsBtGzBLY287WKSIjYovOXAqtJkP+HtFQFKrZd4a6c=
+github.com/modelcontextprotocol/go-sdk v0.8.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
@@ -110,6 +116,8 @@ github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vb
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
@@ -125,6 +133,8 @@ golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1,2 +1,0 @@
-// Package mcp implements the Model Context Protocol server.
-package mcp

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,18 @@
+// Package mcp implements the Model Context Protocol server.
+package mcp
+
+import (
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewMCPServer creates the core MCP server instance.
+// Tools are NOT registered here — that's Story 5.2.
+func NewMCPServer(version string) *mcpsdk.Server {
+	return mcpsdk.NewServer(
+		&mcpsdk.Implementation{
+			Name:    "nano-brain",
+			Version: version,
+		},
+		nil,
+	)
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,30 @@
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/mcp"
+)
+
+func TestNewMCPServer(t *testing.T) {
+	s := mcp.NewMCPServer("1.0.0")
+	if s == nil {
+		t.Fatal("NewMCPServer returned nil")
+	}
+}
+
+func TestNewSSEHandler(t *testing.T) {
+	s := mcp.NewMCPServer("1.0.0")
+	h := mcp.NewSSEHandler(s)
+	if h == nil {
+		t.Fatal("NewSSEHandler returned nil")
+	}
+}
+
+func TestNewStreamableHTTPHandler(t *testing.T) {
+	s := mcp.NewMCPServer("1.0.0")
+	h := mcp.NewStreamableHTTPHandler(s)
+	if h == nil {
+		t.Fatal("NewStreamableHTTPHandler returned nil")
+	}
+}

--- a/internal/mcp/sse.go
+++ b/internal/mcp/sse.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"net/http"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewSSEHandler creates an http.Handler for MCP SSE transport.
+func NewSSEHandler(server *mcpsdk.Server) http.Handler {
+	return mcpsdk.NewSSEHandler(
+		func(_ *http.Request) *mcpsdk.Server {
+			return server
+		},
+		nil,
+	)
+}

--- a/internal/mcp/streamable.go
+++ b/internal/mcp/streamable.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"net/http"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewStreamableHTTPHandler creates an http.Handler for MCP Streamable HTTP transport.
+func NewStreamableHTTPHandler(server *mcpsdk.Server) http.Handler {
+	return mcpsdk.NewStreamableHTTPHandler(
+		func(_ *http.Request) *mcpsdk.Server {
+			return server
+		},
+		nil,
+	)
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/nano-brain/nano-brain/internal/server/handlers"
 )
 
@@ -42,6 +44,16 @@ func registerRoutes(s *Server) {
 	wakeUp := handlers.WakeUpHandler(s.queries, s.logger)
 	api.GET("/wake-up", wakeUp)
 	data.POST("/wake-up", wakeUp)
+
+	sseHandler := mcp.NewSSEHandler(s.mcpServer)
+	streamableHandler := mcp.NewStreamableHTTPHandler(s.mcpServer)
+
+	s.echo.GET("/sse", echo.WrapHandler(sseHandler))
+	s.echo.POST("/sse", echo.WrapHandler(sseHandler))
+
+	s.echo.GET("/mcp", echo.WrapHandler(streamableHandler))
+	s.echo.POST("/mcp", echo.WrapHandler(streamableHandler))
+	s.echo.DELETE("/mcp", echo.WrapHandler(streamableHandler))
 }
 
 const defaultMaxFileSize int64 = 307200

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/embed"
+	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/nano-brain/nano-brain/internal/search"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/watcher"
@@ -31,6 +33,7 @@ type Server struct {
 	embedQueue    *embed.Queue
 	embedder      embed.Embedder
 	searchService *search.SearchService
+	mcpServer     *mcpsdk.Server
 	logger        zerolog.Logger
 	cfg           config.ServerConfig
 	embedCfg      config.EmbeddingConfig
@@ -58,6 +61,7 @@ func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, searchCfg con
 		embedQueue:    eq,
 		embedder:      embedder,
 		searchService: ss,
+		mcpServer:     internalmcp.NewMCPServer(version),
 		logger:        logger,
 		cfg:           cfg,
 		embedCfg:      embedCfg,


### PR DESCRIPTION
## Story 5.1: Mount MCP SSE and Streamable HTTP Transports

**Issue:** #84
**FRs:** FR-66, FR-67
**Epic:** 5 — MCP Integration

### Changes

Adds MCP Go SDK v0.8.0 and mounts both MCP transports on the existing Echo server:

| Route | Transport |
|---|---|
| `GET /sse` | SSE (session init) |
| `POST /sse` | SSE (message delivery) |
| `GET /mcp` | Streamable HTTP (SSE stream) |
| `POST /mcp` | Streamable HTTP (message delivery + session creation) |
| `DELETE /mcp` | Streamable HTTP (session termination) |

### Files

- **Deleted:** `internal/mcp/mcp.go` — placeholder
- **New:** `internal/mcp/server.go` — MCP server constructor
- **New:** `internal/mcp/sse.go` — SSE handler wrapper
- **New:** `internal/mcp/streamable.go` — Streamable HTTP handler wrapper
- **New:** `internal/mcp/server_test.go` — 3 unit tests
- **Modified:** `internal/server/server.go` — mcpServer field + init
- **Modified:** `internal/server/routes.go` — 5 MCP routes registered

### Notes
- SDK v0.8.0 (not latest) due to Go 1.23 compatibility (latest requires Go 1.25+)
- No tools registered yet — Story 5.2
- Transports accept connections and complete MCP init handshake
- Both handlers mounted via `echo.WrapHandler()`

### Tests
- 3 unit tests: constructor non-nil checks
- Full suite: `go test -short ./...` all pass
