### PR TITLE
feat: enforce workspace on all MCP tools + cross-workspace 'all' (Story 5.3)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -209,7 +209,7 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 				UpdatedAt     time.Time `json:"updated_at"`
 			}
 
-			results := make([]resultRow, 0)
+			var results []resultRow
 			limit := int32(maxResults)
 
 			if ws == "all" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -212,7 +212,44 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 			results := make([]resultRow, 0)
 			limit := int32(maxResults)
 
-			if len(tags) > 0 {
+			if ws == "all" {
+				if len(tags) > 0 {
+					rows, err := a.queries.BM25SearchAllWithTags(ctx, sqlc.BM25SearchAllWithTagsParams{
+						Query:      query,
+						Tags:       tags,
+						MaxResults: limit,
+					})
+					if err != nil {
+						return errResult(fmt.Sprintf("bm25 search failed: %v", err)), nil
+					}
+					for _, r := range rows {
+						results = append(results, resultRow{
+							ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+							WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+							Content: r.Content, SourcePath: r.SourcePath,
+							Collection: r.Collection, Tags: r.Tags,
+							Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+						})
+					}
+				} else {
+					rows, err := a.queries.BM25SearchAll(ctx, sqlc.BM25SearchAllParams{
+						Query:      query,
+						MaxResults: limit,
+					})
+					if err != nil {
+						return errResult(fmt.Sprintf("bm25 search failed: %v", err)), nil
+					}
+					for _, r := range rows {
+						results = append(results, resultRow{
+							ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+							WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+							Content: r.Content, SourcePath: r.SourcePath,
+							Collection: r.Collection, Tags: r.Tags,
+							Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+						})
+					}
+				}
+			} else if len(tags) > 0 {
 				rows, err := a.queries.BM25SearchWithTags(ctx, sqlc.BM25SearchWithTagsParams{
 					Query:         query,
 					WorkspaceHash: ws,
@@ -291,15 +328,6 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				return errResult(fmt.Sprintf("embedding query failed: %v", err)), nil
 			}
 
-			rows, err := a.queries.VectorSearch(ctx, sqlc.VectorSearchParams{
-				QueryEmbedding: pgvector_go.NewVector(vec),
-				WorkspaceHash:  ws,
-				MaxResults:     int32(maxResults),
-			})
-			if err != nil {
-				return errResult(fmt.Sprintf("vector search failed: %v", err)), nil
-			}
-
 			type vsearchRow struct {
 				ID            string    `json:"id"`
 				DocumentID    string    `json:"document_id"`
@@ -313,15 +341,45 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				CreatedAt     time.Time `json:"created_at"`
 				UpdatedAt     time.Time `json:"updated_at"`
 			}
-			results := make([]vsearchRow, 0, len(rows))
-			for _, r := range rows {
-				results = append(results, vsearchRow{
-					ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
-					WorkspaceHash: r.WorkspaceHash, Title: r.Title,
-					Content: r.Content, SourcePath: r.SourcePath,
-					Collection: r.Collection, Tags: r.Tags,
-					Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+
+			var results []vsearchRow
+			if ws == "all" {
+				rows, err := a.queries.VectorSearchAll(ctx, sqlc.VectorSearchAllParams{
+					QueryEmbedding: pgvector_go.NewVector(vec),
+					MaxResults:     int32(maxResults),
 				})
+				if err != nil {
+					return errResult(fmt.Sprintf("vector search failed: %v", err)), nil
+				}
+				results = make([]vsearchRow, 0, len(rows))
+				for _, r := range rows {
+					results = append(results, vsearchRow{
+						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+						Content: r.Content, SourcePath: r.SourcePath,
+						Collection: r.Collection, Tags: r.Tags,
+						Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			} else {
+				rows, err := a.queries.VectorSearch(ctx, sqlc.VectorSearchParams{
+					QueryEmbedding: pgvector_go.NewVector(vec),
+					WorkspaceHash:  ws,
+					MaxResults:     int32(maxResults),
+				})
+				if err != nil {
+					return errResult(fmt.Sprintf("vector search failed: %v", err)), nil
+				}
+				results = make([]vsearchRow, 0, len(rows))
+				for _, r := range rows {
+					results = append(results, vsearchRow{
+						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+						Content: r.Content, SourcePath: r.SourcePath,
+						Collection: r.Collection, Tags: r.Tags,
+						Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
 			}
 			return textResult(results)
 		},
@@ -367,6 +425,9 @@ func registerMemoryWrite(server *mcpsdk.Server, a *Adapter) {
 			ws, errRes := requireWorkspace(args)
 			if errRes != nil {
 				return errRes, nil
+			}
+			if ws == "all" {
+				return errResult("workspace 'all' is not valid for write operations"), nil
 			}
 			content := argString(args, "content")
 			if content == "" {
@@ -512,6 +573,9 @@ func registerMemoryTags(server *mcpsdk.Server, a *Adapter) {
 			if errRes != nil {
 				return errRes, nil
 			}
+			if ws == "all" {
+				return errResult("cross-workspace not supported for this tool"), nil
+			}
 
 			rows, err := a.queries.ListCollectionsWithLastUpdated(ctx, ws)
 			if err != nil {
@@ -592,6 +656,9 @@ func registerMemoryUpdate(server *mcpsdk.Server, a *Adapter) {
 			if errRes != nil {
 				return errRes, nil
 			}
+			if ws == "all" {
+				return errResult("workspace 'all' is not valid for write operations"), nil
+			}
 			return textResult(map[string]string{
 				"status":  "accepted",
 				"message": fmt.Sprintf("reindex requested for workspace %s", ws),
@@ -618,6 +685,9 @@ func registerMemoryWakeUp(server *mcpsdk.Server, a *Adapter) {
 			ws, errRes := requireWorkspace(args)
 			if errRes != nil {
 				return errRes, nil
+			}
+			if ws == "all" {
+				return errResult("cross-workspace not supported for this tool"), nil
 			}
 			limit := argInt(args, "limit", 10, 50)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -397,6 +397,8 @@ func registerMemoryGet(server *mcpsdk.Server, a *Adapter) {
 			}, []string{"id", "workspace"}),
 		},
 		func(_ context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			// TODO(story-5.6): When implementing, reject workspace == "all" for write-like behavior
+			// or support cross-workspace get if read-only.
 			return errResult("memory_get not yet implemented (Story 5.6)"), nil
 		},
 	)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -66,5 +67,132 @@ func TestRegisterTools_CountAndNames(t *testing.T) {
 		if got[i] != expected[i] {
 			t.Errorf("tool[%d] = %q, want %q", i, got[i], expected[i])
 		}
+	}
+}
+
+func setupTestClient(t *testing.T) (*mcpsdk.ClientSession, context.Context) {
+	t.Helper()
+	server := internalmcp.NewMCPServer("test")
+	adapter := internalmcp.NewAdapter(nil, nil, nil, nil, nil, config.EmbeddingConfig{}, config.SearchConfig{}, nil, zerolog.Nop())
+	internalmcp.RegisterTools(server, adapter)
+
+	ctx := context.Background()
+	ct, st := mcpsdk.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+	return session, ctx
+}
+
+func TestMemoryWrite_RejectsWorkspaceAll(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_write",
+		Arguments: map[string]any{
+			"workspace": "all",
+			"content":   "test content",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for workspace 'all' on write")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "not valid for write") {
+		t.Errorf("unexpected error message: %s", text)
+	}
+}
+
+func TestMemoryUpdate_RejectsWorkspaceAll(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_update",
+		Arguments: map[string]any{
+			"workspace": "all",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for workspace 'all' on update")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "not valid for write") {
+		t.Errorf("unexpected error message: %s", text)
+	}
+}
+
+func TestMemoryTags_RejectsWorkspaceAll(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_tags",
+		Arguments: map[string]any{
+			"workspace": "all",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for workspace 'all' on tags")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "cross-workspace not supported") {
+		t.Errorf("unexpected error message: %s", text)
+	}
+}
+
+func TestMemoryWakeUp_RejectsWorkspaceAll(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_wake_up",
+		Arguments: map[string]any{
+			"workspace": "all",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for workspace 'all' on wake_up")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "cross-workspace not supported") {
+		t.Errorf("unexpected error message: %s", text)
+	}
+}
+
+func TestMemoryGet_StillWorksAsStub(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_get",
+		Arguments: map[string]any{
+			"workspace": "test-ws",
+			"id":        "some-id",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result from stub")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "not yet implemented") {
+		t.Errorf("unexpected message: %s", text)
 	}
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -15,7 +15,9 @@ import (
 
 type Querier interface {
 	BM25Search(ctx context.Context, arg sqlc.BM25SearchParams) ([]sqlc.BM25SearchRow, error)
+	BM25SearchAll(ctx context.Context, arg sqlc.BM25SearchAllParams) ([]sqlc.BM25SearchAllRow, error)
 	VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error)
+	VectorSearchAll(ctx context.Context, arg sqlc.VectorSearchAllParams) ([]sqlc.VectorSearchAllRow, error)
 }
 
 type Embedder interface {
@@ -67,31 +69,59 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 	g, gctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		rows, err := s.queries.BM25Search(gctx, sqlc.BM25SearchParams{
-			Query:         query,
-			WorkspaceHash: workspace,
-			MaxResults:    fetchLimit,
-		})
-		if err != nil {
-			bm25Err = err
-			s.logger.Warn().Err(err).Msg("bm25 leg failed, degrading")
-			return nil
-		}
-		bm25Results = make([]Result, 0, len(rows))
-		for _, r := range rows {
-			bm25Results = append(bm25Results, Result{
-				ID:            r.ID.String(),
-				DocumentID:    r.DocumentID.String(),
-				WorkspaceHash: r.WorkspaceHash,
-				Title:         r.Title,
-				Content:       r.Content,
-				Score:         r.Score,
-				Tags:          r.Tags,
-				Collection:    r.Collection,
-				SourcePath:    r.SourcePath,
-				CreatedAt:     r.CreatedAt,
-				UpdatedAt:     r.UpdatedAt,
+		if workspace == "all" {
+			rows, err := s.queries.BM25SearchAll(gctx, sqlc.BM25SearchAllParams{
+				Query:      query,
+				MaxResults: fetchLimit,
 			})
+			if err != nil {
+				bm25Err = err
+				s.logger.Warn().Err(err).Msg("bm25 leg failed, degrading")
+				return nil
+			}
+			bm25Results = make([]Result, 0, len(rows))
+			for _, r := range rows {
+				bm25Results = append(bm25Results, Result{
+					ID:            r.ID.String(),
+					DocumentID:    r.DocumentID.String(),
+					WorkspaceHash: r.WorkspaceHash,
+					Title:         r.Title,
+					Content:       r.Content,
+					Score:         r.Score,
+					Tags:          r.Tags,
+					Collection:    r.Collection,
+					SourcePath:    r.SourcePath,
+					CreatedAt:     r.CreatedAt,
+					UpdatedAt:     r.UpdatedAt,
+				})
+			}
+		} else {
+			rows, err := s.queries.BM25Search(gctx, sqlc.BM25SearchParams{
+				Query:         query,
+				WorkspaceHash: workspace,
+				MaxResults:    fetchLimit,
+			})
+			if err != nil {
+				bm25Err = err
+				s.logger.Warn().Err(err).Msg("bm25 leg failed, degrading")
+				return nil
+			}
+			bm25Results = make([]Result, 0, len(rows))
+			for _, r := range rows {
+				bm25Results = append(bm25Results, Result{
+					ID:            r.ID.String(),
+					DocumentID:    r.DocumentID.String(),
+					WorkspaceHash: r.WorkspaceHash,
+					Title:         r.Title,
+					Content:       r.Content,
+					Score:         r.Score,
+					Tags:          r.Tags,
+					Collection:    r.Collection,
+					SourcePath:    r.SourcePath,
+					CreatedAt:     r.CreatedAt,
+					UpdatedAt:     r.UpdatedAt,
+				})
+			}
 		}
 		return nil
 	})
@@ -106,31 +136,59 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 			s.logger.Warn().Err(err).Msg("embed failed, degrading")
 			return nil
 		}
-		rows, err := s.queries.VectorSearch(gctx, sqlc.VectorSearchParams{
-			QueryEmbedding: pgvector_go.NewVector(vec),
-			WorkspaceHash:  workspace,
-			MaxResults:     fetchLimit,
-		})
-		if err != nil {
-			vectorErr = err
-			s.logger.Warn().Err(err).Msg("vector search leg failed, degrading")
-			return nil
-		}
-		vectorResults = make([]Result, 0, len(rows))
-		for _, r := range rows {
-			vectorResults = append(vectorResults, Result{
-				ID:            r.ChunkID.String(),
-				DocumentID:    r.DocumentID.String(),
-				WorkspaceHash: r.WorkspaceHash,
-				Title:         r.Title,
-				Content:       r.Content,
-				Score:         r.Score,
-				Tags:          r.Tags,
-				Collection:    r.Collection,
-				SourcePath:    r.SourcePath,
-				CreatedAt:     r.CreatedAt,
-				UpdatedAt:     r.UpdatedAt,
+		if workspace == "all" {
+			rows, err := s.queries.VectorSearchAll(gctx, sqlc.VectorSearchAllParams{
+				QueryEmbedding: pgvector_go.NewVector(vec),
+				MaxResults:     fetchLimit,
 			})
+			if err != nil {
+				vectorErr = err
+				s.logger.Warn().Err(err).Msg("vector search leg failed, degrading")
+				return nil
+			}
+			vectorResults = make([]Result, 0, len(rows))
+			for _, r := range rows {
+				vectorResults = append(vectorResults, Result{
+					ID:            r.ChunkID.String(),
+					DocumentID:    r.DocumentID.String(),
+					WorkspaceHash: r.WorkspaceHash,
+					Title:         r.Title,
+					Content:       r.Content,
+					Score:         r.Score,
+					Tags:          r.Tags,
+					Collection:    r.Collection,
+					SourcePath:    r.SourcePath,
+					CreatedAt:     r.CreatedAt,
+					UpdatedAt:     r.UpdatedAt,
+				})
+			}
+		} else {
+			rows, err := s.queries.VectorSearch(gctx, sqlc.VectorSearchParams{
+				QueryEmbedding: pgvector_go.NewVector(vec),
+				WorkspaceHash:  workspace,
+				MaxResults:     fetchLimit,
+			})
+			if err != nil {
+				vectorErr = err
+				s.logger.Warn().Err(err).Msg("vector search leg failed, degrading")
+				return nil
+			}
+			vectorResults = make([]Result, 0, len(rows))
+			for _, r := range rows {
+				vectorResults = append(vectorResults, Result{
+					ID:            r.ChunkID.String(),
+					DocumentID:    r.DocumentID.String(),
+					WorkspaceHash: r.WorkspaceHash,
+					Title:         r.Title,
+					Content:       r.Content,
+					Score:         r.Score,
+					Tags:          r.Tags,
+					Collection:    r.Collection,
+					SourcePath:    r.SourcePath,
+					CreatedAt:     r.CreatedAt,
+					UpdatedAt:     r.UpdatedAt,
+				})
+			}
 		}
 		return nil
 	})

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -16,8 +16,16 @@ func (m *mockQuerier) BM25Search(ctx context.Context, arg sqlc.BM25SearchParams)
 	return []sqlc.BM25SearchRow{}, nil
 }
 
+func (m *mockQuerier) BM25SearchAll(ctx context.Context, arg sqlc.BM25SearchAllParams) ([]sqlc.BM25SearchAllRow, error) {
+	return []sqlc.BM25SearchAllRow{}, nil
+}
+
 func (m *mockQuerier) VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
 	return []sqlc.VectorSearchRow{}, nil
+}
+
+func (m *mockQuerier) VectorSearchAll(ctx context.Context, arg sqlc.VectorSearchAllParams) ([]sqlc.VectorSearchAllRow, error) {
+	return []sqlc.VectorSearchAllRow{}, nil
 }
 
 type mockEmbedder struct{}

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -48,3 +48,15 @@ JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = sqlc.arg(workspace_hash)
 ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
 LIMIT sqlc.arg(max_results);
+
+-- name: VectorSearchAll :many
+SELECT e.id, e.chunk_id, e.workspace_hash,
+       c.content, c.metadata, c.document_id,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
+       CAST(1 - (e.embedding <=> sqlc.arg(query_embedding)::vector) AS double precision) AS score
+FROM embeddings e
+JOIN chunks c ON e.chunk_id = c.id
+JOIN documents d ON c.document_id = d.id
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
+LIMIT sqlc.arg(max_results);

--- a/internal/storage/queries/search.sql
+++ b/internal/storage/queries/search.sql
@@ -10,6 +10,17 @@ WHERE c.workspace_hash = sqlc.arg(workspace_hash)
 ORDER BY score DESC, c.id ASC
 LIMIT sqlc.arg(max_results);
 
+-- name: BM25SearchAll :many
+SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', sqlc.arg(query)::text)) AS double precision) AS score
+FROM chunks c
+JOIN documents d ON c.document_id = d.id
+WHERE c.search_vector @@ websearch_to_tsquery('english', sqlc.arg(query)::text)
+ORDER BY score DESC, c.id ASC
+LIMIT sqlc.arg(max_results);
+
 -- name: BM25SearchWithTags :many
 SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
        d.source_path, d.title, d.collection, d.tags,
@@ -19,6 +30,18 @@ FROM chunks c
 JOIN documents d ON c.document_id = d.id
 WHERE c.workspace_hash = sqlc.arg(workspace_hash)
   AND c.search_vector @@ websearch_to_tsquery('english', sqlc.arg(query)::text)
+  AND d.tags && sqlc.arg(tags)::text[]
+ORDER BY score DESC, c.id ASC
+LIMIT sqlc.arg(max_results);
+
+-- name: BM25SearchAllWithTags :many
+SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', sqlc.arg(query)::text)) AS double precision) AS score
+FROM chunks c
+JOIN documents d ON c.document_id = d.id
+WHERE c.search_vector @@ websearch_to_tsquery('english', sqlc.arg(query)::text)
   AND d.tags && sqlc.arg(tags)::text[]
 ORDER BY score DESC, c.id ASC
 LIMIT sqlc.arg(max_results);

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -266,3 +266,74 @@ func (q *Queries) VectorSearch(ctx context.Context, arg VectorSearchParams) ([]V
 	}
 	return items, nil
 }
+
+const vectorSearchAll = `-- name: VectorSearchAll :many
+SELECT e.id, e.chunk_id, e.workspace_hash,
+       c.content, c.metadata, c.document_id,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
+       CAST(1 - (e.embedding <=> $1::vector) AS double precision) AS score
+FROM embeddings e
+JOIN chunks c ON e.chunk_id = c.id
+JOIN documents d ON c.document_id = d.id
+ORDER BY e.embedding <=> $1::vector
+LIMIT $2
+`
+
+type VectorSearchAllParams struct {
+	QueryEmbedding pgvector_go.Vector
+	MaxResults     int32
+}
+
+type VectorSearchAllRow struct {
+	ID            uuid.UUID
+	ChunkID       uuid.UUID
+	WorkspaceHash string
+	Content       string
+	Metadata      pqtype.NullRawMessage
+	DocumentID    uuid.UUID
+	SourcePath    string
+	Title         string
+	Collection    string
+	Tags          []string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	Score         float64
+}
+
+func (q *Queries) VectorSearchAll(ctx context.Context, arg VectorSearchAllParams) ([]VectorSearchAllRow, error) {
+	rows, err := q.db.QueryContext(ctx, vectorSearchAll, arg.QueryEmbedding, arg.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []VectorSearchAllRow
+	for rows.Next() {
+		var i VectorSearchAllRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChunkID,
+			&i.WorkspaceHash,
+			&i.Content,
+			&i.Metadata,
+			&i.DocumentID,
+			&i.SourcePath,
+			&i.Title,
+			&i.Collection,
+			pq.Array(&i.Tags),
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Score,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/storage/sqlc/search.sql.go
+++ b/internal/storage/sqlc/search.sql.go
@@ -86,6 +86,148 @@ func (q *Queries) BM25Search(ctx context.Context, arg BM25SearchParams) ([]BM25S
 	return items, nil
 }
 
+const bM25SearchAll = `-- name: BM25SearchAll :many
+SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', $1::text)) AS double precision) AS score
+FROM chunks c
+JOIN documents d ON c.document_id = d.id
+WHERE c.search_vector @@ websearch_to_tsquery('english', $1::text)
+ORDER BY score DESC, c.id ASC
+LIMIT $2
+`
+
+type BM25SearchAllParams struct {
+	Query      string
+	MaxResults int32
+}
+
+type BM25SearchAllRow struct {
+	ID            uuid.UUID
+	DocumentID    uuid.UUID
+	WorkspaceHash string
+	Content       string
+	ChunkIndex    int32
+	Metadata      pqtype.NullRawMessage
+	SourcePath    string
+	Title         string
+	Collection    string
+	Tags          []string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	Score         float64
+}
+
+func (q *Queries) BM25SearchAll(ctx context.Context, arg BM25SearchAllParams) ([]BM25SearchAllRow, error) {
+	rows, err := q.db.QueryContext(ctx, bM25SearchAll, arg.Query, arg.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BM25SearchAllRow
+	for rows.Next() {
+		var i BM25SearchAllRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.DocumentID,
+			&i.WorkspaceHash,
+			&i.Content,
+			&i.ChunkIndex,
+			&i.Metadata,
+			&i.SourcePath,
+			&i.Title,
+			&i.Collection,
+			pq.Array(&i.Tags),
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Score,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const bM25SearchAllWithTags = `-- name: BM25SearchAllWithTags :many
+SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
+       d.source_path, d.title, d.collection, d.tags,
+       d.created_at, d.updated_at,
+       CAST(ts_rank_cd(c.search_vector, websearch_to_tsquery('english', $1::text)) AS double precision) AS score
+FROM chunks c
+JOIN documents d ON c.document_id = d.id
+WHERE c.search_vector @@ websearch_to_tsquery('english', $1::text)
+  AND d.tags && $2::text[]
+ORDER BY score DESC, c.id ASC
+LIMIT $3
+`
+
+type BM25SearchAllWithTagsParams struct {
+	Query      string
+	Tags       []string
+	MaxResults int32
+}
+
+type BM25SearchAllWithTagsRow struct {
+	ID            uuid.UUID
+	DocumentID    uuid.UUID
+	WorkspaceHash string
+	Content       string
+	ChunkIndex    int32
+	Metadata      pqtype.NullRawMessage
+	SourcePath    string
+	Title         string
+	Collection    string
+	Tags          []string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	Score         float64
+}
+
+func (q *Queries) BM25SearchAllWithTags(ctx context.Context, arg BM25SearchAllWithTagsParams) ([]BM25SearchAllWithTagsRow, error) {
+	rows, err := q.db.QueryContext(ctx, bM25SearchAllWithTags, arg.Query, pq.Array(arg.Tags), arg.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []BM25SearchAllWithTagsRow
+	for rows.Next() {
+		var i BM25SearchAllWithTagsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.DocumentID,
+			&i.WorkspaceHash,
+			&i.Content,
+			&i.ChunkIndex,
+			&i.Metadata,
+			&i.SourcePath,
+			&i.Title,
+			&i.Collection,
+			pq.Array(&i.Tags),
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Score,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const bM25SearchWithTags = `-- name: BM25SearchWithTags :many
 SELECT c.id, c.document_id, c.workspace_hash, c.content, c.chunk_index, c.metadata,
        d.source_path, d.title, d.collection, d.tags,


### PR DESCRIPTION
## Story 5.3: Enforce Workspace Parameter on All Tool Calls

**Issue:** #88
**FRs:** FR-72, NFR-2
**Epic:** 5 — MCP Integration

### Changes

**SQL Queries (new cross-workspace variants):**
- `BM25SearchAll` — BM25 search across all workspaces
- `BM25SearchAllWithTags` — BM25 search with tag filter, all workspaces
- `VectorSearchAll` — Vector search across all workspaces

**Search Service:**
- Extended `Querier` interface with `BM25SearchAll` + `VectorSearchAll`
- `HybridSearch` branches on `workspace == "all"` for both BM25 and vector legs

**MCP Tool Enforcement:**

| Tool | `workspace: "all"` | Behavior |
|---|---|---|
| `memory_query` | ✅ Allowed | Routes to *All query variants via SearchService |
| `memory_search` | ✅ Allowed | Routes to BM25SearchAll/BM25SearchAllWithTags |
| `memory_vsearch` | ✅ Allowed | Routes to VectorSearchAll |
| `memory_write` | ❌ Rejected | `workspace 'all' is not valid for write operations` |
| `memory_update` | ❌ Rejected | Same |
| `memory_tags` | ❌ Rejected | `cross-workspace not supported for this tool` |
| `memory_wake_up` | ❌ Rejected | Same |

### Tests
- 5 new unit tests: write/update reject 'all', tags/wake_up reject 'all', get stub works
- Updated search service mock for new interface
- Full suite: `go test -short ./...` all pass