### PR TITLE
feat: configure 30s KeepAlive on MCP server (Story 5.5)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,17 +2,21 @@
 package mcp
 
 import (
+	"time"
+
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// NewMCPServer creates the core MCP server instance.
-// Tools are NOT registered here — that's Story 5.2.
+const KeepAliveInterval = 30 * time.Second
+
 func NewMCPServer(version string) *mcpsdk.Server {
 	return mcpsdk.NewServer(
 		&mcpsdk.Implementation{
 			Name:    "nano-brain",
 			Version: version,
 		},
-		nil,
+		&mcpsdk.ServerOptions{
+			KeepAlive: KeepAliveInterval,
+		},
 	)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -7,6 +7,8 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// KeepAliveInterval is the period between MCP-level JSON-RPC pings sent to
+// connected clients. Prevents proxy/load-balancer idle-connection timeouts.
 const KeepAliveInterval = 30 * time.Second
 
 func NewMCPServer(version string) *mcpsdk.Server {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
@@ -194,5 +195,11 @@ func TestMemoryGet_StillWorksAsStub(t *testing.T) {
 	text := result.Content[0].(*mcpsdk.TextContent).Text
 	if !strings.Contains(text, "not yet implemented") {
 		t.Errorf("unexpected message: %s", text)
+	}
+}
+
+func TestKeepAliveInterval_Is30Seconds(t *testing.T) {
+	if internalmcp.KeepAliveInterval != 30*time.Second {
+		t.Errorf("KeepAliveInterval = %v, want 30s", internalmcp.KeepAliveInterval)
 	}
 }


### PR DESCRIPTION
## Story 5.5: Streamable HTTP 30-Second SSE Heartbeats

**Issue:** #92
**FR:** FR-74
**Epic:** 5 — MCP Integration

### Changes

- `internal/mcp/server.go`: Set `ServerOptions.KeepAlive = 30 * time.Second`
- Exported `KeepAliveInterval` constant for testability
- `internal/mcp/tools_test.go`: `TestKeepAliveInterval_Is30Seconds`

### How it works

The MCP Go SDK v0.8.0 `KeepAlive` sends periodic JSON-RPC ping requests to connected clients. When a Streamable HTTP session is idle, the server pings every 30s, keeping the SSE connection alive through proxies/load balancers. If the client fails to respond, the session is automatically closed.

### Why JSON-RPC pings instead of SSE comments

The SDK v0.8.0 `StreamableHTTPOptions` doesn't expose an SSE-level heartbeat option. The `KeepAlive` on `ServerOptions` achieves the same goal (preventing proxy timeouts) via MCP protocol-level pings, which is the intended mechanism in the Go SDK.