### PR TITLE
feat: implement OpenCode session harvester (Story 6.1)

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/embed"
+	"github.com/nano-brain/nano-brain/internal/harvest"
 	"github.com/nano-brain/nano-brain/internal/health"
 	"github.com/nano-brain/nano-brain/internal/server"
 	"github.com/nano-brain/nano-brain/internal/storage"
@@ -134,6 +135,26 @@ func main() {
 		g.Go(func() error {
 			return eq.Run(gctx)
 		})
+	}
+
+	if cfg.Harvester.OpenCode.SessionDir != "" {
+		wsHash, err := storage.WorkspaceHash(cfg.Harvester.OpenCode.SessionDir)
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to compute workspace hash for opencode harvester")
+		} else {
+			oh := harvest.NewOpenCodeHarvester(db, logger, cfg.Harvester.OpenCode.SessionDir, wsHash)
+			interval := time.Duration(cfg.Intervals.SessionPoll) * time.Second
+			hr := harvest.NewRunner(oh, eq, interval, logger)
+			g.Go(func() error {
+				return hr.Run(gctx)
+			})
+			logger.Info().
+				Str("session_dir", cfg.Harvester.OpenCode.SessionDir).
+				Dur("interval", interval).
+				Msg("opencode session harvester started")
+		}
+	} else {
+		logger.Info().Msg("opencode session harvester disabled (no session_dir configured)")
 	}
 
 	g.Go(func() error {

--- a/internal/harvest/opencode.go
+++ b/internal/harvest/opencode.go
@@ -20,14 +20,6 @@ import (
 	"github.com/sqlc-dev/pqtype"
 )
 
-// HarvesterQuerier defines the database operations the harvester needs.
-type HarvesterQuerier interface {
-	UpsertDocument(ctx context.Context, arg sqlc.UpsertDocumentParams) (sqlc.UpsertDocumentRow, error)
-	DeleteChunksByDocumentID(ctx context.Context, arg sqlc.DeleteChunksByDocumentIDParams) error
-	UpsertChunk(ctx context.Context, arg sqlc.UpsertChunkParams) (uuid.UUID, error)
-	GetDocumentBySourcePath(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error)
-}
-
 // ChunkEnqueuer enqueues chunk IDs for embedding.
 type ChunkEnqueuer interface {
 	Enqueue(chunkID uuid.UUID) bool
@@ -133,6 +125,7 @@ func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile stri
 	if err != nil {
 		return false, fmt.Errorf("begin tx: %w", err)
 	}
+	defer tx.Rollback() // no-op after commit
 	tq := sqlc.New(tx)
 
 	meta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
@@ -149,7 +142,6 @@ func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile stri
 		Metadata:      meta,
 	})
 	if err != nil {
-		_ = tx.Rollback()
 		return false, fmt.Errorf("upsert document: %w", err)
 	}
 
@@ -157,7 +149,6 @@ func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile stri
 		DocumentID:    docRow.ID,
 		WorkspaceHash: h.workspace,
 	}); err != nil {
-		_ = tx.Rollback()
 		return false, fmt.Errorf("delete old chunks: %w", err)
 	}
 
@@ -177,7 +168,6 @@ func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile stri
 			Metadata:      chunkMeta,
 		})
 		if err != nil {
-			_ = tx.Rollback()
 			return false, fmt.Errorf("upsert chunk: %w", err)
 		}
 		chunkIDs = append(chunkIDs, id)

--- a/internal/harvest/opencode.go
+++ b/internal/harvest/opencode.go
@@ -1,0 +1,400 @@
+package harvest
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nano-brain/nano-brain/internal/chunk"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+	"github.com/sqlc-dev/pqtype"
+)
+
+// HarvesterQuerier defines the database operations the harvester needs.
+type HarvesterQuerier interface {
+	UpsertDocument(ctx context.Context, arg sqlc.UpsertDocumentParams) (sqlc.UpsertDocumentRow, error)
+	DeleteChunksByDocumentID(ctx context.Context, arg sqlc.DeleteChunksByDocumentIDParams) error
+	UpsertChunk(ctx context.Context, arg sqlc.UpsertChunkParams) (uuid.UUID, error)
+	GetDocumentBySourcePath(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error)
+}
+
+// ChunkEnqueuer enqueues chunk IDs for embedding.
+type ChunkEnqueuer interface {
+	Enqueue(chunkID uuid.UUID) bool
+	IsPressured() bool
+}
+
+// OpenCodeHarvester ingests OpenCode session files into the document store.
+type OpenCodeHarvester struct {
+	db        *sql.DB
+	logger    zerolog.Logger
+	sessionDir string
+	workspace  string
+}
+
+// NewOpenCodeHarvester creates a new OpenCode session harvester.
+func NewOpenCodeHarvester(db *sql.DB, logger zerolog.Logger, sessionDir, workspace string) *OpenCodeHarvester {
+	return &OpenCodeHarvester{
+		db:         db,
+		logger:     logger.With().Str("component", "opencode-harvester").Logger(),
+		sessionDir: sessionDir,
+		workspace:  workspace,
+	}
+}
+
+// HarvestAll scans the session directory and ingests all sessions.
+// Returns counts of harvested, skipped, and errored sessions.
+func (h *OpenCodeHarvester) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harvested, skipped, errCount int) {
+	sessionDir := filepath.Join(h.sessionDir, "session")
+	if _, err := os.Stat(sessionDir); os.IsNotExist(err) {
+		h.logger.Debug().Str("dir", sessionDir).Msg("session directory does not exist, skipping")
+		return 0, 0, 0
+	}
+
+	projectDirs, err := os.ReadDir(sessionDir)
+	if err != nil {
+		h.logger.Error().Err(err).Str("dir", sessionDir).Msg("failed to read session directory")
+		return 0, 0, 1
+	}
+
+	for _, projEntry := range projectDirs {
+		if !projEntry.IsDir() {
+			continue
+		}
+		projDir := filepath.Join(sessionDir, projEntry.Name())
+		files, err := os.ReadDir(projDir)
+		if err != nil {
+			h.logger.Error().Err(err).Str("dir", projDir).Msg("failed to read project session directory")
+			errCount++
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
+				continue
+			}
+			filePath := filepath.Join(projDir, f.Name())
+			result, err := h.harvestSession(ctx, filePath, enqueuer)
+			if err != nil {
+				h.logger.Error().Err(err).Str("file", filePath).Msg("failed to harvest session")
+				errCount++
+				continue
+			}
+			if result {
+				harvested++
+			} else {
+				skipped++
+			}
+		}
+	}
+	return
+}
+
+// harvestSession processes a single session file. Returns true if ingested, false if skipped (unchanged).
+func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile string, enqueuer ChunkEnqueuer) (bool, error) {
+	sess, err := parseSessionFile(sessionFile)
+	if err != nil {
+		return false, fmt.Errorf("parse session: %w", err)
+	}
+
+	msgs, err := h.loadMessages(sess.ID)
+	if err != nil {
+		return false, fmt.Errorf("load messages: %w", err)
+	}
+
+	if len(msgs) == 0 {
+		return false, nil
+	}
+
+	md := renderMarkdown(sess, msgs)
+
+	sum := sha256.Sum256([]byte(md))
+	contentHash := hex.EncodeToString(sum[:])
+
+	queries := sqlc.New(h.db)
+	existing, err := queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
+		SourcePath:    sessionFile,
+		WorkspaceHash: h.workspace,
+	})
+	if err == nil && existing.ContentHash == contentHash {
+		return false, nil
+	}
+
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin tx: %w", err)
+	}
+	tq := sqlc.New(tx)
+
+	meta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
+	tags := []string{"opencode", "session"}
+
+	docRow, err := tq.UpsertDocument(ctx, sqlc.UpsertDocumentParams{
+		WorkspaceHash: h.workspace,
+		ContentHash:   contentHash,
+		Title:         sess.Title,
+		Content:       md,
+		SourcePath:    sessionFile,
+		Collection:    "sessions",
+		Tags:          tags,
+		Metadata:      meta,
+	})
+	if err != nil {
+		_ = tx.Rollback()
+		return false, fmt.Errorf("upsert document: %w", err)
+	}
+
+	if err := tq.DeleteChunksByDocumentID(ctx, sqlc.DeleteChunksByDocumentIDParams{
+		DocumentID:    docRow.ID,
+		WorkspaceHash: h.workspace,
+	}); err != nil {
+		_ = tx.Rollback()
+		return false, fmt.Errorf("delete old chunks: %w", err)
+	}
+
+	chunks := chunk.Split(md, chunk.DefaultConfig())
+	chunkMeta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
+	chunkIDs := make([]uuid.UUID, 0, len(chunks))
+
+	for _, ch := range chunks {
+		id, err := tq.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+			DocumentID:    docRow.ID,
+			WorkspaceHash: h.workspace,
+			ContentHash:   ch.Hash,
+			Content:       ch.Content,
+			ChunkIndex:    int32(ch.Sequence),
+			StartLine:     sql.NullInt32{Int32: int32(ch.StartLine), Valid: true},
+			EndLine:       sql.NullInt32{Int32: int32(ch.EndLine), Valid: true},
+			Metadata:      chunkMeta,
+		})
+		if err != nil {
+			_ = tx.Rollback()
+			return false, fmt.Errorf("upsert chunk: %w", err)
+		}
+		chunkIDs = append(chunkIDs, id)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit tx: %w", err)
+	}
+
+	if enqueuer != nil && !enqueuer.IsPressured() {
+		for _, id := range chunkIDs {
+			enqueuer.Enqueue(id)
+		}
+	}
+
+	return true, nil
+}
+
+// loadMessages reads all messages and their text parts for a session.
+func (h *OpenCodeHarvester) loadMessages(sessionID string) ([]renderedMessage, error) {
+	msgDir := filepath.Join(h.sessionDir, "message", sessionID)
+	if _, err := os.Stat(msgDir); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(msgDir)
+	if err != nil {
+		return nil, fmt.Errorf("read message dir: %w", err)
+	}
+
+	var msgs []renderedMessage
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		msg, err := parseMessageFile(filepath.Join(msgDir, e.Name()))
+		if err != nil {
+			h.logger.Warn().Err(err).Str("file", e.Name()).Msg("skipping invalid message file")
+			continue
+		}
+
+		if msg.Role != "user" && msg.Role != "assistant" {
+			continue
+		}
+
+		text, err := h.loadTextParts(msg.ID)
+		if err != nil {
+			h.logger.Warn().Err(err).Str("msg", msg.ID).Msg("failed to load parts")
+			continue
+		}
+		if text == "" {
+			continue
+		}
+
+		msgs = append(msgs, renderedMessage{
+			Role:      msg.Role,
+			Content:   text,
+			CreatedAt: msg.CreatedAt,
+		})
+	}
+
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].CreatedAt.Before(msgs[j].CreatedAt)
+	})
+
+	return msgs, nil
+}
+
+// loadTextParts reads all text-type parts for a message, concatenated.
+func (h *OpenCodeHarvester) loadTextParts(messageID string) (string, error) {
+	partDir := filepath.Join(h.sessionDir, "part", messageID)
+	if _, err := os.Stat(partDir); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	entries, err := os.ReadDir(partDir)
+	if err != nil {
+		return "", fmt.Errorf("read part dir: %w", err)
+	}
+
+	type sortedPart struct {
+		id   string
+		text string
+	}
+	var parts []sortedPart
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		p, err := parsePartFile(filepath.Join(partDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if p.Type == "text" && p.Text != "" {
+			parts = append(parts, sortedPart{id: p.ID, text: p.Text})
+		}
+	}
+
+	sort.Slice(parts, func(i, j int) bool {
+		return parts[i].id < parts[j].id
+	})
+
+	var b strings.Builder
+	for i, p := range parts {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(p.text)
+	}
+	return b.String(), nil
+}
+
+type sessionFile struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Time  struct {
+		Created int64 `json:"created"`
+		Updated int64 `json:"updated"`
+	} `json:"time"`
+	ProjectID string `json:"projectID"`
+	Directory string `json:"directory"`
+}
+
+type messageFile struct {
+	ID        string `json:"id"`
+	SessionID string `json:"sessionID"`
+	Role      string `json:"role"`
+	Time      struct {
+		Created   int64 `json:"created"`
+		Completed int64 `json:"completed"`
+	} `json:"time"`
+	CreatedAt time.Time
+}
+
+type partFile struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Text      string `json:"text"`
+	MessageID string `json:"messageID"`
+}
+
+type renderedMessage struct {
+	Role      string
+	Content   string
+	CreatedAt time.Time
+}
+
+func parseSessionFile(path string) (*sessionFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var s sessionFile
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	if s.ID == "" {
+		return nil, fmt.Errorf("session file missing id")
+	}
+	return &s, nil
+}
+
+func parseMessageFile(path string) (*messageFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m messageFile
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	if m.ID == "" {
+		return nil, fmt.Errorf("message file missing id")
+	}
+	if m.Time.Created > 0 {
+		m.CreatedAt = time.UnixMilli(m.Time.Created)
+	}
+	return &m, nil
+}
+
+func parsePartFile(path string) (*partFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var p partFile
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func renderMarkdown(sess *sessionFile, msgs []renderedMessage) string {
+	var b strings.Builder
+
+	createdAt := time.UnixMilli(sess.Time.Created).UTC().Format(time.RFC3339)
+
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "session_id: %s\n", sess.ID)
+	b.WriteString("source: opencode\n")
+	fmt.Fprintf(&b, "message_count: %d\n", len(msgs))
+	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
+	if sess.Title != "" {
+		fmt.Fprintf(&b, "title: %q\n", sess.Title)
+	}
+	if sess.Directory != "" {
+		fmt.Fprintf(&b, "directory: %q\n", sess.Directory)
+	}
+	b.WriteString("---\n")
+
+	for _, msg := range msgs {
+		ts := msg.CreatedAt.UTC().Format(time.RFC3339)
+		fmt.Fprintf(&b, "\n## %s (%s)\n\n", msg.Role, ts)
+		b.WriteString(msg.Content)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/harvest/opencode.go
+++ b/internal/harvest/opencode.go
@@ -23,7 +23,6 @@ import (
 // ChunkEnqueuer enqueues chunk IDs for embedding.
 type ChunkEnqueuer interface {
 	Enqueue(chunkID uuid.UUID) bool
-	IsPressured() bool
 }
 
 // OpenCodeHarvester ingests OpenCode session files into the document store.
@@ -131,7 +130,7 @@ func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile stri
 	meta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
 	tags := []string{"opencode", "session"}
 
-	docRow, err := tq.UpsertDocument(ctx, sqlc.UpsertDocumentParams{
+	docRow, err := tq.UpsertDocumentBySourcePath(ctx, sqlc.UpsertDocumentBySourcePathParams{
 		WorkspaceHash: h.workspace,
 		ContentHash:   contentHash,
 		Title:         sess.Title,
@@ -177,7 +176,7 @@ func (h *OpenCodeHarvester) harvestSession(ctx context.Context, sessionFile stri
 		return false, fmt.Errorf("commit tx: %w", err)
 	}
 
-	if enqueuer != nil && !enqueuer.IsPressured() {
+	if enqueuer != nil {
 		for _, id := range chunkIDs {
 			enqueuer.Enqueue(id)
 		}

--- a/internal/harvest/opencode_test.go
+++ b/internal/harvest/opencode_test.go
@@ -1,0 +1,353 @@
+package harvest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseSessionFile(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ses_abc.json")
+		writeJSON(t, path, map[string]any{
+			"id":        "ses_abc",
+			"title":     "Test Session",
+			"projectID": "proj123",
+			"directory": "/some/dir",
+			"time":      map[string]any{"created": 1700000000000, "updated": 1700000100000},
+		})
+
+		s, err := parseSessionFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.ID != "ses_abc" {
+			t.Errorf("got ID %q, want ses_abc", s.ID)
+		}
+		if s.Title != "Test Session" {
+			t.Errorf("got Title %q, want Test Session", s.Title)
+		}
+		if s.Time.Created != 1700000000000 {
+			t.Errorf("got Created %d, want 1700000000000", s.Time.Created)
+		}
+	})
+
+	t.Run("missing id", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		writeJSON(t, path, map[string]any{"title": "no id"})
+
+		_, err := parseSessionFile(path)
+		if err == nil {
+			t.Fatal("expected error for missing id")
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		os.MkdirAll(filepath.Dir(path), 0o755)
+		os.WriteFile(path, []byte("{not json"), 0o644)
+
+		_, err := parseSessionFile(path)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := parseSessionFile("/nonexistent/path.json")
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+
+func TestParseMessageFile(t *testing.T) {
+	t.Run("valid user message", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg_001.json")
+		writeJSON(t, path, map[string]any{
+			"id":        "msg_001",
+			"sessionID": "ses_abc",
+			"role":      "user",
+			"time":      map[string]any{"created": 1700000000000},
+		})
+
+		m, err := parseMessageFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.Role != "user" {
+			t.Errorf("got role %q, want user", m.Role)
+		}
+		if m.CreatedAt.IsZero() {
+			t.Error("CreatedAt should not be zero")
+		}
+		expected := time.UnixMilli(1700000000000)
+		if !m.CreatedAt.Equal(expected) {
+			t.Errorf("got CreatedAt %v, want %v", m.CreatedAt, expected)
+		}
+	})
+
+	t.Run("missing id", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "msg.json")
+		writeJSON(t, path, map[string]any{"role": "user"})
+
+		_, err := parseMessageFile(path)
+		if err == nil {
+			t.Fatal("expected error for missing id")
+		}
+	})
+}
+
+func TestParsePartFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prt_001.json")
+	writeJSON(t, path, map[string]any{
+		"id":        "prt_001",
+		"type":      "text",
+		"text":      "Hello world",
+		"messageID": "msg_001",
+	})
+
+	p, err := parsePartFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Type != "text" {
+		t.Errorf("got type %q, want text", p.Type)
+	}
+	if p.Text != "Hello world" {
+		t.Errorf("got text %q, want Hello world", p.Text)
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	sess := &sessionFile{
+		ID:    "ses_test",
+		Title: "My Session",
+	}
+	sess.Time.Created = 1700000000000
+	sess.Directory = "/work/project"
+
+	ts1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2026, 1, 1, 10, 0, 5, 0, time.UTC)
+
+	msgs := []renderedMessage{
+		{Role: "user", Content: "What is Go?", CreatedAt: ts1},
+		{Role: "assistant", Content: "Go is a programming language.", CreatedAt: ts2},
+	}
+
+	md := renderMarkdown(sess, msgs)
+
+	if !strings.Contains(md, "session_id: ses_test") {
+		t.Error("missing session_id in front-matter")
+	}
+	if !strings.Contains(md, "source: opencode") {
+		t.Error("missing source in front-matter")
+	}
+	if !strings.Contains(md, "message_count: 2") {
+		t.Error("missing or wrong message_count")
+	}
+	if !strings.Contains(md, `title: "My Session"`) {
+		t.Error("missing title in front-matter")
+	}
+	if !strings.Contains(md, `directory: "/work/project"`) {
+		t.Error("missing directory in front-matter")
+	}
+	if !strings.Contains(md, "## user (2026-01-01T10:00:00Z)") {
+		t.Error("missing user message heading")
+	}
+	if !strings.Contains(md, "## assistant (2026-01-01T10:00:05Z)") {
+		t.Error("missing assistant message heading")
+	}
+	if !strings.Contains(md, "What is Go?") {
+		t.Error("missing user message content")
+	}
+	if !strings.Contains(md, "Go is a programming language.") {
+		t.Error("missing assistant message content")
+	}
+	if !strings.HasPrefix(md, "---\n") {
+		t.Error("front-matter should start with ---")
+	}
+}
+
+func TestRenderMarkdownEmpty(t *testing.T) {
+	sess := &sessionFile{ID: "ses_empty"}
+	sess.Time.Created = 1700000000000
+
+	md := renderMarkdown(sess, nil)
+	if !strings.Contains(md, "message_count: 0") {
+		t.Error("empty messages should show count 0")
+	}
+}
+
+func TestRenderMarkdownHashStability(t *testing.T) {
+	sess := &sessionFile{ID: "ses_hash", Title: "Hash Test"}
+	sess.Time.Created = 1700000000000
+	msgs := []renderedMessage{
+		{Role: "user", Content: "hello", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+
+	md1 := renderMarkdown(sess, msgs)
+	md2 := renderMarkdown(sess, msgs)
+
+	h1 := sha256.Sum256([]byte(md1))
+	h2 := sha256.Sum256([]byte(md2))
+
+	if hex.EncodeToString(h1[:]) != hex.EncodeToString(h2[:]) {
+		t.Error("same input should produce same hash")
+	}
+}
+
+func TestLoadTextParts(t *testing.T) {
+	dir := t.TempDir()
+	h := &OpenCodeHarvester{sessionDir: dir}
+
+	msgID := "msg_test"
+	partDir := filepath.Join(dir, "part", msgID)
+
+	writeJSON(t, filepath.Join(partDir, "prt_001.json"), map[string]any{
+		"id": "prt_001", "type": "text", "text": "First part", "messageID": msgID,
+	})
+	writeJSON(t, filepath.Join(partDir, "prt_002.json"), map[string]any{
+		"id": "prt_002", "type": "step-start", "messageID": msgID,
+	})
+	writeJSON(t, filepath.Join(partDir, "prt_003.json"), map[string]any{
+		"id": "prt_003", "type": "text", "text": "Second part", "messageID": msgID,
+	})
+
+	text, err := h.loadTextParts(msgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "First part\n\nSecond part" {
+		t.Errorf("got %q, want concatenated text parts", text)
+	}
+}
+
+func TestLoadTextPartsNoDir(t *testing.T) {
+	h := &OpenCodeHarvester{sessionDir: t.TempDir()}
+
+	text, err := h.loadTextParts("msg_nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "" {
+		t.Errorf("expected empty string for missing part dir, got %q", text)
+	}
+}
+
+func TestLoadMessages(t *testing.T) {
+	dir := t.TempDir()
+	h := &OpenCodeHarvester{
+		sessionDir: dir,
+		logger:     zerolog.Nop(),
+	}
+
+	sesID := "ses_loadtest"
+	msgDir := filepath.Join(dir, "message", sesID)
+
+	writeJSON(t, filepath.Join(msgDir, "msg_a.json"), map[string]any{
+		"id": "msg_a", "sessionID": sesID, "role": "user",
+		"time": map[string]any{"created": 1700000002000},
+	})
+	writeJSON(t, filepath.Join(msgDir, "msg_b.json"), map[string]any{
+		"id": "msg_b", "sessionID": sesID, "role": "assistant",
+		"time": map[string]any{"created": 1700000003000},
+	})
+	writeJSON(t, filepath.Join(msgDir, "msg_c.json"), map[string]any{
+		"id": "msg_c", "sessionID": sesID, "role": "system",
+		"time": map[string]any{"created": 1700000001000},
+	})
+
+	partDirA := filepath.Join(dir, "part", "msg_a")
+	writeJSON(t, filepath.Join(partDirA, "prt_01.json"), map[string]any{
+		"id": "prt_01", "type": "text", "text": "user question",
+	})
+	partDirB := filepath.Join(dir, "part", "msg_b")
+	writeJSON(t, filepath.Join(partDirB, "prt_02.json"), map[string]any{
+		"id": "prt_02", "type": "text", "text": "assistant answer",
+	})
+
+	msgs, err := h.loadMessages(sesID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2 (system should be filtered)", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("first message should be user (earlier timestamp), got %s", msgs[0].Role)
+	}
+	if msgs[1].Role != "assistant" {
+		t.Errorf("second message should be assistant, got %s", msgs[1].Role)
+	}
+}
+
+func TestLoadMessagesNoDir(t *testing.T) {
+	h := &OpenCodeHarvester{
+		sessionDir: t.TempDir(),
+		logger:     zerolog.Nop(),
+	}
+
+	msgs, err := h.loadMessages("ses_nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages for missing dir, got %d", len(msgs))
+	}
+}
+
+func TestHarvestAllEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	h := &OpenCodeHarvester{
+		sessionDir: dir,
+		logger:     zerolog.Nop(),
+	}
+
+	harvested, skipped, errCount := h.HarvestAll(context.Background(), nil)
+	if harvested != 0 || skipped != 0 || errCount != 0 {
+		t.Errorf("empty dir: got h=%d s=%d e=%d", harvested, skipped, errCount)
+	}
+}
+
+func TestHarvestAllNoSessionSubdir(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "session"), 0o755)
+	h := &OpenCodeHarvester{
+		sessionDir: dir,
+		logger:     zerolog.Nop(),
+	}
+
+	harvested, skipped, errCount := h.HarvestAll(context.Background(), nil)
+	if harvested != 0 || skipped != 0 || errCount != 0 {
+		t.Errorf("no session subdir: got h=%d s=%d e=%d", harvested, skipped, errCount)
+	}
+}

--- a/internal/harvest/runner.go
+++ b/internal/harvest/runner.go
@@ -1,0 +1,54 @@
+package harvest
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Runner periodically invokes an OpenCodeHarvester.
+type Runner struct {
+	harvester *OpenCodeHarvester
+	enqueuer  ChunkEnqueuer
+	interval  time.Duration
+	logger    zerolog.Logger
+}
+
+// NewRunner creates a Runner that calls HarvestAll at the given interval.
+func NewRunner(harvester *OpenCodeHarvester, enqueuer ChunkEnqueuer, interval time.Duration, logger zerolog.Logger) *Runner {
+	return &Runner{
+		harvester: harvester,
+		enqueuer:  enqueuer,
+		interval:  interval,
+		logger:    logger.With().Str("component", "harvest-runner").Logger(),
+	}
+}
+
+// Run executes an immediate harvest then ticks at the configured interval.
+// It returns nil on context cancellation.
+func (r *Runner) Run(ctx context.Context) error {
+	r.tick(ctx)
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.Info().Msg("harvest runner stopping")
+			return nil
+		case <-ticker.C:
+			r.tick(ctx)
+		}
+	}
+}
+
+func (r *Runner) tick(ctx context.Context) {
+	harvested, skipped, errCount := r.harvester.HarvestAll(ctx, r.enqueuer)
+	r.logger.Info().
+		Int("harvested", harvested).
+		Int("skipped", skipped).
+		Int("errors", errCount).
+		Msg("harvest cycle complete")
+}


### PR DESCRIPTION
## Story 6.1: OpenCode Session Harvester

**Issue:** #96 | **FR:** FR-1, FR-4 | **Epic:** 6 — Session Harvesting

### Changes

**New package: `internal/harvest/`**
- `opencode.go` — `OpenCodeHarvester` parses real OpenCode storage format (`session/`, `message/`, `part/` directories), renders sessions as markdown with YAML front-matter, and ingests via existing write pipeline (SHA-256, upsert, chunk, enqueue)
- `runner.go` — `Runner` background goroutine: immediate tick + periodic `time.NewTicker`, clean shutdown on context cancellation
- `opencode_test.go` — 12 unit tests

**Modified:**
- `cmd/nano-brain/main.go` — wires harvester into errgroup if `SessionDir` configured

### Design Notes
- Discovered real OpenCode storage format differs from spec assumption: data split across 3 directories (`session/`, `message/`, `part/`) vs single JSON file. Harvester handles the real format.
- Collection: `sessions` (hardcoded). Tags: `[opencode, session]`.
- Skips system messages during rendering.
- Hash-based dedup: skip if SHA-256 matches existing doc for same source_path.