### PR TITLE
feat: implement Claude Code session harvester (Story 6.2)

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -137,17 +138,16 @@ func main() {
 		})
 	}
 
+	var hr *harvest.Runner
+	interval := time.Duration(cfg.Intervals.SessionPoll) * time.Second
+
 	if cfg.Harvester.OpenCode.SessionDir != "" {
 		wsHash, err := storage.WorkspaceHash(cfg.Harvester.OpenCode.SessionDir)
 		if err != nil {
 			logger.Warn().Err(err).Msg("failed to compute workspace hash for opencode harvester")
 		} else {
 			oh := harvest.NewOpenCodeHarvester(db, logger, cfg.Harvester.OpenCode.SessionDir, wsHash)
-			interval := time.Duration(cfg.Intervals.SessionPoll) * time.Second
-			hr := harvest.NewRunner(oh, eq, interval, logger)
-			g.Go(func() error {
-				return hr.Run(gctx)
-			})
+			hr = harvest.NewRunner(oh, eq, interval, logger)
 			logger.Info().
 				Str("session_dir", cfg.Harvester.OpenCode.SessionDir).
 				Dur("interval", interval).
@@ -155,6 +155,36 @@ func main() {
 		}
 	} else {
 		logger.Info().Msg("opencode session harvester disabled (no session_dir configured)")
+	}
+
+	if cfg.Harvester.ClaudeCode.Enabled {
+		if _, err := os.Stat(cfg.Harvester.ClaudeCode.SessionDir); os.IsNotExist(err) {
+			logger.Warn().
+				Str("session_dir", cfg.Harvester.ClaudeCode.SessionDir).
+				Msg("claude code harvester enabled but session_dir does not exist, skipping")
+		} else {
+			wsHash, err := storage.WorkspaceHash(cfg.Harvester.ClaudeCode.SessionDir)
+			if err != nil {
+				logger.Warn().Err(err).Msg("failed to compute workspace hash for claude code harvester")
+			} else {
+				ch := harvest.NewClaudeCodeHarvester(db, logger, cfg.Harvester.ClaudeCode.SessionDir, wsHash)
+				if hr == nil {
+					hr = harvest.NewRunner(ch, eq, interval, logger)
+				} else {
+					hr.AddHarvester(ch)
+				}
+				logger.Info().
+					Str("session_dir", cfg.Harvester.ClaudeCode.SessionDir).
+					Dur("interval", interval).
+					Msg("claude code session harvester started")
+			}
+		}
+	}
+
+	if hr != nil {
+		g.Go(func() error {
+			return hr.Run(gctx)
+		})
 	}
 
 	g.Go(func() error {

--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/nano-brain/nano-brain/internal/chunk"
@@ -247,12 +247,17 @@ func renderClaudeCodeMarkdown(sessionID string, msgs []claudeCodeMessage) string
 			fmt.Fprintf(&b, "\n## assistant (%s)\n\n", ts)
 			fmt.Fprintf(&b, "Tool: %s\n", msg.ToolName)
 			if len(msg.ToolInput) > 0 && string(msg.ToolInput) != "null" {
-				var inputMap map[string]interface{}
-				if err := json.Unmarshal(msg.ToolInput, &inputMap); err == nil {
-					for k, v := range inputMap {
-						fmt.Fprintf(&b, "%s: %v\n", k, v)
-					}
+			var inputMap map[string]interface{}
+			if err := json.Unmarshal(msg.ToolInput, &inputMap); err == nil {
+				keys := make([]string, 0, len(inputMap))
+				for k := range inputMap {
+					keys = append(keys, k)
 				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					fmt.Fprintf(&b, "%s: %v\n", k, inputMap[k])
+				}
+			}
 			}
 			b.WriteString("\n")
 
@@ -276,7 +281,3 @@ func renderClaudeCodeMarkdown(sessionID string, msgs []claudeCodeMessage) string
 	return b.String()
 }
 
-// parseTimestamp parses a Claude Code timestamp string into a time.Time.
-func parseTimestamp(ts string) (time.Time, error) {
-	return time.Parse(time.RFC3339Nano, ts)
-}

--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -1,0 +1,282 @@
+package harvest
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nano-brain/nano-brain/internal/chunk"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+	"github.com/sqlc-dev/pqtype"
+)
+
+// ClaudeCodeHarvester ingests Claude Code JSONL session files into the document store.
+type ClaudeCodeHarvester struct {
+	db         *sql.DB
+	logger     zerolog.Logger
+	sessionDir string
+	workspace  string
+}
+
+// NewClaudeCodeHarvester creates a new Claude Code session harvester.
+func NewClaudeCodeHarvester(db *sql.DB, logger zerolog.Logger, sessionDir, workspace string) *ClaudeCodeHarvester {
+	return &ClaudeCodeHarvester{
+		db:         db,
+		logger:     logger.With().Str("component", "claudecode-harvester").Logger(),
+		sessionDir: sessionDir,
+		workspace:  workspace,
+	}
+}
+
+// HarvestAll scans the session directory and ingests all JSONL sessions.
+// Returns counts of harvested, skipped, and errored sessions.
+func (h *ClaudeCodeHarvester) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harvested, skipped, errCount int) {
+	if _, err := os.Stat(h.sessionDir); os.IsNotExist(err) {
+		h.logger.Debug().Str("dir", h.sessionDir).Msg("session directory does not exist, skipping")
+		return 0, 0, 0
+	}
+
+	entries, err := os.ReadDir(h.sessionDir)
+	if err != nil {
+		h.logger.Error().Err(err).Str("dir", h.sessionDir).Msg("failed to read session directory")
+		return 0, 0, 1
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		filePath := filepath.Join(h.sessionDir, e.Name())
+		result, err := h.harvestSession(ctx, filePath, enqueuer)
+		if err != nil {
+			h.logger.Error().Err(err).Str("file", filePath).Msg("failed to harvest session")
+			errCount++
+			continue
+		}
+		if result {
+			harvested++
+		} else {
+			skipped++
+		}
+	}
+	return
+}
+
+// harvestSession processes a single JSONL session file. Returns true if ingested, false if skipped (unchanged).
+func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile string, enqueuer ChunkEnqueuer) (bool, error) {
+	msgs, err := parseJSONLFile(sessionFile)
+	if err != nil {
+		return false, fmt.Errorf("parse JSONL: %w", err)
+	}
+
+	if len(msgs) == 0 {
+		return false, nil
+	}
+
+	sessionID := strings.TrimSuffix(filepath.Base(sessionFile), ".jsonl")
+	md := renderClaudeCodeMarkdown(sessionID, msgs)
+
+	sum := sha256.Sum256([]byte(md))
+	contentHash := hex.EncodeToString(sum[:])
+
+	queries := sqlc.New(h.db)
+	existing, err := queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
+		SourcePath:    sessionFile,
+		WorkspaceHash: h.workspace,
+	})
+	if err == nil && existing.ContentHash == contentHash {
+		return false, nil
+	}
+
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() // no-op after commit
+	tq := sqlc.New(tx)
+
+	meta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
+	tags := []string{"claude_code", "session"}
+
+	docRow, err := tq.UpsertDocumentBySourcePath(ctx, sqlc.UpsertDocumentBySourcePathParams{
+		WorkspaceHash: h.workspace,
+		ContentHash:   contentHash,
+		Title:         "Claude Code Session " + sessionID,
+		Content:       md,
+		SourcePath:    sessionFile,
+		Collection:    "sessions",
+		Tags:          tags,
+		Metadata:      meta,
+	})
+	if err != nil {
+		return false, fmt.Errorf("upsert document: %w", err)
+	}
+
+	if err := tq.DeleteChunksByDocumentID(ctx, sqlc.DeleteChunksByDocumentIDParams{
+		DocumentID:    docRow.ID,
+		WorkspaceHash: h.workspace,
+	}); err != nil {
+		return false, fmt.Errorf("delete old chunks: %w", err)
+	}
+
+	chunks := chunk.Split(md, chunk.DefaultConfig())
+	chunkMeta := pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true}
+	chunkIDs := make([]uuid.UUID, 0, len(chunks))
+
+	for _, ch := range chunks {
+		id, err := tq.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+			DocumentID:    docRow.ID,
+			WorkspaceHash: h.workspace,
+			ContentHash:   ch.Hash,
+			Content:       ch.Content,
+			ChunkIndex:    int32(ch.Sequence),
+			StartLine:     sql.NullInt32{Int32: int32(ch.StartLine), Valid: true},
+			EndLine:       sql.NullInt32{Int32: int32(ch.EndLine), Valid: true},
+			Metadata:      chunkMeta,
+		})
+		if err != nil {
+			return false, fmt.Errorf("upsert chunk: %w", err)
+		}
+		chunkIDs = append(chunkIDs, id)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit tx: %w", err)
+	}
+
+	if enqueuer != nil {
+		for _, id := range chunkIDs {
+			enqueuer.Enqueue(id)
+		}
+	}
+
+	return true, nil
+}
+
+// claudeCodeMessage represents a single line from a Claude Code JSONL transcript.
+type claudeCodeMessage struct {
+	Type      string          `json:"type"`
+	Timestamp string          `json:"timestamp"`
+	Content   string          `json:"content"`
+	ToolName  string          `json:"tool_name"`
+	ToolInput json.RawMessage `json:"tool_input"`
+	ToolOutput json.RawMessage `json:"tool_output"`
+}
+
+// parseJSONLFile reads a Claude Code JSONL session file and returns the messages.
+// Invalid lines are skipped with no error (log + continue pattern).
+func parseJSONLFile(path string) ([]claudeCodeMessage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var msgs []claudeCodeMessage
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // 10MB max line
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var msg claudeCodeMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue // skip invalid lines
+		}
+		if msg.Type == "" {
+			continue
+		}
+		msgs = append(msgs, msg)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan JSONL: %w", err)
+	}
+
+	return msgs, nil
+}
+
+// renderClaudeCodeMarkdown renders Claude Code messages into a markdown document.
+func renderClaudeCodeMarkdown(sessionID string, msgs []claudeCodeMessage) string {
+	var b strings.Builder
+
+	// Determine created_at from first message timestamp
+	var createdAt string
+	if len(msgs) > 0 && msgs[0].Timestamp != "" {
+		createdAt = msgs[0].Timestamp
+	}
+
+	// Count user-visible messages (user + tool_use)
+	messageCount := 0
+	for _, m := range msgs {
+		if m.Type == "user" || m.Type == "tool_use" {
+			messageCount++
+		}
+	}
+
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "session_id: %s\n", sessionID)
+	b.WriteString("source: claude_code\n")
+	fmt.Fprintf(&b, "message_count: %d\n", messageCount)
+	if createdAt != "" {
+		fmt.Fprintf(&b, "created_at: %s\n", createdAt)
+	}
+	b.WriteString("---\n")
+
+	for _, msg := range msgs {
+		ts := msg.Timestamp
+		switch msg.Type {
+		case "user":
+			fmt.Fprintf(&b, "\n## human (%s)\n\n", ts)
+			b.WriteString(msg.Content)
+			b.WriteString("\n")
+
+		case "tool_use":
+			fmt.Fprintf(&b, "\n## assistant (%s)\n\n", ts)
+			fmt.Fprintf(&b, "Tool: %s\n", msg.ToolName)
+			if len(msg.ToolInput) > 0 && string(msg.ToolInput) != "null" {
+				var inputMap map[string]interface{}
+				if err := json.Unmarshal(msg.ToolInput, &inputMap); err == nil {
+					for k, v := range inputMap {
+						fmt.Fprintf(&b, "%s: %v\n", k, v)
+					}
+				}
+			}
+			b.WriteString("\n")
+
+		case "tool_result":
+			// Include tool results inline for context
+			fmt.Fprintf(&b, "\n## tool_result (%s)\n\n", ts)
+			if len(msg.ToolOutput) > 0 && string(msg.ToolOutput) != "null" {
+				var outputMap map[string]interface{}
+				if err := json.Unmarshal(msg.ToolOutput, &outputMap); err == nil {
+					if out, ok := outputMap["output"]; ok {
+						fmt.Fprintf(&b, "%v\n", out)
+					}
+				} else {
+					b.WriteString(string(msg.ToolOutput))
+					b.WriteString("\n")
+				}
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// parseTimestamp parses a Claude Code timestamp string into a time.Time.
+func parseTimestamp(ts string) (time.Time, error) {
+	return time.Parse(time.RFC3339Nano, ts)
+}

--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -269,6 +269,10 @@ func renderClaudeCodeMarkdown(sessionID string, msgs []claudeCodeMessage) string
 				if err := json.Unmarshal(msg.ToolOutput, &outputMap); err == nil {
 					if out, ok := outputMap["output"]; ok {
 						fmt.Fprintf(&b, "%v\n", out)
+					} else {
+						// Fallback: output key missing (e.g. error or other metadata)
+						b.WriteString(string(msg.ToolOutput))
+						b.WriteString("\n")
 					}
 				} else {
 					b.WriteString(string(msg.ToolOutput))

--- a/internal/harvest/claudecode_test.go
+++ b/internal/harvest/claudecode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -238,20 +239,20 @@ func TestClaudeCodeHarvestAllSkipsNonJSONL(t *testing.T) {
 	}
 }
 
-func TestParseTimestamp(t *testing.T) {
-	ts, err := parseTimestamp("2026-01-01T10:00:00Z")
-	if err != nil {
-		t.Fatal(err)
+func TestRenderClaudeCodeMarkdownToolUseHashStability(t *testing.T) {
+	msgs := []claudeCodeMessage{
+		{
+			Type:      "tool_use",
+			Timestamp: "2026-01-01T10:00:00Z",
+			ToolName:  "bash",
+			ToolInput: json.RawMessage(`{"command":"ls -la","timeout":30,"cwd":"/tmp"}`),
+		},
 	}
-	if ts.Year() != 2026 || ts.Month() != 1 || ts.Day() != 1 {
-		t.Errorf("unexpected parsed time: %v", ts)
-	}
-
-	ts2, err := parseTimestamp("2026-01-01T10:00:00.123Z")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ts2.Nanosecond() != 123000000 {
-		t.Errorf("expected nanoseconds 123000000, got %d", ts2.Nanosecond())
+	first := renderClaudeCodeMarkdown("test-session", msgs)
+	for i := 0; i < 50; i++ {
+		got := renderClaudeCodeMarkdown("test-session", msgs)
+		if got != first {
+			t.Fatalf("iteration %d: non-deterministic output.\nfirst:\n%s\ngot:\n%s", i, first, got)
+		}
 	}
 }

--- a/internal/harvest/claudecode_test.go
+++ b/internal/harvest/claudecode_test.go
@@ -1,0 +1,257 @@
+package harvest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func writeLines(t *testing.T, path string, lines []string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseJSONLFile(t *testing.T) {
+	t.Run("valid messages", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ses_abc.jsonl")
+		writeLines(t, path, []string{
+			`{"type":"user","timestamp":"2026-01-01T10:00:00Z","content":"hello"}`,
+			`{"type":"tool_use","timestamp":"2026-01-01T10:00:01Z","tool_name":"bash","tool_input":{"command":"ls"}}`,
+			`{"type":"tool_result","timestamp":"2026-01-01T10:00:02Z","tool_name":"bash","tool_output":{"output":"file.txt"}}`,
+		})
+
+		msgs, err := parseJSONLFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 3 {
+			t.Fatalf("got %d messages, want 3", len(msgs))
+		}
+		if msgs[0].Type != "user" {
+			t.Errorf("first message type = %q, want user", msgs[0].Type)
+		}
+		if msgs[0].Content != "hello" {
+			t.Errorf("first message content = %q, want hello", msgs[0].Content)
+		}
+		if msgs[1].Type != "tool_use" {
+			t.Errorf("second message type = %q, want tool_use", msgs[1].Type)
+		}
+		if msgs[1].ToolName != "bash" {
+			t.Errorf("second message tool_name = %q, want bash", msgs[1].ToolName)
+		}
+	})
+
+	t.Run("skips invalid lines", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ses_bad.jsonl")
+		writeLines(t, path, []string{
+			`{"type":"user","timestamp":"2026-01-01T10:00:00Z","content":"valid"}`,
+			`{not json at all`,
+			``,
+			`{"type":"user","timestamp":"2026-01-01T10:00:01Z","content":"also valid"}`,
+		})
+
+		msgs, err := parseJSONLFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 2 {
+			t.Fatalf("got %d messages, want 2 (invalid lines skipped)", len(msgs))
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ses_empty.jsonl")
+		writeLines(t, path, []string{})
+
+		msgs, err := parseJSONLFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 0 {
+			t.Fatalf("got %d messages, want 0", len(msgs))
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := parseJSONLFile("/nonexistent/ses_nope.jsonl")
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("skips lines with empty type", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ses_notype.jsonl")
+		writeLines(t, path, []string{
+			`{"timestamp":"2026-01-01T10:00:00Z","content":"no type field"}`,
+			`{"type":"user","timestamp":"2026-01-01T10:00:01Z","content":"has type"}`,
+		})
+
+		msgs, err := parseJSONLFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 1 {
+			t.Fatalf("got %d messages, want 1", len(msgs))
+		}
+	})
+}
+
+func TestRenderClaudeCodeMarkdown(t *testing.T) {
+	t.Run("full session", func(t *testing.T) {
+		msgs := []claudeCodeMessage{
+			{Type: "user", Timestamp: "2026-01-01T10:00:00Z", Content: "What is Go?"},
+			{Type: "tool_use", Timestamp: "2026-01-01T10:00:01Z", ToolName: "bash", ToolInput: []byte(`{"command":"go version"}`)},
+			{Type: "tool_result", Timestamp: "2026-01-01T10:00:02Z", ToolName: "bash", ToolOutput: []byte(`{"output":"go1.23"}`)},
+		}
+
+		md := renderClaudeCodeMarkdown("ses_test", msgs)
+
+		if !strings.Contains(md, "session_id: ses_test") {
+			t.Error("missing session_id in front-matter")
+		}
+		if !strings.Contains(md, "source: claude_code") {
+			t.Error("missing source in front-matter")
+		}
+		if !strings.Contains(md, "message_count: 2") {
+			t.Error("message_count should be 2 (user + tool_use)")
+		}
+		if !strings.Contains(md, "created_at: 2026-01-01T10:00:00Z") {
+			t.Error("missing created_at from first message")
+		}
+		if !strings.Contains(md, "## human (2026-01-01T10:00:00Z)") {
+			t.Error("missing human heading")
+		}
+		if !strings.Contains(md, "What is Go?") {
+			t.Error("missing user content")
+		}
+		if !strings.Contains(md, "## assistant (2026-01-01T10:00:01Z)") {
+			t.Error("missing assistant heading")
+		}
+		if !strings.Contains(md, "Tool: bash") {
+			t.Error("missing tool name")
+		}
+		if !strings.Contains(md, "## tool_result (2026-01-01T10:00:02Z)") {
+			t.Error("missing tool_result heading")
+		}
+		if !strings.Contains(md, "go1.23") {
+			t.Error("missing tool output")
+		}
+		if !strings.HasPrefix(md, "---\n") {
+			t.Error("front-matter should start with ---")
+		}
+	})
+
+	t.Run("empty messages", func(t *testing.T) {
+		md := renderClaudeCodeMarkdown("ses_empty", nil)
+		if !strings.Contains(md, "message_count: 0") {
+			t.Error("empty messages should show count 0")
+		}
+		if !strings.Contains(md, "source: claude_code") {
+			t.Error("missing source")
+		}
+	})
+
+	t.Run("user only session", func(t *testing.T) {
+		msgs := []claudeCodeMessage{
+			{Type: "user", Timestamp: "2026-01-01T10:00:00Z", Content: "just a question"},
+		}
+		md := renderClaudeCodeMarkdown("ses_user", msgs)
+		if !strings.Contains(md, "message_count: 1") {
+			t.Error("message_count should be 1")
+		}
+		if !strings.Contains(md, "## human") {
+			t.Error("missing human heading")
+		}
+	})
+}
+
+func TestRenderClaudeCodeMarkdownHashStability(t *testing.T) {
+	msgs := []claudeCodeMessage{
+		{Type: "user", Timestamp: "2026-01-01T10:00:00Z", Content: "hello"},
+	}
+
+	md1 := renderClaudeCodeMarkdown("ses_hash", msgs)
+	md2 := renderClaudeCodeMarkdown("ses_hash", msgs)
+
+	h1 := sha256.Sum256([]byte(md1))
+	h2 := sha256.Sum256([]byte(md2))
+
+	if hex.EncodeToString(h1[:]) != hex.EncodeToString(h2[:]) {
+		t.Error("same input should produce same hash")
+	}
+}
+
+func TestClaudeCodeHarvestAllEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	h := &ClaudeCodeHarvester{
+		sessionDir: dir,
+		logger:     zerolog.Nop(),
+	}
+
+	harvested, skipped, errCount := h.HarvestAll(context.Background(), nil)
+	if harvested != 0 || skipped != 0 || errCount != 0 {
+		t.Errorf("empty dir: got h=%d s=%d e=%d", harvested, skipped, errCount)
+	}
+}
+
+func TestClaudeCodeHarvestAllNonExistentDir(t *testing.T) {
+	h := &ClaudeCodeHarvester{
+		sessionDir: "/nonexistent/path/sessions",
+		logger:     zerolog.Nop(),
+	}
+
+	harvested, skipped, errCount := h.HarvestAll(context.Background(), nil)
+	if harvested != 0 || skipped != 0 || errCount != 0 {
+		t.Errorf("nonexistent dir: got h=%d s=%d e=%d", harvested, skipped, errCount)
+	}
+}
+
+func TestClaudeCodeHarvestAllSkipsNonJSONL(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("not a session"), 0o644)
+	os.WriteFile(filepath.Join(dir, "data.json"), []byte("{}"), 0o644)
+
+	h := &ClaudeCodeHarvester{
+		sessionDir: dir,
+		logger:     zerolog.Nop(),
+	}
+
+	harvested, skipped, errCount := h.HarvestAll(context.Background(), nil)
+	if harvested != 0 || skipped != 0 || errCount != 0 {
+		t.Errorf("non-JSONL files: got h=%d s=%d e=%d", harvested, skipped, errCount)
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	ts, err := parseTimestamp("2026-01-01T10:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts.Year() != 2026 || ts.Month() != 1 || ts.Day() != 1 {
+		t.Errorf("unexpected parsed time: %v", ts)
+	}
+
+	ts2, err := parseTimestamp("2026-01-01T10:00:00.123Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts2.Nanosecond() != 123000000 {
+		t.Errorf("expected nanoseconds 123000000, got %d", ts2.Nanosecond())
+	}
+}

--- a/internal/harvest/runner.go
+++ b/internal/harvest/runner.go
@@ -7,22 +7,32 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Runner periodically invokes an OpenCodeHarvester.
+// Harvester can scan a source and ingest sessions into the document store.
+type Harvester interface {
+	HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harvested, skipped, errCount int)
+}
+
+// Runner periodically invokes one or more Harvesters.
 type Runner struct {
-	harvester *OpenCodeHarvester
-	enqueuer  ChunkEnqueuer
-	interval  time.Duration
-	logger    zerolog.Logger
+	harvesters []Harvester
+	enqueuer   ChunkEnqueuer
+	interval   time.Duration
+	logger     zerolog.Logger
 }
 
 // NewRunner creates a Runner that calls HarvestAll at the given interval.
-func NewRunner(harvester *OpenCodeHarvester, enqueuer ChunkEnqueuer, interval time.Duration, logger zerolog.Logger) *Runner {
+func NewRunner(harvester Harvester, enqueuer ChunkEnqueuer, interval time.Duration, logger zerolog.Logger) *Runner {
 	return &Runner{
-		harvester: harvester,
-		enqueuer:  enqueuer,
-		interval:  interval,
-		logger:    logger.With().Str("component", "harvest-runner").Logger(),
+		harvesters: []Harvester{harvester},
+		enqueuer:   enqueuer,
+		interval:   interval,
+		logger:     logger.With().Str("component", "harvest-runner").Logger(),
 	}
+}
+
+// AddHarvester appends an additional harvester to the runner.
+func (r *Runner) AddHarvester(h Harvester) {
+	r.harvesters = append(r.harvesters, h)
 }
 
 // Run executes an immediate harvest then ticks at the configured interval.
@@ -45,10 +55,16 @@ func (r *Runner) Run(ctx context.Context) error {
 }
 
 func (r *Runner) tick(ctx context.Context) {
-	harvested, skipped, errCount := r.harvester.HarvestAll(ctx, r.enqueuer)
+	var totalHarvested, totalSkipped, totalErrors int
+	for _, h := range r.harvesters {
+		harvested, skipped, errCount := h.HarvestAll(ctx, r.enqueuer)
+		totalHarvested += harvested
+		totalSkipped += skipped
+		totalErrors += errCount
+	}
 	r.logger.Info().
-		Int("harvested", harvested).
-		Int("skipped", skipped).
-		Int("errors", errCount).
+		Int("harvested", totalHarvested).
+		Int("skipped", totalSkipped).
+		Int("errors", totalErrors).
 		Msg("harvest cycle complete")
 }


### PR DESCRIPTION
## Story 6.2: Claude Code Session Harvester

**Issue:** #98 | **FR:** FR-2, FR-4 | **Epic:** 6 — Session Harvesting

### Changes

**New:**
- `internal/harvest/claudecode.go` — parses Claude Code JSONL transcripts from `~/.claude/transcripts/`, renders as markdown with `source: claude_code` front-matter
- `internal/harvest/claudecode_test.go` — 8 unit tests

**Modified:**
- `internal/harvest/runner.go` — `Harvester` interface + `[]Harvester` slice in Runner + `AddHarvester()` method
- `cmd/nano-brain/main.go` — wires Claude Code harvester when `enabled = true`

### Design Notes
- Real JSONL format: types are `user`, `tool_use`, `tool_result` (no `assistant` type)
- 10MB line buffer for large tool outputs
- Shared runner with OpenCode harvester via `AddHarvester()`
- Disabled by default