### PR TITLE
feat: add harvester config to GET /api/status (Story 6.4)

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -102,7 +102,7 @@ func main() {
 		}
 	}
 
-	srv := server.New(cfg.Server, cfg.Embedding, cfg.Search, pool, db, queries, fw, eq, embedder, logger, Version)
+	srv := server.New(cfg.Server, cfg.Embedding, cfg.Search, cfg.Harvester, cfg.Intervals, pool, db, queries, fw, eq, embedder, logger, Version)
 
 	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {

--- a/internal/server/handlers/health.go
+++ b/internal/server/handlers/health.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/rs/zerolog"
 )
 
@@ -21,15 +22,17 @@ type EmbedQueueInfo interface {
 }
 
 type Health struct {
-	pool      PoolChecker
-	queue     EmbedQueueInfo
-	logger    zerolog.Logger
-	version   string
-	startTime time.Time
+	pool         PoolChecker
+	queue        EmbedQueueInfo
+	logger       zerolog.Logger
+	version      string
+	startTime    time.Time
+	harvesterCfg config.HarvesterConfig
+	intervalsCfg config.IntervalsConfig
 }
 
-func NewHealth(pool PoolChecker, logger zerolog.Logger, version string, startTime time.Time, queue EmbedQueueInfo) *Health {
-	return &Health{pool: pool, queue: queue, logger: logger, version: version, startTime: startTime}
+func NewHealth(pool PoolChecker, logger zerolog.Logger, version string, startTime time.Time, queue EmbedQueueInfo, harvesterCfg config.HarvesterConfig, intervalsCfg config.IntervalsConfig) *Health {
+	return &Health{pool: pool, queue: queue, logger: logger, version: version, startTime: startTime, harvesterCfg: harvesterCfg, intervalsCfg: intervalsCfg}
 }
 
 type healthResponse struct {
@@ -41,16 +44,29 @@ type healthResponse struct {
 	Reason         string `json:"reason,omitempty"`
 }
 
+type harvesterStatusResponse struct {
+	PollIntervalSeconds int `json:"poll_interval_seconds"`
+	OpenCode            struct {
+		Enabled    bool   `json:"enabled"`
+		SessionDir string `json:"session_dir"`
+	} `json:"opencode"`
+	ClaudeCode struct {
+		Enabled    bool   `json:"enabled"`
+		SessionDir string `json:"session_dir"`
+	} `json:"claude_code"`
+}
+
 type statusResponse struct {
-	PGStatus             string `json:"pg_status"`
-	MigrationVersion     int    `json:"migration_version"`
-	EmbeddingQueueDepth  int    `json:"embedding_queue_depth"`
-	ActiveProvider       string `json:"active_provider"`
-	WorkspaceCount       int    `json:"workspace_count"`
-	QueueDepth           int    `json:"queue_depth"`
-	QueueCapacity        int    `json:"queue_capacity"`
-	QueueStatus          string `json:"queue_status"`
-	QueuePending         int64  `json:"queue_pending"`
+	PGStatus             string                    `json:"pg_status"`
+	MigrationVersion     int                       `json:"migration_version"`
+	EmbeddingQueueDepth  int                       `json:"embedding_queue_depth"`
+	ActiveProvider       string                    `json:"active_provider"`
+	WorkspaceCount       int                       `json:"workspace_count"`
+	QueueDepth           int                       `json:"queue_depth"`
+	QueueCapacity        int                       `json:"queue_capacity"`
+	QueueStatus          string                    `json:"queue_status"`
+	QueuePending         int64                     `json:"queue_pending"`
+	HarvesterStatus      harvesterStatusResponse   `json:"harvester_status"`
 }
 
 func (h *Health) Health(c echo.Context) error {
@@ -77,12 +93,21 @@ func (h *Health) Status(c echo.Context) error {
 		pgStatus = "unreachable"
 	}
 
+	harvestStatus := harvesterStatusResponse{
+		PollIntervalSeconds: h.intervalsCfg.SessionPoll,
+	}
+	harvestStatus.OpenCode.Enabled = h.harvesterCfg.OpenCode.SessionDir != ""
+	harvestStatus.OpenCode.SessionDir = h.harvesterCfg.OpenCode.SessionDir
+	harvestStatus.ClaudeCode.Enabled = h.harvesterCfg.ClaudeCode.Enabled
+	harvestStatus.ClaudeCode.SessionDir = h.harvesterCfg.ClaudeCode.SessionDir
+
 	resp := statusResponse{
 		PGStatus:            pgStatus,
 		MigrationVersion:    1,
 		EmbeddingQueueDepth: 0,
 		ActiveProvider:      "none",
 		WorkspaceCount:      0,
+		HarvesterStatus:     harvestStatus,
 	}
 
 	if h.queue != nil {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -11,7 +11,7 @@ func registerRoutes(s *Server) {
 	if s.embedQueue != nil {
 		queueInfo = s.embedQueue
 	}
-	h := handlers.NewHealth(s.pool, s.logger, s.version, s.startTime, queueInfo)
+	h := handlers.NewHealth(s.pool, s.logger, s.version, s.startTime, queueInfo, s.harvesterCfg, s.intervalsCfg)
 
 	s.echo.GET("/health", h.Health)
 	s.echo.GET("/api/status", h.Status)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,24 +25,26 @@ type PoolChecker interface {
 }
 
 type Server struct {
-	echo          *echo.Echo
-	pool          PoolChecker
-	db            *sql.DB
-	queries       *sqlc.Queries
-	watcher       *watcher.Watcher
-	embedQueue    *embed.Queue
-	embedder      embed.Embedder
-	searchService *search.SearchService
-	mcpServer     *mcpsdk.Server
-	logger        zerolog.Logger
-	cfg           config.ServerConfig
-	embedCfg      config.EmbeddingConfig
-	searchCfg     config.SearchConfig
-	version       string
-	startTime     time.Time
+	echo           *echo.Echo
+	pool           PoolChecker
+	db             *sql.DB
+	queries        *sqlc.Queries
+	watcher        *watcher.Watcher
+	embedQueue     *embed.Queue
+	embedder       embed.Embedder
+	searchService  *search.SearchService
+	mcpServer      *mcpsdk.Server
+	logger         zerolog.Logger
+	cfg            config.ServerConfig
+	embedCfg       config.EmbeddingConfig
+	searchCfg      config.SearchConfig
+	harvesterCfg   config.HarvesterConfig
+	intervalsCfg   config.IntervalsConfig
+	version        string
+	startTime      time.Time
 }
 
-func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, searchCfg config.SearchConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
+func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, searchCfg config.SearchConfig, harvesterCfg config.HarvesterConfig, intervalsCfg config.IntervalsConfig, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, logger zerolog.Logger, version string) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -62,21 +64,23 @@ func New(cfg config.ServerConfig, embedCfg config.EmbeddingConfig, searchCfg con
 	internalmcp.RegisterTools(mcpServer, mcpAdapter)
 
 	s := &Server{
-		echo:          e,
-		pool:          pool,
-		db:            db,
-		queries:       queries,
-		watcher:       fw,
-		embedQueue:    eq,
-		embedder:      embedder,
-		searchService: ss,
-		mcpServer:     mcpServer,
-		logger:        logger,
-		cfg:           cfg,
-		embedCfg:      embedCfg,
-		searchCfg:     searchCfg,
-		version:       version,
-		startTime:     time.Now(),
+		echo:           e,
+		pool:           pool,
+		db:             db,
+		queries:        queries,
+		watcher:        fw,
+		embedQueue:     eq,
+		embedder:       embedder,
+		searchService:  ss,
+		mcpServer:      mcpServer,
+		logger:         logger,
+		cfg:            cfg,
+		embedCfg:       embedCfg,
+		searchCfg:      searchCfg,
+		harvesterCfg:   harvesterCfg,
+		intervalsCfg:   intervalsCfg,
+		version:        version,
+		startTime:      time.Now(),
 	}
 
 	registerMiddleware(s)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,8 +24,10 @@ func (m *mockPool) Ping(_ context.Context) error {
 
 func newTestServer(pool *mockPool) *server.Server {
 	cfg := config.ServerConfig{Host: "127.0.0.1", Port: 3100}
+	harvesterCfg := config.HarvesterConfig{}
+	intervalsCfg := config.IntervalsConfig{SessionPoll: 120}
 	logger := zerolog.Nop()
-	return server.New(cfg, config.EmbeddingConfig{}, config.SearchConfig{RrfK: 60, Limit: 20}, pool, nil, nil, nil, nil, nil, logger, "test-v1")
+	return server.New(cfg, config.EmbeddingConfig{}, config.SearchConfig{RrfK: 60, Limit: 20}, harvesterCfg, intervalsCfg, pool, nil, nil, nil, nil, nil, logger, "test-v1")
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {
@@ -98,7 +100,7 @@ func TestStatusEndpointShape(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	requiredFields := []string{"pg_status", "migration_version", "embedding_queue_depth", "active_provider", "workspace_count", "queue_depth", "queue_capacity", "queue_status", "queue_pending"}
+	requiredFields := []string{"pg_status", "migration_version", "embedding_queue_depth", "active_provider", "workspace_count", "queue_depth", "queue_capacity", "queue_status", "queue_pending", "harvester_status"}
 	for _, field := range requiredFields {
 		if _, ok := body[field]; !ok {
 			t.Errorf("missing required field: %s", field)


### PR DESCRIPTION
## Story 6.4: Configurable Poll Interval and Harvester Goroutine Lifecycle

**Issue:** #102 | **FR:** FR-5 | **Epic:** 6 — Session Harvesting

### Context
Poll interval, default value, validation, and errgroup lifecycle were already implemented in Stories 6.1-6.2. The missing piece was reflecting harvester config in `GET /api/status`.

### Changes
- Added `harvester_status` to `GET /api/status` response (poll interval, OpenCode status, Claude Code status)
- Wired harvester and intervals config through Server → Health handler
- Updated server constructor and tests

### Acceptance Criteria
- ✅ `intervals.session_poll = 30` → ~30s between cycles (already implemented)
- ✅ Default = 120s (defaults.go)
- ✅ SIGTERM → graceful shutdown (errgroup pattern)
- ✅ Invalid value → config error (validation)
- ✅ GET /api/status reflects harvest config (this PR)