### PR TITLE
feat: CLI harvest command and POST /api/harvest (Story 6.5)

### DIFF
--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -218,6 +218,41 @@ func runStubCmd(endpoint string, args []string) {
 	fmt.Println(string(resp))
 }
 
+func runHarvestCmd(args []string) {
+	var jsonFlag bool
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	resp, _, err := doRequest("POST", getBaseURL()+"/api/harvest", nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		return
+	}
+
+	var result struct {
+		Harvested int `json:"harvested"`
+		Skipped   int `json:"skipped"`
+		Errors    int `json:"errors"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Println(string(resp))
+		return
+	}
+	fmt.Printf("Harvest complete: %d harvested, %d skipped, %d errors\n", result.Harvested, result.Skipped, result.Errors)
+}
+
 func runQueryCmd(args []string) {
 	runStubCmd("query", args)
 }

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -50,6 +50,9 @@ func main() {
 		case "vsearch":
 			runVSearchCmd(args[1:])
 			return
+		case "harvest":
+			runHarvestCmd(args[1:])
+			return
 		}
 	}
 
@@ -182,6 +185,7 @@ func main() {
 	}
 
 	if hr != nil {
+		srv.SetHarvestRunner(hr)
 		g.Go(func() error {
 			return hr.Run(gctx)
 		})

--- a/internal/harvest/runner.go
+++ b/internal/harvest/runner.go
@@ -2,6 +2,7 @@ package harvest
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -14,6 +15,7 @@ type Harvester interface {
 
 // Runner periodically invokes one or more Harvesters.
 type Runner struct {
+	mu         sync.Mutex
 	harvesters []Harvester
 	enqueuer   ChunkEnqueuer
 	interval   time.Duration
@@ -55,9 +57,13 @@ func (r *Runner) Run(ctx context.Context) error {
 }
 
 // RunOnce executes a single harvest cycle synchronously and returns aggregate counts.
+// Serialized by mutex to prevent overlapping ticker and API-triggered harvests.
 func (r *Runner) RunOnce(ctx context.Context) (harvested, skipped, errCount int) {
-	for _, h := range r.harvesters {
-		h, s, e := h.HarvestAll(ctx, r.enqueuer)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, harv := range r.harvesters {
+		h, s, e := harv.HarvestAll(ctx, r.enqueuer)
 		harvested += h
 		skipped += s
 		errCount += e
@@ -66,13 +72,10 @@ func (r *Runner) RunOnce(ctx context.Context) (harvested, skipped, errCount int)
 		Int("harvested", harvested).
 		Int("skipped", skipped).
 		Int("errors", errCount).
-		Msg("harvest cycle complete (on-demand)")
+		Msg("harvest cycle complete")
 	return
 }
 
 func (r *Runner) tick(ctx context.Context) {
-	harvested, skipped, errCount := r.RunOnce(ctx)
-	_ = harvested
-	_ = skipped
-	_ = errCount
+	r.RunOnce(ctx)
 }

--- a/internal/harvest/runner.go
+++ b/internal/harvest/runner.go
@@ -54,17 +54,25 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 }
 
-func (r *Runner) tick(ctx context.Context) {
-	var totalHarvested, totalSkipped, totalErrors int
+// RunOnce executes a single harvest cycle synchronously and returns aggregate counts.
+func (r *Runner) RunOnce(ctx context.Context) (harvested, skipped, errCount int) {
 	for _, h := range r.harvesters {
-		harvested, skipped, errCount := h.HarvestAll(ctx, r.enqueuer)
-		totalHarvested += harvested
-		totalSkipped += skipped
-		totalErrors += errCount
+		h, s, e := h.HarvestAll(ctx, r.enqueuer)
+		harvested += h
+		skipped += s
+		errCount += e
 	}
 	r.logger.Info().
-		Int("harvested", totalHarvested).
-		Int("skipped", totalSkipped).
-		Int("errors", totalErrors).
-		Msg("harvest cycle complete")
+		Int("harvested", harvested).
+		Int("skipped", skipped).
+		Int("errors", errCount).
+		Msg("harvest cycle complete (on-demand)")
+	return
+}
+
+func (r *Runner) tick(ctx context.Context) {
+	harvested, skipped, errCount := r.RunOnce(ctx)
+	_ = harvested
+	_ = skipped
+	_ = errCount
 }

--- a/internal/server/handlers/harvest.go
+++ b/internal/server/handlers/harvest.go
@@ -1,0 +1,35 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+)
+
+type HarvestRunner interface {
+	RunOnce(ctx context.Context) (harvested, skipped, errCount int)
+}
+
+type HarvestResponse struct {
+	Harvested int `json:"harvested"`
+	Skipped   int `json:"skipped"`
+	Errors    int `json:"errors"`
+}
+
+func TriggerHarvest(runnerPtr *HarvestRunner, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		if runnerPtr == nil || *runnerPtr == nil {
+			return echo.NewHTTPError(http.StatusServiceUnavailable, "no harvesters configured")
+		}
+
+		harvested, skipped, errCount := (*runnerPtr).RunOnce(c.Request().Context())
+
+		return c.JSON(http.StatusOK, HarvestResponse{
+			Harvested: harvested,
+			Skipped:   skipped,
+			Errors:    errCount,
+		})
+	}
+}

--- a/internal/server/handlers/harvest.go
+++ b/internal/server/handlers/harvest.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/rs/zerolog"
 )
 
 type HarvestRunner interface {
@@ -18,13 +17,14 @@ type HarvestResponse struct {
 	Errors    int `json:"errors"`
 }
 
-func TriggerHarvest(runnerPtr *HarvestRunner, logger zerolog.Logger) echo.HandlerFunc {
+func TriggerHarvest(getRunner func() HarvestRunner) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		if runnerPtr == nil || *runnerPtr == nil {
+		runner := getRunner()
+		if runner == nil {
 			return echo.NewHTTPError(http.StatusServiceUnavailable, "no harvesters configured")
 		}
 
-		harvested, skipped, errCount := (*runnerPtr).RunOnce(c.Request().Context())
+		harvested, skipped, errCount := runner.RunOnce(c.Request().Context())
 
 		return c.JSON(http.StatusOK, HarvestResponse{
 			Harvested: harvested,

--- a/internal/server/handlers/harvest_test.go
+++ b/internal/server/handlers/harvest_test.go
@@ -1,0 +1,148 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/rs/zerolog"
+)
+
+type mockHarvestRunner struct {
+	harvested int
+	skipped   int
+	errors    int
+}
+
+func (m *mockHarvestRunner) RunOnce(_ context.Context) (int, int, int) {
+	return m.harvested, m.skipped, m.errors
+}
+
+func TestTriggerHarvest_Success(t *testing.T) {
+	runner := handlers.HarvestRunner(&mockHarvestRunner{harvested: 5, skipped: 10, errors: 1})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/harvest", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp handlers.HarvestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Harvested != 5 {
+		t.Errorf("harvested = %d, want 5", resp.Harvested)
+	}
+	if resp.Skipped != 10 {
+		t.Errorf("skipped = %d, want 10", resp.Skipped)
+	}
+	if resp.Errors != 1 {
+		t.Errorf("errors = %d, want 1", resp.Errors)
+	}
+}
+
+func TestTriggerHarvest_NilRunner(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/harvest", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var runner handlers.HarvestRunner
+	h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for nil runner")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %v", err)
+	}
+}
+
+func TestTriggerHarvest_NilPtr(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/harvest", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.TriggerHarvest(nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for nil pointer")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok || he.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %v", err)
+	}
+}
+
+func TestTriggerHarvest_ZeroCounts(t *testing.T) {
+	runner := handlers.HarvestRunner(&mockHarvestRunner{})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/harvest", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp handlers.HarvestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Harvested != 0 || resp.Skipped != 0 || resp.Errors != 0 {
+		t.Errorf("expected all zeros, got %+v", resp)
+	}
+}
+
+func TestTriggerHarvest_ConcurrentCalls(t *testing.T) {
+	runner := handlers.HarvestRunner(&mockHarvestRunner{harvested: 3, skipped: 7, errors: 0})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/api/harvest", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+			if err := h(c); err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", rec.Code)
+				return
+			}
+
+			var resp handlers.HarvestResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Errorf("decode error: %v", err)
+				return
+			}
+			if resp.Harvested != 3 || resp.Skipped != 7 || resp.Errors != 0 {
+				t.Errorf("unexpected response: %+v", resp)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/server/handlers/harvest_test.go
+++ b/internal/server/handlers/harvest_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/server/handlers"
-	"github.com/rs/zerolog"
 )
 
 type mockHarvestRunner struct {
@@ -31,7 +30,7 @@ func TestTriggerHarvest_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+	h := handlers.TriggerHarvest(func() handlers.HarvestRunner { return runner })
 	if err := h(c); err != nil {
 		t.Fatal(err)
 	}
@@ -60,8 +59,7 @@ func TestTriggerHarvest_NilRunner(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	var runner handlers.HarvestRunner
-	h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+	h := handlers.TriggerHarvest(func() handlers.HarvestRunner { return nil })
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for nil runner")
@@ -72,16 +70,16 @@ func TestTriggerHarvest_NilRunner(t *testing.T) {
 	}
 }
 
-func TestTriggerHarvest_NilPtr(t *testing.T) {
+func TestTriggerHarvest_NilGetter(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/api/harvest", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	h := handlers.TriggerHarvest(nil, zerolog.Nop())
+	h := handlers.TriggerHarvest(func() handlers.HarvestRunner { return nil })
 	err := h(c)
 	if err == nil {
-		t.Fatal("expected error for nil pointer")
+		t.Fatal("expected error for nil runner")
 	}
 	he, ok := err.(*echo.HTTPError)
 	if !ok || he.Code != http.StatusServiceUnavailable {
@@ -97,7 +95,7 @@ func TestTriggerHarvest_ZeroCounts(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+	h := handlers.TriggerHarvest(func() handlers.HarvestRunner { return runner })
 	if err := h(c); err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +111,7 @@ func TestTriggerHarvest_ZeroCounts(t *testing.T) {
 
 func TestTriggerHarvest_ConcurrentCalls(t *testing.T) {
 	runner := handlers.HarvestRunner(&mockHarvestRunner{harvested: 3, skipped: 7, errors: 0})
+	getRunner := func() handlers.HarvestRunner { return runner }
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -124,7 +123,7 @@ func TestTriggerHarvest_ConcurrentCalls(t *testing.T) {
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
-			h := handlers.TriggerHarvest(&runner, zerolog.Nop())
+			h := handlers.TriggerHarvest(getRunner)
 			if err := h(c); err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -45,7 +45,7 @@ func registerRoutes(s *Server) {
 	api.GET("/wake-up", wakeUp)
 	data.POST("/wake-up", wakeUp)
 
-	s.echo.POST("/api/harvest", handlers.TriggerHarvest(&s.harvestRunner, s.logger))
+	s.echo.POST("/api/harvest", handlers.TriggerHarvest(s.getHarvestRunner))
 
 	sseHandler := mcp.NewSSEHandler(s.mcpServer)
 	streamableHandler := mcp.NewStreamableHTTPHandler(s.mcpServer)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -45,6 +45,8 @@ func registerRoutes(s *Server) {
 	api.GET("/wake-up", wakeUp)
 	data.POST("/wake-up", wakeUp)
 
+	s.echo.POST("/api/harvest", handlers.TriggerHarvest(&s.harvestRunner, s.logger))
+
 	sseHandler := mcp.NewSSEHandler(s.mcpServer)
 	streamableHandler := mcp.NewStreamableHTTPHandler(s.mcpServer)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -35,6 +36,7 @@ type Server struct {
 	embedder       embed.Embedder
 	searchService  *search.SearchService
 	mcpServer      *mcpsdk.Server
+	harvestMu      sync.RWMutex
 	harvestRunner  handlers.HarvestRunner
 	logger         zerolog.Logger
 	cfg            config.ServerConfig
@@ -114,5 +116,13 @@ func (s *Server) Echo() *echo.Echo {
 }
 
 func (s *Server) SetHarvestRunner(r handlers.HarvestRunner) {
+	s.harvestMu.Lock()
 	s.harvestRunner = r
+	s.harvestMu.Unlock()
+}
+
+func (s *Server) getHarvestRunner() handlers.HarvestRunner {
+	s.harvestMu.RLock()
+	defer s.harvestMu.RUnlock()
+	return s.harvestRunner
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nano-brain/nano-brain/internal/embed"
 	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
@@ -34,6 +35,7 @@ type Server struct {
 	embedder       embed.Embedder
 	searchService  *search.SearchService
 	mcpServer      *mcpsdk.Server
+	harvestRunner  handlers.HarvestRunner
 	logger         zerolog.Logger
 	cfg            config.ServerConfig
 	embedCfg       config.EmbeddingConfig
@@ -109,4 +111,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Echo returns the underlying Echo instance (for test route injection).
 func (s *Server) Echo() *echo.Echo {
 	return s.echo
+}
+
+func (s *Server) SetHarvestRunner(r handlers.HarvestRunner) {
+	s.harvestRunner = r
 }


### PR DESCRIPTION
## Story 6.5: Concurrent Harvester Safety and CLI Trigger

**Issue:** #104 | **FR:** FR-6, FR-80 | **Epic:** 6 — Session Harvesting

### Changes

**New:**
- `internal/server/handlers/harvest.go` — `TriggerHarvest` handler: POST /api/harvest
- `internal/server/handlers/harvest_test.go` — 5 tests (success, nil, concurrent)
- `cmd/nano-brain/commands.go` — `runHarvestCmd` with `--json` flag

**Modified:**
- `internal/harvest/runner.go` — `RunOnce()` method for one-shot execution
- `internal/server/server.go` — `SetHarvestRunner()` for lazy binding
- `internal/server/routes.go` — registered POST /api/harvest
- `cmd/nano-brain/main.go` — harvest subcommand dispatch

### Design
- No application-level locks — PostgreSQL upsert handles concurrent safety
- Pointer-to-interface pattern allows route registration before runner exists
- CLI calls `POST http://localhost:{port}/api/harvest`