### PR TITLE
feat: bench generate command and dataset generator (Story 7.1)

### DIFF
--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/nano-brain/nano-brain/internal/bench"
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	_ "github.com/lib/pq"
+)
+
+func runBenchCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench <generate> [flags]")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "generate":
+		runBenchGenerate(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown bench subcommand: %s\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func runBenchGenerate(args []string) {
+	var workspace, output string
+	var scale int
+	var jsonFlag bool
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--scale":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "--scale requires a value")
+				os.Exit(1)
+			}
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n < 1 {
+				fmt.Fprintln(os.Stderr, "--scale must be a positive integer")
+				os.Exit(1)
+			}
+			scale = n
+		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "--workspace requires a value")
+				os.Exit(1)
+			}
+			i++
+			workspace = args[i]
+		case "--output":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "--output requires a value")
+				os.Exit(1)
+			}
+			i++
+			output = args[i]
+		case "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	if workspace == "" || scale == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench generate --scale=N --workspace=HASH [--output=FILE] [--json]")
+		os.Exit(1)
+	}
+
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	db, err := sql.Open("postgres", cfg.Database.URL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	queries := sqlc.New(db)
+	store := &sqlcAdapter{q: queries}
+
+	dataset, err := bench.Generate(ctx, store, workspace, scale)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	data, err := json.MarshalIndent(dataset, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal dataset: %v\n", err)
+		os.Exit(1)
+	}
+
+	if output != "" {
+		if err := os.WriteFile(output, data, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write output file: %v\n", err)
+			os.Exit(1)
+		}
+		if !jsonFlag {
+			fmt.Printf("Dataset written to %s (%d entries)\n", output, len(dataset.Entries))
+		}
+		return
+	}
+
+	fmt.Println(string(data))
+}
+
+type sqlcAdapter struct {
+	q *sqlc.Queries
+}
+
+func (a *sqlcAdapter) CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error) {
+	return a.q.CountDocumentsByWorkspace(ctx, workspaceHash)
+}
+
+func (a *sqlcAdapter) ListDocumentsByWorkspace(ctx context.Context, workspaceHash string) ([]bench.DocumentRow, error) {
+	rows, err := a.q.ListDocumentsByWorkspace(ctx, workspaceHash)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]bench.DocumentRow, len(rows))
+	for i, r := range rows {
+		result[i] = bench.DocumentRow{
+			ID:            r.ID,
+			WorkspaceHash: r.WorkspaceHash,
+			ContentHash:   r.ContentHash,
+			Title:         r.Title,
+			SourcePath:    r.SourcePath,
+			Collection:    r.Collection,
+		}
+	}
+	return result, nil
+}

--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/nano-brain/nano-brain/internal/bench"
 	"github.com/nano-brain/nano-brain/internal/config"
@@ -28,7 +29,20 @@ func runBenchCmd(args []string) {
 	}
 }
 
+func splitEqualsArgs(args []string) []string {
+	var out []string
+	for _, a := range args {
+		if k, v, ok := strings.Cut(a, "="); ok && strings.HasPrefix(k, "--") {
+			out = append(out, k, v)
+		} else {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
 func runBenchGenerate(args []string) {
+	args = splitEqualsArgs(args)
 	var workspace, output string
 	var scale int
 	var jsonFlag bool
@@ -80,6 +94,8 @@ func runBenchGenerate(args []string) {
 		os.Exit(1)
 	}
 
+	ctx := context.Background()
+
 	db, err := sql.Open("postgres", cfg.Database.URL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
@@ -87,7 +103,10 @@ func runBenchGenerate(args []string) {
 	}
 	defer db.Close()
 
-	ctx := context.Background()
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to connect to database: %v\n", err)
+		os.Exit(1)
+	}
 	queries := sqlc.New(db)
 	store := &sqlcAdapter{q: queries}
 
@@ -119,10 +138,6 @@ func runBenchGenerate(args []string) {
 
 type sqlcAdapter struct {
 	q *sqlc.Queries
-}
-
-func (a *sqlcAdapter) CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error) {
-	return a.q.CountDocumentsByWorkspace(ctx, workspaceHash)
 }
 
 func (a *sqlcAdapter) ListDocumentsByWorkspace(ctx context.Context, workspaceHash string) ([]bench.DocumentRow, error) {

--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -6,13 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/nano-brain/nano-brain/internal/bench"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func runBenchCmd(args []string) {
@@ -94,9 +96,10 @@ func runBenchGenerate(args []string) {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
-	db, err := sql.Open("postgres", cfg.Database.URL)
+	db, err := sql.Open("pgx", cfg.Database.URL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
 		os.Exit(1)

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -53,6 +53,9 @@ func main() {
 		case "harvest":
 			runHarvestCmd(args[1:])
 			return
+		case "bench":
+			runBenchCmd(args[1:])
+			return
 		}
 	}
 

--- a/internal/bench/generate.go
+++ b/internal/bench/generate.go
@@ -1,0 +1,81 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type DocumentRow struct {
+	ID            uuid.UUID
+	WorkspaceHash string
+	ContentHash   string
+	Title         string
+	SourcePath    string
+	Collection    string
+}
+
+type DataStore interface {
+	CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error)
+	ListDocumentsByWorkspace(ctx context.Context, workspaceHash string) ([]DocumentRow, error)
+}
+
+func Generate(ctx context.Context, store DataStore, workspaceHash string, scale int) (*BenchmarkDataset, error) {
+	if scale < 1 {
+		return nil, fmt.Errorf("scale must be a positive integer, got %d", scale)
+	}
+
+	count, err := store.CountDocumentsByWorkspace(ctx, workspaceHash)
+	if err != nil {
+		return nil, fmt.Errorf("counting documents: %w", err)
+	}
+	if count < int64(scale) {
+		return nil, fmt.Errorf("workspace %q has %d documents, need at least %d", workspaceHash, count, scale)
+	}
+
+	docs, err := store.ListDocumentsByWorkspace(ctx, workspaceHash)
+	if err != nil {
+		return nil, fmt.Errorf("listing documents: %w", err)
+	}
+
+	shuffled := make([]DocumentRow, len(docs))
+	copy(shuffled, docs)
+	rng := rand.New(rand.NewSource(42))
+	rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	sampled := shuffled[:scale]
+
+	entries := make([]DatasetEntry, 0, scale)
+	for _, doc := range sampled {
+		query := deriveQuery(doc)
+		if query == "" {
+			continue
+		}
+		entries = append(entries, DatasetEntry{
+			Query:          query,
+			RelevantDocIDs: []string{doc.ID.String()},
+			SourceDocID:    doc.ID.String(),
+			SourceTitle:    doc.Title,
+		})
+	}
+
+	return &BenchmarkDataset{
+		Scale:         scale,
+		WorkspaceHash: workspaceHash,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Entries:       entries,
+	}, nil
+}
+
+func deriveQuery(doc DocumentRow) string {
+	if doc.Title != "" {
+		return strings.TrimSpace(doc.Title)
+	}
+	if doc.SourcePath != "" {
+		return strings.TrimSpace(doc.SourcePath)
+	}
+	return ""
+}

--- a/internal/bench/generate.go
+++ b/internal/bench/generate.go
@@ -20,7 +20,6 @@ type DocumentRow struct {
 }
 
 type DataStore interface {
-	CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error)
 	ListDocumentsByWorkspace(ctx context.Context, workspaceHash string) ([]DocumentRow, error)
 }
 
@@ -29,17 +28,12 @@ func Generate(ctx context.Context, store DataStore, workspaceHash string, scale 
 		return nil, fmt.Errorf("scale must be a positive integer, got %d", scale)
 	}
 
-	count, err := store.CountDocumentsByWorkspace(ctx, workspaceHash)
-	if err != nil {
-		return nil, fmt.Errorf("counting documents: %w", err)
-	}
-	if count < int64(scale) {
-		return nil, fmt.Errorf("workspace %q has %d documents, need at least %d", workspaceHash, count, scale)
-	}
-
 	docs, err := store.ListDocumentsByWorkspace(ctx, workspaceHash)
 	if err != nil {
 		return nil, fmt.Errorf("listing documents: %w", err)
+	}
+	if len(docs) < scale {
+		return nil, fmt.Errorf("workspace %q has %d documents, need at least %d", workspaceHash, len(docs), scale)
 	}
 
 	shuffled := make([]DocumentRow, len(docs))
@@ -50,12 +44,8 @@ func Generate(ctx context.Context, store DataStore, workspaceHash string, scale 
 
 	entries := make([]DatasetEntry, 0, scale)
 	for _, doc := range sampled {
-		query := deriveQuery(doc)
-		if query == "" {
-			continue
-		}
 		entries = append(entries, DatasetEntry{
-			Query:          query,
+			Query:          deriveQuery(doc),
 			RelevantDocIDs: []string{doc.ID.String()},
 			SourceDocID:    doc.ID.String(),
 			SourceTitle:    doc.Title,
@@ -77,5 +67,5 @@ func deriveQuery(doc DocumentRow) string {
 	if doc.SourcePath != "" {
 		return strings.TrimSpace(doc.SourcePath)
 	}
-	return ""
+	return doc.ID.String()
 }

--- a/internal/bench/generate_test.go
+++ b/internal/bench/generate_test.go
@@ -10,16 +10,8 @@ import (
 )
 
 type mockStore struct {
-	count int64
-	docs  []DocumentRow
-	err   error
-}
-
-func (m *mockStore) CountDocumentsByWorkspace(_ context.Context, _ string) (int64, error) {
-	if m.err != nil {
-		return 0, m.err
-	}
-	return m.count, nil
+	docs []DocumentRow
+	err  error
 }
 
 func (m *mockStore) ListDocumentsByWorkspace(_ context.Context, _ string) ([]DocumentRow, error) {
@@ -46,7 +38,7 @@ func makeDocs(n int) []DocumentRow {
 
 func TestGenerate_Success(t *testing.T) {
 	docs := makeDocs(10)
-	store := &mockStore{count: 10, docs: docs}
+	store := &mockStore{docs: docs}
 
 	ds, err := Generate(context.Background(), store, "ws-test", 5)
 	if err != nil {
@@ -75,7 +67,7 @@ func TestGenerate_Success(t *testing.T) {
 }
 
 func TestGenerate_InsufficientDocuments(t *testing.T) {
-	store := &mockStore{count: 3, docs: makeDocs(3)}
+	store := &mockStore{docs: makeDocs(3)}
 
 	_, err := Generate(context.Background(), store, "ws-test", 10)
 	if err == nil {
@@ -84,7 +76,7 @@ func TestGenerate_InsufficientDocuments(t *testing.T) {
 }
 
 func TestGenerate_InvalidScale(t *testing.T) {
-	store := &mockStore{count: 10, docs: makeDocs(10)}
+	store := &mockStore{docs: makeDocs(10)}
 
 	_, err := Generate(context.Background(), store, "ws-test", 0)
 	if err == nil {
@@ -105,16 +97,41 @@ func TestGenerate_StoreError(t *testing.T) {
 	}
 }
 
+func TestGenerate_ListError(t *testing.T) {
+	store := &mockStore{err: fmt.Errorf("list query failed")}
+
+	_, err := Generate(context.Background(), store, "ws-test", 1)
+	if err == nil {
+		t.Fatal("expected error from list failure")
+	}
+}
+
+func TestGenerate_EmptyTitleAndPath(t *testing.T) {
+	id := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	store := &mockStore{docs: []DocumentRow{{ID: id, WorkspaceHash: "ws-test", ContentHash: "h1"}}}
+
+	ds, err := Generate(context.Background(), store, "ws-test", 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ds.Entries) != 1 {
+		t.Fatalf("entries count = %d, want 1", len(ds.Entries))
+	}
+	if ds.Entries[0].Query != id.String() {
+		t.Errorf("query = %q, want doc ID %q", ds.Entries[0].Query, id.String())
+	}
+}
+
 func TestGenerate_Deterministic(t *testing.T) {
 	docs := makeDocs(20)
-	store := &mockStore{count: 20, docs: docs}
+	store := &mockStore{docs: docs}
 
 	ds1, err := Generate(context.Background(), store, "ws-test", 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	store2 := &mockStore{count: 20, docs: docs}
+	store2 := &mockStore{docs: docs}
 	ds2, err := Generate(context.Background(), store2, "ws-test", 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -144,9 +161,9 @@ func TestDeriveQuery(t *testing.T) {
 			want: "/path/to/file.md",
 		},
 		{
-			name: "returns empty when both empty",
-			doc:  DocumentRow{Title: "", SourcePath: ""},
-			want: "",
+			name: "falls back to doc ID when both empty",
+			doc:  DocumentRow{ID: uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), Title: "", SourcePath: ""},
+			want: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		},
 		{
 			name: "trims whitespace",

--- a/internal/bench/generate_test.go
+++ b/internal/bench/generate_test.go
@@ -1,0 +1,204 @@
+package bench
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type mockStore struct {
+	count int64
+	docs  []DocumentRow
+	err   error
+}
+
+func (m *mockStore) CountDocumentsByWorkspace(_ context.Context, _ string) (int64, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	return m.count, nil
+}
+
+func (m *mockStore) ListDocumentsByWorkspace(_ context.Context, _ string) ([]DocumentRow, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.docs, nil
+}
+
+func makeDocs(n int) []DocumentRow {
+	docs := make([]DocumentRow, n)
+	for i := range docs {
+		docs[i] = DocumentRow{
+			ID:            uuid.New(),
+			WorkspaceHash: "ws-test",
+			ContentHash:   fmt.Sprintf("hash-%d", i),
+			Title:         fmt.Sprintf("Document %d", i),
+			SourcePath:    fmt.Sprintf("/path/to/doc-%d.md", i),
+			Collection:    "test-collection",
+		}
+	}
+	return docs
+}
+
+func TestGenerate_Success(t *testing.T) {
+	docs := makeDocs(10)
+	store := &mockStore{count: 10, docs: docs}
+
+	ds, err := Generate(context.Background(), store, "ws-test", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ds.Scale != 5 {
+		t.Errorf("scale = %d, want 5", ds.Scale)
+	}
+	if ds.WorkspaceHash != "ws-test" {
+		t.Errorf("workspace_hash = %q, want %q", ds.WorkspaceHash, "ws-test")
+	}
+	if len(ds.Entries) != 5 {
+		t.Errorf("entries count = %d, want 5", len(ds.Entries))
+	}
+	for _, e := range ds.Entries {
+		if e.Query == "" {
+			t.Error("entry has empty query")
+		}
+		if len(e.RelevantDocIDs) != 1 {
+			t.Errorf("relevant_doc_ids count = %d, want 1", len(e.RelevantDocIDs))
+		}
+		if e.SourceDocID == "" {
+			t.Error("entry has empty source_doc_id")
+		}
+	}
+}
+
+func TestGenerate_InsufficientDocuments(t *testing.T) {
+	store := &mockStore{count: 3, docs: makeDocs(3)}
+
+	_, err := Generate(context.Background(), store, "ws-test", 10)
+	if err == nil {
+		t.Fatal("expected error for insufficient documents")
+	}
+}
+
+func TestGenerate_InvalidScale(t *testing.T) {
+	store := &mockStore{count: 10, docs: makeDocs(10)}
+
+	_, err := Generate(context.Background(), store, "ws-test", 0)
+	if err == nil {
+		t.Fatal("expected error for scale=0")
+	}
+	_, err = Generate(context.Background(), store, "ws-test", -1)
+	if err == nil {
+		t.Fatal("expected error for scale=-1")
+	}
+}
+
+func TestGenerate_StoreError(t *testing.T) {
+	store := &mockStore{err: fmt.Errorf("db connection failed")}
+
+	_, err := Generate(context.Background(), store, "ws-test", 5)
+	if err == nil {
+		t.Fatal("expected error from store failure")
+	}
+}
+
+func TestGenerate_Deterministic(t *testing.T) {
+	docs := makeDocs(20)
+	store := &mockStore{count: 20, docs: docs}
+
+	ds1, err := Generate(context.Background(), store, "ws-test", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	store2 := &mockStore{count: 20, docs: docs}
+	ds2, err := Generate(context.Background(), store2, "ws-test", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := range ds1.Entries {
+		if ds1.Entries[i].SourceDocID != ds2.Entries[i].SourceDocID {
+			t.Errorf("entry %d: source_doc_id mismatch (not deterministic)", i)
+		}
+	}
+}
+
+func TestDeriveQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  DocumentRow
+		want string
+	}{
+		{
+			name: "uses title when present",
+			doc:  DocumentRow{Title: "My Document Title", SourcePath: "/path"},
+			want: "My Document Title",
+		},
+		{
+			name: "falls back to source_path",
+			doc:  DocumentRow{Title: "", SourcePath: "/path/to/file.md"},
+			want: "/path/to/file.md",
+		},
+		{
+			name: "returns empty when both empty",
+			doc:  DocumentRow{Title: "", SourcePath: ""},
+			want: "",
+		},
+		{
+			name: "trims whitespace",
+			doc:  DocumentRow{Title: "  spaced title  "},
+			want: "spaced title",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveQuery(tt.doc)
+			if got != tt.want {
+				t.Errorf("deriveQuery() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBenchmarkDataset_JSONRoundtrip(t *testing.T) {
+	ds := BenchmarkDataset{
+		Scale:         5,
+		WorkspaceHash: "ws-test",
+		GeneratedAt:   "2025-01-01T00:00:00Z",
+		Entries: []DatasetEntry{
+			{
+				Query:          "test query",
+				RelevantDocIDs: []string{"id-1"},
+				SourceDocID:    "id-1",
+				SourceTitle:    "Test Doc",
+			},
+		},
+	}
+
+	data, err := json.Marshal(ds)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded BenchmarkDataset
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.Scale != ds.Scale {
+		t.Errorf("scale = %d, want %d", decoded.Scale, ds.Scale)
+	}
+	if decoded.WorkspaceHash != ds.WorkspaceHash {
+		t.Errorf("workspace_hash = %q, want %q", decoded.WorkspaceHash, ds.WorkspaceHash)
+	}
+	if len(decoded.Entries) != 1 {
+		t.Fatalf("entries count = %d, want 1", len(decoded.Entries))
+	}
+	if decoded.Entries[0].Query != "test query" {
+		t.Errorf("entry query = %q, want %q", decoded.Entries[0].Query, "test query")
+	}
+}

--- a/internal/bench/types.go
+++ b/internal/bench/types.go
@@ -1,0 +1,18 @@
+// Package bench provides benchmark dataset generation and evaluation tools.
+package bench
+
+// DatasetEntry represents a single query-document pair for retrieval evaluation.
+type DatasetEntry struct {
+	Query          string   `json:"query"`
+	RelevantDocIDs []string `json:"relevant_doc_ids"`
+	SourceDocID    string   `json:"source_doc_id"`
+	SourceTitle    string   `json:"source_title"`
+}
+
+// BenchmarkDataset holds a complete benchmark dataset with metadata.
+type BenchmarkDataset struct {
+	Scale         int            `json:"scale"`
+	WorkspaceHash string         `json:"workspace_hash"`
+	GeneratedAt   string         `json:"generated_at"`
+	Entries       []DatasetEntry `json:"entries"`
+}


### PR DESCRIPTION
## Story 7.1: Dataset Generator (bench generate)

**Issue:** #106 | **FR:** FR-37 | **Epic:** 7 — Benchmarking Suite

### Changes

**New:**
- `internal/bench/types.go` — `BenchmarkDataset`, `DatasetEntry` types
- `internal/bench/generate.go` — `Generate()` function with `DataStore` interface
- `internal/bench/generate_test.go` — 7 unit tests
- `cmd/nano-brain/bench.go` — CLI: `bench generate --scale=N --workspace=HASH`

**Modified:**
- `cmd/nano-brain/main.go` — added `bench` subcommand dispatch

### Design
- Direct DB connection (not API) for bench tooling — self-contained
- Deterministic sampling (fixed seed) for reproducible datasets
- Query derivation: document title → query, fallback to source_path
- `DataStore` interface decouples from sqlc for testability