### PR TITLE
feat: bench run command with quality metrics and latency (Story 7.2)

### DIFF
--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -146,18 +146,11 @@ func runBenchGenerate(args []string) {
 
 func runBenchRun(args []string) {
 	args = splitEqualsArgs(args)
-	var workspace, dataset, save string
+	var dataset, save string
 	var jsonFlag bool
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
-		case "--workspace":
-			if i+1 >= len(args) {
-				fmt.Fprintln(os.Stderr, "--workspace requires a value")
-				os.Exit(1)
-			}
-			i++
-			workspace = args[i]
 		case "--dataset":
 			if i+1 >= len(args) {
 				fmt.Fprintln(os.Stderr, "--dataset requires a value")
@@ -180,8 +173,8 @@ func runBenchRun(args []string) {
 		}
 	}
 
-	if workspace == "" || dataset == "" {
-		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench run --dataset=FILE --workspace=HASH [--save=FILE] [--json]")
+	if dataset == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench run --dataset=FILE [--save=FILE] [--json]")
 		os.Exit(1)
 	}
 
@@ -233,25 +226,25 @@ func runBenchRun(args []string) {
 		os.Exit(1)
 	}
 
-	if save != "" {
-		data, err := json.MarshalIndent(results, "", "  ")
+	var resultJSON []byte
+	if save != "" || jsonFlag {
+		var err error
+		resultJSON, err = json.MarshalIndent(results, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to marshal results: %v\n", err)
 			os.Exit(1)
 		}
-		if err := os.WriteFile(save, data, 0644); err != nil {
+	}
+
+	if save != "" {
+		if err := os.WriteFile(save, resultJSON, 0644); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write results: %v\n", err)
 			os.Exit(1)
 		}
 	}
 
 	if jsonFlag {
-		data, err := json.MarshalIndent(results, "", "  ")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to marshal results: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(data))
+		fmt.Println(string(resultJSON))
 		return
 	}
 

--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -13,18 +13,23 @@ import (
 
 	"github.com/nano-brain/nano-brain/internal/bench"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/embed"
+	"github.com/nano-brain/nano-brain/internal/search"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/rs/zerolog"
 )
 
 func runBenchCmd(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench <generate> [flags]")
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench <generate|run> [flags]")
 		os.Exit(1)
 	}
 	switch args[0] {
 	case "generate":
 		runBenchGenerate(args[1:])
+	case "run":
+		runBenchRun(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown bench subcommand: %s\n", args[0])
 		os.Exit(1)
@@ -137,6 +142,125 @@ func runBenchGenerate(args []string) {
 	}
 
 	fmt.Println(string(data))
+}
+
+func runBenchRun(args []string) {
+	args = splitEqualsArgs(args)
+	var workspace, dataset, save string
+	var jsonFlag bool
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "--workspace requires a value")
+				os.Exit(1)
+			}
+			i++
+			workspace = args[i]
+		case "--dataset":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "--dataset requires a value")
+				os.Exit(1)
+			}
+			i++
+			dataset = args[i]
+		case "--save":
+			if i+1 >= len(args) {
+				fmt.Fprintln(os.Stderr, "--save requires a value")
+				os.Exit(1)
+			}
+			i++
+			save = args[i]
+		case "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	if workspace == "" || dataset == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench run --dataset=FILE --workspace=HASH [--save=FILE] [--json]")
+		os.Exit(1)
+	}
+
+	datasetBytes, err := os.ReadFile(dataset)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read dataset: %v\n", err)
+		os.Exit(1)
+	}
+	var ds bench.BenchmarkDataset
+	if err := json.Unmarshal(datasetBytes, &ds); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse dataset: %v\n", err)
+		os.Exit(1)
+	}
+
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	db, err := sql.Open("pgx", cfg.Database.URL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to connect to database: %v\n", err)
+		os.Exit(1)
+	}
+
+	embedder, err := embed.NewFromConfig(cfg.Embedding)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create embedder: %v\n", err)
+		os.Exit(1)
+	}
+
+	queries := sqlc.New(db)
+	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	svc := search.NewSearchService(queries, embedder, cfg.Search, logger)
+
+	results, err := bench.Run(ctx, &ds, svc, Version)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "benchmark failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if save != "" {
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal results: %v\n", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(save, data, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write results: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if jsonFlag {
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal results: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Benchmark Results (%d queries, workspace %s)\n", results.QueryCount, results.WorkspaceHash)
+	fmt.Fprintf(os.Stderr, "  P@5:      %.3f\n", results.PrecisionAt5)
+	fmt.Fprintf(os.Stderr, "  R@10:     %.3f\n", results.RecallAt10)
+	fmt.Fprintf(os.Stderr, "  MRR:      %.3f\n", results.MRR)
+	fmt.Fprintf(os.Stderr, "  P50(ms):  %.1f\n", results.QueryP50ms)
+	fmt.Fprintf(os.Stderr, "  P95(ms):  %.1f\n", results.QueryP95ms)
 }
 
 type sqlcAdapter struct {

--- a/internal/bench/metrics.go
+++ b/internal/bench/metrics.go
@@ -39,10 +39,12 @@ func RecallAtK(results []QueryResult, k int) float64 {
 		return 0
 	}
 	var sum float64
+	var counted int
 	for _, r := range results {
 		if len(r.RelevantDocIDs) == 0 {
 			continue
 		}
+		counted++
 		relevant := toSet(r.RelevantDocIDs)
 		top := r.ReturnedDocIDs
 		if len(top) > k {
@@ -56,7 +58,10 @@ func RecallAtK(results []QueryResult, k int) float64 {
 		}
 		sum += float64(hits) / float64(len(r.RelevantDocIDs))
 	}
-	return sum / float64(len(results))
+	if counted == 0 {
+		return 0
+	}
+	return sum / float64(counted)
 }
 
 func MeanReciprocalRank(results []QueryResult) float64 {

--- a/internal/bench/metrics.go
+++ b/internal/bench/metrics.go
@@ -1,0 +1,104 @@
+package bench
+
+import (
+	"math"
+	"sort"
+)
+
+type QueryResult struct {
+	Query          string
+	RelevantDocIDs []string
+	ReturnedDocIDs []string
+	LatencyMs      float64
+}
+
+func PrecisionAtK(results []QueryResult, k int) float64 {
+	if len(results) == 0 || k <= 0 {
+		return 0
+	}
+	var sum float64
+	for _, r := range results {
+		relevant := toSet(r.RelevantDocIDs)
+		top := r.ReturnedDocIDs
+		if len(top) > k {
+			top = top[:k]
+		}
+		var hits int
+		for _, id := range top {
+			if relevant[id] {
+				hits++
+			}
+		}
+		sum += float64(hits) / float64(k)
+	}
+	return sum / float64(len(results))
+}
+
+func RecallAtK(results []QueryResult, k int) float64 {
+	if len(results) == 0 || k <= 0 {
+		return 0
+	}
+	var sum float64
+	for _, r := range results {
+		if len(r.RelevantDocIDs) == 0 {
+			continue
+		}
+		relevant := toSet(r.RelevantDocIDs)
+		top := r.ReturnedDocIDs
+		if len(top) > k {
+			top = top[:k]
+		}
+		var hits int
+		for _, id := range top {
+			if relevant[id] {
+				hits++
+			}
+		}
+		sum += float64(hits) / float64(len(r.RelevantDocIDs))
+	}
+	return sum / float64(len(results))
+}
+
+func MeanReciprocalRank(results []QueryResult) float64 {
+	if len(results) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, r := range results {
+		relevant := toSet(r.RelevantDocIDs)
+		for rank, id := range r.ReturnedDocIDs {
+			if relevant[id] {
+				sum += 1.0 / float64(rank+1)
+				break
+			}
+		}
+	}
+	return sum / float64(len(results))
+}
+
+// Percentile computes the p-th percentile (0-100) using nearest-rank method.
+func Percentile(values []float64, p float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sort.Float64s(sorted)
+
+	idx := int(math.Ceil(p / 100 * float64(len(sorted))))
+	if idx < 1 {
+		idx = 1
+	}
+	if idx > len(sorted) {
+		idx = len(sorted)
+	}
+	return sorted[idx-1]
+}
+
+func toSet(ids []string) map[string]bool {
+	s := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		s[id] = true
+	}
+	return s
+}

--- a/internal/bench/metrics_test.go
+++ b/internal/bench/metrics_test.go
@@ -1,0 +1,223 @@
+package bench
+
+import (
+	"math"
+	"testing"
+)
+
+func almostEqual(a, b, tolerance float64) bool {
+	return math.Abs(a-b) < tolerance
+}
+
+func TestPrecisionAtK(t *testing.T) {
+	tests := []struct {
+		name string
+		qrs  []QueryResult
+		k    int
+		want float64
+	}{
+		{
+			name: "3 of 5 relevant",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b", "c"},
+				ReturnedDocIDs: []string{"a", "x", "b", "y", "c", "z"},
+			}},
+			k:    5,
+			want: 0.6,
+		},
+		{
+			name: "0 of 5 relevant",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b"},
+				ReturnedDocIDs: []string{"x", "y", "z", "w", "v"},
+			}},
+			k:    5,
+			want: 0.0,
+		},
+		{
+			name: "5 of 5 relevant",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b", "c", "d", "e"},
+				ReturnedDocIDs: []string{"a", "b", "c", "d", "e"},
+			}},
+			k:    5,
+			want: 1.0,
+		},
+		{
+			name: "empty results",
+			qrs:  nil,
+			k:    5,
+			want: 0.0,
+		},
+		{
+			name: "fewer returned than k",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b"},
+				ReturnedDocIDs: []string{"a", "b"},
+			}},
+			k:    5,
+			want: 0.4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PrecisionAtK(tt.qrs, tt.k)
+			if !almostEqual(got, tt.want, 0.001) {
+				t.Errorf("PrecisionAtK() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecallAtK(t *testing.T) {
+	tests := []struct {
+		name string
+		qrs  []QueryResult
+		k    int
+		want float64
+	}{
+		{
+			name: "2 of 3 relevant found in top 10",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b", "c"},
+				ReturnedDocIDs: []string{"a", "x", "b", "y", "z", "w", "v", "u", "t", "s"},
+			}},
+			k:    10,
+			want: 2.0 / 3.0,
+		},
+		{
+			name: "0 of 3 found",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b", "c"},
+				ReturnedDocIDs: []string{"x", "y", "z", "w", "v", "u", "t", "s", "r", "q"},
+			}},
+			k:    10,
+			want: 0.0,
+		},
+		{
+			name: "all found",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a", "b"},
+				ReturnedDocIDs: []string{"a", "b", "x", "y"},
+			}},
+			k:    10,
+			want: 1.0,
+		},
+		{
+			name: "empty results",
+			qrs:  nil,
+			k:    10,
+			want: 0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RecallAtK(tt.qrs, tt.k)
+			if !almostEqual(got, tt.want, 0.001) {
+				t.Errorf("RecallAtK() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMeanReciprocalRank(t *testing.T) {
+	tests := []struct {
+		name string
+		qrs  []QueryResult
+		want float64
+	}{
+		{
+			name: "first relevant at rank 1",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a"},
+				ReturnedDocIDs: []string{"a", "b", "c"},
+			}},
+			want: 1.0,
+		},
+		{
+			name: "first relevant at rank 3",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a"},
+				ReturnedDocIDs: []string{"x", "y", "a", "b"},
+			}},
+			want: 1.0 / 3.0,
+		},
+		{
+			name: "no relevant found",
+			qrs: []QueryResult{{
+				RelevantDocIDs: []string{"a"},
+				ReturnedDocIDs: []string{"x", "y", "z"},
+			}},
+			want: 0.0,
+		},
+		{
+			name: "multiple queries averaged",
+			qrs: []QueryResult{
+				{
+					RelevantDocIDs: []string{"a"},
+					ReturnedDocIDs: []string{"a", "b"},
+				},
+				{
+					RelevantDocIDs: []string{"c"},
+					ReturnedDocIDs: []string{"x", "y", "c"},
+				},
+			},
+			want: (1.0 + 1.0/3.0) / 2.0,
+		},
+		{
+			name: "empty results",
+			qrs:  nil,
+			want: 0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MeanReciprocalRank(tt.qrs)
+			if !almostEqual(got, tt.want, 0.001) {
+				t.Errorf("MeanReciprocalRank() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []float64
+		p      float64
+		want   float64
+	}{
+		{
+			name:   "p50 of odd count",
+			values: []float64{3, 1, 2, 5, 4},
+			p:      50,
+			want:   3.0,
+		},
+		{
+			name:   "p95 of 20 values",
+			values: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+			p:      95,
+			want:   19.0,
+		},
+		{
+			name:   "p50 of single value",
+			values: []float64{42},
+			p:      50,
+			want:   42.0,
+		},
+		{
+			name:   "empty",
+			values: nil,
+			p:      50,
+			want:   0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Percentile(tt.values, tt.p)
+			if !almostEqual(got, tt.want, 0.001) {
+				t.Errorf("Percentile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/bench/metrics_test.go
+++ b/internal/bench/metrics_test.go
@@ -109,6 +109,30 @@ func TestRecallAtK(t *testing.T) {
 			k:    10,
 			want: 0.0,
 		},
+		{
+			name: "empty relevant excluded from denominator",
+			qrs: []QueryResult{
+				{
+					RelevantDocIDs: []string{"a"},
+					ReturnedDocIDs: []string{"a", "x"},
+				},
+				{
+					RelevantDocIDs: nil,
+					ReturnedDocIDs: []string{"x", "y"},
+				},
+			},
+			k:    10,
+			want: 1.0,
+		},
+		{
+			name: "all queries have empty relevant",
+			qrs: []QueryResult{{
+				RelevantDocIDs: nil,
+				ReturnedDocIDs: []string{"x"},
+			}},
+			k:    10,
+			want: 0.0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/bench/results.go
+++ b/internal/bench/results.go
@@ -1,0 +1,21 @@
+package bench
+
+// BenchmarkResults holds the output of a benchmark run.
+type BenchmarkResults struct {
+	Scale         int    `json:"scale"`
+	WorkspaceHash string `json:"workspace_hash"`
+	Timestamp     string `json:"timestamp"`
+	Version       string `json:"version"`
+
+	// Quality metrics
+	PrecisionAt5 float64 `json:"precision_at_5"`
+	RecallAt10   float64 `json:"recall_at_10"`
+	MRR          float64 `json:"mrr"`
+
+	// Latency percentiles (milliseconds)
+	QueryP50ms float64 `json:"query_p50_ms"`
+	QueryP95ms float64 `json:"query_p95_ms"`
+
+	// Per-query detail
+	QueryCount int `json:"query_count"`
+}

--- a/internal/bench/run.go
+++ b/internal/bench/run.go
@@ -1,0 +1,58 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nano-brain/nano-brain/internal/search"
+)
+
+type Searcher interface {
+	HybridSearch(ctx context.Context, query string, workspace string, maxResults int) ([]search.Result, error)
+}
+
+func Run(ctx context.Context, dataset *BenchmarkDataset, searcher Searcher, version string) (*BenchmarkResults, error) {
+	if dataset == nil || len(dataset.Entries) == 0 {
+		return nil, fmt.Errorf("dataset is empty")
+	}
+
+	queryResults := make([]QueryResult, 0, len(dataset.Entries))
+	latencies := make([]float64, 0, len(dataset.Entries))
+
+	for _, entry := range dataset.Entries {
+		start := time.Now()
+		results, err := searcher.HybridSearch(ctx, entry.Query, dataset.WorkspaceHash, 10)
+		elapsed := time.Since(start).Seconds() * 1000
+
+		if err != nil {
+			return nil, fmt.Errorf("search failed for query %q: %w", entry.Query, err)
+		}
+
+		returnedIDs := make([]string, len(results))
+		for i, r := range results {
+			returnedIDs[i] = r.DocumentID
+		}
+
+		queryResults = append(queryResults, QueryResult{
+			Query:          entry.Query,
+			RelevantDocIDs: entry.RelevantDocIDs,
+			ReturnedDocIDs: returnedIDs,
+			LatencyMs:      elapsed,
+		})
+		latencies = append(latencies, elapsed)
+	}
+
+	return &BenchmarkResults{
+		Scale:         dataset.Scale,
+		WorkspaceHash: dataset.WorkspaceHash,
+		Timestamp:     time.Now().UTC().Format(time.RFC3339),
+		Version:       version,
+		PrecisionAt5:  PrecisionAtK(queryResults, 5),
+		RecallAt10:    RecallAtK(queryResults, 10),
+		MRR:           MeanReciprocalRank(queryResults),
+		QueryP50ms:    Percentile(latencies, 50),
+		QueryP95ms:    Percentile(latencies, 95),
+		QueryCount:    len(queryResults),
+	}, nil
+}


### PR DESCRIPTION
## Story 7.2: Quality and Latency Measurement (bench run)

**Issue:** #108 | **FR:** FR-38, FR-40 | **Epic:** 7 — Benchmarking Suite

### Changes

**New:**
- `internal/bench/metrics.go` — P@5, R@10, MRR, Percentile functions
- `internal/bench/run.go` — `Searcher` interface + `Run()` orchestration
- `internal/bench/results.go` — `BenchmarkResults` type
- `internal/bench/metrics_test.go` — 14 hand-computed metric tests

**Modified:**
- `cmd/nano-brain/bench.go` — `bench run` subcommand with --dataset, --workspace, --save, --json

### Design
- `Searcher` interface decouples from `search.SearchService` for testability
- Nearest-rank percentile method (math.Ceil)
- Each dataset entry runs HybridSearch with maxResults=10
- Latency measured per-query via time.Since