### PR TITLE
feat: bench compare command for regression detection (Story 7.3)

### DIFF
--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -22,7 +22,7 @@ import (
 
 func runBenchCmd(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench <generate|run> [flags]")
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench <generate|run|compare> [flags]")
 		os.Exit(1)
 	}
 	switch args[0] {
@@ -30,6 +30,8 @@ func runBenchCmd(args []string) {
 		runBenchGenerate(args[1:])
 	case "run":
 		runBenchRun(args[1:])
+	case "compare":
+		runBenchCompare(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown bench subcommand: %s\n", args[0])
 		os.Exit(1)
@@ -254,6 +256,94 @@ func runBenchRun(args []string) {
 	fmt.Fprintf(os.Stderr, "  MRR:      %.3f\n", results.MRR)
 	fmt.Fprintf(os.Stderr, "  P50(ms):  %.1f\n", results.QueryP50ms)
 	fmt.Fprintf(os.Stderr, "  P95(ms):  %.1f\n", results.QueryP95ms)
+}
+
+func runBenchCompare(args []string) {
+	var jsonFlag bool
+	var positionalArgs []string
+
+	for _, arg := range args {
+		if arg == "--json" {
+			jsonFlag = true
+		} else {
+			positionalArgs = append(positionalArgs, arg)
+		}
+	}
+
+	if len(positionalArgs) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench compare <new.json> <baseline.json> [--json]")
+		os.Exit(1)
+	}
+
+	newFile := positionalArgs[0]
+	baselineFile := positionalArgs[1]
+
+	newBytes, err := os.ReadFile(newFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read new results: %v\n", err)
+		os.Exit(1)
+	}
+	var newResults bench.BenchmarkResults
+	if err := json.Unmarshal(newBytes, &newResults); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse new results: %v\n", err)
+		os.Exit(1)
+	}
+
+	baselineBytes, err := os.ReadFile(baselineFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read baseline results: %v\n", err)
+		os.Exit(1)
+	}
+	var baselineResults bench.BenchmarkResults
+	if err := json.Unmarshal(baselineBytes, &baselineResults); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse baseline results: %v\n", err)
+		os.Exit(1)
+	}
+
+	result := bench.Compare(&newResults, &baselineResults)
+
+	if jsonFlag {
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to marshal result: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+	} else {
+		fmt.Fprintln(os.Stderr, "Benchmark Comparison")
+		fmt.Fprintln(os.Stderr, "====================")
+		fmt.Fprintf(os.Stderr, "Status: ")
+		if result.Passed {
+			fmt.Fprintln(os.Stderr, "PASS")
+		} else {
+			fmt.Fprintln(os.Stderr, "FAIL")
+		}
+
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Deltas:")
+		fmt.Fprintf(os.Stderr, "  %-15s %12s %12s %12s\n", "Metric", "Baseline", "New", "Change")
+		for _, metric := range []string{"P@5", "R@10", "MRR", "Query P50", "Query P95"} {
+			if delta, ok := result.Deltas[metric]; ok {
+				sign := ""
+				if delta.Change >= 0 {
+					sign = "+"
+				}
+				fmt.Fprintf(os.Stderr, "  %-15s %12.4f %12.4f %12s%.4f\n", metric, delta.Baseline, delta.New, sign, delta.Change)
+			}
+		}
+
+		if len(result.Regressions) > 0 {
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Regressions:")
+			for _, reg := range result.Regressions {
+				fmt.Fprintf(os.Stderr, "  %s\n", reg.Message)
+			}
+		}
+	}
+
+	if !result.Passed {
+		os.Exit(1)
+	}
 }
 
 type sqlcAdapter struct {

--- a/internal/bench/compare.go
+++ b/internal/bench/compare.go
@@ -1,0 +1,131 @@
+package bench
+
+import (
+	"fmt"
+)
+
+// ComparisonResult holds the output of comparing two benchmark runs.
+type ComparisonResult struct {
+	Passed      bool             `json:"passed"`
+	Regressions []Regression     `json:"regressions"`
+	Deltas      map[string]Delta `json:"deltas"`
+}
+
+// Regression describes a metric that failed its threshold check.
+type Regression struct {
+	Metric    string  `json:"metric"`
+	Baseline  float64 `json:"baseline"`
+	New       float64 `json:"new"`
+	Drop      float64 `json:"drop"`
+	Threshold float64 `json:"threshold"`
+	Message   string  `json:"message"`
+}
+
+// Delta describes the change in a metric between two runs.
+type Delta struct {
+	Baseline float64 `json:"baseline"`
+	New      float64 `json:"new"`
+	Change   float64 `json:"change"` // positive = improvement
+}
+
+// Compare takes new and baseline benchmark results and returns a ComparisonResult.
+// Thresholds (from spec):
+// - P@5: drop > 0.10 from baseline → regression (higher is better)
+// - R@10: drop > 0.10 from baseline → regression (higher is better)
+// - MRR: drop > 0.05 from baseline → regression (higher is better)
+// - Query P95: new > 2x baseline → regression (lower is better)
+// Uses epsilon comparison for floating-point thresholds.
+const epsilon = 1e-9
+
+func Compare(newResults, baseline *BenchmarkResults) *ComparisonResult {
+	result := &ComparisonResult{
+		Passed:      true,
+		Regressions: []Regression{},
+		Deltas:      make(map[string]Delta),
+	}
+
+	// P@5: higher is better, drop > 0.10 is regression
+	p5Drop := baseline.PrecisionAt5 - newResults.PrecisionAt5
+	result.Deltas["P@5"] = Delta{
+		Baseline: baseline.PrecisionAt5,
+		New:      newResults.PrecisionAt5,
+		Change:   newResults.PrecisionAt5 - baseline.PrecisionAt5,
+	}
+	if p5Drop > 0.10+epsilon {
+		result.Passed = false
+		result.Regressions = append(result.Regressions, Regression{
+			Metric:    "P@5",
+			Baseline:  baseline.PrecisionAt5,
+			New:       newResults.PrecisionAt5,
+			Drop:      p5Drop,
+			Threshold: 0.10,
+			Message:   fmt.Sprintf("P@5 dropped by %.4f (threshold: 0.10)", p5Drop),
+		})
+	}
+
+	// R@10: higher is better, drop > 0.10 is regression
+	r10Drop := baseline.RecallAt10 - newResults.RecallAt10
+	result.Deltas["R@10"] = Delta{
+		Baseline: baseline.RecallAt10,
+		New:      newResults.RecallAt10,
+		Change:   newResults.RecallAt10 - baseline.RecallAt10,
+	}
+	if r10Drop > 0.10+epsilon {
+		result.Passed = false
+		result.Regressions = append(result.Regressions, Regression{
+			Metric:    "R@10",
+			Baseline:  baseline.RecallAt10,
+			New:       newResults.RecallAt10,
+			Drop:      r10Drop,
+			Threshold: 0.10,
+			Message:   fmt.Sprintf("R@10 dropped by %.4f (threshold: 0.10)", r10Drop),
+		})
+	}
+
+	// MRR: higher is better, drop > 0.05 is regression
+	mrrDrop := baseline.MRR - newResults.MRR
+	result.Deltas["MRR"] = Delta{
+		Baseline: baseline.MRR,
+		New:      newResults.MRR,
+		Change:   newResults.MRR - baseline.MRR,
+	}
+	if mrrDrop > 0.05+epsilon {
+		result.Passed = false
+		result.Regressions = append(result.Regressions, Regression{
+			Metric:    "MRR",
+			Baseline:  baseline.MRR,
+			New:       newResults.MRR,
+			Drop:      mrrDrop,
+			Threshold: 0.05,
+			Message:   fmt.Sprintf("MRR dropped by %.4f (threshold: 0.05)", mrrDrop),
+		})
+	}
+
+	// Query P95: lower is better, new > 2x baseline is regression
+	p95Ratio := 2.0
+	result.Deltas["Query P95"] = Delta{
+		Baseline: baseline.QueryP95ms,
+		New:      newResults.QueryP95ms,
+		Change:   baseline.QueryP95ms - newResults.QueryP95ms,
+	}
+	if newResults.QueryP95ms > p95Ratio*baseline.QueryP95ms+epsilon {
+		result.Passed = false
+		result.Regressions = append(result.Regressions, Regression{
+			Metric:    "Query P95",
+			Baseline:  baseline.QueryP95ms,
+			New:       newResults.QueryP95ms,
+			Drop:      newResults.QueryP95ms / baseline.QueryP95ms,
+			Threshold: p95Ratio,
+			Message:   fmt.Sprintf("Query P95 increased by %.2fx (threshold: 2.00x)", newResults.QueryP95ms/baseline.QueryP95ms),
+		})
+	}
+
+	// Query P50: lower is better, for completeness (no threshold check)
+	result.Deltas["Query P50"] = Delta{
+		Baseline: baseline.QueryP50ms,
+		New:      newResults.QueryP50ms,
+		Change:   baseline.QueryP50ms - newResults.QueryP50ms, // positive = improvement (lower is better)
+	}
+
+	return result
+}

--- a/internal/bench/compare.go
+++ b/internal/bench/compare.go
@@ -110,13 +110,21 @@ func Compare(newResults, baseline *BenchmarkResults) *ComparisonResult {
 	}
 	if newResults.QueryP95ms > p95Ratio*baseline.QueryP95ms+epsilon {
 		result.Passed = false
+		ratio := 0.0
+		if baseline.QueryP95ms > 0 {
+			ratio = newResults.QueryP95ms / baseline.QueryP95ms
+		}
+		message := fmt.Sprintf("Query P95 increased by %.2fx (threshold: 2.00x)", ratio)
+		if baseline.QueryP95ms == 0 {
+			message = "Query P95 regression: baseline was 0ms"
+		}
 		result.Regressions = append(result.Regressions, Regression{
 			Metric:    "Query P95",
 			Baseline:  baseline.QueryP95ms,
 			New:       newResults.QueryP95ms,
-			Drop:      newResults.QueryP95ms / baseline.QueryP95ms,
+			Drop:      ratio,
 			Threshold: p95Ratio,
-			Message:   fmt.Sprintf("Query P95 increased by %.2fx (threshold: 2.00x)", newResults.QueryP95ms/baseline.QueryP95ms),
+			Message:   message,
 		})
 	}
 

--- a/internal/bench/compare_test.go
+++ b/internal/bench/compare_test.go
@@ -1,0 +1,307 @@
+package bench
+
+import (
+	"math"
+	"testing"
+)
+
+func almostEqualDelta(a, b, tolerance float64) bool {
+	return math.Abs(a-b) < tolerance
+}
+
+func TestCompareAllMetricsWithinThreshold(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.8,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.79,
+		RecallAt10:   0.74,
+		MRR:          0.89,
+		QueryP50ms:   51.0,
+		QueryP95ms:   101.0,
+	}
+	result := Compare(newResults, baseline)
+	if !result.Passed {
+		t.Errorf("expected Passed=true, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 0 {
+		t.Errorf("expected 0 regressions, got %d", len(result.Regressions))
+	}
+}
+
+func TestComparePrecisionAt5Exactly10DropBoundary(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.70,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if !result.Passed {
+		t.Errorf("expected Passed=true at exactly 0.10 drop, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 0 {
+		t.Errorf("expected 0 regressions at boundary, got %d", len(result.Regressions))
+	}
+}
+
+func TestComparePrecisionAt5Over10DropRegression(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.69,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if result.Passed {
+		t.Errorf("expected Passed=false for 0.11 drop, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 1 {
+		t.Errorf("expected 1 regression, got %d", len(result.Regressions))
+	}
+	if result.Regressions[0].Metric != "P@5" {
+		t.Errorf("expected P@5 regression, got %s", result.Regressions[0].Metric)
+	}
+}
+
+func TestCompareRecallAt10Over10DropRegression(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.80,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.69,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if result.Passed {
+		t.Errorf("expected Passed=false for 0.11 drop, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 1 {
+		t.Errorf("expected 1 regression, got %d", len(result.Regressions))
+	}
+	if result.Regressions[0].Metric != "R@10" {
+		t.Errorf("expected R@10 regression, got %s", result.Regressions[0].Metric)
+	}
+}
+
+func TestCompareMRROver05DropRegression(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          1.0,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.94,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if result.Passed {
+		t.Errorf("expected Passed=false for 0.06 drop, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 1 {
+		t.Errorf("expected 1 regression, got %d", len(result.Regressions))
+	}
+	if result.Regressions[0].Metric != "MRR" {
+		t.Errorf("expected MRR regression, got %s", result.Regressions[0].Metric)
+	}
+}
+
+func TestCompareMRRExactly05DropBoundary(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          1.0,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.95,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if !result.Passed {
+		t.Errorf("expected Passed=true at exactly 0.05 drop, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 0 {
+		t.Errorf("expected 0 regressions at boundary, got %d", len(result.Regressions))
+	}
+}
+
+func TestCompareQueryP95Exactly2xBoundary(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   200.0,
+	}
+	result := Compare(newResults, baseline)
+	if !result.Passed {
+		t.Errorf("expected Passed=true at exactly 2.0x, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 0 {
+		t.Errorf("expected 0 regressions at boundary, got %d", len(result.Regressions))
+	}
+}
+
+func TestCompareQueryP95Over2xRegression(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   200.1,
+	}
+	result := Compare(newResults, baseline)
+	if result.Passed {
+		t.Errorf("expected Passed=false for 2.001x, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 1 {
+		t.Errorf("expected 1 regression, got %d", len(result.Regressions))
+	}
+	if result.Regressions[0].Metric != "Query P95" {
+		t.Errorf("expected Query P95 regression, got %s", result.Regressions[0].Metric)
+	}
+}
+
+func TestCompareMultipleRegressions(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.80,
+		MRR:          1.0,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.69,
+		RecallAt10:   0.69,
+		MRR:          0.94,
+		QueryP50ms:   50.0,
+		QueryP95ms:   250.0,
+	}
+	result := Compare(newResults, baseline)
+	if result.Passed {
+		t.Errorf("expected Passed=false with multiple regressions, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 4 {
+		t.Errorf("expected 4 regressions, got %d", len(result.Regressions))
+	}
+}
+
+func TestCompareAllMetricsImproved(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.70,
+		RecallAt10:   0.70,
+		MRR:          0.8,
+		QueryP50ms:   100.0,
+		QueryP95ms:   200.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.85,
+		RecallAt10:   0.85,
+		MRR:          0.95,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if !result.Passed {
+		t.Errorf("expected Passed=true with all improvements, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 0 {
+		t.Errorf("expected 0 regressions, got %d", len(result.Regressions))
+	}
+
+	if result.Deltas["P@5"].Change <= 0 {
+		t.Errorf("expected positive change for P@5 improvement, got %f", result.Deltas["P@5"].Change)
+	}
+	if result.Deltas["Query P95"].Change <= 0 {
+		t.Errorf("expected positive change for Query P95 improvement (lower is better), got %f", result.Deltas["Query P95"].Change)
+	}
+}
+
+func TestCompareDeltasComputed(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.75,
+		RecallAt10:   0.70,
+		MRR:          0.85,
+		QueryP50ms:   55.0,
+		QueryP95ms:   120.0,
+	}
+	result := Compare(newResults, baseline)
+
+	if len(result.Deltas) != 5 {
+		t.Errorf("expected 5 deltas, got %d", len(result.Deltas))
+	}
+
+	p5Delta := result.Deltas["P@5"]
+	if !almostEqualDelta(p5Delta.Baseline, 0.80, 0.001) {
+		t.Errorf("expected P@5 baseline 0.80, got %f", p5Delta.Baseline)
+	}
+	if !almostEqualDelta(p5Delta.New, 0.75, 0.001) {
+		t.Errorf("expected P@5 new 0.75, got %f", p5Delta.New)
+	}
+	if !almostEqualDelta(p5Delta.Change, -0.05, 0.001) {
+		t.Errorf("expected P@5 change -0.05, got %f", p5Delta.Change)
+	}
+
+	p95Delta := result.Deltas["Query P95"]
+	if !almostEqualDelta(p95Delta.Change, -20.0, 0.001) {
+		t.Errorf("expected Query P95 change -20.0 (positive improvement), got %f", p95Delta.Change)
+	}
+}

--- a/internal/bench/compare_test.go
+++ b/internal/bench/compare_test.go
@@ -1,6 +1,7 @@
 package bench
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 )
@@ -303,5 +304,64 @@ func TestCompareDeltasComputed(t *testing.T) {
 	p95Delta := result.Deltas["Query P95"]
 	if !almostEqualDelta(p95Delta.Change, -20.0, 0.001) {
 		t.Errorf("expected Query P95 change -20.0 (positive improvement), got %f", p95Delta.Change)
+	}
+}
+
+func TestCompareZeroBaselineP95(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   0.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.75,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   5.0,
+	}
+	result := Compare(newResults, baseline)
+	if result.Passed {
+		t.Errorf("expected Passed=false for P95 regression (zero baseline), got %v", result.Passed)
+	}
+	if len(result.Regressions) != 1 {
+		t.Errorf("expected 1 regression, got %d", len(result.Regressions))
+	}
+	if result.Regressions[0].Metric != "Query P95" {
+		t.Errorf("expected Query P95 regression, got %s", result.Regressions[0].Metric)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("expected ComparisonResult to be JSON-marshable, got error: %v", err)
+	}
+	if data == nil {
+		t.Errorf("expected non-nil JSON data")
+	}
+}
+
+func TestCompareRecallAt10Exactly10DropBoundary(t *testing.T) {
+	baseline := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.80,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	newResults := &BenchmarkResults{
+		PrecisionAt5: 0.80,
+		RecallAt10:   0.70,
+		MRR:          0.9,
+		QueryP50ms:   50.0,
+		QueryP95ms:   100.0,
+	}
+	result := Compare(newResults, baseline)
+	if !result.Passed {
+		t.Errorf("expected Passed=true at exactly 0.10 drop, got %v", result.Passed)
+	}
+	if len(result.Regressions) != 0 {
+		t.Errorf("expected 0 regressions at boundary, got %d", len(result.Regressions))
 	}
 }


### PR DESCRIPTION
## Story 7.3: Regression Detection (bench compare)

**Issue:** #110 | **FR:** FR-39 | **Epic:** 7 — Benchmarking Suite

### Changes

**New:**
- `internal/bench/compare.go` — Compare() function with threshold logic
- `internal/bench/compare_test.go` — 10 unit tests (boundary values, multi-regression)

**Modified:**
- `cmd/nano-brain/bench.go` — `bench compare` subcommand

### Thresholds
- P@5 drop > 0.10 → regression
- R@10 drop > 0.10 → regression
- MRR drop > 0.05 → regression  
- Query P95 > 2x baseline → regression

All regressions reported (no short-circuit). Exit 1 on any regression.