### PR TITLE
feat: bench --help and JSON round-trip validation (Story 7.5)

### DIFF
--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -20,9 +20,38 @@ import (
 	"github.com/rs/zerolog"
 )
 
+func printBenchHelp() {
+	help := `Usage: nano-brain bench <command> [flags]
+
+Commands:
+  generate   Generate benchmark dataset from workspace documents
+             --scale=N         Number of query-answer pairs to generate (required)
+             --workspace=HASH  Workspace hash to sample from (required)
+             --output=FILE     Output file path (default: stdout)
+             --json            Machine-readable JSON output
+
+  run        Execute search benchmark and measure quality/latency metrics
+             --dataset=FILE    Path to generated dataset JSON (required)
+             --save=FILE       Save results to JSON file
+             --json            Machine-readable JSON output
+
+  compare    Compare two benchmark result files for regression detection
+             <new.json>        Path to new results file
+             <baseline.json>   Path to baseline results file
+             --json            Machine-readable JSON output
+
+  stress     Concurrent write stress test
+             --concurrency=N      Number of concurrent writers (required)
+             --docs-per-writer=M  Documents per writer (default: 10)
+             --workspace=HASH     Workspace hash (required)
+             --json               Machine-readable JSON output
+`
+	fmt.Fprint(os.Stderr, help)
+}
+
 func runBenchCmd(args []string) {
-	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: nano-brain bench <generate|run|compare|stress> [flags]")
+	if len(args) == 0 || (len(args) > 0 && (args[0] == "--help" || args[0] == "-h")) {
+		printBenchHelp()
 		os.Exit(1)
 	}
 	switch args[0] {
@@ -35,7 +64,8 @@ func runBenchCmd(args []string) {
 	case "stress":
 		runBenchStress(args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown bench subcommand: %s\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown bench subcommand: %s\n\n", args[0])
+		printBenchHelp()
 		os.Exit(1)
 	}
 }

--- a/internal/bench/generate_test.go
+++ b/internal/bench/generate_test.go
@@ -219,3 +219,68 @@ func TestBenchmarkDataset_JSONRoundtrip(t *testing.T) {
 		t.Errorf("entry query = %q, want %q", decoded.Entries[0].Query, "test query")
 	}
 }
+
+func TestBenchmarkResults_JSONRoundtrip(t *testing.T) {
+	results := BenchmarkResults{
+		Scale:        42,
+		WorkspaceHash: "ws-prod-hash",
+		Timestamp:    "2025-01-15T12:34:56Z",
+		Version:      "v1.2.3",
+
+		// Quality metrics
+		PrecisionAt5: 0.8523,
+		RecallAt10:   0.7142,
+		MRR:          0.6789,
+
+		// Latency percentiles (milliseconds)
+		QueryP50ms: 45.67,
+		QueryP95ms: 234.56,
+
+		// Per-query detail
+		QueryCount: 100,
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Unmarshal back
+	var decoded BenchmarkResults
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	// Verify all fields match
+	if decoded.Scale != results.Scale {
+		t.Errorf("scale = %d, want %d", decoded.Scale, results.Scale)
+	}
+	if decoded.WorkspaceHash != results.WorkspaceHash {
+		t.Errorf("workspace_hash = %q, want %q", decoded.WorkspaceHash, results.WorkspaceHash)
+	}
+	if decoded.Timestamp != results.Timestamp {
+		t.Errorf("timestamp = %q, want %q", decoded.Timestamp, results.Timestamp)
+	}
+	if decoded.Version != results.Version {
+		t.Errorf("version = %q, want %q", decoded.Version, results.Version)
+	}
+	if decoded.PrecisionAt5 != results.PrecisionAt5 {
+		t.Errorf("precision_at_5 = %.4f, want %.4f", decoded.PrecisionAt5, results.PrecisionAt5)
+	}
+	if decoded.RecallAt10 != results.RecallAt10 {
+		t.Errorf("recall_at_10 = %.4f, want %.4f", decoded.RecallAt10, results.RecallAt10)
+	}
+	if decoded.MRR != results.MRR {
+		t.Errorf("mrr = %.4f, want %.4f", decoded.MRR, results.MRR)
+	}
+	if decoded.QueryP50ms != results.QueryP50ms {
+		t.Errorf("query_p50_ms = %.2f, want %.2f", decoded.QueryP50ms, results.QueryP50ms)
+	}
+	if decoded.QueryP95ms != results.QueryP95ms {
+		t.Errorf("query_p95_ms = %.2f, want %.2f", decoded.QueryP95ms, results.QueryP95ms)
+	}
+	if decoded.QueryCount != results.QueryCount {
+		t.Errorf("query_count = %d, want %d", decoded.QueryCount, results.QueryCount)
+	}
+}


### PR DESCRIPTION
## Story 7.5: Bench CLI Plumbing and --save Round-trip

**Issue:** #114 | **FR:** FR-40 | **Epic:** 7 — Benchmarking Suite

### Changes

**Modified:**
- `cmd/nano-brain/bench.go` — `bench --help` with all subcommand docs
- `internal/bench/generate_test.go` — BenchmarkResults JSON round-trip test

### Design
- S-complexity plumbing story
- Help covers generate, run, compare, stress with all flags
- Round-trip test validates --save / --json schema compatibility with bench compare input