### PR TITLE
feat: CLI operations commands — logs, docker, status, db:migrate goose (Story 8.4)

### DIFF
--- a/cmd/nano-brain/client.go
+++ b/cmd/nano-brain/client.go
@@ -5,33 +5,34 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-func getBaseURL() string {
+func resolveHostPort() (string, int) {
 	host := os.Getenv("NANO_BRAIN_HOST")
 	if host == "" {
 		host = "localhost"
 	}
-	port := os.Getenv("NANO_BRAIN_PORT")
-	if port == "" {
-		port = "3100"
+	port := 3100
+	if p := os.Getenv("NANO_BRAIN_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil && v > 0 && v <= 65535 {
+			port = v
+		}
 	}
-	return fmt.Sprintf("http://%s:%s", host, port)
+	return host, port
+}
+
+func getBaseURL() string {
+	host, port := resolveHostPort()
+	return fmt.Sprintf("http://%s:%d", host, port)
 }
 
 func doRequest(method, url string, body io.Reader) ([]byte, int, error) {
-	host := os.Getenv("NANO_BRAIN_HOST")
-	if host == "" {
-		host = "localhost"
-	}
-	port := os.Getenv("NANO_BRAIN_PORT")
-	if port == "" {
-		port = "3100"
-	}
+	host, port := resolveHostPort()
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -45,7 +46,7 @@ func doRequest(method, url string, body io.Reader) ([]byte, int, error) {
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") ||
 			strings.Contains(err.Error(), "dial tcp") {
-			return nil, 0, fmt.Errorf("cannot connect to nano-brain server at %s:%s", host, port)
+			return nil, 0, fmt.Errorf("cannot connect to nano-brain server at %s:%d", host, port)
 		}
 		return nil, 0, fmt.Errorf("request failed: %w", err)
 	}

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -59,6 +59,15 @@ func main() {
 		case "db:migrate":
 			runDBMigrateCmd(args[1:])
 			return
+		case "logs":
+			runLogsCmd(args[1:])
+			return
+		case "docker":
+			runDockerCmd(args[1:])
+			return
+		case "status":
+			runStatusCmd(args[1:])
+			return
 		}
 	}
 

--- a/cmd/nano-brain/migrate.go
+++ b/cmd/nano-brain/migrate.go
@@ -17,6 +17,7 @@ import (
 func runDBMigrateCmd(args []string) {
 	var fromV1 string
 	var workspace string
+	var jsonFlag bool
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -34,6 +35,8 @@ func runDBMigrateCmd(args []string) {
 			}
 			i++
 			workspace = args[i]
+		case "--json":
+			jsonFlag = true
 		default:
 			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
 			os.Exit(1)
@@ -41,8 +44,8 @@ func runDBMigrateCmd(args []string) {
 	}
 
 	if fromV1 == "" {
-		fmt.Fprintln(os.Stderr, "Usage: nano-brain db:migrate --from-v1 <sqlite-path> [--workspace <hash>]")
-		os.Exit(1)
+		runGooseMigrateCmd(jsonFlag)
+		return
 	}
 
 	if workspace == "" {

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -20,22 +20,6 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-// resolveHostPort returns the host and port for connecting to the nano-brain server,
-// honoring NANO_BRAIN_HOST and NANO_BRAIN_PORT env vars.
-func resolveHostPort() (string, int) {
-	host := os.Getenv("NANO_BRAIN_HOST")
-	if host == "" {
-		host = "localhost"
-	}
-	port := 3100
-	if p := os.Getenv("NANO_BRAIN_PORT"); p != "" {
-		if v, err := strconv.Atoi(p); err == nil && v > 0 {
-			port = v
-		}
-	}
-	return host, port
-}
-
 // defaultLogPath returns the default log file path.
 func defaultLogPath() string {
 	home, err := os.UserHomeDir()
@@ -121,7 +105,10 @@ func resolveLogPath() string {
 	return defaultLogPath()
 }
 
-// tailLines reads the last n lines from a file.
+const tailChunkSize = 64 * 1024
+
+// tailLines reads the last n lines from a file by reading backward from EOF
+// in fixed-size chunks. Memory usage is capped regardless of file size.
 func tailLines(path string, n int) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -129,20 +116,59 @@ func tailLines(path string, n int) ([]string, error) {
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-	var lines []string
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat log file: %w", err)
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading log file: %w", err)
+	fileSize := stat.Size()
+	if fileSize == 0 {
+		return nil, nil
 	}
 
-	if len(lines) > n {
-		lines = lines[len(lines)-n:]
+	var collected []string
+	remaining := fileSize
+	var leftover []byte
+
+	for remaining > 0 && len(collected) < n {
+		chunkSize := int64(tailChunkSize)
+		if chunkSize > remaining {
+			chunkSize = remaining
+		}
+		offset := remaining - chunkSize
+		remaining = offset
+
+		buf := make([]byte, chunkSize)
+		if _, err := f.ReadAt(buf, offset); err != nil && err != io.EOF {
+			return nil, fmt.Errorf("error reading log file: %w", err)
+		}
+
+		if len(leftover) > 0 {
+			buf = append(buf, leftover...)
+			leftover = nil
+		}
+
+		lines := strings.Split(string(buf), "\n")
+
+		if offset > 0 {
+			leftover = []byte(lines[0])
+			lines = lines[1:]
+		}
+
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+
+		collected = append(lines, collected...)
 	}
-	return lines, nil
+
+	if len(leftover) > 0 && string(leftover) != "" {
+		collected = append([]string{string(leftover)}, collected...)
+	}
+
+	if len(collected) > n {
+		collected = collected[len(collected)-n:]
+	}
+	return collected, nil
 }
 
 // tailFollow implements simple tail -f behavior.

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/migrations"
+	"github.com/pressly/goose/v3"
+)
+
+// resolveHostPort returns the host and port for connecting to the nano-brain server,
+// honoring NANO_BRAIN_HOST and NANO_BRAIN_PORT env vars.
+func resolveHostPort() (string, int) {
+	host := os.Getenv("NANO_BRAIN_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := 3100
+	if p := os.Getenv("NANO_BRAIN_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil && v > 0 {
+			port = v
+		}
+	}
+	return host, port
+}
+
+// defaultLogPath returns the default log file path.
+func defaultLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "nano-brain.log"
+	}
+	return filepath.Join(home, ".nano-brain", "logs", "nano-brain.log")
+}
+
+// runLogsCmd implements the "logs" CLI command.
+func runLogsCmd(args []string) {
+	count := 50
+	follow := false
+	jsonFlag := false
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-n":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "-n requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			v, err := strconv.Atoi(args[i])
+			if err != nil || v < 1 {
+				fmt.Fprintf(os.Stderr, "-n value must be a positive integer\n")
+				os.Exit(1)
+			}
+			count = v
+		case "-f", "--follow":
+			follow = true
+		case "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	logPath := resolveLogPath()
+
+	if follow {
+		if err := tailFollow(logPath, jsonFlag); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	lines, err := tailLines(logPath, count)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		out, _ := json.Marshal(map[string]interface{}{
+			"file":  logPath,
+			"lines": lines,
+			"count": len(lines),
+		})
+		fmt.Println(string(out))
+		return
+	}
+
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+}
+
+// resolveLogPath determines the log file path from config or defaults.
+func resolveLogPath() string {
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err == nil && cfg.Logging.File != "" {
+		p := cfg.Logging.File
+		if strings.HasPrefix(p, "~") {
+			if home, err := os.UserHomeDir(); err == nil {
+				p = filepath.Join(home, p[1:])
+			}
+		}
+		return p
+	}
+	return defaultLogPath()
+}
+
+// tailLines reads the last n lines from a file.
+func tailLines(path string, n int) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open log file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading log file: %w", err)
+	}
+
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines, nil
+}
+
+// tailFollow implements simple tail -f behavior.
+func tailFollow(path string, jsonFlag bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("cannot open log file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("cannot seek to end: %w", err)
+	}
+
+	if !jsonFlag {
+		fmt.Fprintf(os.Stderr, "Following %s (Ctrl+C to stop)\n", path)
+	}
+
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		line = strings.TrimRight(line, "\n\r")
+		if line == "" {
+			continue
+		}
+		fmt.Println(line)
+	}
+}
+
+// runDockerCmd implements the "docker" CLI command.
+func runDockerCmd(args []string) {
+	jsonFlag := false
+	var subCmd string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			jsonFlag = true
+		case "start", "stop", "status":
+			subCmd = args[i]
+		default:
+			fmt.Fprintf(os.Stderr, "unknown argument: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	if subCmd == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain docker <start|stop|status> [--json]")
+		os.Exit(1)
+	}
+
+	composeDir := resolveComposeDir()
+
+	switch subCmd {
+	case "start":
+		runDockerStart(composeDir, jsonFlag)
+	case "stop":
+		runDockerStop(composeDir, jsonFlag)
+	case "status":
+		runDockerStatus(composeDir, jsonFlag)
+	}
+}
+
+// resolveComposeDir determines the docker-compose directory.
+func resolveComposeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	return filepath.Join(home, ".nano-brain")
+}
+
+func runDockerStart(dir string, jsonFlag bool) {
+	cmd := exec.Command("docker", "compose", "up", "-d")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if jsonFlag {
+			j, _ := json.Marshal(map[string]interface{}{
+				"status": "error",
+				"error":  err.Error(),
+				"output": string(out),
+			})
+			fmt.Println(string(j))
+		} else {
+			fmt.Fprintf(os.Stderr, "Error starting docker compose: %v\n%s", err, string(out))
+		}
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		j, _ := json.Marshal(map[string]interface{}{
+			"status": "started",
+			"output": string(out),
+		})
+		fmt.Println(string(j))
+	} else {
+		fmt.Println("Docker compose started")
+		if len(out) > 0 {
+			fmt.Print(string(out))
+		}
+	}
+}
+
+func runDockerStop(dir string, jsonFlag bool) {
+	cmd := exec.Command("docker", "compose", "down")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if jsonFlag {
+			j, _ := json.Marshal(map[string]interface{}{
+				"status": "error",
+				"error":  err.Error(),
+				"output": string(out),
+			})
+			fmt.Println(string(j))
+		} else {
+			fmt.Fprintf(os.Stderr, "Error stopping docker compose: %v\n%s", err, string(out))
+		}
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		j, _ := json.Marshal(map[string]interface{}{
+			"status": "stopped",
+			"output": string(out),
+		})
+		fmt.Println(string(j))
+	} else {
+		fmt.Println("Docker compose stopped")
+		if len(out) > 0 {
+			fmt.Print(string(out))
+		}
+	}
+}
+
+func runDockerStatus(dir string, jsonFlag bool) {
+	cmd := exec.Command("docker", "compose", "ps", "--format", "json")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if jsonFlag {
+			j, _ := json.Marshal(map[string]interface{}{
+				"status": "error",
+				"error":  err.Error(),
+				"output": string(out),
+			})
+			fmt.Println(string(j))
+		} else {
+			fmt.Fprintf(os.Stderr, "Error getting docker compose status: %v\n%s", err, string(out))
+		}
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Print(string(out))
+		return
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	fmt.Printf("%-30s %-15s %-20s\n", "NAME", "STATUS", "PORTS")
+	fmt.Println(strings.Repeat("-", 65))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var svc struct {
+			Name   string `json:"Name"`
+			State  string `json:"State"`
+			Status string `json:"Status"`
+			Ports  string `json:"Ports"`
+		}
+		if err := json.Unmarshal([]byte(line), &svc); err != nil {
+			fmt.Println(line)
+			continue
+		}
+		status := svc.State
+		if svc.Status != "" {
+			status = svc.Status
+		}
+		fmt.Printf("%-30s %-15s %-20s\n", svc.Name, status, svc.Ports)
+	}
+}
+
+// runStatusCmd implements the enhanced "status" CLI command.
+func runStatusCmd(args []string) {
+	jsonFlag := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	resp, _, err := doRequest("GET", getBaseURL()+"/api/status", nil)
+	if err != nil {
+		if jsonFlag {
+			j, _ := json.Marshal(map[string]interface{}{
+				"status": "unreachable",
+				"error":  err.Error(),
+			})
+			fmt.Println(string(j))
+		} else {
+			fmt.Fprintf(os.Stderr, "Cannot reach nano-brain server: %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		return
+	}
+
+	var status map[string]interface{}
+	if err := json.Unmarshal(resp, &status); err != nil {
+		fmt.Println(string(resp))
+		return
+	}
+
+	fmt.Println("nano-brain status")
+	fmt.Println(strings.Repeat("=", 40))
+
+	if v, ok := status["status"]; ok {
+		fmt.Printf("  Server:       %v\n", v)
+	}
+	if v, ok := status["version"]; ok {
+		fmt.Printf("  Version:      %v\n", v)
+	}
+	if v, ok := status["uptime"]; ok {
+		fmt.Printf("  Uptime:       %v\n", v)
+	}
+
+	if db, ok := status["database"].(map[string]interface{}); ok {
+		fmt.Println("\nDatabase:")
+		if v, ok := db["status"]; ok {
+			fmt.Printf("  Status:       %v\n", v)
+		}
+		if v, ok := db["pool_size"]; ok {
+			fmt.Printf("  Pool size:    %v\n", v)
+		}
+		if v, ok := db["active_conns"]; ok {
+			fmt.Printf("  Active conns: %v\n", v)
+		}
+		if v, ok := db["idle_conns"]; ok {
+			fmt.Printf("  Idle conns:   %v\n", v)
+		}
+	}
+
+	if v, ok := status["workspaces"]; ok {
+		fmt.Printf("\nWorkspaces:     %v\n", v)
+	}
+	if v, ok := status["workspace_count"]; ok {
+		fmt.Printf("\nWorkspaces:     %v\n", v)
+	}
+
+	if v, ok := status["collections"]; ok {
+		fmt.Printf("Collections:    %v\n", v)
+	}
+	if v, ok := status["collection_count"]; ok {
+		fmt.Printf("Collections:    %v\n", v)
+	}
+
+	if eq, ok := status["embedding_queue"].(map[string]interface{}); ok {
+		fmt.Println("\nEmbedding Queue:")
+		if v, ok := eq["depth"]; ok {
+			fmt.Printf("  Queue depth:  %v\n", v)
+		}
+		if v, ok := eq["pending"]; ok {
+			fmt.Printf("  Pending:      %v\n", v)
+		}
+	}
+}
+
+// runGooseMigrateCmd runs pending goose migrations from embedded SQL files.
+func runGooseMigrateCmd(jsonFlag bool) {
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	if cfg.Database.URL == "" {
+		fmt.Fprintln(os.Stderr, "Error: database.url not configured")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, cfg.Database.URL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	db := stdlib.OpenDBFromPool(pool)
+	defer db.Close()
+
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error setting dialect: %v\n", err)
+		os.Exit(1)
+	}
+
+	current, err := goose.GetDBVersionContext(ctx, db)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting current version: %v\n", err)
+		os.Exit(1)
+	}
+
+	goose.SetLogger(goose.NopLogger())
+
+	if err := goose.UpContext(ctx, db, "."); err != nil {
+		if jsonFlag {
+			j, _ := json.Marshal(map[string]interface{}{
+				"status":           "error",
+				"error":            err.Error(),
+				"previous_version": current,
+			})
+			fmt.Println(string(j))
+		} else {
+			fmt.Fprintf(os.Stderr, "Migration failed: %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	after, err := goose.GetDBVersionContext(ctx, db)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting post-migration version: %v\n", err)
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		j, _ := json.Marshal(map[string]interface{}{
+			"status":           "ok",
+			"previous_version": current,
+			"current_version":  after,
+			"migrations_run":   after - current,
+		})
+		fmt.Println(string(j))
+	} else {
+		if after == current {
+			fmt.Printf("Database is up to date (version %d)\n", after)
+		} else {
+			fmt.Printf("Migrated from version %d to %d (%d migrations applied)\n", current, after, after-current)
+		}
+	}
+}

--- a/cmd/nano-brain/ops_test.go
+++ b/cmd/nano-brain/ops_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveHostPort_Defaults(t *testing.T) {
+	t.Setenv("NANO_BRAIN_HOST", "")
+	t.Setenv("NANO_BRAIN_PORT", "")
+	host, port := resolveHostPort()
+	if host != "localhost" {
+		t.Errorf("host = %q, want %q", host, "localhost")
+	}
+	if port != 3100 {
+		t.Errorf("port = %d, want %d", port, 3100)
+	}
+}
+
+func TestResolveHostPort_EnvOverride(t *testing.T) {
+	t.Setenv("NANO_BRAIN_HOST", "myhost")
+	t.Setenv("NANO_BRAIN_PORT", "9090")
+	host, port := resolveHostPort()
+	if host != "myhost" {
+		t.Errorf("host = %q, want %q", host, "myhost")
+	}
+	if port != 9090 {
+		t.Errorf("port = %d, want %d", port, 9090)
+	}
+}
+
+func TestResolveHostPort_InvalidPort(t *testing.T) {
+	t.Setenv("NANO_BRAIN_HOST", "")
+	t.Setenv("NANO_BRAIN_PORT", "notanumber")
+	_, port := resolveHostPort()
+	if port != 3100 {
+		t.Errorf("port = %d, want default %d for invalid input", port, 3100)
+	}
+}
+
+func TestTailLines_Basic(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+	content := "line1\nline2\nline3\nline4\nline5\n"
+	if err := os.WriteFile(logFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := tailLines(logFile, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 3 {
+		t.Errorf("got %d lines, want 3", len(lines))
+	}
+	if lines[0] != "line3" || lines[1] != "line4" || lines[2] != "line5" {
+		t.Errorf("got %v, want [line3 line4 line5]", lines)
+	}
+}
+
+func TestTailLines_FewerThanRequested(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+	content := "line1\nline2\n"
+	if err := os.WriteFile(logFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := tailLines(logFile, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 2 {
+		t.Errorf("got %d lines, want 2", len(lines))
+	}
+}
+
+func TestTailLines_FileNotFound(t *testing.T) {
+	_, err := tailLines("/nonexistent/file.log", 10)
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestRunStatusCmd_JSON(t *testing.T) {
+	statusResp := map[string]interface{}{
+		"status":  "ok",
+		"version": "test",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/status" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(statusResp)
+	}))
+	defer ts.Close()
+
+	parts := strings.Split(strings.TrimPrefix(ts.URL, "http://"), ":")
+	t.Setenv("NANO_BRAIN_HOST", parts[0])
+	if len(parts) > 1 {
+		t.Setenv("NANO_BRAIN_PORT", parts[1])
+	}
+
+	resp, _, err := doRequest("GET", ts.URL+"/api/status", nil)
+	if err != nil {
+		t.Fatalf("doRequest failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if result["status"] != "ok" {
+		t.Errorf("status = %v, want ok", result["status"])
+	}
+}
+
+func TestDefaultLogPath(t *testing.T) {
+	p := defaultLogPath()
+	if !strings.Contains(p, ".nano-brain") || !strings.HasSuffix(p, "nano-brain.log") {
+		t.Errorf("defaultLogPath() = %q, want path containing .nano-brain/logs/nano-brain.log", p)
+	}
+}

--- a/cmd/nano-brain/ops_test.go
+++ b/cmd/nano-brain/ops_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,6 +41,15 @@ func TestResolveHostPort_InvalidPort(t *testing.T) {
 	_, port := resolveHostPort()
 	if port != 3100 {
 		t.Errorf("port = %d, want default %d for invalid input", port, 3100)
+	}
+}
+
+func TestResolveHostPort_OutOfRangePort(t *testing.T) {
+	t.Setenv("NANO_BRAIN_HOST", "")
+	t.Setenv("NANO_BRAIN_PORT", "99999")
+	_, port := resolveHostPort()
+	if port != 3100 {
+		t.Errorf("port = %d, want default %d for out-of-range port", port, 3100)
 	}
 }
 
@@ -84,6 +94,50 @@ func TestTailLines_FileNotFound(t *testing.T) {
 	_, err := tailLines("/nonexistent/file.log", 10)
 	if err == nil {
 		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestTailLines_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "empty.log")
+	if err := os.WriteFile(logFile, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := tailLines(logFile, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 0 {
+		t.Errorf("got %d lines, want 0 for empty file", len(lines))
+	}
+}
+
+func TestTailLines_MultiChunk(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "big.log")
+
+	var b strings.Builder
+	totalLines := 2000
+	for i := 1; i <= totalLines; i++ {
+		fmt.Fprintf(&b, "line-%04d\n", i)
+	}
+	if err := os.WriteFile(logFile, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lines, err := tailLines(logFile, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) != 5 {
+		t.Fatalf("got %d lines, want 5", len(lines))
+	}
+	if lines[0] != "line-1996" {
+		t.Errorf("lines[0] = %q, want %q", lines[0], "line-1996")
+	}
+	if lines[4] != "line-2000" {
+		t.Errorf("lines[4] = %q, want %q", lines[4], "line-2000")
 	}
 }
 


### PR DESCRIPTION
## Story 8.4: CLI Operations Commands

**Issue:** #122 | **FR:** FR-79, FR-81, FR-82, FR-96 | **Epic:** 8 | **Complexity:** M

### Changes
**New:**
- `cmd/nano-brain/ops.go` — logs, docker, status, goose migrate commands
- `cmd/nano-brain/ops_test.go` — 7 unit tests

**Modified:**
- `cmd/nano-brain/main.go` — added logs/docker/status dispatch
- `cmd/nano-brain/migrate.go` — goose fallback when no --from-v1

### Features
- `logs -n 50` / `logs -f`: tail log file with follow mode
- `docker start/stop/status`: wraps docker compose
- `status`: calls GET /api/status, human-readable + --json
- `db:migrate`: runs pending goose migrations (embedded SQL)
- All commands support `--json` output
- `NANO_BRAIN_HOST`/`NANO_BRAIN_PORT` env vars honored

Closes #122