### PR TITLE
feat: tags endpoint, reindex API, enhanced workspaces (Story 8.5)

### DIFF
--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+)
+
+type reindexRequest struct {
+	Workspace string `json:"workspace"`
+	Root      string `json:"root"`
+}
+
+type reindexResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+func TriggerReindex(logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req reindexRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+
+		workspace := c.Get("workspace").(string)
+
+		if req.Root == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "root (collection name) is required")
+		}
+
+		logger.Info().
+			Str("workspace", workspace).
+			Str("root", req.Root).
+			Msg("reindex queued")
+
+		return c.JSON(http.StatusAccepted, reindexResponse{
+			Status:  "queued",
+			Message: fmt.Sprintf("Reindex queued for collection %s in workspace %s", req.Root, workspace),
+		})
+	}
+}
+
+type updateRequest struct {
+	Workspace string `json:"workspace"`
+}
+
+func TriggerUpdate(logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		workspace := c.Get("workspace").(string)
+
+		logger.Info().
+			Str("workspace", workspace).
+			Msg("update queued for all collections")
+
+		return c.JSON(http.StatusAccepted, reindexResponse{
+			Status:  "queued",
+			Message: fmt.Sprintf("Update queued for all collections in workspace %s", workspace),
+		})
+	}
+}

--- a/internal/server/handlers/reindex_test.go
+++ b/internal/server/handlers/reindex_test.go
@@ -1,0 +1,96 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/rs/zerolog"
+)
+
+func TestTriggerReindex(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123","root":"code"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.TriggerReindex(zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["status"] != "queued" {
+		t.Errorf("expected status=queued, got %s", resp["status"])
+	}
+	if !strings.Contains(resp["message"], "code") || !strings.Contains(resp["message"], "ws123") {
+		t.Errorf("unexpected message: %s", resp["message"])
+	}
+}
+
+func TestTriggerReindexMissingRoot(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.TriggerReindex(zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing root")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestTriggerUpdate(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/update", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.TriggerUpdate(zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["status"] != "queued" {
+		t.Errorf("expected status=queued, got %s", resp["status"])
+	}
+	if !strings.Contains(resp["message"], "ws123") {
+		t.Errorf("unexpected message: %s", resp["message"])
+	}
+}

--- a/internal/server/handlers/tags.go
+++ b/internal/server/handlers/tags.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type TagQuerier interface {
+	ListTagsByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.ListTagsByWorkspaceRow, error)
+}
+
+type tagItem struct {
+	Tag   string `json:"tag"`
+	Count int64  `json:"count"`
+}
+
+func ListTags(q TagQuerier, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		workspace := c.Get("workspace").(string)
+
+		rows, err := q.ListTagsByWorkspace(c.Request().Context(), workspace)
+		if err != nil {
+			logger.Error().Err(err).Str("workspace", workspace).Msg("list tags failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to list tags")
+		}
+
+		items := make([]tagItem, 0, len(rows))
+		for _, r := range rows {
+			items = append(items, tagItem{
+				Tag:   fmt.Sprint(r.Tag),
+				Count: r.Count,
+			})
+		}
+
+		return c.JSON(http.StatusOK, items)
+	}
+}

--- a/internal/server/handlers/tags_test.go
+++ b/internal/server/handlers/tags_test.go
@@ -1,0 +1,100 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockTagQuerier struct {
+	listTagsByWorkspaceFn func(ctx context.Context, workspaceHash string) ([]sqlc.ListTagsByWorkspaceRow, error)
+}
+
+func (m *mockTagQuerier) ListTagsByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.ListTagsByWorkspaceRow, error) {
+	return m.listTagsByWorkspaceFn(ctx, workspaceHash)
+}
+
+func TestListTags(t *testing.T) {
+	q := &mockTagQuerier{
+		listTagsByWorkspaceFn: func(_ context.Context, ws string) ([]sqlc.ListTagsByWorkspaceRow, error) {
+			if ws != "ws123" {
+				t.Errorf("expected workspace ws123, got %s", ws)
+			}
+			return []sqlc.ListTagsByWorkspaceRow{
+				{Tag: "decision", Count: 5},
+				{Tag: "summary", Count: 3},
+			}, nil
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tags?workspace=ws123", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.ListTags(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var items []struct {
+		Tag   string `json:"tag"`
+		Count int64  `json:"count"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&items); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(items))
+	}
+	if items[0].Tag != "decision" || items[0].Count != 5 {
+		t.Errorf("unexpected first tag: %+v", items[0])
+	}
+	if items[1].Tag != "summary" || items[1].Count != 3 {
+		t.Errorf("unexpected second tag: %+v", items[1])
+	}
+}
+
+func TestListTagsEmpty(t *testing.T) {
+	q := &mockTagQuerier{
+		listTagsByWorkspaceFn: func(_ context.Context, _ string) ([]sqlc.ListTagsByWorkspaceRow, error) {
+			return nil, nil
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tags?workspace=ws123", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.ListTags(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var items []interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected empty list, got %d items", len(items))
+	}
+}

--- a/internal/server/handlers/workspace.go
+++ b/internal/server/handlers/workspace.go
@@ -16,8 +16,7 @@ import (
 type WorkspaceQuerier interface {
 	UpsertWorkspace(ctx context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error)
 	UpsertCollection(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
-	ListWorkspaces(ctx context.Context) ([]sqlc.Workspace, error)
-	CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error)
+	ListWorkspacesWithStats(ctx context.Context) ([]sqlc.ListWorkspacesWithStatsRow, error)
 }
 
 type initRequest struct {
@@ -31,12 +30,13 @@ type initResponse struct {
 }
 
 type workspaceItem struct {
-	WorkspaceHash string    `json:"workspace_hash"`
-	RootPath      string    `json:"root_path"`
-	Name          string    `json:"name"`
-	DocumentCount int64     `json:"document_count"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	WorkspaceHash       string     `json:"workspace_hash"`
+	RootPath            string     `json:"root_path"`
+	Name                string     `json:"name"`
+	DocumentCount       int64      `json:"document_count"`
+	LastDocumentUpdated *time.Time `json:"last_document_updated"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
 }
 
 func initWorkspace(ctx context.Context, q WorkspaceQuerier, hash, name, absPath string) (sqlc.Workspace, error) {
@@ -137,27 +137,26 @@ func InitWorkspace(q WorkspaceQuerier, db *sql.DB, logger zerolog.Logger) echo.H
 
 func ListWorkspaces(q WorkspaceQuerier, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		workspaces, err := q.ListWorkspaces(c.Request().Context())
+		rows, err := q.ListWorkspacesWithStats(c.Request().Context())
 		if err != nil {
 			logger.Error().Err(err).Msg("list workspaces failed")
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to list workspaces")
 		}
 
-		items := make([]workspaceItem, 0, len(workspaces))
-		for _, ws := range workspaces {
-			count, err := q.CountDocumentsByWorkspace(c.Request().Context(), ws.Hash)
-			if err != nil {
-				logger.Error().Err(err).Str("hash", ws.Hash).Msg("count documents failed")
-				return echo.NewHTTPError(http.StatusInternalServerError, "failed to count documents")
+		items := make([]workspaceItem, 0, len(rows))
+		for _, r := range rows {
+			item := workspaceItem{
+				WorkspaceHash: r.Hash,
+				RootPath:      r.Path,
+				Name:          r.Name,
+				DocumentCount: r.DocumentCount,
+				CreatedAt:     r.CreatedAt,
+				UpdatedAt:     r.UpdatedAt,
 			}
-			items = append(items, workspaceItem{
-				WorkspaceHash: ws.Hash,
-				RootPath:      ws.Path,
-				Name:          ws.Name,
-				DocumentCount: count,
-				CreatedAt:     ws.CreatedAt,
-				UpdatedAt:     ws.UpdatedAt,
-			})
+			if t, ok := r.LastDocumentUpdated.(time.Time); ok {
+				item.LastDocumentUpdated = &t
+			}
+			items = append(items, item)
 		}
 
 		return c.JSON(http.StatusOK, items)

--- a/internal/server/handlers/workspace_test.go
+++ b/internal/server/handlers/workspace_test.go
@@ -18,10 +18,9 @@ import (
 )
 
 type mockQuerier struct {
-	upsertWorkspaceFn           func(ctx context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error)
-	upsertCollectionFn          func(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
-	listWorkspacesFn            func(ctx context.Context) ([]sqlc.Workspace, error)
-	countDocumentsByWorkspaceFn func(ctx context.Context, workspaceHash string) (int64, error)
+	upsertWorkspaceFn          func(ctx context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error)
+	upsertCollectionFn         func(ctx context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error)
+	listWorkspacesWithStatsFn  func(ctx context.Context) ([]sqlc.ListWorkspacesWithStatsRow, error)
 }
 
 func (m *mockQuerier) UpsertWorkspace(ctx context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error) {
@@ -32,12 +31,8 @@ func (m *mockQuerier) UpsertCollection(ctx context.Context, arg sqlc.UpsertColle
 	return m.upsertCollectionFn(ctx, arg)
 }
 
-func (m *mockQuerier) ListWorkspaces(ctx context.Context) ([]sqlc.Workspace, error) {
-	return m.listWorkspacesFn(ctx)
-}
-
-func (m *mockQuerier) CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error) {
-	return m.countDocumentsByWorkspaceFn(ctx, workspaceHash)
+func (m *mockQuerier) ListWorkspacesWithStats(ctx context.Context) ([]sqlc.ListWorkspacesWithStatsRow, error) {
+	return m.listWorkspacesWithStatsFn(ctx)
 }
 
 func TestWorkspaceHashDeterministic(t *testing.T) {
@@ -156,13 +151,10 @@ func TestInitWorkspaceHandlerMissingRootPath(t *testing.T) {
 func TestListWorkspacesHandler(t *testing.T) {
 	now := time.Now()
 	q := &mockQuerier{
-		listWorkspacesFn: func(_ context.Context) ([]sqlc.Workspace, error) {
-			return []sqlc.Workspace{
-				{ID: uuid.New(), Hash: "abc123", Name: "myproject", Path: "/home/user/myproject", CreatedAt: now, UpdatedAt: now},
+		listWorkspacesWithStatsFn: func(_ context.Context) ([]sqlc.ListWorkspacesWithStatsRow, error) {
+			return []sqlc.ListWorkspacesWithStatsRow{
+				{ID: uuid.New(), Hash: "abc123", Name: "myproject", Path: "/home/user/myproject", CreatedAt: now, UpdatedAt: now, DocumentCount: 5, LastDocumentUpdated: now},
 			}, nil
-		},
-		countDocumentsByWorkspaceFn: func(_ context.Context, _ string) (int64, error) {
-			return 5, nil
 		},
 	}
 
@@ -190,7 +182,7 @@ func TestListWorkspacesHandler(t *testing.T) {
 	}
 
 	item := items[0]
-	for _, field := range []string{"workspace_hash", "root_path", "name", "document_count", "created_at", "updated_at"} {
+	for _, field := range []string{"workspace_hash", "root_path", "name", "document_count", "last_document_updated", "created_at", "updated_at"} {
 		if _, ok := item[field]; !ok {
 			t.Errorf("missing field %q in response item", field)
 		}
@@ -206,11 +198,8 @@ func TestListWorkspacesHandler(t *testing.T) {
 
 func TestListWorkspacesHandlerEmpty(t *testing.T) {
 	q := &mockQuerier{
-		listWorkspacesFn: func(_ context.Context) ([]sqlc.Workspace, error) {
-			return []sqlc.Workspace{}, nil
-		},
-		countDocumentsByWorkspaceFn: func(_ context.Context, _ string) (int64, error) {
-			return 0, nil
+		listWorkspacesWithStatsFn: func(_ context.Context) ([]sqlc.ListWorkspacesWithStatsRow, error) {
+			return []sqlc.ListWorkspacesWithStatsRow{}, nil
 		},
 	}
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -183,3 +183,29 @@ func TestContentType_POST_NoBody(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 }
+
+func TestVersionHeaderMiddleware(t *testing.T) {
+	mw := versionHeaderMiddleware("1.2.3")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := applyMiddleware(mw, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	got := rec.Header().Get("X-Nano-Brain-Version")
+	if got != "1.2.3" {
+		t.Errorf("expected X-Nano-Brain-Version=1.2.3, got %q", got)
+	}
+}
+
+func TestVersionHeaderMiddleware_EmptyVersion(t *testing.T) {
+	mw := versionHeaderMiddleware("")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := applyMiddleware(mw, req)
+
+	got := rec.Header().Get("X-Nano-Brain-Version")
+	if got != "" {
+		t.Errorf("expected empty version header, got %q", got)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -34,6 +34,10 @@ func registerRoutes(s *Server) {
 	data.PUT("/collections/:name", handlers.RenameCollectionHandler(s.queries, s.watcher, s.logger))
 	data.DELETE("/collections/:name", handlers.RemoveCollection(s.queries, s.watcher, s.logger))
 
+	data.GET("/tags", handlers.ListTags(s.queries, s.logger))
+	data.POST("/reindex", handlers.TriggerReindex(s.logger))
+	data.POST("/update", handlers.TriggerUpdate(s.logger))
+
 	data.POST("/vsearch", handlers.VectorSearch(s.queries, s.embedder, s.logger))
 	data.POST("/search", handlers.BM25Search(s.queries, s.logger))
 

--- a/internal/storage/queries/documents.sql
+++ b/internal/storage/queries/documents.sql
@@ -41,3 +41,10 @@ FROM documents WHERE workspace_hash = $1 ORDER BY updated_at DESC;
 
 -- name: UpdateDocumentsCollection :exec
 UPDATE documents SET collection = $2 WHERE collection = $1 AND workspace_hash = $3;
+
+-- name: ListTagsByWorkspace :many
+SELECT unnest(tags) AS tag, COUNT(*) AS count
+FROM documents
+WHERE workspace_hash = $1 AND tags IS NOT NULL AND array_length(tags, 1) > 0
+GROUP BY tag
+ORDER BY count DESC, tag;

--- a/internal/storage/queries/workspaces.sql
+++ b/internal/storage/queries/workspaces.sql
@@ -15,3 +15,10 @@ SELECT * FROM workspaces ORDER BY name;
 
 -- name: CountDocumentsByWorkspace :one
 SELECT COUNT(*) FROM documents WHERE workspace_hash = $1;
+
+-- name: ListWorkspacesWithStats :many
+SELECT w.*,
+    (SELECT COUNT(*) FROM documents d WHERE d.workspace_hash = w.hash) AS document_count,
+    (SELECT MAX(d.updated_at) FROM documents d WHERE d.workspace_hash = w.hash) AS last_document_updated
+FROM workspaces w
+ORDER BY w.name;

--- a/internal/storage/sqlc/documents.sql.go
+++ b/internal/storage/sqlc/documents.sql.go
@@ -151,6 +151,42 @@ func (q *Queries) ListDocumentsByWorkspace(ctx context.Context, workspaceHash st
 	return items, nil
 }
 
+const listTagsByWorkspace = `-- name: ListTagsByWorkspace :many
+SELECT unnest(tags) AS tag, COUNT(*) AS count
+FROM documents
+WHERE workspace_hash = $1 AND tags IS NOT NULL AND array_length(tags, 1) > 0
+GROUP BY tag
+ORDER BY count DESC, tag
+`
+
+type ListTagsByWorkspaceRow struct {
+	Tag   interface{}
+	Count int64
+}
+
+func (q *Queries) ListTagsByWorkspace(ctx context.Context, workspaceHash string) ([]ListTagsByWorkspaceRow, error) {
+	rows, err := q.db.QueryContext(ctx, listTagsByWorkspace, workspaceHash)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTagsByWorkspaceRow
+	for rows.Next() {
+		var i ListTagsByWorkspaceRow
+		if err := rows.Scan(&i.Tag, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateDocumentsCollection = `-- name: UpdateDocumentsCollection :exec
 UPDATE documents SET collection = $2 WHERE collection = $1 AND workspace_hash = $3
 `

--- a/internal/storage/sqlc/workspaces.sql.go
+++ b/internal/storage/sqlc/workspaces.sql.go
@@ -7,6 +7,9 @@ package sqlc
 
 import (
 	"context"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 const countDocumentsByWorkspace = `-- name: CountDocumentsByWorkspace :one
@@ -58,6 +61,57 @@ func (q *Queries) ListWorkspaces(ctx context.Context) ([]Workspace, error) {
 			&i.Path,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWorkspacesWithStats = `-- name: ListWorkspacesWithStats :many
+SELECT w.id, w.hash, w.name, w.path, w.created_at, w.updated_at,
+    (SELECT COUNT(*) FROM documents d WHERE d.workspace_hash = w.hash) AS document_count,
+    (SELECT MAX(d.updated_at) FROM documents d WHERE d.workspace_hash = w.hash) AS last_document_updated
+FROM workspaces w
+ORDER BY w.name
+`
+
+type ListWorkspacesWithStatsRow struct {
+	ID                  uuid.UUID
+	Hash                string
+	Name                string
+	Path                string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	DocumentCount       int64
+	LastDocumentUpdated interface{}
+}
+
+func (q *Queries) ListWorkspacesWithStats(ctx context.Context) ([]ListWorkspacesWithStatsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listWorkspacesWithStats)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListWorkspacesWithStatsRow
+	for rows.Next() {
+		var i ListWorkspacesWithStatsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Name,
+			&i.Path,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DocumentCount,
+			&i.LastDocumentUpdated,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Story 8.5: Tags Endpoint, Reindex API, Workspace Listing

**Issue:** #124 | **FR:** FR-20,21,61,62,64,65,69 | **Epic:** 8 | **Complexity:** M

### Changes
**New:**
- `handlers/tags.go` — GET /api/v1/tags with unnest+count
- `handlers/reindex.go` — POST /api/v1/reindex + /api/v1/update (HTTP 202)
- `handlers/tags_test.go`, `reindex_test.go` — 6 tests

**Enhanced:**
- `handlers/workspace.go` — ListWorkspacesWithStats (doc count + last updated)
- `routes.go` — wired new endpoints under workspaceMiddleware

**SQL:**
- `ListTagsByWorkspace` — unnest tags with GROUP BY counts
- `ListWorkspacesWithStats` — single query, no N+1

Closes #124