### PR TITLE
feat(cli): add daemon management (serve -d, stop, restart) #135

### DIFF
--- a/cmd/nano-brain/daemon.go
+++ b/cmd/nano-brain/daemon.go
@@ -1,0 +1,182 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func pidFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "nano-brain.pid"
+	}
+	return filepath.Join(home, ".nano-brain", "nano-brain.pid")
+}
+
+func readPID() (int, error) {
+	data, err := os.ReadFile(pidFilePath())
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}
+
+func isRunning(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func runServeCmd(args []string, configPath string) {
+	daemon := false
+	for _, a := range args {
+		switch a {
+		case "-d", "--detach":
+			daemon = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", a)
+			fmt.Fprintln(os.Stderr, "Usage: nano-brain serve [-d]")
+			os.Exit(1)
+		}
+	}
+
+	if daemon {
+		runServeDaemon(configPath)
+		return
+	}
+
+	startServer(configPath)
+}
+
+func runServeDaemon(configPath string) {
+	if pid, err := readPID(); err == nil && isRunning(pid) {
+		fmt.Fprintf(os.Stderr, "nano-brain is already running (PID: %d)\n", pid)
+		os.Exit(1)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot resolve binary path: %v\n", err)
+		os.Exit(1)
+	}
+
+	logPath := defaultLogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot create log directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot open log file %s: %v\n", logPath, err)
+		os.Exit(1)
+	}
+
+	childArgs := []string{exe, "--daemon-child"}
+	if configPath != "" {
+		childArgs = append(childArgs, "--config", configPath)
+	}
+
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot open /dev/null: %v\n", err)
+		os.Exit(1)
+	}
+
+	attr := &os.ProcAttr{
+		Dir:   "/",
+		Files: []*os.File{devNull, logFile, logFile},
+		Sys:   &syscall.SysProcAttr{Setsid: true},
+	}
+
+	proc, err := os.StartProcess(exe, childArgs, attr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start daemon: %v\n", err)
+		os.Exit(1)
+	}
+
+	childPID := proc.Pid
+
+	if err := os.MkdirAll(filepath.Dir(pidFilePath()), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot create PID directory: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(pidFilePath(), []byte(strconv.Itoa(childPID)), 0600); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot write PID file: %v\n", err)
+		os.Exit(1)
+	}
+
+	_ = proc.Release()
+	_ = logFile.Close()
+	_ = devNull.Close()
+
+	fmt.Printf("nano-brain started (PID: %d)\n", childPID)
+	fmt.Printf("Logs: %s\n", logPath)
+}
+
+func runStopCmd() {
+	pid, err := readPID()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "nano-brain is not running")
+		os.Exit(1)
+	}
+
+	if !isRunning(pid) {
+		_ = os.Remove(pidFilePath())
+		fmt.Fprintln(os.Stderr, "nano-brain is not running (cleaned stale PID file)")
+		os.Exit(1)
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot find process %d: %v\n", pid, err)
+		os.Exit(1)
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to send SIGTERM to PID %d: %v\n", pid, err)
+		os.Exit(1)
+	}
+
+	for i := 0; i < 50; i++ {
+		time.Sleep(100 * time.Millisecond)
+		if !isRunning(pid) {
+			_ = os.Remove(pidFilePath())
+			fmt.Println("nano-brain stopped")
+			return
+		}
+	}
+
+	_ = proc.Signal(syscall.SIGKILL)
+	_ = os.Remove(pidFilePath())
+	fmt.Println("nano-brain stopped (forced)")
+}
+
+func runRestartCmd(args []string, configPath string) {
+	if pid, err := readPID(); err == nil && isRunning(pid) {
+		proc, _ := os.FindProcess(pid)
+		_ = proc.Signal(syscall.SIGTERM)
+		for i := 0; i < 50; i++ {
+			time.Sleep(100 * time.Millisecond)
+			if !isRunning(pid) {
+				break
+			}
+		}
+		if isRunning(pid) {
+			_ = proc.Signal(syscall.SIGKILL)
+			time.Sleep(200 * time.Millisecond)
+		}
+		_ = os.Remove(pidFilePath())
+	}
+
+	runServeDaemon(configPath)
+}

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -28,11 +28,29 @@ var Version = "dev"
 
 func main() {
 	var configPath string
+	var daemonChild bool
 	flag.StringVar(&configPath, "config", "", "path to config file (default: ~/.nano-brain/config.yml)")
+	flag.BoolVar(&daemonChild, "daemon-child", false, "")
 	flag.Parse()
+
+	// Hidden --daemon-child flag: run server directly (called by serve -d)
+	if daemonChild {
+		defer os.Remove(pidFilePath())
+		startServer(configPath)
+		return
+	}
 
 	if args := flag.Args(); len(args) > 0 {
 		switch args[0] {
+		case "serve":
+			runServeCmd(args[1:], configPath)
+			return
+		case "stop":
+			runStopCmd()
+			return
+		case "restart":
+			runRestartCmd(args[1:], configPath)
+			return
 		case "collection":
 			runCollectionCmd(args[1:])
 			return
@@ -88,6 +106,12 @@ func main() {
 		}
 	}
 
+	// No args: start server foreground (backward compat)
+	startServer(configPath)
+}
+
+// startServer runs the nano-brain HTTP server (blocking).
+func startServer(configPath string) {
 	if configPath == "" {
 		configPath = config.DefaultConfigPath()
 	}

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -534,7 +534,11 @@ func printUsage() {
 Usage: nano-brain [command] [flags]
 
 Commands:
-  (no command)       Start the server
+  (no command)       Start the server (foreground)
+  serve              Start the server (foreground)
+  serve -d           Start the server (background/daemon)
+  stop               Stop background server
+  restart            Restart background server
   init               Interactive setup wizard (or --root <path> to register workspace)
   doctor             Check prerequisites (PostgreSQL, pgvector, embedding provider)
   status             Show server status


### PR DESCRIPTION
## Summary

Add daemon management commands for running nano-brain server in background mode.

### New Commands
- `serve` — Start server (foreground, same as no-args)
- `serve -d` — Start server as background daemon
- `stop` — Stop background server
- `restart` — Restart background server

### Implementation
- Self-re-exec pattern: `serve -d` forks child with hidden `--daemon-child` flag
- PID file: `~/.nano-brain/nano-brain.pid`
- Log file: `~/.nano-brain/logs/nano-brain.log`
- Double-start protection (checks existing PID)
- Stale PID cleanup (process no longer running)
- Unix-only (`//go:build !windows`)

### Testing
- Build + unit tests pass
- E2E verified: serve -d, stop, restart, double-start protection, stale PID cleanup

Closes #135