### PR TITLE
feat(cli): container server guard — port check + auto-config #137

### DIFF
--- a/cmd/nano-brain/daemon.go
+++ b/cmd/nano-brain/daemon.go
@@ -58,6 +58,11 @@ func runServeCmd(args []string, configPath string) {
 }
 
 func runServeDaemon(configPath string) {
+	if err := guardBeforeStart(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+
 	if pid, err := readPID(); err == nil && isRunning(pid) {
 		fmt.Fprintf(os.Stderr, "nano-brain is already running (PID: %d)\n", pid)
 		os.Exit(1)

--- a/cmd/nano-brain/guard.go
+++ b/cmd/nano-brain/guard.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+func isContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return true
+	}
+	return false
+}
+
+func resolvePort() int {
+	if p := os.Getenv("NANO_BRAIN_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil && v > 0 && v <= 65535 {
+			return v
+		}
+	}
+	return 3100
+}
+
+func autoConfigContainer() bool {
+	if !isContainer() {
+		return false
+	}
+	if os.Getenv("NANO_BRAIN_HOST") != "" {
+		return false
+	}
+	os.Setenv("NANO_BRAIN_HOST", "host.docker.internal")
+	fmt.Fprintf(os.Stderr, "Detected container environment. Using host.docker.internal:%d for server communication.\n", resolvePort())
+	return true
+}
+
+func probeServer(addr string) bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s/api/status", addr))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return true
+}
+
+func checkExistingServer(port int) error {
+	addr := fmt.Sprintf("localhost:%d", port)
+	if probeServer(addr) {
+		return fmt.Errorf("nano-brain server already running at %s", addr)
+	}
+	if os.Getenv("NANO_BRAIN_HOST") == "" {
+		dockerAddr := fmt.Sprintf("host.docker.internal:%d", port)
+		if probeServer(dockerAddr) {
+			return fmt.Errorf("nano-brain server already running at %s", dockerAddr)
+		}
+	}
+	return nil
+}
+
+func guardBeforeStart() error {
+	autoConfigContainer()
+	if os.Getenv("NANO_BRAIN_ALLOW_DUPLICATE_SERVER") == "1" {
+		return nil
+	}
+	return checkExistingServer(resolvePort())
+}

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -112,6 +112,11 @@ func main() {
 
 // startServer runs the nano-brain HTTP server (blocking).
 func startServer(configPath string) {
+	if err := guardBeforeStart(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+
 	if configPath == "" {
 		configPath = config.DefaultConfigPath()
 	}


### PR DESCRIPTION
## Summary

Prevents duplicate nano-brain server starts and auto-configures container environments.

### Guard Logic (new file: `guard.go`)

**A. Port Check** — before starting, probes for existing server:
- `GET /api/status` on `localhost:{port}`
- If `NANO_BRAIN_HOST` not set, also probes `host.docker.internal:{port}`
- If any responds → refuse to start

**B. Container Detection** — detects Docker (`/.dockerenv`) and Kubernetes (`KUBERNETES_SERVICE_HOST`):
- Auto-sets `NANO_BRAIN_HOST=host.docker.internal` if not already set
- Prints warning to stderr

### Override
`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1` bypasses port check.

### Guard Placement
- `startServer()` in main.go (covers no-args + serve + --daemon-child)
- `runServeDaemon()` in daemon.go (fails fast before fork)

### E2E Verified
- [x] Container detected (/.dockerenv)
- [x] Duplicate server blocked (serve -d, then second serve -d → error)
- [x] Foreground start blocked when daemon running
- [x] Override allows duplicate start
- [x] Auto-config sets NANO_BRAIN_HOST in container
- [x] CLI commands (status, stop) work from container

Closes #137