### PR TITLE
feat(npm): migrate to @nano-step/nano-brain + CI auto-publish #139

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,1 +1,0 @@
-# Removed: v1 npm workflow. See ci.yml for v2 Go CI.

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -1,1 +1,0 @@
-# Removed: v1 npm workflow. See ci.yml for v2 Go CI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,39 @@ jobs:
         with:
           generate_release_notes: true
           files: artifacts/*
+
+  npm-publish:
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          if [[ "${{ github.ref_name }}" == *"-beta"* || "${{ github.ref_name }}" == *"-alpha"* || "${{ github.ref_name }}" == *"-rc"* ]]; then
+            echo "tag=beta" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set version from git tag
+        run: npm version --no-git-tag-version "${GITHUB_REF_NAME#v}"
+
+      - name: Publish @nano-step/nano-brain
+        run: npm publish --tag ${{ steps.npm-tag.outputs.tag }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish nano-brain (unscoped alias)
+        run: |
+          node -e "const p=require('./package.json'); p.name='nano-brain'; delete p.publishConfig; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          npm publish --tag ${{ steps.npm-tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ docker run -d --name nanobrain-pg -p 5432:5432 \
 ollama pull nomic-embed-text
 
 # Check prerequisites
-npx nano-brain@beta doctor
+npx @nano-step/nano-brain@beta doctor
 
 # Start server
-npx nano-brain@beta
+npx @nano-step/nano-brain@beta
 ```
 
+> **Also available as:** `npx nano-brain@beta` (unscoped alias)
+>
 > **Note:** Do NOT run `npx nano-brain` from the nano-brain source directory — npm will resolve the local package instead of the registry. Run from any other directory.
 
 ### Option B: Build from source

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "nano-brain",
-  "version": "2.0.0-beta.5",
+  "name": "@nano-step/nano-brain",
+  "version": "0.0.0-dev",
   "description": "Persistent memory and code intelligence for AI coding agents",
   "bin": {
     "nano-brain": "npm/run.js"
   },
   "scripts": {
     "postinstall": "node npm/postinstall.js"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Migrate npm package to scoped `@nano-step/nano-brain` under the nano-step org, with CI auto-publish on tag push.

### Changes

| File | Change |
|------|--------|
| `package.json` | name → `@nano-step/nano-brain`, add `publishConfig.access: public`, version → `0.0.0-dev` (derived from git tag at publish time) |
| `release.yml` | New `npm-publish` job: dual publish `@nano-step/nano-brain` + `nano-brain` |
| `publish-beta.yml` | Deleted (stub) |
| `publish-stable.yml` | Deleted (stub) |
| `README.md` | Updated Quick Start with `@nano-step/nano-brain@beta` |

### How It Works

1. Push tag `v2.0.0-beta.6` → release.yml triggers
2. Build job: compile 4 platform binaries
3. Release job: create GitHub Release with binaries
4. **npm-publish job** (new):
   - Derive version from git tag (`v2.0.0-beta.6` → `2.0.0-beta.6`)
   - Determine npm tag (`-beta` → `--tag beta`, else → `--tag latest`)
   - Publish `@nano-step/nano-brain` (scoped, primary)
   - Publish `nano-brain` (unscoped, alias)

### Users Can Use Either
```bash
npx @nano-step/nano-brain@beta  # official, scoped
npx nano-brain@beta             # short alias
```

Closes #139