### PR TITLE
feat(cli): add reindex command — wire CLI to POST /api/v1/reindex (#159)

### DIFF
--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -287,6 +287,70 @@ func runHarvestCmd(args []string) {
 		Msg("cli command completed")
 }
 
+func runReindexCmd(args []string) {
+	cliLog.Info().Str("cmd", "reindex").Msg("cli command started")
+	var root, workspace string
+	var jsonFlag bool
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--root":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--root requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			root = args[i]
+		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			workspace = args[i]
+		case "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+
+	if root == "" {
+		fmt.Fprintf(os.Stderr, "--root is required\n")
+		os.Exit(1)
+	}
+
+	// Build request body
+	reqBody := map[string]string{"root": root}
+	if workspace != "" {
+		reqBody["workspace"] = workspace
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to marshal request: %v\n", err)
+		cliLog.Error().Err(err).Str("cmd", "reindex").Msg("failed to marshal request")
+		os.Exit(1)
+	}
+
+	resp, _, err := doRequest("POST", getBaseURL()+"/api/v1/reindex", bytes.NewReader(bodyBytes))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		cliLog.Error().Err(err).Str("cmd", "reindex").Msg("reindex request failed")
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "reindex").Msg("cli command completed")
+		return
+	}
+
+	fmt.Printf("Reindex queued for collection '%s'\n", root)
+	cliLog.Info().Str("cmd", "reindex").Str("root", root).Msg("cli command completed")
+}
+
 func runQueryCmd(args []string) {
 	runStubCmd("query", args)
 }

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -88,6 +88,9 @@ func main() {
 		case "harvest":
 			runHarvestCmd(args[1:])
 			return
+		case "reindex":
+			runReindexCmd(args[1:])
+			return
 		case "bench":
 			runBenchCmd(args[1:])
 			return

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -563,9 +563,10 @@ Commands:
   vsearch            Vector similarity search
   workspaces         List registered workspaces (alias: ls)
   write              Write a document
-  collection         Manage collections (add/remove/list)
-  harvest            Trigger session harvesting
-  logs               View log file (-f to follow, -n <count>)
+   collection         Manage collections (add/remove/list)
+   harvest            Trigger session harvesting
+   reindex            Queue collection reindex
+   logs               View log file (-f to follow, -n <count>)
   docker             Manage Docker Compose (start/stop/status)
   db:migrate         Run database migrations
   bench              Benchmarking suite (generate/run/compare/stress)


### PR DESCRIPTION
## Summary
Adds the missing `reindex` CLI command to nano-brain v2. The `POST /api/v1/reindex` server endpoint already existed; this PR wires the CLI to it.

Closes #159

## Changes
- `cmd/nano-brain/main.go` — add `case "reindex"` dispatcher (3 lines)
- `cmd/nano-brain/commands.go` — implement `runReindexCmd`: flags `--root` (required), `--workspace`, `--json`; calls `POST /api/v1/reindex`
- `cmd/nano-brain/ops.go` — add `reindex` to `printUsage()` help text

## Usage
```bash
nano-brain reindex --root my-collection
nano-brain reindex --root my-collection --workspace abc123
nano-brain reindex --root my-collection --json
```

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...   (all 17 packages)
```

## Lane
tiny (single-module CLI wiring, 0 risk flags)

## Change Type
bug-fix