### PR TITLE
fix(server): implement POST /api/v1/reindex — replace no-op stub (#162)

### DIFF
--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -1,12 +1,19 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
 )
+
+type ReindexQuerier interface {
+	ResetEmbedStatusByCollection(ctx context.Context, arg sqlc.ResetEmbedStatusByCollectionParams) (int64, error)
+}
 
 type reindexRequest struct {
 	Workspace string `json:"workspace"`
@@ -14,11 +21,13 @@ type reindexRequest struct {
 }
 
 type reindexResponse struct {
-	Status  string `json:"status"`
-	Message string `json:"message"`
+	Status          string `json:"status"`
+	ChunksEnqueued  int64  `json:"chunks_enqueued"`
+	WatcherTriggered bool  `json:"watcher_triggered"`
+	Message         string `json:"message"`
 }
 
-func TriggerReindex(logger zerolog.Logger) echo.HandlerFunc {
+func TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var req reindexRequest
 		if err := c.Bind(&req); err != nil {
@@ -31,15 +40,29 @@ func TriggerReindex(logger zerolog.Logger) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusBadRequest, "root (collection name) is required")
 		}
 
+		n, err := queries.ResetEmbedStatusByCollection(c.Request().Context(), sqlc.ResetEmbedStatusByCollectionParams{
+			WorkspaceHash: workspace,
+			Collection:    req.Root,
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("reset embed status: %v", err))
+		}
+
+		triggered := w.TriggerRescanByName(req.Root, workspace)
+
 		reqLog := LoggerFromCtx(c, logger)
 		reqLog.Info().
 			Str("workspace", workspace).
 			Str("root", req.Root).
+			Int64("chunks_enqueued", n).
+			Bool("watcher_triggered", triggered).
 			Msg("reindex queued")
 
 		return c.JSON(http.StatusAccepted, reindexResponse{
-			Status:  "queued",
-			Message: fmt.Sprintf("Reindex queued for collection %s in workspace %s", req.Root, workspace),
+			Status:          "queued",
+			ChunksEnqueued:  n,
+			WatcherTriggered: triggered,
+			Message:         fmt.Sprintf("Reindex queued for collection %s in workspace %s", req.Root, workspace),
 		})
 	}
 }

--- a/internal/server/handlers/reindex_test.go
+++ b/internal/server/handlers/reindex_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,9 +9,33 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
 )
+
+type mockReindexQuerier struct {
+	called     bool
+	returnN    int64
+	returnErr  error
+	lastParams sqlc.ResetEmbedStatusByCollectionParams
+}
+
+func (m *mockReindexQuerier) ResetEmbedStatusByCollection(_ context.Context, arg sqlc.ResetEmbedStatusByCollectionParams) (int64, error) {
+	m.called = true
+	m.lastParams = arg
+	return m.returnN, m.returnErr
+}
+
+func newTestWatcherForHandler() *watcher.Watcher {
+	cfg := config.Config{
+		Watcher: config.WatcherConfig{DebounceMs: 2000, ReindexInterval: 300},
+		Storage: config.StorageConfig{MaxFileSize: 1024, MaxSize: 10240},
+	}
+	return watcher.New(nil, nil, zerolog.Nop(), cfg)
+}
 
 func TestTriggerReindex(t *testing.T) {
 	e := echo.New()
@@ -21,7 +46,10 @@ func TestTriggerReindex(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.Set("workspace", "ws123")
 
-	h := handlers.TriggerReindex(zerolog.Nop())
+	mq := &mockReindexQuerier{returnN: 5}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
@@ -30,15 +58,26 @@ func TestTriggerReindex(t *testing.T) {
 		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]string
+	if !mq.called {
+		t.Fatal("expected ResetEmbedStatusByCollection to be called")
+	}
+	if mq.lastParams.WorkspaceHash != "ws123" || mq.lastParams.Collection != "code" {
+		t.Errorf("unexpected params: %+v", mq.lastParams)
+	}
+
+	var resp map[string]interface{}
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
 	if resp["status"] != "queued" {
-		t.Errorf("expected status=queued, got %s", resp["status"])
+		t.Errorf("expected status=queued, got %v", resp["status"])
 	}
-	if !strings.Contains(resp["message"], "code") || !strings.Contains(resp["message"], "ws123") {
-		t.Errorf("unexpected message: %s", resp["message"])
+	if resp["chunks_enqueued"] != float64(5) {
+		t.Errorf("expected chunks_enqueued=5, got %v", resp["chunks_enqueued"])
+	}
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "code") || !strings.Contains(msg, "ws123") {
+		t.Errorf("unexpected message: %s", msg)
 	}
 }
 
@@ -51,7 +90,10 @@ func TestTriggerReindexMissingRoot(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.Set("workspace", "ws123")
 
-	h := handlers.TriggerReindex(zerolog.Nop())
+	mq := &mockReindexQuerier{}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, zerolog.Nop())
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for missing root")
@@ -62,6 +104,9 @@ func TestTriggerReindexMissingRoot(t *testing.T) {
 	}
 	if he.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", he.Code)
+	}
+	if mq.called {
+		t.Error("expected ResetEmbedStatusByCollection not to be called on missing root")
 	}
 }
 
@@ -83,14 +128,15 @@ func TestTriggerUpdate(t *testing.T) {
 		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
 	}
 
-	var resp map[string]string
+	var resp map[string]interface{}
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
 	if resp["status"] != "queued" {
-		t.Errorf("expected status=queued, got %s", resp["status"])
+		t.Errorf("expected status=queued, got %v", resp["status"])
 	}
-	if !strings.Contains(resp["message"], "ws123") {
-		t.Errorf("unexpected message: %s", resp["message"])
+	msg, _ := resp["message"].(string)
+	if !strings.Contains(msg, "ws123") {
+		t.Errorf("unexpected message: %s", msg)
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -39,7 +39,7 @@ func registerRoutes(s *Server) {
 	data.DELETE("/collections/:name", handlers.RemoveCollection(s.queries, s.watcher, s.logger))
 
 	data.GET("/tags", handlers.ListTags(s.queries, s.logger))
-	data.POST("/reindex", handlers.TriggerReindex(s.logger))
+	data.POST("/reindex", handlers.TriggerReindex(s.queries, s.watcher, s.logger))
 	data.POST("/update", handlers.TriggerUpdate(s.logger))
 
 	data.POST("/vsearch", handlers.VectorSearch(s.queries, s.embedder, s.logger, s.recorder))

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -49,6 +49,14 @@ WHERE e.workspace_hash = sqlc.arg(workspace_hash)
 ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
 LIMIT sqlc.arg(max_results);
 
+-- name: ResetEmbedStatusByCollection :execrows
+UPDATE chunks
+SET embed_status = 'pending'
+FROM documents
+WHERE chunks.document_id = documents.id
+  AND chunks.workspace_hash = @workspace_hash
+  AND documents.collection = @collection;
+
 -- name: VectorSearchAll :many
 SELECT e.id, e.chunk_id, e.workspace_hash,
        c.content, c.metadata, c.document_id,

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -194,6 +194,28 @@ func (q *Queries) ResetEmbedStatus(ctx context.Context, workspaceHash string) er
 	return err
 }
 
+const resetEmbedStatusByCollection = `-- name: ResetEmbedStatusByCollection :execrows
+UPDATE chunks
+SET embed_status = 'pending'
+FROM documents
+WHERE chunks.document_id = documents.id
+  AND chunks.workspace_hash = $1
+  AND documents.collection = $2
+`
+
+type ResetEmbedStatusByCollectionParams struct {
+	WorkspaceHash string
+	Collection    string
+}
+
+func (q *Queries) ResetEmbedStatusByCollection(ctx context.Context, arg ResetEmbedStatusByCollectionParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, resetEmbedStatusByCollection, arg.WorkspaceHash, arg.Collection)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const vectorSearch = `-- name: VectorSearch :many
 SELECT e.id, e.chunk_id, e.workspace_hash,
        c.content, c.metadata, c.document_id,

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -104,6 +104,21 @@ func (w *Watcher) Unwatch(dirPath string) error {
 	return nil
 }
 
+// TriggerRescanByName marks the directory of a named collection dirty so the
+// watcher will re-scan it on the next debounce tick. Returns true if the
+// collection was found, false if it is not registered with this watcher.
+func (w *Watcher) TriggerRescanByName(collectionName, workspaceHash string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for path, col := range w.collections {
+		if col.name == collectionName && col.workspaceHash == workspaceHash {
+			w.dirty[path] = true
+			return true
+		}
+	}
+	return false
+}
+
 func (w *Watcher) Run(ctx context.Context) error {
 	fsw, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -264,3 +264,37 @@ func TestWatchUnwatch(t *testing.T) {
 	}
 	w.mu.Unlock()
 }
+
+func TestTriggerRescanByName(t *testing.T) {
+	dir := t.TempDir()
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 2000, 300)
+
+	if err := w.Watch("mycol", dir, "ws42", "*.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	absDir, _ := filepath.Abs(dir)
+
+	found := w.TriggerRescanByName("mycol", "ws42")
+	if !found {
+		t.Fatal("expected TriggerRescanByName to return true for registered collection")
+	}
+
+	w.mu.Lock()
+	if !w.dirty[absDir] {
+		w.mu.Unlock()
+		t.Fatal("expected directory to be marked dirty")
+	}
+	w.mu.Unlock()
+
+	notFound := w.TriggerRescanByName("other", "ws42")
+	if notFound {
+		t.Fatal("expected TriggerRescanByName to return false for unregistered collection")
+	}
+
+	notFoundWS := w.TriggerRescanByName("mycol", "wrongws")
+	if notFoundWS {
+		t.Fatal("expected TriggerRescanByName to return false for wrong workspace")
+	}
+}

--- a/openspec/changes/reindex-real-impl/.openspec.yaml
+++ b/openspec/changes/reindex-real-impl/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/reindex-real-impl/design.md
+++ b/openspec/changes/reindex-real-impl/design.md
@@ -1,0 +1,158 @@
+## Context
+
+`POST /api/v1/reindex` is registered at `internal/server/routes.go:42` as:
+
+```go
+data.POST("/reindex", handlers.TriggerReindex(s.logger))
+```
+
+`TriggerReindex` (handlers/reindex.go:21-44) currently only logs and returns 202. No storage interaction, no watcher interaction.
+
+The watcher (`internal/watcher/watcher.go`) runs as a goroutine alongside the HTTP server. It maintains a map of `watchedCollection` entries (keyed by absolute directory path) and a `dirty` map. When the `dirty` map has entries, `processDirty` re-scans those directories. All internal methods that drive rescanning (`processDirty`, `processAll`, `scanCollection`) are unexported.
+
+The embed queue (`internal/embed/queue.go`) has a `scanPending` loop that picks up chunks with `embed_status='pending'` and processes them. It is already wired and running. The existing `ResetEmbedStatus` SQL query resets embed_status for an entire workspace — not scoped to a collection.
+
+**Dependency injection of watcher into the handler:**  
+`s.watcher` is a `*watcher.Watcher` already stored on the `Server` struct. Other handlers (e.g., `AddCollection`, `RemoveCollection`, `RenameCollectionHandler`) already receive `s.watcher` as a parameter. The pattern is established: extend `TriggerReindex` to accept `queries` and `watcher`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `POST /api/v1/reindex` marks all chunks for the named collection as `embed_status='pending'` so the embed queue re-embeds them.
+- `POST /api/v1/reindex` triggers the watcher to rescan the collection's directory so new/modified files are ingested.
+- Handler signature updated; routes updated to pass `s.queries` and `s.watcher`.
+- New SQL query scoped to collection (not whole workspace).
+- New `TriggerRescan` method exported from watcher for handler use.
+
+**Non-Goals:**
+- No database schema migration (no new columns or tables).
+- No change to the response shape or HTTP status code.
+- No change to `TriggerUpdate` (the whole-workspace update endpoint) — leave it as-is for now.
+- No cleanup of stale files (the existing TODO in watcher for deletion handling is separate).
+
+## Decisions
+
+### Decision 1: Where does the collection-scoped "mark pending" happen?
+
+**Options:**
+- A) Handler queries storage directly (new SQL query, new sqlc method).
+- B) Watcher's new `TriggerRescan` method also handles the mark-pending step.
+
+**Choice: A** — Handler calls storage to mark chunks pending, then calls watcher to rescan. These are two separate concerns. The watcher should not own the "reset embed status" responsibility; that belongs to the storage layer. Keeping them separate makes each piece testable in isolation.
+
+### Decision 2: How does the handler find the collection's directory path for the watcher?
+
+The watcher's `collections` map is keyed by absolute directory path. The handler knows the collection name and workspace hash from the request. It must look up the collection's path from storage.
+
+**Options:**
+- A) Add a new SQL query `GetCollectionByName` and pass the result to watcher.
+- B) Add a `TriggerRescanByName(collectionName, workspaceHash string)` method to watcher that does the lookup itself using its own `collections` map.
+
+**Choice: B** — The watcher already holds a `collections` map indexed by directory path that maps to `watchedCollection{name, dirPath, workspaceHash, ...}`. A reverse lookup by `(collectionName, workspaceHash)` is O(n) over watched collections (typically tiny). This avoids an extra SQL round-trip and a new query. The watcher's map is the authoritative in-memory state for what is currently being watched.
+
+### Decision 3: New SQL query scope
+
+The existing `ResetEmbedStatus` resets all chunks in a workspace. We need a collection-scoped version. Since `embed_status` lives on `chunks` and collection lives on `documents`, the new query needs a JOIN:
+
+```sql
+-- name: ResetEmbedStatusByCollection :exec
+UPDATE chunks SET embed_status = 'pending'
+FROM documents
+WHERE chunks.document_id = documents.id
+  AND chunks.workspace_hash = $1
+  AND documents.collection = $2;
+```
+
+This requires `sqlc generate` to regenerate `internal/storage/sqlc/embeddings.sql.go`.
+
+### Decision 4: Watcher `TriggerRescanByName` implementation
+
+```go
+// TriggerRescanByName marks the directory for the named collection as dirty,
+// causing the watcher's debounce loop to rescan it on the next cycle.
+// Returns false if the collection is not currently watched (not an error — the
+// handler should still return 202 since the mark-pending step succeeded).
+func (w *Watcher) TriggerRescanByName(collectionName, workspaceHash string) bool {
+    w.mu.Lock()
+    defer w.mu.Unlock()
+    for absPath, col := range w.collections {
+        if col.name == collectionName && col.workspaceHash == workspaceHash {
+            w.dirty[absPath] = true
+            return true
+        }
+    }
+    return false
+}
+```
+
+The watcher's `Run` loop will pick up the dirty entry on the next debounce tick and call `processDirty` → `scanCollection`. This is fire-and-forget from the handler's perspective, matching the existing 202 Accepted semantics.
+
+### Decision 5: Handler signature
+
+```go
+func TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc
+```
+
+A new minimal interface `ReindexQuerier` (in the handlers package) wraps the single method needed:
+
+```go
+type ReindexQuerier interface {
+    ResetEmbedStatusByCollection(ctx context.Context, arg sqlc.ResetEmbedStatusByCollectionParams) error
+}
+```
+
+`*sqlc.Queries` satisfies this interface automatically once the new query is generated.
+
+The route registration becomes:
+
+```go
+data.POST("/reindex", handlers.TriggerReindex(s.queries, s.watcher, s.logger))
+```
+
+## Exact Execution Flow
+
+```
+POST /api/v1/reindex  {root: "my-collection"}
+  │
+  ├─ middleware: extract workspace hash → c.Set("workspace", wsHash)
+  │
+  ├─ TriggerReindex handler:
+  │    1. Bind request → {workspace, root}
+  │    2. Validate root != ""
+  │    3. queries.ResetEmbedStatusByCollection(ctx, {workspace_hash, collection})
+  │       → UPDATE chunks SET embed_status='pending' FROM documents WHERE ...
+  │    4. watcher.TriggerRescanByName(root, workspace)
+  │       → marks collection dir dirty in watcher.dirty map
+  │    5. Return 202 {status:"queued", message:"Reindex queued for collection X..."}
+  │
+  ├─ watcher goroutine (debounce cycle):
+  │    processDirty() → scanCollection() → processFile() per file
+  │    → upsertWithTx() → upsert document + delete+rewrite chunks
+  │
+  └─ embed queue goroutine (scanPending loop):
+       GetPendingChunks() → processChunk() → embed → MarkChunkEmbedded()
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/storage/queries/embeddings.sql` | Add `ResetEmbedStatusByCollection` query |
+| `internal/storage/sqlc/embeddings.sql.go` | Regenerated by `sqlc generate` |
+| `internal/watcher/watcher.go` | Add exported `TriggerRescanByName(name, wsHash string) bool` |
+| `internal/server/handlers/reindex.go` | Replace stub with real impl; add `ReindexQuerier` interface |
+| `internal/server/routes.go` | Pass `s.queries`, `s.watcher` to `TriggerReindex` |
+
+## Risks / Trade-offs
+
+- **Watcher not running or collection not watched** → `TriggerRescanByName` returns false; handler still returns 202 (mark-pending succeeded). The embed queue will process the pending chunks regardless. The watcher rescan is a best-effort optimization to pick up file changes; it is not required for the embed-status reset to take effect.
+
+- **Large collections** → Marking many chunks pending triggers a large embed queue flush. This is the correct behaviour — the caller explicitly requested a reindex. The embed queue processes concurrently and non-blocking relative to the HTTP handler.
+
+- **sqlc generate required** → Any contributor must run `sqlc generate` after adding the SQL query. This is a standard workflow step for this codebase and is documented in the README. No CI breakage if they forget — the generated file is committed.
+
+- **Race between mark-pending and watcher rescan** → If the watcher rescans and re-upserts documents before the embed queue processes the pending chunks, the upsert will delete and recreate chunks (each created with `embed_status='pending'` by default from the schema). This is safe — the net result is the same.
+
+## Open Questions
+
+None — all design decisions are resolved above.

--- a/openspec/changes/reindex-real-impl/proposal.md
+++ b/openspec/changes/reindex-real-impl/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`POST /api/v1/reindex` accepts a collection name and returns `202 Accepted` but performs no actual work — it logs "reindex queued" and returns. Callers (agents, CLI, MCP tools) believe reindexing was triggered when nothing happened. This defeats the purpose of the endpoint and causes silent data staleness. Fixes [#162](https://github.com/nano-step/nano-brain/issues/162).
+
+## What Changes
+
+- `internal/server/handlers/reindex.go`: `TriggerReindex` is replaced with a real implementation that (1) marks all chunks for the named collection as `embed_status='pending'` via storage, and (2) triggers the watcher to rescan that collection's directory so new/changed files are re-ingested.
+- `internal/storage/queries/embeddings.sql`: Add `ResetEmbedStatusByCollection` query — resets `embed_status` to `'pending'` for all chunks whose document belongs to a given collection in a workspace.
+- `internal/storage/sqlc/`: Regenerate with `sqlc generate` to expose the new query.
+- `internal/watcher/watcher.go`: Add exported `TriggerRescan(collectionName string)` method that marks the collection's directory dirty so the watcher's debounce loop re-scans it on the next cycle.
+- `internal/server/routes.go`: Pass `s.queries` and `s.watcher` to `TriggerReindex` (currently the handler takes only a logger).
+
+## Capabilities
+
+### New Capabilities
+- `reindex-api`: `POST /api/v1/reindex` actually marks collection chunks pending and triggers a watcher rescan, returning 202 once both operations succeed.
+
+### Modified Capabilities
+- (none — no spec-level requirement changes to existing capabilities)
+
+## Impact
+
+- **API contract**: Response shape unchanged (`{ "status": "queued", "message": "..." }`); behavior changes from no-op to real work. Callers that called this endpoint expecting a no-op could see unexpected reprocessing — but those callers were broken anyway.
+- **Storage**: New SQL query touches `chunks` table (UPDATE). Scoped to workspace + collection via a JOIN on `documents`. No schema migration required.
+- **Watcher**: A new exported method is added; no behavioural change to the existing `Watch`/`Unwatch`/`Run` contract.
+- **Handler signature change**: `TriggerReindex(logger)` → `TriggerReindex(queries, watcher, logger)`. Routes must be updated.
+- **No new external dependencies.**

--- a/openspec/changes/reindex-real-impl/specs/reindex-api/spec.md
+++ b/openspec/changes/reindex-real-impl/specs/reindex-api/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: reindex marks collection chunks pending
+When `POST /api/v1/reindex` is called with a valid collection name, the server SHALL update `embed_status` to `'pending'` for all chunks belonging to documents in that collection and workspace. This ensures the embed queue will re-embed those chunks on its next scan cycle.
+
+#### Scenario: Successful reindex triggers embed reset
+- **WHEN** `POST /api/v1/reindex` is called with `{"root": "my-collection"}` and the workspace header is valid
+- **THEN** the server SHALL return HTTP 202 with `{"status": "queued", "message": "Reindex queued for collection my-collection in workspace <wsHash>"}` and all chunks for documents in `my-collection` SHALL have `embed_status = 'pending'` in the database
+
+#### Scenario: Missing root field returns 400
+- **WHEN** `POST /api/v1/reindex` is called with `{}` (no `root` field) or an empty `root`
+- **THEN** the server SHALL return HTTP 400 with an error message and SHALL NOT modify any chunks
+
+#### Scenario: Invalid request body returns 400
+- **WHEN** `POST /api/v1/reindex` is called with a malformed JSON body
+- **THEN** the server SHALL return HTTP 400 and SHALL NOT modify any chunks
+
+#### Scenario: Collection with no chunks is accepted
+- **WHEN** `POST /api/v1/reindex` is called with a valid collection name that has no documents or chunks in the workspace
+- **THEN** the server SHALL return HTTP 202 (zero rows updated is not an error)
+
+### Requirement: reindex triggers watcher rescan
+When `POST /api/v1/reindex` is called and the named collection is currently watched, the server SHALL trigger the watcher to rescan that collection's directory on its next debounce cycle, so that new or modified files are ingested.
+
+#### Scenario: Watched collection is rescanned
+- **WHEN** `POST /api/v1/reindex` is called for a collection that is actively watched by the watcher
+- **THEN** the watcher SHALL schedule a rescan of that collection's directory (mark dirty), which will run on the next debounce cycle
+
+#### Scenario: Unwatched collection still returns 202
+- **WHEN** `POST /api/v1/reindex` is called for a collection that is not currently in the watcher's watch list (e.g., watcher not running or collection was never watched)
+- **THEN** the server SHALL still return HTTP 202, since the embed-status reset succeeded; the watcher rescan is best-effort

--- a/openspec/changes/reindex-real-impl/tasks.md
+++ b/openspec/changes/reindex-real-impl/tasks.md
@@ -1,0 +1,28 @@
+## 1. Storage: Add collection-scoped embed reset query
+
+- [ ] 1.1 Add `ResetEmbedStatusByCollection` query to `internal/storage/queries/embeddings.sql` — `UPDATE chunks SET embed_status = 'pending' FROM documents WHERE chunks.document_id = documents.id AND chunks.workspace_hash = $1 AND documents.collection = $2`
+- [ ] 1.2 Run `sqlc generate` to regenerate `internal/storage/sqlc/embeddings.sql.go` with the new `ResetEmbedStatusByCollection` function and `ResetEmbedStatusByCollectionParams` struct
+- [ ] 1.3 Verify `CGO_ENABLED=0 go build ./...` passes after sqlc regeneration
+
+## 2. Watcher: Expose TriggerRescanByName
+
+- [ ] 2.1 Add exported method `TriggerRescanByName(collectionName, workspaceHash string) bool` to `internal/watcher/watcher.go` — iterates `w.collections` under `w.mu`, marks the matching directory dirty, returns true if found
+- [ ] 2.2 Verify `CGO_ENABLED=0 go build ./...` passes after watcher change
+
+## 3. Handler: Replace stub with real implementation
+
+- [ ] 3.1 Add `ReindexQuerier` interface to `internal/server/handlers/reindex.go` with single method `ResetEmbedStatusByCollection(ctx, arg) error`
+- [ ] 3.2 Update `TriggerReindex` signature to `TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc`
+- [ ] 3.3 Implement handler body: bind request → validate root → call `queries.ResetEmbedStatusByCollection` → call `w.TriggerRescanByName` → return 202
+- [ ] 3.4 Verify `CGO_ENABLED=0 go build ./...` passes with new handler
+
+## 4. Routes: Wire dependencies
+
+- [ ] 4.1 Update `internal/server/routes.go` line 42 from `handlers.TriggerReindex(s.logger)` to `handlers.TriggerReindex(s.queries, s.watcher, s.logger)`
+- [ ] 4.2 Verify `CGO_ENABLED=0 go build ./...` passes
+
+## 5. Tests
+
+- [ ] 5.1 Add unit test for `watcher.TriggerRescanByName` — test: collection found marks dirty and returns true; collection not found returns false
+- [ ] 5.2 Add handler test for `TriggerReindex` — test: valid request calls `ResetEmbedStatusByCollection` and `TriggerRescanByName`; missing root returns 400
+- [ ] 5.3 Run full validation ladder: `CGO_ENABLED=0 go build ./... && go vet ./... && go test -race -short ./...`


### PR DESCRIPTION
## Summary
Replaces the `POST /api/v1/reindex` no-op stub with a real implementation that resets chunk embed status and triggers a watcher rescan.

Closes #162

## Changes

| File | What changed |
|------|--------------|
| `internal/storage/queries/embeddings.sql` | Add `ResetEmbedStatusByCollection :execrows` — UPDATE chunks JOIN documents by collection |
| `internal/storage/sqlc/embeddings.sql.go` | Auto-generated via `sqlc generate` |
| `internal/watcher/watcher.go` | Add `TriggerRescanByName(name, workspaceHash string) bool` — marks matching collection dir dirty |
| `internal/server/handlers/reindex.go` | Replace stub — bind → reset chunks → trigger watcher → return 202 with counts |
| `internal/server/routes.go` | Wire `s.queries` + `s.watcher` into `TriggerReindex` |
| `internal/server/handlers/reindex_test.go` | Update to new signature; add valid/missing-root tests |
| `internal/watcher/watcher_test.go` | Add `TestTriggerRescanByName` (found/not-found cases) |

## Response shape (before → after)
```
// Before (stub)
{"status":"queued","message":"Reindex queued for collection X"}

// After (real)
{"status":"queued","chunks_enqueued":42,"watcher_triggered":true,"message":"Reindex queued for collection X"}
```

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...   (all packages including internal/server, internal/server/handlers, internal/watcher)
```

## Lane
normal (touches watcher internals + SQL query + handler + routes, 2 risk flags)