### PR TITLE
fix(cli): reindex auto-derives workspace hash from --root path

### DIFF
--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/storage"
 )
 
 func runInitCmd(args []string, configPath string) {
@@ -321,11 +323,17 @@ func runReindexCmd(args []string) {
 		os.Exit(1)
 	}
 
-	// Build request body
-	reqBody := map[string]string{"root": root}
-	if workspace != "" {
-		reqBody["workspace"] = workspace
+	if workspace == "" {
+		h, err := storage.WorkspaceHash(root)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: could not resolve workspace for path %q: %v\n", root, err)
+			cliLog.Error().Err(err).Str("cmd", "reindex").Str("root", root).Msg("failed to derive workspace hash")
+			os.Exit(1)
+		}
+		workspace = h
 	}
+
+	reqBody := map[string]string{"root": root, "workspace": workspace}
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {


### PR DESCRIPTION
## Problem
\`nano-brain reindex --root /path/to/project\` fails with 400:
\`\`\`
Error: server returned 400: {"error":"workspace_required","message":"A workspace identifier is required..."}
\`\`\`

The middleware requires \`workspace\` in the POST body, but \`runReindexCmd\` only sent \`{"root":"<path>"}\` when \`--workspace\` was not explicitly passed.

## Fix
When \`--workspace\` is not provided, auto-derive the workspace hash from \`--root\` via \`storage.WorkspaceHash()\` — the same SHA-256 derivation that \`init --root <path>\` uses. The user never needs to know or pass the hash.

## Before / After
\`\`\`bash
# Before — required knowing your workspace hash
nano-brain reindex --root /my/project --workspace 7f443561...  # broken without --workspace

# After — just pass the path
nano-brain reindex --root /my/project   # ✓ works
\`\`\`

## Changes
- `cmd/nano-brain/commands.go` — add `storage` import; compute workspace hash from root when `--workspace` omitted

## Validation
\`\`\`
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...
\`\`\`

## Lane
tiny (single-function change, 0 risk flags)