### PR TITLE
chore(ci): upgrade Node.js 20 → 24 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Determine npm tag


### PR DESCRIPTION
GitHub Actions Node.js 20 is deprecated and will be forcibly retired June 2, 2026.

One-line change in `.github/workflows/release.yml`: `node-version: 20` → `24`.

Lane: tiny (config change only, no code touched).