### PR TITLE
fix(embed): recover embed_failed chunks in periodic scan

### DIFF
--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -30,6 +30,7 @@ const (
 type QueueQuerier interface {
 	GetChunkByID(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error)
 	GetAllPendingChunks(ctx context.Context, limit int32) ([]uuid.UUID, error)
+	GetAllFailedChunks(ctx context.Context, limit int32) ([]uuid.UUID, error)
 	InsertEmbedding(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
 	MarkChunkEmbedded(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
 	MarkChunkEmbedFailed(ctx context.Context, arg sqlc.MarkChunkEmbedFailedParams) error
@@ -150,17 +151,32 @@ func (q *Queue) Run(ctx context.Context) error {
 }
 
 func (q *Queue) scanPending(ctx context.Context) {
+	total := q.scanByStatus(ctx, false)
+	recovered := q.scanByStatus(ctx, true)
+	q.logger.Info().Int("pending", total).Int("recovered", recovered).Msg("scan complete")
+}
+
+func (q *Queue) scanByStatus(ctx context.Context, failed bool) int {
 	total := 0
 	for {
-		ids, err := q.queries.GetAllPendingChunks(ctx, scanBatchSize)
+		var ids []uuid.UUID
+		var err error
+		if failed {
+			ids, err = q.queries.GetAllFailedChunks(ctx, scanBatchSize)
+		} else {
+			ids, err = q.queries.GetAllPendingChunks(ctx, scanBatchSize)
+		}
 		if err != nil {
-			q.logger.Error().Err(err).Msg("failed to scan pending chunks")
-			return
+			q.logger.Error().Err(err).Bool("failed", failed).Msg("failed to scan chunks")
+			return total
 		}
 		for _, id := range ids {
+			if failed {
+				q.clearRetries(id)
+			}
 			if !q.Enqueue(id) {
-				q.logger.Info().Int("total", total).Msg("scan complete (queue full)")
-				return
+				q.logger.Info().Int("total", total).Bool("failed", failed).Msg("scan stopped (queue full)")
+				return total
 			}
 			total++
 		}
@@ -168,7 +184,7 @@ func (q *Queue) scanPending(ctx context.Context) {
 			break
 		}
 	}
-	q.logger.Info().Int("total", total).Msg("scan complete")
+	return total
 }
 
 func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -41,6 +41,7 @@ type mockQuerier struct {
 	mu                        sync.Mutex
 	getChunkByIDFn            func(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error)
 	getAllPendingChunksFn      func(ctx context.Context, limit int32) ([]uuid.UUID, error)
+	getAllFailedChunksFn       func(ctx context.Context, limit int32) ([]uuid.UUID, error)
 	insertEmbeddingFn         func(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
 	markChunkEmbeddedFn       func(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
 	markChunkEmbedFailedFn    func(ctx context.Context, arg sqlc.MarkChunkEmbedFailedParams) error
@@ -63,6 +64,13 @@ func (m *mockQuerier) GetChunkByID(ctx context.Context, id uuid.UUID) (sqlc.GetC
 func (m *mockQuerier) GetAllPendingChunks(ctx context.Context, limit int32) ([]uuid.UUID, error) {
 	if m.getAllPendingChunksFn != nil {
 		return m.getAllPendingChunksFn(ctx, limit)
+	}
+	return nil, nil
+}
+
+func (m *mockQuerier) GetAllFailedChunks(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+	if m.getAllFailedChunksFn != nil {
+		return m.getAllFailedChunksFn(ctx, limit)
 	}
 	return nil, nil
 }
@@ -557,6 +565,39 @@ func TestQueue_Status_Rejecting(t *testing.T) {
 	eq.pending.Store(rejectionThreshold)
 	if s := eq.Status(); s != "rejecting" {
 		t.Errorf("status = %q, want rejecting", s)
+	}
+}
+
+func TestQueue_ScanPendingRecoversFailed(t *testing.T) {
+	failedID := uuid.New()
+	mq := &mockQuerier{
+		getAllFailedChunksFn: func(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+			return []uuid.UUID{failedID}, nil
+		},
+	}
+
+	eq := newTestQueue(&mockEmbedder{}, mq)
+	eq.retries[failedID] = maxRetries
+
+	eq.scanPending(context.Background())
+
+	eq.retriesMu.Lock()
+	count := eq.retries[failedID]
+	eq.retriesMu.Unlock()
+	if count != 0 {
+		t.Errorf("retries[failedID] = %d after scan, want 0 (cleared for fresh attempt)", count)
+	}
+
+	found := false
+	for i := 0; i < len(eq.ch); i++ {
+		id := <-eq.ch
+		if id == failedID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("failedID not enqueued by scanPending, want it re-enqueued for retry")
 	}
 }
 

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -36,6 +36,12 @@ WHERE embed_status = 'pending'
 ORDER BY created_at ASC
 LIMIT $1;
 
+-- name: GetAllFailedChunks :many
+SELECT id FROM chunks
+WHERE embed_status = 'embed_failed'
+ORDER BY created_at ASC
+LIMIT $1;
+
 -- name: VectorSearch :many
 SELECT e.id, e.chunk_id, e.workspace_hash,
        c.content, c.metadata, c.document_id,

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -37,6 +37,36 @@ func (q *Queries) CountPendingChunks(ctx context.Context, workspaceHash string) 
 	return count, err
 }
 
+const getAllFailedChunks = `-- name: GetAllFailedChunks :many
+SELECT id FROM chunks
+WHERE embed_status = 'embed_failed'
+ORDER BY created_at ASC
+LIMIT $1
+`
+
+func (q *Queries) GetAllFailedChunks(ctx context.Context, limit int32) ([]uuid.UUID, error) {
+	rows, err := q.db.QueryContext(ctx, getAllFailedChunks, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getAllPendingChunks = `-- name: GetAllPendingChunks :many
 SELECT id FROM chunks
 WHERE embed_status = 'pending'


### PR DESCRIPTION
## Problem (#149)
Chunks marked `embed_failed` after 3 retries were permanently stuck. `GetAllPendingChunks` only queries `embed_status = 'pending'` — failed chunks were never re-queued by the 5-minute rescan.

## Root Cause
`scanPending` → `GetAllPendingChunks` → `WHERE embed_status = 'pending'`. After 3 failures, `MarkChunkEmbedFailed` sets status to `embed_failed`. No code ever touched those rows again.

## Fix
- Add `GetAllFailedChunks` SQL query (`WHERE embed_status = 'embed_failed'`)
- `scanPending` now calls both: pending first, then failed
- Failed chunks have their in-memory retry counter cleared (`clearRetries`) so they get 3 fresh attempts next cycle
- If embedding provider recovers (was down temporarily), failed chunks are automatically recovered within the next 5-min rescan

## Changes
| File | Change |
|------|--------|
| `internal/storage/queries/embeddings.sql` | +`GetAllFailedChunks` query |
| `internal/storage/sqlc/embeddings.sql.go` | regenerated |
| `internal/embed/queue.go` | `QueueQuerier` interface + `scanByStatus` helper |
| `internal/embed/queue_test.go` | mock + `TestQueue_ScanPendingRecoversFailed` |

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...  (including new TestQueue_ScanPendingRecoversFailed)
```

Lane: normal (embed logic + SQL + generated code, no migration needed)