### PR TITLE
fix(watcher): skip non-existent collection paths silently

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -78,6 +78,10 @@ func (w *Watcher) Watch(collectionName, dirPath, workspaceHash, globPattern stri
 	}
 
 	if w.fsw != nil {
+		if _, err := os.Stat(absPath); err != nil {
+			w.logger.Info().Str("dir", absPath).Str("collection", collectionName).Msg("collection path not found, skipping watch")
+			return nil
+		}
 		if err := w.fsw.Add(absPath); err != nil {
 			return fmt.Errorf("watch dir %s: %w", absPath, err)
 		}
@@ -134,6 +138,10 @@ func (w *Watcher) Run(ctx context.Context) error {
 	w.mu.Lock()
 	w.fsw = fsw
 	for absPath, col := range w.collections {
+		if _, err := os.Stat(absPath); err != nil {
+			w.logger.Info().Str("dir", absPath).Str("collection", col.name).Msg("collection path not found, skipping watch")
+			continue
+		}
 		if err := fsw.Add(absPath); err != nil {
 			w.logger.Warn().Err(err).Str("dir", absPath).Msg("failed to add watch")
 			continue


### PR DESCRIPTION
## Problem (#133)
Server startup emits WARN logs for every stale collection path loaded from DB:
```
WARN  failed to add watch  dir=/path/that/no/longer/exists
```
These are harmless (path was deleted or came from v1 migration) but noisy and alarming.

## Fix
`os.Stat` the path before `fsw.Add`. If it doesn't exist → `Info` log + skip. Applied to both `Run` startup loop and live `Watch` registration.

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...
```

Lane: tiny (2 guard clauses, no logic change)