### PR TITLE
feat(ux): auto-trigger reindex + harvest after init --root

### DIFF
--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -88,7 +88,24 @@ func runInitCmd(args []string, configPath string) {
 	fmt.Printf("Root path: %s\n", result.RootPath)
 	fmt.Println()
 	fmt.Println(result.AgentsSnippet)
+
+	triggerInitBackground(result.WorkspaceHash, root)
+
 	cliLog.Info().Str("cmd", "init").Str("workspace_hash", result.WorkspaceHash).Msg("cli command completed")
+}
+
+func triggerInitBackground(workspaceHash, root string) {
+	reindexBody, _ := json.Marshal(map[string]string{"workspace": workspaceHash, "root": root})
+	if _, _, err := doRequest("POST", getBaseURL()+"/api/v1/reindex", bytes.NewReader(reindexBody)); err != nil {
+		cliLog.Warn().Err(err).Str("workspace", workspaceHash).Msg("auto reindex trigger failed")
+	}
+
+	if _, _, err := doRequest("POST", getBaseURL()+"/api/harvest", nil); err != nil {
+		cliLog.Warn().Err(err).Msg("auto harvest trigger failed")
+	}
+
+	fmt.Println()
+	fmt.Println("Indexing codebase in background. Run 'nano-brain status' to check progress.")
 }
 
 func runWriteCmd(args []string) {


### PR DESCRIPTION
## Problem (#150)
`init --root` only registered the workspace (docs=0). Users had to manually run `reindex` and `harvest` — no prompting, silent.

## Fix
After successful workspace registration, `runInitCmd` fires:
1. `POST /api/v1/reindex` — queues codebase indexing (202, non-blocking)
2. `POST /api/harvest` — triggers session harvesting (non-blocking)
3. Prints hint: `Indexing codebase in background. Run 'nano-brain status' to check progress.`

Both endpoints return immediately. Failures are logged at WARN but do not fail the init.

```
$ nano-brain init --root /my/project
Workspace registered: 7f443561...
Root path: /my/project

## nano-brain Access
...

Indexing codebase in background. Run 'nano-brain status' to check progress.
```

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...
```

Lane: tiny (CLI-only, no server changes)