### PR TITLE
fix(ux): treat harvest 503 as info, not warn on init

### DIFF
--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -100,8 +100,12 @@ func triggerInitBackground(workspaceHash, root string) {
 		cliLog.Warn().Err(err).Str("workspace", workspaceHash).Msg("auto reindex trigger failed")
 	}
 
-	if _, _, err := doRequest("POST", getBaseURL()+"/api/harvest", nil); err != nil {
-		cliLog.Warn().Err(err).Msg("auto harvest trigger failed")
+	if _, status, err := doRequest("POST", getBaseURL()+"/api/harvest", nil); err != nil {
+		if status == 503 {
+			cliLog.Info().Msg("harvest skipped: no session harvester configured")
+		} else {
+			cliLog.Warn().Err(err).Msg("auto harvest trigger failed")
+		}
 	}
 
 	fmt.Println()


### PR DESCRIPTION
## Problem
`init --root` auto-triggers harvest. On a fresh install with no `session_dir` configured, the server returns 503 `no harvesters configured`. This is expected and harmless, but was logged at WARN level — appearing as a scary error to the user.

```
WRN auto harvest trigger failed error="server returned 503: {"error":"http_error","message":"no harvesters configured"}"
```

## Fix
Check the HTTP status code from `doRequest`. If 503 → demote to `Info` with a clear message. Only non-503 failures stay at WARN.

## Before / After
```
# Before
WRN auto harvest trigger failed error="server returned 503: no harvesters configured"

# After — nothing shown to user (Info level, below default threshold)
```

Lane: tiny (2 lines in triggerInitBackground)