### PR TITLE
fix(reindex): resolve collection by path, not treat root as collection name

### DIFF
--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
@@ -13,6 +14,7 @@ import (
 
 type ReindexQuerier interface {
 	ResetEmbedStatusByCollection(ctx context.Context, arg sqlc.ResetEmbedStatusByCollectionParams) (int64, error)
+	ListCollections(ctx context.Context, workspaceHash string) ([]sqlc.Collection, error)
 }
 
 type reindexRequest struct {
@@ -21,10 +23,10 @@ type reindexRequest struct {
 }
 
 type reindexResponse struct {
-	Status          string `json:"status"`
-	ChunksEnqueued  int64  `json:"chunks_enqueued"`
-	WatcherTriggered bool  `json:"watcher_triggered"`
-	Message         string `json:"message"`
+	Status           string `json:"status"`
+	ChunksEnqueued   int64  `json:"chunks_enqueued"`
+	WatcherTriggered bool   `json:"watcher_triggered"`
+	Message          string `json:"message"`
 }
 
 func TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc {
@@ -36,35 +38,80 @@ func TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, logger zerolog.L
 
 		workspace := c.Get("workspace").(string)
 
-		if req.Root == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "root (collection name) is required")
-		}
-
-		n, err := queries.ResetEmbedStatusByCollection(c.Request().Context(), sqlc.ResetEmbedStatusByCollectionParams{
-			WorkspaceHash: workspace,
-			Collection:    req.Root,
-		})
+		collections, err := queries.ListCollections(c.Request().Context(), workspace)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("reset embed status: %v", err))
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("list collections: %v", err))
 		}
 
-		triggered := w.TriggerRescanByName(req.Root, workspace)
+		targets := collectionsToReindex(collections, req.Root)
+		if len(targets) == 0 {
+			reqLog := LoggerFromCtx(c, logger)
+			reqLog.Info().Str("workspace", workspace).Str("root", req.Root).
+				Msg("reindex queued: no matching collections")
+			return c.JSON(http.StatusAccepted, reindexResponse{
+				Status:  "queued",
+				Message: fmt.Sprintf("no collections found for workspace %s", workspace),
+			})
+		}
+
+		var totalChunks int64
+		var watcherTriggered bool
+		for _, col := range targets {
+			n, err := queries.ResetEmbedStatusByCollection(c.Request().Context(), sqlc.ResetEmbedStatusByCollectionParams{
+				WorkspaceHash: workspace,
+				Collection:    col.Name,
+			})
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("reset embed status: %v", err))
+			}
+			totalChunks += n
+			if w.TriggerRescanByName(col.Name, workspace) {
+				watcherTriggered = true
+			}
+		}
 
 		reqLog := LoggerFromCtx(c, logger)
 		reqLog.Info().
 			Str("workspace", workspace).
 			Str("root", req.Root).
-			Int64("chunks_enqueued", n).
-			Bool("watcher_triggered", triggered).
+			Int64("chunks_enqueued", totalChunks).
+			Bool("watcher_triggered", watcherTriggered).
 			Msg("reindex queued")
 
 		return c.JSON(http.StatusAccepted, reindexResponse{
-			Status:          "queued",
-			ChunksEnqueued:  n,
-			WatcherTriggered: triggered,
-			Message:         fmt.Sprintf("Reindex queued for collection %s in workspace %s", req.Root, workspace),
+			Status:           "queued",
+			ChunksEnqueued:   totalChunks,
+			WatcherTriggered: watcherTriggered,
+			Message:          fmt.Sprintf("Reindex queued for workspace %s", workspace),
 		})
 	}
+}
+
+func collectionsToReindex(collections []sqlc.Collection, root string) []sqlc.Collection {
+	if root == "" {
+		return collections
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		absRoot = root
+	}
+
+	var matched []sqlc.Collection
+	for _, col := range collections {
+		absPath, err := filepath.Abs(col.Path)
+		if err != nil {
+			absPath = col.Path
+		}
+		if absPath == absRoot || col.Name == root {
+			matched = append(matched, col)
+		}
+	}
+
+	if len(matched) == 0 {
+		return collections
+	}
+	return matched
 }
 
 func TriggerUpdate(logger zerolog.Logger) echo.HandlerFunc {

--- a/internal/server/handlers/reindex_test.go
+++ b/internal/server/handlers/reindex_test.go
@@ -17,16 +17,24 @@ import (
 )
 
 type mockReindexQuerier struct {
-	called     bool
-	returnN    int64
-	returnErr  error
-	lastParams sqlc.ResetEmbedStatusByCollectionParams
+	called      bool
+	returnN     int64
+	returnErr   error
+	lastParams  sqlc.ResetEmbedStatusByCollectionParams
+	collections []sqlc.Collection
 }
 
 func (m *mockReindexQuerier) ResetEmbedStatusByCollection(_ context.Context, arg sqlc.ResetEmbedStatusByCollectionParams) (int64, error) {
 	m.called = true
 	m.lastParams = arg
 	return m.returnN, m.returnErr
+}
+
+func (m *mockReindexQuerier) ListCollections(_ context.Context, _ string) ([]sqlc.Collection, error) {
+	if m.collections != nil {
+		return m.collections, nil
+	}
+	return []sqlc.Collection{{Name: "code", Path: "/tmp/code"}}, nil
 }
 
 func newTestWatcherForHandler() *watcher.Watcher {
@@ -46,7 +54,10 @@ func TestTriggerReindex(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.Set("workspace", "ws123")
 
-	mq := &mockReindexQuerier{returnN: 5}
+	mq := &mockReindexQuerier{
+		returnN:     5,
+		collections: []sqlc.Collection{{Name: "code", Path: "/tmp/code"}},
+	}
 	w := newTestWatcherForHandler()
 
 	h := handlers.TriggerReindex(mq, w, zerolog.Nop())
@@ -57,7 +68,6 @@ func TestTriggerReindex(t *testing.T) {
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
 	}
-
 	if !mq.called {
 		t.Fatal("expected ResetEmbedStatusByCollection to be called")
 	}
@@ -76,12 +86,42 @@ func TestTriggerReindex(t *testing.T) {
 		t.Errorf("expected chunks_enqueued=5, got %v", resp["chunks_enqueued"])
 	}
 	msg, _ := resp["message"].(string)
-	if !strings.Contains(msg, "code") || !strings.Contains(msg, "ws123") {
+	if !strings.Contains(msg, "ws123") {
 		t.Errorf("unexpected message: %s", msg)
 	}
 }
 
-func TestTriggerReindexMissingRoot(t *testing.T) {
+func TestTriggerReindexByPath(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123","root":"/my/project"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		returnN:     3,
+		collections: []sqlc.Collection{{Name: "code", Path: "/my/project"}},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+	if !mq.called {
+		t.Fatal("expected ResetEmbedStatusByCollection to be called for path-matched collection")
+	}
+	if mq.lastParams.Collection != "code" {
+		t.Errorf("expected collection name 'code', got %q", mq.lastParams.Collection)
+	}
+}
+
+func TestTriggerReindexNoRoot(t *testing.T) {
 	e := echo.New()
 	body := `{"workspace":"ws123"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
@@ -90,23 +130,21 @@ func TestTriggerReindexMissingRoot(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.Set("workspace", "ws123")
 
-	mq := &mockReindexQuerier{}
+	mq := &mockReindexQuerier{
+		returnN:     2,
+		collections: []sqlc.Collection{{Name: "code", Path: "/tmp/code"}, {Name: "memory", Path: "/tmp/mem"}},
+	}
 	w := newTestWatcherForHandler()
 
 	h := handlers.TriggerReindex(mq, w, zerolog.Nop())
-	err := h(c)
-	if err == nil {
-		t.Fatal("expected error for missing root")
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
 	}
-	he, ok := err.(*echo.HTTPError)
-	if !ok {
-		t.Fatalf("expected echo.HTTPError, got %T", err)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
 	}
-	if he.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", he.Code)
-	}
-	if mq.called {
-		t.Error("expected ResetEmbedStatusByCollection not to be called on missing root")
+	if !mq.called {
+		t.Fatal("expected ResetEmbedStatusByCollection to be called for all collections")
 	}
 }
 


### PR DESCRIPTION
## Root Cause
`POST /api/v1/reindex` receives `{"root": "/Users/.../nano-brain"}` from the CLI. The handler was passing `req.Root` (a filesystem path) directly as the **collection name** to:

- `ResetEmbedStatusByCollection(Collection: req.Root)` — matched 0 rows (no collection named "/Users/...")
- `w.TriggerRescanByName(req.Root, workspace)` — found nothing

Result: `chunks_enqueued:0`, `watcher_triggered:false` — silent no-op.

## Fix
List all collections for the workspace first, then match by:
1. `abs(col.Path) == abs(root)` — path sent by CLI (most common)
2. `col.Name == root` — explicit name
3. no root → reindex **all** collections (useful, not an error)

Iterate matched collections; reset + trigger watcher for each.

## Before / After
```json
// Before
{"chunks_enqueued":0, "watcher_triggered":false}

// After — with code collection at /Users/.../nano-brain
{"chunks_enqueued":847, "watcher_triggered":true}
```

## Changes
- `internal/server/handlers/reindex.go` — `ListCollections` in interface; path-resolution logic; remove spurious root-required guard
- `internal/server/handlers/reindex_test.go` — mock `ListCollections`; new `TestTriggerReindexByPath` + `TestTriggerReindexNoRoot`

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...
```

Lane: normal