### PR TITLE
fix(init): always prompt for harvester session_dir, add Claude Code detection

### DIFF
--- a/cmd/nano-brain/detect.go
+++ b/cmd/nano-brain/detect.go
@@ -23,6 +23,46 @@ func detectOpenCodeStorageDir() string {
 	return ""
 }
 
+func detectClaudeCodeStorageDir() string {
+	if v := os.Getenv("CLAUDECODE_STORAGE_DIR"); v != "" {
+		if _, err := os.Stat(v); err == nil {
+			return v
+		}
+	}
+	for _, p := range platformClaudeCodePaths() {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+func platformClaudeCodePaths() []string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return nil
+	}
+	candidates := []string{
+		filepath.Join(home, ".claude", "projects"),
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = append(candidates,
+			filepath.Join(home, "Library", "Application Support", "Claude", "projects"),
+		)
+	case "linux":
+		if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+			candidates = append(candidates, filepath.Join(xdg, "claude", "projects"))
+		}
+		candidates = append(candidates, filepath.Join(home, ".local", "share", "claude", "projects"))
+	case "windows":
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			candidates = append(candidates, filepath.Join(appdata, "Claude", "projects"))
+		}
+	}
+	return candidates
+}
+
 func platformOpenCodePaths() []string {
 	switch runtime.GOOS {
 	case "linux":

--- a/cmd/nano-brain/init.go
+++ b/cmd/nano-brain/init.go
@@ -101,19 +101,32 @@ func runInteractiveInit(configPath string) {
 		embBlock = fmt.Sprintf("embedding:\n  provider: %s\n  url: %s\n  model: %s\n  concurrency: 3\n", provider, embURL, model)
 	}
 
-	var harvesterSessionDir string
-	if detected := detectOpenCodeStorageDir(); detected != "" {
-		fmt.Printf("  OpenCode detected at %s\n", detected)
-		answer := promptWithDefault(scanner, "Enable session harvesting?", "Y")
-		if answer != "n" && answer != "N" {
-			harvesterSessionDir = detected
-		}
+	fmt.Print("\n── Harvester (session indexing) ──\n")
+	detectedOC := detectOpenCodeStorageDir()
+	if detectedOC != "" {
+		fmt.Printf("  OpenCode storage auto-detected: %s\n", detectedOC)
+	} else {
+		fmt.Println("  OpenCode storage not found automatically.")
 	}
+	ocSessionDir := promptWithDefault(scanner, "OpenCode session_dir (leave blank to skip)", detectedOC)
+
+	detectedCC := detectClaudeCodeStorageDir()
+	if detectedCC != "" {
+		fmt.Printf("  Claude Code storage auto-detected: %s\n", detectedCC)
+	}
+	ccSessionDir := promptWithDefault(scanner, "Claude Code session_dir (leave blank to skip)", detectedCC)
 
 	var harvesterBlock string
-	if harvesterSessionDir != "" {
-		harvesterBlock = fmt.Sprintf("\nharvester:\n  opencode:\n    session_dir: %s\n  claudecode:\n    enabled: false\n    session_dir: \"\"\n", harvesterSessionDir)
+	ocLine := "\"\""
+	if ocSessionDir != "" {
+		ocLine = ocSessionDir
 	}
+	ccEnabled := ccSessionDir != ""
+	ccLine := "\"\""
+	if ccSessionDir != "" {
+		ccLine = ccSessionDir
+	}
+	harvesterBlock = fmt.Sprintf("\nharvester:\n  opencode:\n    session_dir: %s\n  claudecode:\n    enabled: %v\n    session_dir: %s\n", ocLine, ccEnabled, ccLine)
 
 	yaml := fmt.Sprintf(`server:
   host: localhost


### PR DESCRIPTION
## Problem
The init wizard silently skipped the entire harvester config section when `detectOpenCodeStorageDir()` returned `""`. User had no way to manually set `session_dir` and had no idea the harvester feature existed.

## Fix
- **Always show** the `── Harvester (session indexing) ──` section
- Auto-detected path shown as default; user can override or clear it
- Add `Claude Code session_dir` prompt with `detectClaudeCodeStorageDir()`
- `detectClaudeCodeStorageDir()` checks `~/.claude/projects` + platform-specific paths (macOS `Library/Application Support`, Linux XDG, Windows APPDATA)
- `harvesterBlock` **always written** to config (empty string when user skips)

## Before
```
  Server port [3100]: 

── Config preview ──   ← harvester section missing entirely if not auto-detected
```

## After
```
  Server port [3100]:

── Harvester (session indexing) ──
  OpenCode storage not found automatically.
  OpenCode session_dir (leave blank to skip): /Users/me/.config/opencode/storage
  Claude Code session_dir (leave blank to skip): /Users/me/.claude/projects

── Config preview ──
...
harvester:
  opencode:
    session_dir: /Users/me/.config/opencode/storage
  claudecode:
    enabled: true
    session_dir: /Users/me/.claude/projects
```

## Validation
```
✓ CGO_ENABLED=0 go build ./...
✓ go vet ./...
✓ go test -race -short ./...
```