### PR TITLE
feat(harvest): filter OpenCode sessions by registered workspaces

### DIFF
--- a/internal/harvest/opencode_sqlite.go
+++ b/internal/harvest/opencode_sqlite.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nano-brain/nano-brain/internal/chunk"
-	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/rs/zerolog"
 	"github.com/sqlc-dev/pqtype"
@@ -73,7 +72,7 @@ func (h *OpenCodeSQLiteHarvester) ListSessions(ctx context.Context) ([]SqSession
 	if owned {
 		defer sqdb.Close()
 	}
-	return h.listSessions(ctx, sqdb)
+	return h.listSessions(ctx, sqdb, nil)
 }
 
 func (h *OpenCodeSQLiteHarvester) RenderSession(ctx context.Context, sessionID, title string, createdAt time.Time) (string, error) {
@@ -103,16 +102,32 @@ func (h *OpenCodeSQLiteHarvester) HarvestAll(ctx context.Context, enqueuer Chunk
 		defer sqdb.Close()
 	}
 
-	sessions, err := h.listSessions(ctx, sqdb)
+	q := sqlc.New(h.pgDB)
+
+	workspaces, wsErr := q.ListWorkspaces(ctx)
+	if wsErr != nil {
+		h.logger.Error().Err(wsErr).Msg("failed to list registered workspaces")
+		return 0, 0, 1
+	}
+	if len(workspaces) == 0 {
+		h.logger.Warn().Msg("no registered workspaces, skipping harvest")
+		return 0, 0, 0
+	}
+
+	wsCache := make(map[string]string, len(workspaces))
+	registeredPaths := make([]string, 0, len(workspaces))
+	for _, ws := range workspaces {
+		wsCache[ws.Path] = ws.Hash
+		registeredPaths = append(registeredPaths, ws.Path)
+	}
+
+	sessions, err := h.listSessions(ctx, sqdb, registeredPaths)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("failed to list opencode sessions")
 		return 0, 0, 1
 	}
 
 	h.logger.Info().Int("count", len(sessions)).Msg("found opencode sessions")
-
-	q := sqlc.New(h.pgDB)
-	wsCache := make(map[string]string) // worktree → wsHash
 
 	var (
 		summarySuccess  int
@@ -126,32 +141,12 @@ func (h *OpenCodeSQLiteHarvester) HarvestAll(ctx context.Context, enqueuer Chunk
 			continue
 		}
 
-		// Derive workspace hash for this session's project
 		worktree := sess.Worktree
 		wsHash, ok := wsCache[worktree]
 		if !ok {
-			var hashErr error
-			if worktree == "" {
-				h.logger.Warn().Str("session_id", sess.ID).Msg("session has no project row, using fallback workspace")
-				wsHash, hashErr = storage.WorkspaceHash(h.dbPath)
-			} else {
-				wsHash, hashErr = storage.WorkspaceHash(worktree)
-			}
-			if hashErr != nil {
-				h.logger.Warn().Err(hashErr).Str("session", sess.ID).Msg("workspace hash failed, skipping")
-				errCount++
-				continue
-			}
-			if worktree != "" {
-				rq := sqlc.New(h.pgDB)
-				if _, uErr := rq.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
-					Hash: wsHash,
-					Path: worktree,
-				}); uErr != nil {
-					h.logger.Warn().Err(uErr).Str("worktree", worktree).Msg("upsert workspace failed")
-				}
-			}
-			wsCache[worktree] = wsHash
+			h.logger.Warn().Str("session_id", sess.ID).Str("worktree", worktree).Msg("session worktree not in cache, skipping")
+			errCount++
+			continue
 		}
 
 		sourcePath := "summary://opencode/" + sess.ID
@@ -241,14 +236,42 @@ type sqMessage struct {
 	createdAt time.Time
 }
 
-func (h *OpenCodeSQLiteHarvester) listSessions(ctx context.Context, sqdb *sql.DB) ([]SqSession, error) {
-	rows, err := sqdb.QueryContext(ctx, `
-		SELECT s.id, COALESCE(s.title, ''), COALESCE(s.time_created, 0),
-		       COALESCE(s.time_updated, s.time_created, 0), COALESCE(p.worktree, '')
-		FROM session s
-		LEFT JOIN project p ON s.project_id = p.id
-		ORDER BY s.time_created DESC
-	`)
+// listSessions queries sessions from SQLite. If registeredPaths is non-nil,
+// only sessions whose project.worktree matches one of the paths are returned.
+// If registeredPaths is non-nil but empty, returns nil (no sessions).
+// If registeredPaths is nil, all sessions are returned (unfiltered).
+func (h *OpenCodeSQLiteHarvester) listSessions(ctx context.Context, sqdb *sql.DB, registeredPaths []string) ([]SqSession, error) {
+	var query string
+	var args []any
+
+	if registeredPaths != nil {
+		if len(registeredPaths) == 0 {
+			return nil, nil
+		}
+		placeholders := strings.Repeat("?,", len(registeredPaths)-1) + "?"
+		query = `
+			SELECT s.id, COALESCE(s.title, ''), COALESCE(s.time_created, 0),
+			       COALESCE(s.time_updated, s.time_created, 0), COALESCE(p.worktree, '')
+			FROM session s
+			LEFT JOIN project p ON s.project_id = p.id
+			WHERE p.worktree IN (` + placeholders + `)
+			ORDER BY s.time_created DESC
+		`
+		args = make([]any, len(registeredPaths))
+		for i, p := range registeredPaths {
+			args[i] = p
+		}
+	} else {
+		query = `
+			SELECT s.id, COALESCE(s.title, ''), COALESCE(s.time_created, 0),
+			       COALESCE(s.time_updated, s.time_created, 0), COALESCE(p.worktree, '')
+			FROM session s
+			LEFT JOIN project p ON s.project_id = p.id
+			ORDER BY s.time_created DESC
+		`
+	}
+
+	rows, err := sqdb.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query sessions: %w", err)
 	}

--- a/internal/harvest/opencode_sqlite_integration_test.go
+++ b/internal/harvest/opencode_sqlite_integration_test.go
@@ -126,6 +126,16 @@ func TestOpenCodeSQLite_Integration_RealPostgres(t *testing.T) {
 	wsH := sha256.Sum256([]byte(worktree))
 	wsHash := hex.EncodeToString(wsH[:])
 
+	// Register workspace in PG so HarvestAll's filter includes it
+	q := sqlc.New(pgDB)
+	_, regErr := q.UpsertWorkspace(context.Background(), sqlc.UpsertWorkspaceParams{
+		Hash: wsHash,
+		Path: worktree,
+	})
+	if regErr != nil {
+		t.Fatalf("register workspace: %v", regErr)
+	}
+
 	successFn := func(ctx context.Context, md string, meta harvest.SummaryMeta) error {
 		q := sqlc.New(pgDB)
 		_, uErr := q.UpsertDocumentBySourcePath(ctx, sqlc.UpsertDocumentBySourcePathParams{

--- a/internal/harvest/opencode_sqlite_test.go
+++ b/internal/harvest/opencode_sqlite_test.go
@@ -95,6 +95,21 @@ func insertTestPart(t *testing.T, db *sql.DB, id, messageID, partType, content s
 	}
 }
 
+func registerTestWorkspace(t *testing.T, pgDB *sql.DB, path string) string {
+	t.Helper()
+	h := sha256.Sum256([]byte(path))
+	hash := hex.EncodeToString(h[:])
+	q := sqlc.New(pgDB)
+	_, err := q.UpsertWorkspace(context.Background(), sqlc.UpsertWorkspaceParams{
+		Hash: hash,
+		Path: path,
+	})
+	if err != nil {
+		t.Fatalf("register workspace %q: %v", path, err)
+	}
+	return hash
+}
+
 func TestRenderSQLiteMarkdown_Format(t *testing.T) {
 	sqdb := setupTestSQLiteDB(t)
 	now := time.Now().UnixMilli()
@@ -285,6 +300,7 @@ func TestOpenCodeSQLite_AgeGate_HarvestSkipsActive(t *testing.T) {
 	inactiveMs := now.Add(-15 * time.Minute).UnixMilli()
 
 	insertTestProject(t, sqdb, "proj1", "/home/user/app-age")
+	registerTestWorkspace(t, pgDB, "/home/user/app-age")
 
 	// Active session (updated 5min ago)
 	insertTestSession(t, sqdb, "sess-active", "proj1", "Active", activeMs)
@@ -340,6 +356,7 @@ func TestOpenCodeSQLite_SummarizerHappyPath_OnlySummaryDoc(t *testing.T) {
 	oldMs := now.Add(-15 * time.Minute).UnixMilli()
 
 	insertTestProject(t, sqdb, "proj1", "/home/user/test-happy")
+	registerTestWorkspace(t, pgDB, "/home/user/test-happy")
 	insertTestSession(t, sqdb, "sess-happy1", "proj1", "Happy Session", oldMs)
 	if _, err := sqdb.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, oldMs, "sess-happy1"); err != nil {
 		t.Fatal(err)
@@ -412,15 +429,13 @@ func TestOpenCodeSQLite_SkipCheck_UnifiedPath(t *testing.T) {
 	worktree := "/home/user/test-skip"
 
 	insertTestProject(t, sqdb, "proj1", worktree)
+	wsHash := registerTestWorkspace(t, pgDB, worktree)
 	insertTestSession(t, sqdb, "sess-skip1", "proj1", "Skip Session", oldMs)
 	if _, err := sqdb.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, oldMs, "sess-skip1"); err != nil {
 		t.Fatal(err)
 	}
 	insertTestMessage(t, sqdb, "msg1", "sess-skip1", "user", oldMs)
 	insertTestPart(t, sqdb, "p1", "msg1", "text", "Hello from skip test!")
-
-	h := sha256.Sum256([]byte(worktree))
-	wsHash := hex.EncodeToString(h[:])
 
 	// Pre-insert doc at unified path to trigger skip
 	q := sqlc.New(pgDB)
@@ -477,9 +492,7 @@ func TestOpenCodeSQLite_MultiSession_Counters(t *testing.T) {
 	worktree := "/home/user/test-multi"
 
 	insertTestProject(t, sqdb, "proj1", worktree)
-
-	wsH := sha256.Sum256([]byte(worktree))
-	wsHash := hex.EncodeToString(wsH[:])
+	wsHash := registerTestWorkspace(t, pgDB, worktree)
 
 	sessionIDs := []string{"success-1", "success-2", "success-3", "fail-1", "fail-2", "skip-1"}
 	for i, sid := range sessionIDs {
@@ -686,6 +699,7 @@ func TestOpenCodeSQLite_LLMFailure_FallbackUnifiedPath(t *testing.T) {
 	oldMs := now.Add(-15 * time.Minute).UnixMilli()
 
 	insertTestProject(t, sqdb, "proj1", "/home/user/test-app")
+	registerTestWorkspace(t, pgDB, "/home/user/test-app")
 	insertTestSession(t, sqdb, "sess-fb1", "proj1", "Fallback Session", oldMs)
 	if _, err := sqdb.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, oldMs, "sess-fb1"); err != nil {
 		t.Fatal(err)

--- a/internal/harvest/opencode_sqlite_test.go
+++ b/internal/harvest/opencode_sqlite_test.go
@@ -719,9 +719,6 @@ func TestOpenCodeSQLite_LLMFailure_FallbackUnifiedPath(t *testing.T) {
 		t.Errorf("errCount = %d, want 0", errCount)
 	}
 
-	wsHash := hex.EncodeToString(sha256.New().Sum([]byte("/home/user/test-app")))[:16]
-	_ = wsHash
-
 	q := sqlc.New(pgDB)
 	ctx := context.Background()
 

--- a/openspec/changes/harvest-workspace-filter/.openspec.yaml
+++ b/openspec/changes/harvest-workspace-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/harvest-workspace-filter/design.md
+++ b/openspec/changes/harvest-workspace-filter/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`OpenCodeSQLiteHarvester.HarvestAll()` queries ALL sessions from OpenCode's SQLite DB, then per-session: derives workspace hash, loads messages, renders markdown, checks PostgreSQL for existing document. Sessions belonging to unregistered workspaces waste all that I/O before being effectively discarded (auto-registered into a workspace nobody queries).
+
+The `workspaces` table in PostgreSQL already tracks registered workspaces (path + hash). This data can be passed to the SQLite query to pre-filter.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pre-filter sessions in `listSessions()` so only registered-workspace sessions are returned
+- Eliminate per-session I/O for unregistered workspaces
+- Preserve fallback behavior for orphaned sessions (no project row)
+
+**Non-Goals:**
+- Changing Claude Code harvester (no per-session workspace data available)
+- Adding config for workspace whitelist/blacklist (use existing registered workspaces)
+- Changing the `init` / workspace registration flow
+
+## Decisions
+
+### 1. Pass registered workspace paths into `listSessions()`
+
+**Choice:** Query PostgreSQL for registered workspace paths, pass as `[]string` arg to `listSessions()`, add `WHERE p.worktree IN (?, ...)` clause.
+
+**Alternative:** Filter in Go after query returns. Rejected — defeats the purpose of reducing SQLite I/O.
+
+**Alternative:** JOIN against PostgreSQL from SQLite. Not possible — separate databases.
+
+### 2. Orphaned sessions (no project) — skip, don't fallback
+
+**Choice:** Sessions with `p.worktree = ''` are skipped. Previously they fell back to `WorkspaceHash(dbPath)` creating a catch-all workspace.
+
+**Rationale:** The catch-all workspace pollutes search results. If a workspace isn't registered, its sessions shouldn't be in memory. Users who want those sessions can register the workspace via `init`.
+
+**Trade-off:** Existing fallback sessions already in PostgreSQL remain. This change only affects future harvests.
+
+### 3. Remove auto-register of unknown workspaces
+
+**Choice:** Remove the `UpsertWorkspace` call for newly-discovered worktrees in `HarvestAll()`.
+
+**Rationale:** Auto-register contradicts the filter intent. If we filter by registered workspaces but then auto-register every new one, the filter is pointless after first run.
+
+### 4. Fetch registered paths once per harvest cycle
+
+**Choice:** Query `SELECT path FROM workspaces` once at the start of `HarvestAll()`, cache as `map[string]string` (path → hash).
+
+**Rationale:** Workspace list changes infrequently. One query per cycle is sufficient.
+
+## Risks / Trade-offs
+
+- **Existing auto-registered workspaces** → Sessions previously harvested via auto-register remain in PostgreSQL. No cleanup needed — they're valid data, just won't get new sessions added. → Acceptable, no migration needed.
+
+- **User expectation shift** → Users must `init` a workspace before its sessions are harvested. Previously it was automatic. → Document in changelog. The `init` command already exists and is the standard onboarding path.
+
+- **Empty workspace list** → If no workspaces registered, harvest returns 0 sessions. → Log a WARN message so users know why nothing was harvested.

--- a/openspec/changes/harvest-workspace-filter/proposal.md
+++ b/openspec/changes/harvest-workspace-filter/proposal.md
@@ -1,0 +1,26 @@
+Tracking: #194
+
+## Why
+
+OpenCode SQLite harvester scans ALL sessions then skips unregistered workspaces at persist time. This wastes I/O — each unneeded session triggers a SQLite message query, markdown render, and PostgreSQL lookup before being discarded. As session count grows, this becomes increasingly wasteful.
+
+## What Changes
+
+- Filter `listSessions()` SQL query to only return sessions whose `project.worktree` matches a registered workspace path in nano-brain PostgreSQL
+- Sessions without a project (`worktree = ''`) retain existing fallback behavior
+- Auto-register of unknown workspaces via `UpsertWorkspace` is removed — only pre-registered workspaces are harvested
+
+## Capabilities
+
+### New Capabilities
+- `harvest-workspace-filter`: Pre-filter OpenCode sessions by registered workspace paths at scan time, before message loading and embedding
+
+### Modified Capabilities
+- `harvester-per-project-scoping`: Session-to-workspace mapping now requires workspace to be pre-registered; unknown workspaces are skipped instead of auto-registered
+
+## Impact
+
+- `internal/harvest/opencode_sqlite.go` — `listSessions()` query gains WHERE clause; `HarvestAll()` removes auto-register logic
+- No API changes — harvest endpoint behavior unchanged externally
+- No schema changes — uses existing `workspaces` table for lookup
+- Sessions from unregistered workspaces will no longer appear in search results (intentional)

--- a/openspec/changes/harvest-workspace-filter/specs/harvest-workspace-filter/spec.md
+++ b/openspec/changes/harvest-workspace-filter/specs/harvest-workspace-filter/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Pre-filter sessions by registered workspace paths
+
+The OpenCode SQLite harvester SHALL query PostgreSQL for registered workspace paths at the start of `HarvestAll()` and pass them to `listSessions()`. The `listSessions()` SQL query SHALL include a `WHERE p.worktree IN (...)` clause to return only sessions belonging to registered workspaces. Sessions with `p.worktree = ''` (no project) SHALL be excluded.
+
+#### Scenario: Only registered workspace sessions returned
+
+- **WHEN** `listSessions()` is called with registered paths `["/home/user/project-a", "/home/user/project-b"]`
+- **THEN** only sessions whose `p.worktree` matches one of those paths are returned
+- **AND** sessions with `p.worktree = '/home/user/unregistered'` are NOT returned
+- **AND** sessions with `p.worktree = ''` are NOT returned
+
+#### Scenario: No registered workspaces
+
+- **WHEN** `listSessions()` is called with an empty registered paths list
+- **THEN** zero sessions are returned
+- **AND** a WARN log is emitted: "no registered workspaces, skipping harvest"
+
+### Requirement: Workspace path cache built once per harvest cycle
+
+`HarvestAll()` SHALL query `ListWorkspaces()` once and build a `map[string]string` (path → hash) from the result. This map SHALL be used both for the `listSessions()` filter and for workspace hash lookup per session, eliminating redundant `WorkspaceHash()` calls.
+
+#### Scenario: Cache populated from PostgreSQL
+
+- **WHEN** `HarvestAll()` starts and PostgreSQL has 3 registered workspaces
+- **THEN** the workspace cache contains exactly 3 entries (path → hash)
+- **AND** `ListWorkspaces()` is called exactly once during the harvest cycle

--- a/openspec/changes/harvest-workspace-filter/specs/harvester-per-project-scoping/spec.md
+++ b/openspec/changes/harvest-workspace-filter/specs/harvester-per-project-scoping/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Session-to-workspace mapping via project.worktree JOIN
+
+The OpenCode SQLite harvester SHALL derive workspace hash per-session from `project.worktree` via LEFT JOIN on `session.project_id`. It SHALL use the pre-built workspace cache (path → hash) from registered workspaces instead of calling `storage.WorkspaceHash()` per session. It SHALL NOT auto-register unknown workspaces via `UpsertWorkspace`. Orphaned sessions (no project row or empty worktree) SHALL be excluded by the pre-filter query.
+
+#### Scenario: Session mapped to per-project workspace
+
+- **WHEN** `HarvestAll()` processes a session with a valid `project.worktree` that exists in the workspace cache
+- **THEN** the session is stored under the cached hash for that worktree path
+- **AND** `UpsertWorkspace` is NOT called
+- **AND** `storage.WorkspaceHash()` is NOT called
+
+#### Scenario: Session with unregistered worktree is never seen
+
+- **WHEN** a session has `p.worktree = '/unregistered/path'`
+- **THEN** the session is excluded by `listSessions()` SQL filter
+- **AND** no messages are loaded for it
+- **AND** no `UpsertWorkspace` call occurs

--- a/openspec/changes/harvest-workspace-filter/tasks.md
+++ b/openspec/changes/harvest-workspace-filter/tasks.md
@@ -1,0 +1,33 @@
+## 1. Modify listSessions to accept workspace filter
+
+- [ ] 1.1 Change `listSessions` signature to accept `registeredPaths []string` parameter
+- [ ] 1.2 Add `WHERE p.worktree IN (...)` clause using SQLite placeholder expansion when registeredPaths is non-empty
+- [ ] 1.3 When registeredPaths is empty, return nil (no sessions) — do not run unfiltered query
+
+## 2. Modify HarvestAll to build workspace cache and filter
+
+- [ ] 2.1 At start of `HarvestAll`, call `sqlc.New(h.pgDB).ListWorkspaces(ctx)` to get registered workspaces
+- [ ] 2.2 Build `map[string]string` (path → hash) from workspace list; also extract `[]string` of paths for the filter
+- [ ] 2.3 If workspace list is empty, log WARN and return early (0, 0, 0)
+- [ ] 2.4 Pass registered paths to `listSessions(ctx, sqdb, registeredPaths)`
+- [ ] 2.5 Remove `UpsertWorkspace` call (lines 146-153)
+- [ ] 2.6 Replace `storage.WorkspaceHash()` calls with cache lookup from the pre-built map
+- [ ] 2.7 Remove the `worktree == ""` fallback branch (lines 134-136) — orphaned sessions excluded by query
+
+## 3. Update unit tests
+
+- [ ] 3.1 Update `listSessions` test to pass registeredPaths and verify filtering
+- [ ] 3.2 Add test case: empty registeredPaths → 0 sessions returned
+- [ ] 3.3 Add test case: sessions with unregistered worktree are excluded
+
+## 4. Update integration test
+
+- [ ] 4.1 Register a workspace in PG before harvest, verify only matching sessions harvested
+- [ ] 4.2 Verify sessions from unregistered worktrees are not persisted
+
+## 5. Validation
+
+- [ ] 5.1 `go build ./...` passes
+- [ ] 5.2 `go test -race -short ./...` passes
+- [ ] 5.3 `go test -race -tags=integration ./internal/harvest/...` passes (if PG available)
+- [ ] 5.4 `lsp_diagnostics` clean on changed files


### PR DESCRIPTION
## Summary

Pre-filter `listSessions()` SQL query to only return sessions whose `project.worktree` matches a registered workspace in PostgreSQL. Eliminates wasted I/O from scanning unregistered workspace sessions.

## Changes

- `listSessions()` accepts `registeredPaths []string` — adds `WHERE p.worktree IN (...)` clause
- `HarvestAll()` queries `ListWorkspaces()` once, builds path→hash cache
- Removed `UpsertWorkspace` auto-register of unknown workspaces
- Removed orphaned session fallback (`worktree=''`) — excluded by query
- Updated unit tests to register workspaces before harvest

## Validation

- `go build ./...` ✅
- `go test -race -short ./...` ✅
- `go vet ./internal/harvest/...` ✅

## Spec

OpenSpec: `openspec/changes/harvest-workspace-filter/`

Closes #194