### PR TITLE
feat(graph): add TypeScript, JavaScript, Python graph extractors and CLI commands

### DIFF
--- a/cmd/nano-brain/cmd_code_impact.go
+++ b/cmd/nano-brain/cmd_code_impact.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func runCodeImpactCmd(args []string) {
+	cliLog.Info().Str("cmd", "code-impact").Msg("cli command started")
+
+	var symbol, workspace string
+	var jsonFlag bool
+	depth := 2
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			workspace = args[i]
+		case "--depth":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--depth requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			v, err := strconv.Atoi(args[i])
+			if err != nil || v < 1 {
+				fmt.Fprintf(os.Stderr, "--depth must be a positive integer\n")
+				os.Exit(1)
+			}
+			depth = v
+		case "--json":
+			jsonFlag = true
+		case "--help", "-h":
+			fmt.Fprintln(os.Stderr, "Usage: nano-brain code-impact <symbol> --workspace <hash> [--depth N] [--json]")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "  --depth N    Max depth for impact traversal (default 2, clamped to [1,3] by server)")
+			os.Exit(0)
+		default:
+			if strings.HasPrefix(args[i], "--") {
+				fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+			if symbol == "" {
+				symbol = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "unexpected argument: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+	if symbol == "" || workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain code-impact <symbol> --workspace <hash> [--depth N] [--json]")
+		os.Exit(1)
+	}
+
+	body := map[string]any{
+		"workspace": workspace,
+		"node":      symbol,
+		"max_depth": depth,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	resp, _, err := doRequest("POST", getBaseURL()+"/api/v1/graph/impact", bytes.NewReader(data))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "code-impact").Msg("cli command completed")
+		return
+	}
+
+	var result struct {
+		Node     string `json:"node"`
+		Impacted []struct {
+			Node     string `json:"node"`
+			Depth    int    `json:"depth"`
+			EdgeType string `json:"edge_type"`
+		} `json:"impacted"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "code-impact").Msg("cli command completed")
+		return
+	}
+
+	fmt.Printf("Impact analysis for: %s\n", result.Node)
+	if len(result.Impacted) == 0 {
+		fmt.Println("  (no impacted nodes found)")
+	} else {
+		fmt.Printf("  %d impacted node(s):\n", len(result.Impacted))
+		for _, n := range result.Impacted {
+			fmt.Printf("    [depth=%d] %s (%s)\n", n.Depth, n.Node, n.EdgeType)
+		}
+	}
+
+	cliLog.Info().Str("cmd", "code-impact").Msg("cli command completed")
+}

--- a/cmd/nano-brain/cmd_context.go
+++ b/cmd/nano-brain/cmd_context.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+func runContextCmd(args []string) {
+	cliLog.Info().Str("cmd", "context").Msg("cli command started")
+
+	var symbol, workspace string
+	var jsonFlag bool
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			workspace = args[i]
+		case "--json":
+			jsonFlag = true
+		default:
+			if strings.HasPrefix(args[i], "--") {
+				fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+			if symbol == "" {
+				symbol = args[i]
+			} else {
+				fmt.Fprintf(os.Stderr, "unexpected argument: %s\n", args[i])
+				os.Exit(1)
+			}
+		}
+	}
+	if symbol == "" || workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain context <symbol> --workspace <hash> [--json]")
+		os.Exit(1)
+	}
+
+	base := getBaseURL()
+
+	symURL := fmt.Sprintf("%s/api/v1/symbols?query=%s&workspace=%s&limit=1",
+		base, url.QueryEscape(symbol), url.QueryEscape(workspace))
+	symResp, _, err := doRequest("GET", symURL, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching symbols: %v\n", err)
+		os.Exit(1)
+	}
+
+	var symResult struct {
+		Symbols []struct {
+			Name       string `json:"name"`
+			Kind       string `json:"kind"`
+			Language   string `json:"language"`
+			SourcePath string `json:"source_path"`
+		} `json:"symbols"`
+	}
+	if err := json.Unmarshal(symResp, &symResult); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing symbol response: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(symResult.Symbols) == 0 {
+		fmt.Fprintf(os.Stderr, "No symbol found for %q\n", symbol)
+		os.Exit(1)
+	}
+	sym := symResult.Symbols[0]
+	node := sym.SourcePath + "::" + sym.Name
+
+	outEdges := queryGraphEdges(base, workspace, node, "out")
+	inEdges := queryGraphEdges(base, workspace, node, "in")
+
+	if jsonFlag {
+		output := map[string]any{
+			"symbol":    sym.Name,
+			"file":      sym.SourcePath,
+			"kind":      sym.Kind,
+			"language":  sym.Language,
+			"calls_out": outEdges,
+			"called_by": inEdges,
+		}
+		data, _ := json.MarshalIndent(output, "", "  ")
+		fmt.Println(string(data))
+		cliLog.Info().Str("cmd", "context").Msg("cli command completed")
+		return
+	}
+
+	fmt.Printf("Symbol: %s\n", sym.Name)
+	fmt.Printf("File:   %s\n", sym.SourcePath)
+	fmt.Printf("Kind:   %s\n", sym.Kind)
+	fmt.Printf("Lang:   %s\n", sym.Language)
+	fmt.Println()
+
+	if len(outEdges) > 0 {
+		fmt.Printf("Calls out (%d):\n", len(outEdges))
+		for _, e := range outEdges {
+			fmt.Printf("  -> %s\n", e.Target)
+		}
+	} else {
+		fmt.Println("Calls out: (none)")
+	}
+	fmt.Println()
+
+	if len(inEdges) > 0 {
+		fmt.Printf("Called by (%d):\n", len(inEdges))
+		for _, e := range inEdges {
+			fmt.Printf("  <- %s\n", e.Source)
+		}
+	} else {
+		fmt.Println("Called by: (none)")
+	}
+
+	cliLog.Info().Str("cmd", "context").Msg("cli command completed")
+}
+
+type graphEdge struct {
+	Source   string `json:"source"`
+	Target   string `json:"target"`
+	EdgeType string `json:"edge_type"`
+}
+
+func queryGraphEdges(base, workspace, node, direction string) []graphEdge {
+	body := map[string]string{
+		"workspace": workspace,
+		"node":      node,
+		"direction": direction,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil
+	}
+	resp, _, err := doRequest("POST", base+"/api/v1/graph/query", bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+	var result struct {
+		Edges []graphEdge `json:"edges"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil
+	}
+	return result.Edges
+}

--- a/cmd/nano-brain/cmd_detect_changes.go
+++ b/cmd/nano-brain/cmd_detect_changes.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runDetectChangesCmd(args []string) {
+	cliLog.Info().Str("cmd", "detect-changes").Msg("cli command started")
+
+	var workspace string
+	var jsonFlag, allFlag bool
+	staged := true
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(1)
+			}
+			i++
+			workspace = args[i]
+		case "--staged":
+			staged = true
+			allFlag = false
+		case "--all":
+			allFlag = true
+			staged = false
+		case "--json":
+			jsonFlag = true
+		default:
+			if strings.HasPrefix(args[i], "--") {
+				fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "unexpected argument: %s\n", args[i])
+			os.Exit(1)
+		}
+	}
+	if workspace == "" {
+		fmt.Fprintln(os.Stderr, "Usage: nano-brain detect-changes --workspace <hash> [--staged|--all] [--json]")
+		os.Exit(1)
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: git is not installed or not in PATH")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	diffArgs := []string{"diff", "--name-only"}
+	if staged && !allFlag {
+		diffArgs = append(diffArgs, "--staged")
+	}
+	out, err := exec.CommandContext(ctx, "git", diffArgs...).Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error running git diff: %v\n", err)
+		os.Exit(1)
+	}
+
+	files := parseLines(string(out))
+	if len(files) == 0 {
+		if jsonFlag {
+			fmt.Println(`{"files":[],"symbols":[],"impacted":[]}`)
+		} else {
+			fmt.Println("No changed files detected.")
+		}
+		cliLog.Info().Str("cmd", "detect-changes").Msg("cli command completed")
+		return
+	}
+
+	type changedSymbol struct {
+		File   string `json:"file"`
+		Symbol string `json:"symbol"`
+		Line   int    `json:"line"`
+	}
+
+	type impactedNode struct {
+		Node     string `json:"node"`
+		Depth    int    `json:"depth"`
+		EdgeType string `json:"edge_type"`
+		Via      string `json:"via"`
+	}
+
+	var symbols []changedSymbol
+	var impacted []impactedNode
+	base := getBaseURL()
+
+	for _, file := range files {
+		symResp := queryFileSymbols(base, workspace, file)
+		for _, sym := range symResp {
+			if sym.SourcePath != file {
+				continue
+			}
+			symbols = append(symbols, changedSymbol{
+				File:   file,
+				Symbol: sym.Name,
+			})
+
+			node := file + "::" + sym.Name
+			impactBody := map[string]any{
+				"workspace": workspace,
+				"node":      node,
+				"max_depth": 1,
+			}
+			data, _ := json.Marshal(impactBody)
+			resp, _, err := doRequest("POST", base+"/api/v1/graph/impact", bytes.NewReader(data))
+			if err != nil {
+				continue
+			}
+			var impResult struct {
+				Impacted []struct {
+					Node     string `json:"node"`
+					Depth    int    `json:"depth"`
+					EdgeType string `json:"edge_type"`
+				} `json:"impacted"`
+			}
+			if json.Unmarshal(resp, &impResult) == nil {
+				for _, imp := range impResult.Impacted {
+					impacted = append(impacted, impactedNode{
+						Node:     imp.Node,
+						Depth:    imp.Depth,
+						EdgeType: imp.EdgeType,
+						Via:      sym.Name,
+					})
+				}
+			}
+		}
+	}
+
+	if jsonFlag {
+		output := map[string]any{
+			"files":    files,
+			"symbols":  symbols,
+			"impacted": impacted,
+		}
+		data, _ := json.MarshalIndent(output, "", "  ")
+		fmt.Println(string(data))
+		cliLog.Info().Str("cmd", "detect-changes").Msg("cli command completed")
+		return
+	}
+
+	fmt.Printf("Changed files (%d):\n", len(files))
+	for _, f := range files {
+		fmt.Printf("  %s\n", f)
+	}
+	fmt.Println()
+
+	if len(symbols) > 0 {
+		fmt.Printf("Changed symbols (%d):\n", len(symbols))
+		for _, s := range symbols {
+			fmt.Printf("  %s :: %s\n", s.File, s.Symbol)
+		}
+	} else {
+		fmt.Println("Changed symbols: (none found in index)")
+	}
+	fmt.Println()
+
+	if len(impacted) > 0 {
+		fmt.Printf("Impacted nodes (%d):\n", len(impacted))
+		for _, n := range impacted {
+			fmt.Printf("  %s (via %s, %s)\n", n.Node, n.Via, n.EdgeType)
+		}
+	} else {
+		fmt.Println("Impacted nodes: (none)")
+	}
+
+	cliLog.Info().Str("cmd", "detect-changes").Msg("cli command completed")
+}
+
+func parseLines(s string) []string {
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+type fileSymbol struct {
+	Name       string
+	Kind       string
+	Language   string
+	SourcePath string
+}
+
+func queryFileSymbols(base, workspace, file string) []fileSymbol {
+	u := fmt.Sprintf("%s/api/v1/symbols?workspace=%s&query=%s&limit=100",
+		base, workspace, file)
+	resp, _, err := doRequest("GET", u, nil)
+	if err != nil {
+		return nil
+	}
+	var result struct {
+		Symbols []fileSymbol `json:"symbols"`
+	}
+	if json.Unmarshal(resp, &result) != nil {
+		return nil
+	}
+	return result.Symbols
+}
+
+func getChangedLineRanges(ctx context.Context, file string, staged bool) [][2]int {
+	diffArgs := []string{"diff"}
+	if staged {
+		diffArgs = append(diffArgs, "--staged")
+	}
+	diffArgs = append(diffArgs, file)
+	out, err := exec.CommandContext(ctx, "git", diffArgs...).Output()
+	if err != nil {
+		return nil
+	}
+	return parseHunkHeaders(string(out))
+}
+
+func parseHunkHeaders(diff string) [][2]int {
+	var ranges [][2]int
+	for _, line := range strings.Split(diff, "\n") {
+		if !strings.HasPrefix(line, "@@ ") {
+			continue
+		}
+		plus := ""
+		parts := strings.Split(line, " ")
+		for _, p := range parts {
+			if strings.HasPrefix(p, "+") && !strings.HasPrefix(p, "+++") {
+				plus = p[1:]
+				break
+			}
+		}
+		if plus == "" {
+			continue
+		}
+		comma := strings.Index(plus, ",")
+		if comma < 0 {
+			start, err := strconv.Atoi(plus)
+			if err == nil {
+				ranges = append(ranges, [2]int{start, start})
+			}
+			continue
+		}
+		start, err1 := strconv.Atoi(plus[:comma])
+		count, err2 := strconv.Atoi(plus[comma+1:])
+		if err1 == nil && err2 == nil && count > 0 {
+			ranges = append(ranges, [2]int{start, start + count - 1})
+		}
+	}
+	return ranges
+}

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -116,6 +116,15 @@ func main() {
 		case "doctor":
 			runDoctorCmd(args[1:], configPath)
 			return
+		case "context":
+			runContextCmd(args[1:])
+			return
+		case "code-impact":
+			runCodeImpactCmd(args[1:])
+			return
+		case "detect-changes":
+			runDetectChangesCmd(args[1:])
+			return
 		case "reset-embeddings":
 			runResetEmbeddingsCmd(args[1:])
 			return
@@ -244,6 +253,21 @@ func startServer(configPath string) {
 		logger.Warn().Err(err).Msg("go graph extractor init failed, skipping")
 	} else {
 		graphExtractors = append(graphExtractors, goGE)
+	}
+	if tsGE, err := graph.NewTypeScriptGraphExtractor(); err != nil {
+		logger.Warn().Err(err).Msg("typescript graph extractor init failed, skipping")
+	} else {
+		graphExtractors = append(graphExtractors, tsGE)
+	}
+	if jsGE, err := graph.NewJavaScriptGraphExtractor(); err != nil {
+		logger.Warn().Err(err).Msg("javascript graph extractor init failed, skipping")
+	} else {
+		graphExtractors = append(graphExtractors, jsGE)
+	}
+	if pyGE, err := graph.NewPythonGraphExtractor(); err != nil {
+		logger.Warn().Err(err).Msg("python graph extractor init failed, skipping")
+	} else {
+		graphExtractors = append(graphExtractors, pyGE)
 	}
 	graphRegistry := graph.NewRegistry(graphExtractors...)
 

--- a/internal/graph/javascript_extractor.go
+++ b/internal/graph/javascript_extractor.go
@@ -1,0 +1,250 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const jsGraphImportQuery = `
+(import_statement source: (string) @path)
+`
+
+const jsGraphContainsQuery = `
+(function_declaration name: (identifier) @name) @decl
+(class_declaration name: (identifier) @name) @decl
+(lexical_declaration (variable_declarator name: (identifier) @name)) @decl
+`
+
+const jsGraphCallFuncQuery = `
+(function_declaration name: (identifier) @fn_name body: (statement_block) @body) @fn_decl
+(method_definition name: (property_identifier) @fn_name body: (statement_block) @body) @fn_decl
+(lexical_declaration (variable_declarator name: (identifier) @fn_name value: (arrow_function body: (statement_block) @body))) @fn_decl
+`
+
+const jsGraphCallExprQuery = `
+(call_expression function: (identifier) @callee)
+(call_expression function: (member_expression property: (property_identifier) @callee))
+`
+
+type JavaScriptGraphExtractor struct {
+	lang          *gotreesitter.Language
+	importQuery   *gotreesitter.Query
+	containsQuery *gotreesitter.Query
+	callFuncQuery *gotreesitter.Query
+	callExprQuery *gotreesitter.Query
+}
+
+func NewJavaScriptGraphExtractor() (*JavaScriptGraphExtractor, error) {
+	lang := grammars.JavascriptLanguage()
+
+	iq, err := gotreesitter.NewQuery(jsGraphImportQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("js import query: %w", err)
+	}
+	cq, err := gotreesitter.NewQuery(jsGraphContainsQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("js contains query: %w", err)
+	}
+	fq, err := gotreesitter.NewQuery(jsGraphCallFuncQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("js call func query: %w", err)
+	}
+	eq, err := gotreesitter.NewQuery(jsGraphCallExprQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("js call expr query: %w", err)
+	}
+	return &JavaScriptGraphExtractor{
+		lang:          lang,
+		importQuery:   iq,
+		containsQuery: cq,
+		callFuncQuery: fq,
+		callExprQuery: eq,
+	}, nil
+}
+
+func (e *JavaScriptGraphExtractor) Supports(ext string) bool {
+	return ext == ".js" || ext == ".jsx"
+}
+
+func (e *JavaScriptGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
+	parser := gotreesitter.NewParser(e.lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	edges = append(edges, e.extractContains(bt, tree, content, relFile)...)
+	edges = append(edges, e.extractImports(bt, tree, content, relFile)...)
+	edges = append(edges, e.extractCalls(bt, tree, content, relFile)...)
+	return edges, nil
+}
+
+func (e *JavaScriptGraphExtractor) extractContains(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
+	matches := e.containsQuery.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		var nameNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			if cap.Name == "name" {
+				nameNode = cap.Node
+			}
+		}
+		if nameNode == nil {
+			continue
+		}
+		name := bt.NodeText(nameNode)
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		edges = append(edges, Edge{
+			SourceNode: filePath,
+			TargetNode: filePath + "::" + name,
+			Kind:       EdgeContains,
+			SourceFile: filePath,
+			Line:       lineForByte(content, nameNode.StartByte()),
+			Language:   "javascript",
+		})
+	}
+	return edges
+}
+
+func (e *JavaScriptGraphExtractor) extractImports(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
+	matches := e.importQuery.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			raw := bt.NodeText(cap.Node)
+			importPath := strings.Trim(raw, "\"'`")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath,
+				TargetNode: importPath,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "javascript",
+			})
+		}
+	}
+
+	root := tree.RootNode()
+	e.walkRequireJS(bt, root, content, filePath, seen, &edges)
+
+	return edges
+}
+
+func (e *JavaScriptGraphExtractor) walkRequireJS(bt *gotreesitter.BoundTree, node *gotreesitter.Node, content []byte, filePath string, seen map[string]bool, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(e.lang) == "call_expression" {
+		fnNode := node.ChildByFieldName("function", e.lang)
+		if fnNode != nil && fnNode.Type(e.lang) == "identifier" && bt.NodeText(fnNode) == "require" {
+			argsNode := node.ChildByFieldName("arguments", e.lang)
+			if argsNode != nil {
+				argNode := firstChildOfType(argsNode, e.lang, "string")
+				if argNode != nil {
+					raw := bt.NodeText(argNode)
+					importPath := strings.Trim(raw, "\"'`")
+					if importPath != "" && !seen[importPath] {
+						seen[importPath] = true
+						*edges = append(*edges, Edge{
+							SourceNode: filePath,
+							TargetNode: importPath,
+							Kind:       EdgeImports,
+							SourceFile: filePath,
+							Line:       lineForByte(content, fnNode.StartByte()),
+							Language:   "javascript",
+						})
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		e.walkRequireJS(bt, node.Child(i), content, filePath, seen, edges)
+	}
+}
+
+func (e *JavaScriptGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
+	funcMatches := e.callFuncQuery.Execute(tree)
+	var funcs []funcRange
+	for _, match := range funcMatches {
+		var name string
+		var declNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			switch cap.Name {
+			case "fn_name":
+				name = bt.NodeText(cap.Node)
+			case "fn_decl":
+				declNode = cap.Node
+			}
+		}
+		if name != "" && declNode != nil {
+			funcs = append(funcs, funcRange{
+				name:      name,
+				startByte: declNode.StartByte(),
+				endByte:   declNode.EndByte(),
+			})
+		}
+	}
+
+	if len(funcs) == 0 {
+		return nil
+	}
+
+	callMatches := e.callExprQuery.Execute(tree)
+	seen := map[string]bool{}
+	var edges []Edge
+
+	for _, match := range callMatches {
+		for _, cap := range match.Captures {
+			if cap.Name != "callee" {
+				continue
+			}
+			callByte := cap.Node.StartByte()
+			callee := bt.NodeText(cap.Node)
+			if callee == "" {
+				continue
+			}
+			enclosing := enclosingFunc(funcs, callByte)
+			if enclosing == "" {
+				continue
+			}
+			key := enclosing + "->" + callee
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath + "::" + enclosing,
+				TargetNode: callee,
+				Kind:       EdgeCalls,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "javascript",
+			})
+		}
+	}
+	return edges
+}

--- a/internal/graph/javascript_extractor_test.go
+++ b/internal/graph/javascript_extractor_test.go
@@ -1,0 +1,199 @@
+package graph_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func TestJavaScriptGraphExtractor_Supports(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		{".js", true},
+		{".jsx", true},
+		{".ts", false},
+		{".go", false},
+	}
+	for _, tt := range tests {
+		if got := ex.Supports(tt.ext); got != tt.want {
+			t.Errorf("Supports(%q) = %v, want %v", tt.ext, got, tt.want)
+		}
+	}
+}
+
+func TestJavaScriptGraphExtractor_EmptyFile(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := ex.ExtractEdges("empty.js", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from empty file, got %d", len(edges))
+	}
+}
+
+func TestJavaScriptGraphExtractor_CommentsOnly(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := ex.ExtractEdges("comments.js", []byte("// comment\n/* block */\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(edges))
+	}
+}
+
+func TestJavaScriptGraphExtractor_SyntaxError(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte("function broken( { return }\nimport { x } from \"mod\";\n")
+	edges, err := ex.ExtractEdges("broken.js", src)
+	if err != nil {
+		t.Fatal("should not error on partial parse:", err)
+	}
+	_ = edges
+}
+
+func TestJavaScriptGraphExtractor_Fixture(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixturePath := filepath.Join("testdata", "javascript", "sample.js")
+	content, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	edges, err := ex.ExtractEdges(fixturePath, content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var contains, imports, calls []graph.Edge
+	for _, e := range edges {
+		switch e.Kind {
+		case graph.EdgeContains:
+			contains = append(contains, e)
+		case graph.EdgeImports:
+			imports = append(imports, e)
+		case graph.EdgeCalls:
+			calls = append(calls, e)
+		}
+	}
+
+	if len(imports) < 2 {
+		t.Errorf("expected >=2 import edges (fs, path), got %d: %v", len(imports), imports)
+	}
+
+	foundRequire := false
+	for _, e := range imports {
+		if e.TargetNode == "path" {
+			foundRequire = true
+		}
+	}
+	if !foundRequire {
+		t.Error("expected require('path') to produce import edge")
+	}
+
+	if len(contains) < 3 {
+		t.Errorf("expected >=3 contains edges, got %d", len(contains))
+	}
+
+	if len(calls) == 0 {
+		t.Error("expected >=1 call edges")
+	}
+
+	foundCall := false
+	for _, e := range calls {
+		if e.TargetNode == "parseBody" {
+			foundCall = true
+		}
+	}
+	if !foundCall {
+		t.Error("expected call edge to parseBody")
+	}
+
+	for _, e := range edges {
+		if e.SourceFile == "" {
+			t.Errorf("edge missing SourceFile: %+v", e)
+		}
+		if e.Language != "javascript" {
+			t.Errorf("edge wrong Language: %+v", e)
+		}
+		if e.Line == 0 {
+			t.Errorf("edge has zero Line: %+v", e)
+		}
+	}
+}
+
+func TestJavaScriptGraphExtractor_ArrowFunction(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`const handler = () => {
+  processData();
+  console.log("done");
+};
+`)
+	edges, err := ex.ExtractEdges("test.js", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callees := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls {
+			callees[e.TargetNode] = true
+		}
+	}
+	if !callees["processData"] {
+		t.Error("expected call edge for processData inside arrow function")
+	}
+	if !callees["log"] {
+		t.Error("expected call edge for console.log inside arrow function")
+	}
+}
+
+func TestJavaScriptGraphExtractor_RequireVsOtherCalls(t *testing.T) {
+	ex, err := graph.NewJavaScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`const fs = require("fs");
+console.log("hello");
+`)
+	edges, err := ex.ExtractEdges("test.js", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundFsImport := false
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports && e.TargetNode == "fs" {
+			foundFsImport = true
+		}
+		if e.Kind == graph.EdgeImports && e.TargetNode == "hello" {
+			t.Error("console.log should not produce import edge")
+		}
+	}
+	if !foundFsImport {
+		t.Error("require('fs') should produce import edge")
+	}
+}

--- a/internal/graph/python_extractor.go
+++ b/internal/graph/python_extractor.go
@@ -1,0 +1,256 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const pyGraphImportQuery = `
+(import_statement name: (dotted_name) @path)
+(import_from_statement module_name: (dotted_name) @path)
+`
+
+const pyGraphContainsQuery = `
+(function_definition name: (identifier) @name) @decl
+(class_definition name: (identifier) @name) @decl
+`
+
+const pyGraphAssignQuery = `
+(assignment left: (identifier) @name) @decl
+`
+
+const pyGraphCallFuncQuery = `
+(function_definition name: (identifier) @fn_name body: (block) @body) @fn_decl
+`
+
+const pyGraphCallExprQuery = `
+(call function: (identifier) @callee)
+(call function: (attribute attribute: (identifier) @callee))
+`
+
+type PythonGraphExtractor struct {
+	lang          *gotreesitter.Language
+	importQuery   *gotreesitter.Query
+	containsQuery *gotreesitter.Query
+	assignQuery   *gotreesitter.Query
+	callFuncQuery *gotreesitter.Query
+	callExprQuery *gotreesitter.Query
+}
+
+func NewPythonGraphExtractor() (*PythonGraphExtractor, error) {
+	lang := grammars.PythonLanguage()
+
+	iq, err := gotreesitter.NewQuery(pyGraphImportQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("py import query: %w", err)
+	}
+	cq, err := gotreesitter.NewQuery(pyGraphContainsQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("py contains query: %w", err)
+	}
+	aq, err := gotreesitter.NewQuery(pyGraphAssignQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("py assign query: %w", err)
+	}
+	fq, err := gotreesitter.NewQuery(pyGraphCallFuncQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("py call func query: %w", err)
+	}
+	eq, err := gotreesitter.NewQuery(pyGraphCallExprQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("py call expr query: %w", err)
+	}
+	return &PythonGraphExtractor{
+		lang:          lang,
+		importQuery:   iq,
+		containsQuery: cq,
+		assignQuery:   aq,
+		callFuncQuery: fq,
+		callExprQuery: eq,
+	}, nil
+}
+
+func (e *PythonGraphExtractor) Supports(ext string) bool {
+	return ext == ".py"
+}
+
+func (e *PythonGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
+	parser := gotreesitter.NewParser(e.lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	edges = append(edges, e.extractContains(bt, tree, content, relFile)...)
+	edges = append(edges, e.extractImports(bt, tree, content, relFile)...)
+	edges = append(edges, e.extractCalls(bt, tree, content, relFile)...)
+	return edges, nil
+}
+
+func (e *PythonGraphExtractor) extractContains(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
+	var edges []Edge
+	seen := map[string]bool{}
+
+	matches := e.containsQuery.Execute(tree)
+	for _, match := range matches {
+		var nameNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			if cap.Name == "name" {
+				nameNode = cap.Node
+			}
+		}
+		if nameNode == nil {
+			continue
+		}
+		name := bt.NodeText(nameNode)
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		edges = append(edges, Edge{
+			SourceNode: filePath,
+			TargetNode: filePath + "::" + name,
+			Kind:       EdgeContains,
+			SourceFile: filePath,
+			Line:       lineForByte(content, nameNode.StartByte()),
+			Language:   "python",
+		})
+	}
+
+	assignMatches := e.assignQuery.Execute(tree)
+	for _, match := range assignMatches {
+		var nameNode *gotreesitter.Node
+		var declNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			switch cap.Name {
+			case "name":
+				nameNode = cap.Node
+			case "decl":
+				declNode = cap.Node
+			}
+		}
+		if nameNode == nil || declNode == nil {
+			continue
+		}
+		parent := declNode.Parent()
+		if parent == nil || parent.Type(e.lang) != "module" {
+			continue
+		}
+		name := bt.NodeText(nameNode)
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		edges = append(edges, Edge{
+			SourceNode: filePath,
+			TargetNode: filePath + "::" + name,
+			Kind:       EdgeContains,
+			SourceFile: filePath,
+			Line:       lineForByte(content, nameNode.StartByte()),
+			Language:   "python",
+		})
+	}
+
+	return edges
+}
+
+func (e *PythonGraphExtractor) extractImports(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
+	matches := e.importQuery.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			importPath := bt.NodeText(cap.Node)
+			importPath = strings.ReplaceAll(importPath, " ", "")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath,
+				TargetNode: importPath,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "python",
+			})
+		}
+	}
+	return edges
+}
+
+func (e *PythonGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
+	funcMatches := e.callFuncQuery.Execute(tree)
+	var funcs []funcRange
+	for _, match := range funcMatches {
+		var name string
+		var declNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			switch cap.Name {
+			case "fn_name":
+				name = bt.NodeText(cap.Node)
+			case "fn_decl":
+				declNode = cap.Node
+			}
+		}
+		if name != "" && declNode != nil {
+			funcs = append(funcs, funcRange{
+				name:      name,
+				startByte: declNode.StartByte(),
+				endByte:   declNode.EndByte(),
+			})
+		}
+	}
+
+	if len(funcs) == 0 {
+		return nil
+	}
+
+	callMatches := e.callExprQuery.Execute(tree)
+	seen := map[string]bool{}
+	var edges []Edge
+
+	for _, match := range callMatches {
+		for _, cap := range match.Captures {
+			if cap.Name != "callee" {
+				continue
+			}
+			callByte := cap.Node.StartByte()
+			callee := bt.NodeText(cap.Node)
+			if callee == "" {
+				continue
+			}
+			enclosing := enclosingFunc(funcs, callByte)
+			if enclosing == "" {
+				continue
+			}
+			key := enclosing + "->" + callee
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath + "::" + enclosing,
+				TargetNode: callee,
+				Kind:       EdgeCalls,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "python",
+			})
+		}
+	}
+	return edges
+}

--- a/internal/graph/python_extractor_test.go
+++ b/internal/graph/python_extractor_test.go
@@ -1,0 +1,214 @@
+package graph_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func TestPythonGraphExtractor_Supports(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		{".py", true},
+		{".go", false},
+		{".js", false},
+	}
+	for _, tt := range tests {
+		if got := ex.Supports(tt.ext); got != tt.want {
+			t.Errorf("Supports(%q) = %v, want %v", tt.ext, got, tt.want)
+		}
+	}
+}
+
+func TestPythonGraphExtractor_EmptyFile(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := ex.ExtractEdges("empty.py", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from empty file, got %d", len(edges))
+	}
+}
+
+func TestPythonGraphExtractor_CommentsOnly(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := ex.ExtractEdges("comments.py", []byte("# just a comment\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(edges))
+	}
+}
+
+func TestPythonGraphExtractor_SyntaxError(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte("def broken(\n    pass\nimport os\n")
+	edges, err := ex.ExtractEdges("broken.py", src)
+	if err != nil {
+		t.Fatal("should not error on partial parse:", err)
+	}
+	_ = edges
+}
+
+func TestPythonGraphExtractor_Fixture(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixturePath := filepath.Join("testdata", "python", "sample.py")
+	content, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	edges, err := ex.ExtractEdges(fixturePath, content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var contains, imports, calls []graph.Edge
+	for _, e := range edges {
+		switch e.Kind {
+		case graph.EdgeContains:
+			contains = append(contains, e)
+		case graph.EdgeImports:
+			imports = append(imports, e)
+		case graph.EdgeCalls:
+			calls = append(calls, e)
+		}
+	}
+
+	if len(imports) < 2 {
+		t.Errorf("expected >=2 import edges (os, pathlib), got %d: %v", len(imports), imports)
+	}
+
+	if len(contains) < 4 {
+		t.Errorf("expected >=4 contains edges (main, helper, Server, CONFIG), got %d: %v", len(contains), contains)
+	}
+
+	foundConfig := false
+	for _, e := range contains {
+		if e.TargetNode == fixturePath+"::CONFIG" {
+			foundConfig = true
+		}
+	}
+	if !foundConfig {
+		t.Error("expected module-level CONFIG assignment as contains edge")
+	}
+
+	if len(calls) == 0 {
+		t.Error("expected >=1 call edges")
+	}
+
+	foundCall := false
+	foundAttrCall := false
+	for _, e := range calls {
+		if e.TargetNode == "helper" {
+			foundCall = true
+		}
+		if e.TargetNode == "join" {
+			foundAttrCall = true
+		}
+	}
+	if !foundCall {
+		t.Error("expected call edge to helper")
+	}
+	if !foundAttrCall {
+		t.Error("expected call edge to join (attribute call os.path.join)")
+	}
+
+	for _, e := range edges {
+		if e.SourceFile == "" {
+			t.Errorf("edge missing SourceFile: %+v", e)
+		}
+		if e.Language != "python" {
+			t.Errorf("edge wrong Language: %+v", e)
+		}
+		if e.Line == 0 {
+			t.Errorf("edge has zero Line: %+v", e)
+		}
+	}
+}
+
+func TestPythonGraphExtractor_AttributeCall(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`def process():
+    os.path.join("/tmp", "file")
+    logger.info("hello")
+    direct_call()
+`)
+	edges, err := ex.ExtractEdges("test.py", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callees := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls {
+			callees[e.TargetNode] = true
+		}
+	}
+	if !callees["join"] {
+		t.Error("expected call edge for os.path.join")
+	}
+	if !callees["info"] {
+		t.Error("expected call edge for logger.info")
+	}
+	if !callees["direct_call"] {
+		t.Error("expected call edge for direct_call")
+	}
+}
+
+func TestPythonGraphExtractor_NestedAssignment(t *testing.T) {
+	ex, err := graph.NewPythonGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`MODULE_VAR = 1
+
+def func():
+    local_var = 2
+`)
+	edges, err := ex.ExtractEdges("test.py", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range edges {
+		if e.Kind == graph.EdgeContains && e.TargetNode == "test.py::local_var" {
+			t.Error("nested assignment local_var should NOT produce contains edge")
+		}
+	}
+
+	foundModule := false
+	for _, e := range edges {
+		if e.Kind == graph.EdgeContains && e.TargetNode == "test.py::MODULE_VAR" {
+			foundModule = true
+		}
+	}
+	if !foundModule {
+		t.Error("module-level MODULE_VAR should produce contains edge")
+	}
+}

--- a/internal/graph/testdata/javascript/sample.js
+++ b/internal/graph/testdata/javascript/sample.js
@@ -1,0 +1,20 @@
+import { readFile } from "fs";
+const path = require("path");
+
+class Router {
+  handle(req) {
+    return this.dispatch(req);
+  }
+}
+
+function processRequest(req) {
+  const data = parseBody(req);
+  console.log(data);
+  return data;
+}
+
+function parseBody(req) {
+  return JSON.parse(req.body);
+}
+
+const config = { port: 3000 };

--- a/internal/graph/testdata/python/sample.py
+++ b/internal/graph/testdata/python/sample.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+CONFIG = {"key": "value"}
+
+def main():
+    x = 10
+    result = helper()
+    print(result)
+    os.path.join("/tmp", "file")
+
+def helper():
+    return 42
+
+class Server:
+    def start(self):
+        self.run()

--- a/internal/graph/testdata/typescript/sample.ts
+++ b/internal/graph/testdata/typescript/sample.ts
@@ -1,0 +1,31 @@
+import { readFile } from "fs";
+import path from "path";
+const lodash = require("lodash");
+
+interface Config {
+  port: number;
+}
+
+type Handler = (req: Request) => Response;
+
+enum Status {
+  Active,
+  Inactive,
+}
+
+class Server {
+  start() {
+    console.log("starting");
+  }
+}
+
+function handleRequest(req: Request): Response {
+  const result = processData(req);
+  return result;
+}
+
+function processData(data: any): any {
+  return data;
+}
+
+const helper = "not a function";

--- a/internal/graph/typescript_extractor.go
+++ b/internal/graph/typescript_extractor.go
@@ -1,0 +1,303 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const tsImportQuery = `
+(import_statement source: (string) @path)
+`
+
+const tsContainsQuery = `
+(function_declaration name: (identifier) @name) @decl
+(class_declaration name: (type_identifier) @name) @decl
+(interface_declaration name: (type_identifier) @name) @decl
+(type_alias_declaration name: (type_identifier) @name) @decl
+(enum_declaration name: (identifier) @name) @decl
+(lexical_declaration (variable_declarator name: (identifier) @name)) @decl
+`
+
+const tsCallFuncQuery = `
+(function_declaration name: (identifier) @fn_name body: (statement_block) @body) @fn_decl
+(method_definition name: (property_identifier) @fn_name body: (statement_block) @body) @fn_decl
+(lexical_declaration (variable_declarator name: (identifier) @fn_name value: (arrow_function body: (statement_block) @body))) @fn_decl
+`
+
+const tsCallExprQuery = `
+(call_expression function: (identifier) @callee)
+(call_expression function: (member_expression property: (property_identifier) @callee))
+`
+
+type TypeScriptGraphExtractor struct {
+	lang          *gotreesitter.Language
+	tsxLang       *gotreesitter.Language
+	importQuery   *gotreesitter.Query
+	tsxImportQ    *gotreesitter.Query
+	containsQuery *gotreesitter.Query
+	tsxContainsQ  *gotreesitter.Query
+	callFuncQuery *gotreesitter.Query
+	tsxCallFuncQ  *gotreesitter.Query
+	callExprQuery *gotreesitter.Query
+	tsxCallExprQ  *gotreesitter.Query
+}
+
+func NewTypeScriptGraphExtractor() (*TypeScriptGraphExtractor, error) {
+	lang := grammars.TypescriptLanguage()
+	tsxLang := grammars.TsxLanguage()
+
+	iq, err := gotreesitter.NewQuery(tsImportQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("ts import query: %w", err)
+	}
+	tsxIQ, err := gotreesitter.NewQuery(tsImportQuery, tsxLang)
+	if err != nil {
+		return nil, fmt.Errorf("tsx import query: %w", err)
+	}
+	cq, err := gotreesitter.NewQuery(tsContainsQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("ts contains query: %w", err)
+	}
+	tsxCQ, err := gotreesitter.NewQuery(tsContainsQuery, tsxLang)
+	if err != nil {
+		return nil, fmt.Errorf("tsx contains query: %w", err)
+	}
+	fq, err := gotreesitter.NewQuery(tsCallFuncQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("ts call func query: %w", err)
+	}
+	tsxFQ, err := gotreesitter.NewQuery(tsCallFuncQuery, tsxLang)
+	if err != nil {
+		return nil, fmt.Errorf("tsx call func query: %w", err)
+	}
+	eq, err := gotreesitter.NewQuery(tsCallExprQuery, lang)
+	if err != nil {
+		return nil, fmt.Errorf("ts call expr query: %w", err)
+	}
+	tsxEQ, err := gotreesitter.NewQuery(tsCallExprQuery, tsxLang)
+	if err != nil {
+		return nil, fmt.Errorf("tsx call expr query: %w", err)
+	}
+
+	return &TypeScriptGraphExtractor{
+		lang:          lang,
+		tsxLang:       tsxLang,
+		importQuery:   iq,
+		tsxImportQ:    tsxIQ,
+		containsQuery: cq,
+		tsxContainsQ:  tsxCQ,
+		callFuncQuery: fq,
+		tsxCallFuncQ:  tsxFQ,
+		callExprQuery: eq,
+		tsxCallExprQ:  tsxEQ,
+	}, nil
+}
+
+func (e *TypeScriptGraphExtractor) Supports(ext string) bool {
+	return ext == ".ts" || ext == ".tsx"
+}
+
+func (e *TypeScriptGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
+	lang, importQ, containsQ, callFuncQ, callExprQ := e.lang, e.importQuery, e.containsQuery, e.callFuncQuery, e.callExprQuery
+	if filepath.Ext(filePath) == ".tsx" {
+		lang, importQ, containsQ, callFuncQ, callExprQ = e.tsxLang, e.tsxImportQ, e.tsxContainsQ, e.tsxCallFuncQ, e.tsxCallExprQ
+	}
+
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	edges = append(edges, e.extractContains(bt, tree, content, relFile, containsQ)...)
+	edges = append(edges, e.extractImports(bt, tree, content, relFile, lang, importQ)...)
+	edges = append(edges, e.extractCalls(bt, tree, content, relFile, callFuncQ, callExprQ)...)
+	return edges, nil
+}
+
+func (e *TypeScriptGraphExtractor) extractContains(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, q *gotreesitter.Query) []Edge {
+	matches := q.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		var nameNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			if cap.Name == "name" {
+				nameNode = cap.Node
+			}
+		}
+		if nameNode == nil {
+			continue
+		}
+		name := bt.NodeText(nameNode)
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		edges = append(edges, Edge{
+			SourceNode: filePath,
+			TargetNode: filePath + "::" + name,
+			Kind:       EdgeContains,
+			SourceFile: filePath,
+			Line:       lineForByte(content, nameNode.StartByte()),
+			Language:   "typescript",
+		})
+	}
+	return edges
+}
+
+func (e *TypeScriptGraphExtractor) extractImports(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, q *gotreesitter.Query) []Edge {
+	matches := q.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			raw := bt.NodeText(cap.Node)
+			importPath := strings.Trim(raw, "\"'`")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath,
+				TargetNode: importPath,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "typescript",
+			})
+		}
+	}
+
+	edges = append(edges, e.extractRequireImports(bt, tree, content, filePath, lang, seen)...)
+
+	return edges
+}
+
+func (e *TypeScriptGraphExtractor) extractRequireImports(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool) []Edge {
+	root := tree.RootNode()
+	var edges []Edge
+	e.walkRequire(bt, root, content, filePath, lang, seen, &edges)
+	return edges
+}
+
+func (e *TypeScriptGraphExtractor) walkRequire(bt *gotreesitter.BoundTree, node *gotreesitter.Node, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(lang) == "call_expression" {
+		fnNode := node.ChildByFieldName("function", lang)
+		if fnNode != nil && fnNode.Type(lang) == "identifier" && bt.NodeText(fnNode) == "require" {
+			argsNode := node.ChildByFieldName("arguments", lang)
+			if argsNode != nil {
+				argNode := firstChildOfType(argsNode, lang, "string")
+				if argNode != nil {
+					raw := bt.NodeText(argNode)
+					importPath := strings.Trim(raw, "\"'`")
+					if importPath != "" && !seen[importPath] {
+						seen[importPath] = true
+						*edges = append(*edges, Edge{
+							SourceNode: filePath,
+							TargetNode: importPath,
+							Kind:       EdgeImports,
+							SourceFile: filePath,
+							Line:       lineForByte(content, fnNode.StartByte()),
+							Language:   "typescript",
+						})
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		e.walkRequire(bt, node.Child(i), content, filePath, lang, seen, edges)
+	}
+}
+
+func (e *TypeScriptGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, funcQ, exprQ *gotreesitter.Query) []Edge {
+	funcMatches := funcQ.Execute(tree)
+	var funcs []funcRange
+	for _, match := range funcMatches {
+		var name string
+		var declNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			switch cap.Name {
+			case "fn_name":
+				name = bt.NodeText(cap.Node)
+			case "fn_decl":
+				declNode = cap.Node
+			}
+		}
+		if name != "" && declNode != nil {
+			funcs = append(funcs, funcRange{
+				name:      name,
+				startByte: declNode.StartByte(),
+				endByte:   declNode.EndByte(),
+			})
+		}
+	}
+
+	if len(funcs) == 0 {
+		return nil
+	}
+
+	callMatches := exprQ.Execute(tree)
+	seen := map[string]bool{}
+	var edges []Edge
+
+	for _, match := range callMatches {
+		for _, cap := range match.Captures {
+			if cap.Name != "callee" {
+				continue
+			}
+			callByte := cap.Node.StartByte()
+			callee := bt.NodeText(cap.Node)
+			if callee == "" {
+				continue
+			}
+			enclosing := enclosingFunc(funcs, callByte)
+			if enclosing == "" {
+				continue
+			}
+			key := enclosing + "->" + callee
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath + "::" + enclosing,
+				TargetNode: callee,
+				Kind:       EdgeCalls,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "typescript",
+			})
+		}
+	}
+	return edges
+}
+
+func firstChildOfType(node *gotreesitter.Node, lang *gotreesitter.Language, nodeType string) *gotreesitter.Node {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		c := node.Child(i)
+		if c != nil && c.Type(lang) == nodeType {
+			return c
+		}
+	}
+	return nil
+}
+

--- a/internal/graph/typescript_extractor_test.go
+++ b/internal/graph/typescript_extractor_test.go
@@ -1,0 +1,202 @@
+package graph_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func TestTypeScriptGraphExtractor_Supports(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		{".ts", true},
+		{".tsx", true},
+		{".go", false},
+		{".js", false},
+	}
+	for _, tt := range tests {
+		if got := ex.Supports(tt.ext); got != tt.want {
+			t.Errorf("Supports(%q) = %v, want %v", tt.ext, got, tt.want)
+		}
+	}
+}
+
+func TestTypeScriptGraphExtractor_EmptyFile(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := ex.ExtractEdges("empty.ts", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from empty file, got %d", len(edges))
+	}
+}
+
+func TestTypeScriptGraphExtractor_CommentsOnly(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte("// just a comment\n/* block comment */\n")
+	edges, err := ex.ExtractEdges("comments.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from comments-only file, got %d", len(edges))
+	}
+}
+
+func TestTypeScriptGraphExtractor_SyntaxError(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte("function broken( { return }\nimport { x } from \"mod\";\n")
+	edges, err := ex.ExtractEdges("broken.ts", src)
+	if err != nil {
+		t.Fatal("should not error on partial parse:", err)
+	}
+	_ = edges
+}
+
+func TestTypeScriptGraphExtractor_Fixture(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixturePath := filepath.Join("testdata", "typescript", "sample.ts")
+	content, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	edges, err := ex.ExtractEdges(fixturePath, content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var contains, imports, calls []graph.Edge
+	for _, e := range edges {
+		switch e.Kind {
+		case graph.EdgeContains:
+			contains = append(contains, e)
+		case graph.EdgeImports:
+			imports = append(imports, e)
+		case graph.EdgeCalls:
+			calls = append(calls, e)
+		}
+	}
+
+	if len(imports) < 3 {
+		t.Errorf("expected >=3 import edges (fs, path, lodash), got %d: %v", len(imports), imports)
+	}
+
+	foundRequire := false
+	for _, e := range imports {
+		if e.TargetNode == "lodash" {
+			foundRequire = true
+		}
+	}
+	if !foundRequire {
+		t.Error("expected require('lodash') to produce import edge")
+	}
+
+	if len(contains) < 4 {
+		t.Errorf("expected >=4 contains edges, got %d", len(contains))
+	}
+
+	if len(calls) == 0 {
+		t.Error("expected >=1 call edges")
+	}
+
+	foundCall := false
+	for _, e := range calls {
+		if e.TargetNode == "processData" {
+			foundCall = true
+		}
+	}
+	if !foundCall {
+		t.Error("expected call edge to processData")
+	}
+
+	for _, e := range edges {
+		if e.SourceFile == "" {
+			t.Errorf("edge missing SourceFile: %+v", e)
+		}
+		if e.Language != "typescript" {
+			t.Errorf("edge wrong Language: %+v", e)
+		}
+		if e.Line == 0 {
+			t.Errorf("edge has zero Line: %+v", e)
+		}
+	}
+}
+
+func TestTypeScriptGraphExtractor_ArrowFunction(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`const handler = () => {
+  processData();
+  console.log("done");
+};
+`)
+	edges, err := ex.ExtractEdges("test.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callees := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls {
+			callees[e.TargetNode] = true
+		}
+	}
+	if !callees["processData"] {
+		t.Error("expected call edge for processData inside arrow function")
+	}
+	if !callees["log"] {
+		t.Error("expected call edge for console.log inside arrow function")
+	}
+}
+
+func TestTypeScriptGraphExtractor_RequireVsOtherCalls(t *testing.T) {
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`const fs = require("fs");
+console.log("hello");
+`)
+	edges, err := ex.ExtractEdges("test.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports && e.TargetNode == "hello" {
+			t.Error("console.log should not produce import edge")
+		}
+	}
+	foundFsImport := false
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports && e.TargetNode == "fs" {
+			foundFsImport = true
+		}
+	}
+	if !foundFsImport {
+		t.Error("require('fs') should produce import edge")
+	}
+}


### PR DESCRIPTION
## Summary

Add multi-language code intelligence support extending the existing Go-only graph extraction to TypeScript, JavaScript, and Python.

### Graph Extractors
- **TypeScriptGraphExtractor**: function/method declarations, ES6 + require() imports, two-phase call detection, dual grammar (TS + TSX)
- **JavaScriptGraphExtractor**: function/method declarations, ES6 + require() imports, two-phase call detection
- **PythonGraphExtractor**: function declarations, import/from imports, two-phase call detection, module-level assignment filter

### CLI Commands
- `context`: query symbol relationships via graph API
- `code-impact`: analyze change impact with configurable depth (clamped 1-3)
- `detect-changes`: map git diff to affected symbols and edges (10s timeout, git existence check)

### Design Decisions
- All extractors follow `GoGraphExtractor` pattern: tree-sitter queries with two-phase call detection
- No new DB migrations — reuses existing `graph_edges` table
- `CGO_ENABLED=0` compatible via gotreesitter pure Go bindings
- TSX uses `TsxLanguage()` grammar, TS uses `TypescriptLanguage()`
- Python uses `call` node type (not `call_expression`), `block` (not `statement_block`)
- require() detected via post-filter on `call_expression` function node text

### Verification
- `go build ./...` ✅
- `go vet ./...` ✅  
- `go test -race -short -count=1 ./...` — all 19 packages pass ✅

### OpenSpec
- Change: `extend-code-intelligence`
- Deep-design: Metis + Oracle gate passed with 9 corrections applied

Closes #196