### PR TITLE
docs(harness): add 3 anti-footgun rules to prevent merge mistakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,9 @@ This project uses an engineering harness for risk-classified, spec-driven develo
 - **No starting work without a GitHub issue.**
 - **No archiving without Review Verdict = PASS.**
 - **No modifying harness rules without user approval.**
+- **No direct commits to `master` or `b-main`.** Always work on a feature branch (`feat/`, `fix/`, `chore/`, `docs/`) and open a PR. The only exception is a merge commit produced by resolving an existing PR's conflicts — and even then the resolution should normally happen on the PR's head branch, not on the target.
+- **No `git push origin <branch>` without first verifying you are ON `<branch>`.** Always run `git branch --show-current` (or check `git status` header) before pushing. Pushing while on the wrong branch silently returns "Everything up-to-date" without error. Use `git push` (no args, relies on upstream tracking) when in doubt.
+- **No merging trunk-into-trunk locally.** If a PR's base needs to absorb its head (e.g. `b-main → master`), let the GitHub merge button handle it after conflicts are resolved on the PR head. Local `git merge origin/<other-trunk>` followed by `push origin <this-trunk>` bypasses CI gates and PR review history.
 
 ### Git push workflow (container environment)
 


### PR DESCRIPTION
Hardens HARNESS rules in `AGENTS.md` to prevent the specific footguns that occurred during PR #201 conflict resolution:

## New Forbidden Practices

### 1. No direct commits to `master` or `b-main`
Always work on a feature branch (`feat/`, `fix/`, `chore/`, `docs/`) and open a PR. The only exception is a merge commit produced by resolving an existing PR's conflicts — and even then the resolution should normally happen on the PR's head branch, not on the target.

**Triggered by**: In PR #201, the merge commit landed straight on local `master` and then got pushed to `origin/master`, bypassing PR review history.

### 2. No `git push origin <branch>` without verifying you are ON `<branch>`
Always run `git branch --show-current` (or check `git status` header) before pushing. Pushing while on the wrong branch silently returns "Everything up-to-date" without error. Use plain `git push` (no args, relies on upstream tracking) when in doubt.

**Triggered by**: I was sitting on `master` but ran `git push origin b-main` — git returned "Everything up-to-date" (a false positive — local `b-main` truly hadn't moved). Wasted a turn before I noticed the commit had landed on `master` instead.

### 3. No merging trunk-into-trunk locally
If a PR's base needs to absorb its head (e.g. `b-main → master`), let the GitHub merge button handle it after conflicts are resolved on the PR head. Local `git merge origin/<other-trunk>` followed by `push origin <this-trunk>` bypasses CI gates and PR review history.

**Triggered by**: For PR #201 I did `git merge origin/b-main` from local `master` and pushed master. The PR closed (GitHub detected reachability) but no CI/review ever ran on the merge commit.

## Verification
- Single-file docs change, no code touched
- Self-eating-dogfood: this PR follows the new rules (feature branch, base=master, no direct push to trunk)