### PR TITLE
chore(npm): commit empty package-lock.json for shared-workflows compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ _bmad/config.user.yaml
 .opencode/worktree-sessions.json
 .opencode/.repo-id
 
-# Node (no npm deps in this project)
-package-lock.json
-
 # Go
 /nano-brain
 *.exe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "@nano-step/nano-brain",
+  "version": "0.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nano-step/nano-brain",
+      "version": "0.0.0-dev",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "nano-brain": "npm/run.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes PR #203 publish-stable failure on first master push.

publish-stable.yml runs `npm ci --ignore-scripts` which requires package-lock.json. nano-brain has zero npm dependencies so the lock is 328 bytes of metadata only — no real install happens at the publish step.

Postinstall behavior in consumer environments unchanged (still downloads Go binary from GH Release).

Removes 'package-lock.json' from .gitignore.

After this merges, publish-stable should succeed and produce the first semver release.