### PR TITLE
chore(npm): sync package.json version to 2026.5.2902

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nano-step/nano-brain",
-  "version": "0.0.0-dev",
+  "version": "2026.5.2902",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nano-step/nano-brain",
-      "version": "0.0.0-dev",
+      "version": "2026.5.2902",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nano-step/nano-brain",
-  "version": "0.0.0",
+  "version": "2026.5.2902",
   "description": "Persistent memory and code intelligence for AI coding agents",
   "bin": {
     "nano-brain": "npm/run.js"


### PR DESCRIPTION
Continuing the publish-stable fix chain. After #204 fixed the lockfile, publish-stable bumped 0.0.0-dev → 0.0.0 and tried to publish, but npm rejected: all 37 existing published versions are higher than 0.0.0 (latest published is 2026.5.2902).

The failed run STILL committed 'chore: bump version to v0.0.0 [skip ci]' to master though — so master now has package.json.version=0.0.0.

This PR syncs package.json.version=2026.5.2902 (= currently @latest on npm) so the next publish-stable run patch-bumps to 2026.5.2903 which is greater than every published version.

After this merges: publish-stable runs → 2026.5.2903 → tag v2026.5.2903 → npm publish → GH Release shell → release.yml fires on tag → Go binaries attached.