### PR TITLE
chore(npm): manual publish 2026.5.2903 (user testing)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nano-step/nano-brain",
-  "version": "0.0.0-dev",
+  "version": "2026.5.2903",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nano-step/nano-brain",
-      "version": "0.0.0-dev",
+      "version": "2026.5.2903",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nano-step/nano-brain",
-  "version": "0.0.0",
+  "version": "2026.5.2903",
   "description": "Persistent memory and code intelligence for AI coding agents",
   "bin": {
     "nano-brain": "npm/run.js"


### PR DESCRIPTION
Manual publish to unblock user testing — auto-publish path (publish-stable.yml) will be fixed in a follow-up.

## Status
- ✅ Tag `v2026.5.2903` created
- ✅ GH Release with 4-platform binaries: https://github.com/nano-step/nano-brain/releases/tag/v2026.5.2903
- ✅ `@nano-step/nano-brain@2026.5.2903` published, dist-tag latest
- ✅ `nano-brain@2026.5.2903` published, dist-tag latest
- ✅ E2E install verified: `npm install @nano-step/nano-brain` downloads binary + runs (reports `nano-brain v2026.5.2903`)

## Next
Fix publish-stable.yml so future master pushes auto-publish:
1. Stop publish-stable from committing the bump when npm publish later fails (the failed 0.0.0 attempt left a stray commit on master)
2. Decide if we keep date-based versioning or switch to semver (publish-stable assumes semver)