### PR TITLE
fix(embed): break ollama-400 infinite loop + lower max_chars

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -286,7 +286,8 @@ func startServer(configPath string) {
 			logger.Error().Err(embedErr).Str("provider", cfg.Embedding.Provider).Str("url", cfg.Embedding.URL).Msg("embedding provider init failed")
 		} else {
 			embedder = e
-			eq = embed.NewQueue(embedder, queries, logger, cfg.Embedding.Provider, cfg.Embedding.Model, cfg.Embedding.Concurrency)
+			eq = embed.NewQueue(embedder, queries, logger, cfg.Embedding.Provider, cfg.Embedding.Model, cfg.Embedding.Concurrency).
+				WithMaxChars(cfg.Embedding.MaxChars)
 			fw.WithEmbedQueue(eq)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,12 +42,19 @@ type DatabaseConfig struct {
 }
 
 // EmbeddingConfig holds embedding provider configuration.
+//
+// MaxChars is the per-embed-call character budget used to truncate oversized
+// chunks before sending to the provider. Default 3000 chars is empirically
+// safe for nomic-embed-text's 2048-token context window (SentencePiece tokenizes
+// dense CSV/code at ~1 char/token, so 4000 chars produced >2048 tokens and
+// triggered ollama 400s — see issue #208).
 type EmbeddingConfig struct {
 	Provider     string `koanf:"provider"`
 	URL          string `koanf:"url"`
 	Model        string `koanf:"model"`
 	Dimension    int    `koanf:"dimension"`
 	Concurrency  int    `koanf:"concurrency"`
+	MaxChars     int    `koanf:"max_chars"`
 	VoyageAPIKey string `koanf:"voyage_api_key"`
 }
 
@@ -197,6 +204,7 @@ func Load(configPath string) (*Config, error) {
 		"OPENCODE_STORAGE_DIR":     "harvester.opencode.session_dir",
 		"OPENCODE_DB_PATH":         "harvester.opencode.db_path",
 		"OPENCODE_DB_ROOT":         "harvester.opencode.db_root",
+		"NANO_BRAIN_EMBED_MAX_CHARS": "embedding.max_chars",
 		"NANO_BRAIN_SUMMARIZE_API_KEY": "summarization.api_key",
 	}
 	for envVar, key := range specialEnvVars {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -25,6 +25,7 @@ func getDefaults() *Config {
 			URL:         "http://localhost:11434",
 			Model:       "nomic-embed-text",
 			Concurrency: 3,
+			MaxChars:    3000,
 			VoyageAPIKey: "",
 		},
 		Harvester: HarvesterConfig{

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,10 +29,13 @@ const (
 	backoffMax         = 300 * time.Second
 	rejectionThreshold = 50000
 	maxRetries         = 3
-	// maxEmbedChars is a conservative char limit per embed call.
-	// nomic-embed-text has a 2048-token context window. With ~2 chars/token worst-case
-	// (CJK, code), 4000 chars gives a safe margin below the hard limit.
-	maxEmbedChars = 4000
+	// defaultMaxEmbedChars is the fallback char budget when EmbeddingConfig.MaxChars
+	// is unset. SentencePiece tokenizes dense CSV/code at ~1 char/token, so 3000 chars
+	// stays well under nomic-embed-text's 2048-token limit (worst case ~2300 tokens).
+	// Override via config (embedding.max_chars) or env (NANO_BRAIN_EMBED_MAX_CHARS).
+	// History: 8000 → 4000 → 3000 across issues #208 and prior. Do not raise without
+	// confirming via real ollama tokenization on dense CSV input.
+	defaultMaxEmbedChars = 3000
 )
 
 type QueueQuerier interface {
@@ -41,6 +45,7 @@ type QueueQuerier interface {
 	InsertEmbedding(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
 	MarkChunkEmbedded(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
 	MarkChunkEmbedFailed(ctx context.Context, arg sqlc.MarkChunkEmbedFailedParams) error
+	MarkChunkEmbedPermanentlyFailed(ctx context.Context, arg sqlc.MarkChunkEmbedPermanentlyFailedParams) error
 }
 
 type Queue struct {
@@ -51,6 +56,7 @@ type Queue struct {
 	provider    string
 	model       string
 	concurrency int
+	maxChars    int
 	backoff     backoffState
 	mu          sync.Mutex
 	pending        atomic.Int64
@@ -75,9 +81,17 @@ func NewQueue(embedder Embedder, queries QueueQuerier, logger zerolog.Logger, pr
 		provider:    provider,
 		model:       model,
 		concurrency: concurrency,
+		maxChars:    defaultMaxEmbedChars,
 		backoff:     backoffState{current: 0},
 		retries:     make(map[uuid.UUID]int),
 	}
+}
+
+func (q *Queue) WithMaxChars(n int) *Queue {
+	if n > 0 {
+		q.maxChars = n
+	}
+	return q
 }
 
 func (q *Queue) Enqueue(chunkID uuid.UUID) bool {
@@ -229,7 +243,7 @@ func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
 
 	embedCtx, cancel := context.WithTimeout(ctx, embedTimeout)
 	defer cancel()
-	content := truncateToMaxChars(chunk.Content, maxEmbedChars)
+	content := truncateToMaxChars(chunk.Content, q.maxChars)
 	if len(content) < len(chunk.Content) {
 		q.logger.Warn().
 			Str("chunk_id", chunkID.String()).
@@ -243,6 +257,23 @@ func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
 			Str("chunk_id", chunkID.String()).
 			Str("file", chunk.SourcePath).
 			Msg("embedding failed")
+		if isDeterministicEmbedError(err) {
+			if mErr := q.queries.MarkChunkEmbedPermanentlyFailed(ctx, sqlc.MarkChunkEmbedPermanentlyFailedParams{
+				ID:            chunkID,
+				WorkspaceHash: chunk.WorkspaceHash,
+			}); mErr != nil {
+				q.logger.Error().Err(mErr).Str("chunk_id", chunkID.String()).Msg("mark embed_permanently_failed failed")
+			}
+			q.pending.Add(-1)
+			q.clearRetries(chunkID)
+			q.logger.Warn().
+				Str("chunk_id", chunkID.String()).
+				Str("reason", err.Error()).
+				Int("content_len", len(content)).
+				Int("max_chars", q.maxChars).
+				Msg("chunk marked embed_permanently_failed (deterministic error — not retryable)")
+			return
+		}
 		q.increaseBackoff()
 		q.handleRetry(ctx, chunkID, chunk.WorkspaceHash)
 		return
@@ -349,6 +380,22 @@ func truncateToMaxChars(s string, max int) string {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated
+}
+
+// isDeterministicEmbedError reports whether the embedder error is content-shape
+// driven (will recur on every retry) rather than transient. Triggers the
+// permanent-failure path so the chunk stops re-entering the rescan loop.
+// Issue #208: ollama returns HTTP 400 with body containing "context length"
+// or "input length" when tokenized input exceeds model's context window.
+func isDeterministicEmbedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context length") ||
+		strings.Contains(msg, "input length") ||
+		strings.Contains(msg, "exceeds context") ||
+		strings.Contains(msg, "maximum context")
 }
 
 func (q *Queue) checkCapacity() {

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -2,6 +2,7 @@ package embed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -45,9 +46,11 @@ type mockQuerier struct {
 	insertEmbeddingFn                     func(ctx context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error)
 	markChunkEmbeddedFn                   func(ctx context.Context, arg sqlc.MarkChunkEmbeddedParams) error
 	markChunkEmbedFailedFn                func(ctx context.Context, arg sqlc.MarkChunkEmbedFailedParams) error
+	markChunkEmbedPermanentlyFailedFn     func(ctx context.Context, arg sqlc.MarkChunkEmbedPermanentlyFailedParams) error
 	insertEmbeddingCalls                  int
 	markChunkEmbeddedCalls                int
 	markChunkEmbedFailedCalls             int
+	markChunkEmbedPermanentlyFailedCalls  int
 }
 
 func (m *mockQuerier) GetChunkByID(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error) {
@@ -101,6 +104,16 @@ func (m *mockQuerier) MarkChunkEmbedFailed(ctx context.Context, arg sqlc.MarkChu
 	m.mu.Unlock()
 	if m.markChunkEmbedFailedFn != nil {
 		return m.markChunkEmbedFailedFn(ctx, arg)
+	}
+	return nil
+}
+
+func (m *mockQuerier) MarkChunkEmbedPermanentlyFailed(ctx context.Context, arg sqlc.MarkChunkEmbedPermanentlyFailedParams) error {
+	m.mu.Lock()
+	m.markChunkEmbedPermanentlyFailedCalls++
+	m.mu.Unlock()
+	if m.markChunkEmbedPermanentlyFailedFn != nil {
+		return m.markChunkEmbedPermanentlyFailedFn(ctx, arg)
 	}
 	return nil
 }
@@ -661,5 +674,110 @@ func TestScanFailed_WorkspaceScoped(t *testing.T) {
 
 	if len(eq.ch) != 0 {
 		t.Errorf("channel len = %d, want 0: failed chunks for unregistered workspace must not be enqueued", len(eq.ch))
+	}
+}
+
+func TestIsDeterministicEmbedError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("network timeout"), false},
+		{"ollama_context_length", errors.New(`ollama: unexpected status 400: {"error":"the input length exceeds the context length"}`), true},
+		{"context_length_lowercase", errors.New("context length exceeded"), true},
+		{"input_length", errors.New("input length too large"), true},
+		{"exceeds_context", errors.New("text exceeds context window"), true},
+		{"maximum_context", errors.New("input larger than maximum context"), true},
+		{"transient_500", errors.New("ollama: unexpected status 500: internal error"), false},
+		{"transient_503", errors.New("ollama: unexpected status 503: service unavailable"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDeterministicEmbedError(tc.err)
+			if got != tc.want {
+				t.Errorf("isDeterministicEmbedError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithMaxChars(t *testing.T) {
+	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
+	if eq.maxChars != defaultMaxEmbedChars {
+		t.Errorf("default maxChars = %d, want %d", eq.maxChars, defaultMaxEmbedChars)
+	}
+	eq.WithMaxChars(2000)
+	if eq.maxChars != 2000 {
+		t.Errorf("after WithMaxChars(2000), got %d", eq.maxChars)
+	}
+	eq.WithMaxChars(0)
+	if eq.maxChars != 2000 {
+		t.Errorf("WithMaxChars(0) should be no-op, got %d", eq.maxChars)
+	}
+	eq.WithMaxChars(-1)
+	if eq.maxChars != 2000 {
+		t.Errorf("WithMaxChars(-1) should be no-op, got %d", eq.maxChars)
+	}
+}
+
+func TestProcessChunk_DeterministicErrorMarksPermanentlyFailed(t *testing.T) {
+	chunkID := uuid.New()
+	mq := &mockQuerier{
+		getChunkByIDFn: func(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error) {
+			return sqlc.GetChunkByIDRow{
+				ID:            chunkID,
+				WorkspaceHash: "ws1",
+				Content:       "some content",
+			}, nil
+		},
+	}
+	me := &mockEmbedder{
+		embedFn: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, errors.New(`ollama: unexpected status 400: {"error":"the input length exceeds the context length"}`)
+		},
+	}
+	eq := newTestQueue(me, mq)
+	eq.pending.Add(1)
+	eq.processChunk(context.Background(), chunkID)
+
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	if mq.markChunkEmbedPermanentlyFailedCalls != 1 {
+		t.Errorf("MarkChunkEmbedPermanentlyFailed calls = %d, want 1", mq.markChunkEmbedPermanentlyFailedCalls)
+	}
+	if mq.markChunkEmbedFailedCalls != 0 {
+		t.Errorf("MarkChunkEmbedFailed calls = %d, want 0 (deterministic must skip retry path)", mq.markChunkEmbedFailedCalls)
+	}
+	if eq.pending.Load() != 0 {
+		t.Errorf("pending counter = %d, want 0 (permanent failure must decrement)", eq.pending.Load())
+	}
+}
+
+func TestProcessChunk_TransientErrorStillRetries(t *testing.T) {
+	chunkID := uuid.New()
+	mq := &mockQuerier{
+		getChunkByIDFn: func(ctx context.Context, id uuid.UUID) (sqlc.GetChunkByIDRow, error) {
+			return sqlc.GetChunkByIDRow{
+				ID:            chunkID,
+				WorkspaceHash: "ws1",
+				Content:       "some content",
+			}, nil
+		},
+	}
+	me := &mockEmbedder{
+		embedFn: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	eq := newTestQueue(me, mq)
+	eq.pending.Add(1)
+	eq.processChunk(context.Background(), chunkID)
+
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	if mq.markChunkEmbedPermanentlyFailedCalls != 0 {
+		t.Errorf("MarkChunkEmbedPermanentlyFailed calls = %d, want 0 (transient must NOT permanently fail)", mq.markChunkEmbedPermanentlyFailedCalls)
 	}
 }

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -21,6 +21,9 @@ UPDATE chunks SET embed_status = 'embedded' WHERE id = $1 AND workspace_hash = $
 -- name: MarkChunkEmbedFailed :exec
 UPDATE chunks SET embed_status = 'embed_failed' WHERE id = $1 AND workspace_hash = $2;
 
+-- name: MarkChunkEmbedPermanentlyFailed :exec
+UPDATE chunks SET embed_status = 'embed_permanently_failed' WHERE id = $1 AND workspace_hash = $2;
+
 -- name: CountPendingChunks :one
 SELECT count(*) FROM chunks WHERE workspace_hash = $1 AND embed_status = 'pending';
 

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -281,6 +281,20 @@ func (q *Queries) MarkChunkEmbedFailed(ctx context.Context, arg MarkChunkEmbedFa
 	return err
 }
 
+const markChunkEmbedPermanentlyFailed = `-- name: MarkChunkEmbedPermanentlyFailed :exec
+UPDATE chunks SET embed_status = 'embed_permanently_failed' WHERE id = $1 AND workspace_hash = $2
+`
+
+type MarkChunkEmbedPermanentlyFailedParams struct {
+	ID            uuid.UUID
+	WorkspaceHash string
+}
+
+func (q *Queries) MarkChunkEmbedPermanentlyFailed(ctx context.Context, arg MarkChunkEmbedPermanentlyFailedParams) error {
+	_, err := q.db.ExecContext(ctx, markChunkEmbedPermanentlyFailed, arg.ID, arg.WorkspaceHash)
+	return err
+}
+
 const markChunkEmbedded = `-- name: MarkChunkEmbedded :exec
 UPDATE chunks SET embed_status = 'embedded' WHERE id = $1 AND workspace_hash = $2
 `


### PR DESCRIPTION
Closes #208.

## Bug

Chunks of dense content (CSV files in particular) trigger ollama `HTTP 400 'input length exceeds the context length'`. After 3 retries the chunk is marked `embed_failed`, but the rescan loop re-enqueues failed chunks every 5min so it never gives up — **infinite loop**.

User-reported log excerpt:
```
WRN chunk truncated before embedding (exceeds context limit) chunk_id=2ce4428b... original_len=4431 truncated_len=4000
ERR embedding failed error="ollama: unexpected status 400: {\"error\":\"the input length exceeds the context length\"}"
DBG chunk re-enqueued for retry chunk_id=2ce4428b... retry=1
```

## Root cause

The char-budget assumption is **inverted**. Old comment claimed "~2 chars/token worst-case" → 4000 char budget. Reality: SentencePiece tokenizes dense CSV/code at ~1 char/token, so 4000 chars produces ~4000 tokens, well over nomic-embed-text's 2048-token limit.

## Two-part fix

### 1. Lower the budget + make it configurable
- `defaultMaxEmbedChars: 4000 → 3000` (safe at ~1.3 chars/token = ~2300 tokens worst case)
- New config field `embedding.max_chars` + env `NANO_BRAIN_EMBED_MAX_CHARS`
- `Queue.WithMaxChars(n)` setter — plumbed from main.go
- Backward compat: zero/missing config keeps default 3000

### 2. Stop the infinite loop on deterministic errors
- New `embed_status` value: `embed_permanently_failed`
- New sqlc query `MarkChunkEmbedPermanentlyFailed`
- `isDeterministicEmbedError(err)` classifier matches: `context length`, `input length`, `exceeds context`, `maximum context` (case-insensitive)
- When embedder returns a deterministic error, `processChunk` **skips the retry queue entirely** and immediately marks the chunk `embed_permanently_failed`
- `GetFailedChunksAllWorkspaces` filters by `embed_status = 'embed_failed'` only, so permanently_failed chunks are **never re-enqueued** by the rescan loop. **Loop broken.**
- Transient errors (network, 5xx) keep the existing retry + backoff + `embed_failed` path → still recoverable on next rescan.

## Tests

- `TestIsDeterministicEmbedError` — 9 cases incl. nil, transient (500/503/network), 4 deterministic substrings
- `TestWithMaxChars` — default, override, zero/negative no-op
- `TestProcessChunk_DeterministicErrorMarksPermanentlyFailed` — full process-chunk flow with a 400 "context length" error; verifies permanently_failed called exactly once, retry path NOT taken, pending decrements
- `TestProcessChunk_TransientErrorStillRetries` — same flow with "connection refused"; verifies permanently_failed NOT called

`go test -race -short -count=1 ./...` → **PASS (18/18 packages)**

## Manual QA

Tested against real ollama at `host.docker.internal:11434` with the exact 4431-char dense-CSV input from #208. Embed succeeded on this instance (model load differs from user's, can't reproduce exact error here), but **the loop-break fix is independent of the threshold** — even if 3000 is too high for some env, chunks now go to `embed_permanently_failed` after 3 retries instead of looping forever.

## Backward compat

✅ Existing configs without `embedding.max_chars` use default 3000 (was hardcoded 4000 — now configurable AND lower).
✅ `embed_status = 'embed_failed'` still retried on rescan (transient errors unchanged).
✅ Only deterministic-classified errors take the new permanent-failure path.

## Recovery for existing stuck chunks

After this merges, operators with chunks already in the infinite loop can run:
```sql
UPDATE chunks SET embed_status = 'embed_permanently_failed'
WHERE embed_status = 'embed_failed' AND <heuristic>;
```
…or just let the next harvest re-chunk the file at the new 3000-char limit.