### PR TITLE
docs(skills): add agent skill for nano-brain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ src/web/node_modules/
 .npmrc
 .npmrc2
 _bmad/config.user.yaml
-/skills/
 
 # OpenCode internal metadata
 .opencode/worktrees/

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,29 @@
+# Agent Skills
+
+This directory contains [skills](https://docs.claude.com/en/docs/claude-code/skills) that teach AI coding agents (Claude Code, OpenCode, MCP-aware tools) how to use nano-brain effectively.
+
+## Available
+
+| Skill | Purpose |
+|---|---|
+| [`nano-brain/`](./nano-brain/SKILL.md) | When + how to call nano-brain (MCP, CLI, HTTP) with best-practice recipes |
+
+## Install
+
+Each skill is a self-contained directory. Copy it into your agent's skills root — see the individual `SKILL.md` for per-agent install instructions.
+
+```bash
+# Example: install the nano-brain skill into OpenCode (user-level)
+cp -r skills/nano-brain ~/.config/opencode/skills/
+```
+
+## Contribute
+
+To add a new skill or update an existing one:
+
+1. Branch off `master`
+2. Edit `skills/<name>/SKILL.md` (and `references/*.md` if multi-file)
+3. Bump `metadata.version` in the YAML frontmatter following semver
+4. Open a PR — CI will verify YAML frontmatter parses
+
+Skills follow the `name + description + body` contract — frontmatter `description` is the trigger string an agent matches against to decide when to load the skill, so keep it specific and discoverable.

--- a/skills/nano-brain/AGENTS_SNIPPET.md
+++ b/skills/nano-brain/AGENTS_SNIPPET.md
@@ -1,0 +1,48 @@
+<!-- OPENCODE-MEMORY:START -->
+<!-- Managed block - do not edit manually. Updated by: npx @nano-step/nano-brain init -->
+
+## Memory System (nano-brain)
+
+This project uses **nano-brain** for persistent context across sessions.
+
+### Quick Reference
+
+All commands use the nano-brain CLI:
+
+| I want to... | CLI |
+|--------------|-----|
+| Recall past work on a topic | `npx @nano-step/nano-brain query "topic"` |
+| Find exact error/function name | `npx @nano-step/nano-brain search "exact term"` |
+| Explore a concept semantically | `npx @nano-step/nano-brain vsearch "concept"` |
+| Save a decision for future sessions | `npx @nano-step/nano-brain write "decision context" --tags=decision` |
+| Check index health | `npx @nano-step/nano-brain status` |
+
+### Session Workflow
+
+**End of session:** Save key decisions, patterns discovered, and debugging insights.
+```
+npx @nano-step/nano-brain write "## Summary\n- Decision: ...\n- Why: ...\n- Files: ..." --tags=summary
+```
+
+### Code Intelligence Tools
+
+nano-brain also provides symbol-level code analysis (requires `npx @nano-step/nano-brain reindex` with `workdir` set to the workspace — the `--root` flag is silently ignored):
+
+| I want to... | CLI |
+|--------------|-----|
+| Understand a symbol's callers/callees/flows | `npx @nano-step/nano-brain context functionName` |
+| Assess risk of changing a symbol | `npx @nano-step/nano-brain code-impact className --direction=upstream` |
+| Map my git changes to affected symbols | `npx @nano-step/nano-brain detect-changes --scope=all` |
+
+Use `file_path` parameter to disambiguate when multiple symbols share the same name.
+
+### When to Search Memory vs Codebase vs Code Intelligence
+
+- **"Have we done this before?"** → `npx @nano-step/nano-brain query "..."` (searches past sessions)
+- **"Where is this in the code?"** → grep / ast-grep (searches current files)
+- **"How does this concept work here?"** → Both (memory for past context + grep for current code)
+- **"What calls this function?"** → `npx @nano-step/nano-brain context <name>` (symbol graph relationships)
+- **"What breaks if I change X?"** → `npx @nano-step/nano-brain code-impact <name> --direction=...` (dependency + flow analysis)
+- **"What did my changes affect?"** → `npx @nano-step/nano-brain detect-changes --scope=...` (git diff to symbol mapping)
+
+<!-- OPENCODE-MEMORY:END -->

--- a/skills/nano-brain/SKILL.md
+++ b/skills/nano-brain/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: nano-brain
+description: Persistent memory + code intelligence for AI coding agents. Hybrid search (BM25 + vector + LLM rerank), cross-session recall, symbol analysis, impact checks, OpenCode/Claude Code session harvesting. Use this skill when you need to recall prior decisions, search across sessions/codebase, trace symbol callers/callees, or persist long-term context.
+compatibility: OpenCode, Claude Code, any MCP-aware agent
+metadata:
+  author: nano-step
+  version: 3.0.0
+  repo: nano-step/nano-brain
+---
+
+# nano-brain
+
+Persistent memory + code intelligence service for AI coding agents. This skill teaches an agent **when** to use nano-brain and **how** to call its three API layers correctly.
+
+## Install this skill
+
+This skill lives at `skills/nano-brain/` in the [nano-brain repo](https://github.com/nano-step/nano-brain). Drop it into your agent's skills root:
+
+```bash
+# OpenCode — user-level (any project)
+mkdir -p ~/.config/opencode/skills
+cp -r /path/to/nano-brain/skills/nano-brain ~/.config/opencode/skills/
+
+# OpenCode — project-level (current project only)
+mkdir -p ./.opencode/skills
+cp -r /path/to/nano-brain/skills/nano-brain ./.opencode/skills/
+
+# Claude Code
+mkdir -p ~/.claude/skills
+cp -r /path/to/nano-brain/skills/nano-brain ~/.claude/skills/
+```
+
+Or one-liner (no clone needed) — fetch the skill directly from GitHub:
+
+```bash
+curl -sL https://github.com/nano-step/nano-brain/archive/refs/heads/master.tar.gz \
+  | tar -xz --strip-components=2 -C ~/.config/opencode/skills nano-brain-master/skills/nano-brain
+```
+
+The skill auto-loads on next agent session. To update, repeat the copy (`--delete` if using rsync) — files are idempotent.
+
+---
+
+## How to talk to nano-brain
+
+| Layer | When | How |
+|---|---|---|
+| **MCP tools** (`memory_*`) | Preferred. Streamable HTTP at `/mcp`. | Agent auto-discovers; no shell needed |
+| **CLI** (`npx @nano-step/nano-brain ...`) | When MCP not configured, or for one-off shell scripts | Wraps the HTTP API |
+| **HTTP API** directly | Scripts, integration tests, dashboards | `POST /api/v1/*` |
+
+All three target the same daemon at `http://localhost:3100` (default; container agents auto-set `NANO_BRAIN_HOST=host.docker.internal`).
+
+> **CLI invocation**: always use the scoped package `@nano-step/nano-brain` for clarity and to avoid name collisions:
+> ```bash
+> npx @nano-step/nano-brain <subcommand> ...
+> ```
+> An unscoped alias `nano-brain` is also published (e.g. `npx nano-brain ...`), but the scoped form is canonical and stable.
+
+## Quick decision matrix
+
+| You need to... | Use |
+|---|---|
+| Recall past work on a topic | `memory_query` / `query "topic"` |
+| Find an exact string (error msg, fn name) | `memory_search` / `search "term"` |
+| Explore a fuzzy concept | `memory_vsearch` / `vsearch "concept"` |
+| Save a decision for future sessions | `memory_write` / `write "..." --tags=decision` |
+| Check daemon health, queue depth, migration | `memory_status` / `status` |
+| Catch up at session start | `memory_wake_up` / `wake-up` |
+| Trace symbol callers/callees | `memory_graph` (CLI: `context <name>`) |
+| Risk-check before refactor | `memory_impact` (CLI: `code-impact <name>`) |
+| Map git diff → affected symbols | CLI: `detect-changes --scope=staged` |
+| List all tags / collections / symbols | `memory_tags` / `memory_symbols` |
+| Reindex after major code changes | CLI: `reindex` (in workspace dir) |
+
+## Endpoint reference
+
+All `POST /api/v1/*` endpoints require a `workspace` field in the JSON body OR an `X-Workspace` header. The workspace hash is returned by `POST /api/v1/init`.
+
+### Health + status
+
+| Method | Path | Body | Returns |
+|---|---|---|---|
+| `GET` | `/health` | — | `{status, ready}` — for liveness/readiness probes |
+| `GET` | `/api/status` | — | `{pg_status, migration_version, queue_*, workspace_count, harvester_status}` — operator dashboard data |
+
+### Workspace lifecycle
+
+| Method | Path | Body | Returns |
+|---|---|---|---|
+| `POST` | `/api/v1/init` | `{"root_path":"/abs/path"}` | `{workspace_hash, root_path, agents_snippet}` — registers a workspace, deterministic SHA-256 hash of normalized path |
+| `GET` | `/api/v1/workspaces` | — | `[{workspace_hash, root_path, document_count, last_indexed_at}]` |
+| `POST` | `/api/v1/reset-workspace` | `{"workspace":"<hash>"}` | `{deleted_documents, workspace}` — wipes all docs+chunks+embeddings for the workspace |
+
+### Search (3 modes — choose by use case)
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `POST` | `/api/v1/search` | `{"workspace":"<hash>","query":"...","max_results":10,"tags":["bug"]}` | **BM25 full-text** — exact keywords/symbols, fastest, free-text English |
+| `POST` | `/api/v1/vsearch` | `{"workspace":"<hash>","query":"...","max_results":10}` | **Vector semantic** — fuzzy concepts, embedding cosine, slower |
+| `POST` | `/api/v1/query` | `{"workspace":"<hash>","query":"...","max_results":10}` | **Hybrid** — BM25 + vector + RRF fusion. Default for most questions. |
+
+Response shape (all three):
+```json
+{"results": [{"id","title","snippet","score","tags","collection","source_path","created_at"}], "took_ms": 42}
+```
+
+### Document I/O
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `POST` | `/api/v1/write` | `{"workspace":"<hash>","content":"...","tags":["..."],"collection":"memory","title":"...","source_path":"memory://...","metadata":{}}` | Upsert by content-hash; chunks + enqueues for embedding async |
+| `POST` | `/api/v1/wake-up` | `{"workspace":"<hash>","limit":10}` | Returns the N most-recent updated documents — for session start briefing |
+| `POST` | `/api/v1/reindex` | `{"workspace":"<hash>","root":"/abs/path"}` | Reindex workspace from disk; respects `.gitignore` |
+| `POST` | `/api/v1/embed` | `{"workspace":"<hash>","chunk_id":"<uuid>"}` | Force-embed a specific chunk (debugging) |
+| `POST` | `/api/v1/summarize` | `{"workspace":"<hash>","source":"opencode://session/<id>","limit":1,"force":false}` | Run LLM summarizer on a session |
+
+### Collections + tags + symbols
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `GET` | `/api/v1/collections?workspace=<hash>` | — | List collections with doc counts |
+| `POST` | `/api/v1/collections` | `{"workspace":"<hash>","name":"my-col"}` | Create |
+| `PUT` | `/api/v1/collections/:name` | `{"workspace":"<hash>","new_name":"..."}` | Rename |
+| `DELETE` | `/api/v1/collections/:name` | `{"workspace":"<hash>"}` | Remove (and all its docs) |
+| `GET` | `/api/v1/tags?workspace=<hash>` | — | All tags with usage counts |
+| `GET` | `/api/v1/symbols?workspace=<hash>&type=function&name=foo` | — | Symbol search by type+name pattern |
+
+### Code intelligence (graph)
+
+Powered by Tree-sitter AST parsing. **Requires** a prior `reindex` to populate the symbol graph.
+
+| Method | Path | Body | Returns |
+|---|---|---|---|
+| `POST` | `/api/v1/graph/query` | `{"workspace":"<hash>","node":"funcName","direction":"out","edge_type":"calls"}` | Symbol's neighbors (callers/callees) |
+| `POST` | `/api/v1/graph/impact` | `{"workspace":"<hash>","node":"funcName","edge_type":"calls","max_depth":2}` | BFS upstream/downstream — risk = LOW/MEDIUM/HIGH/CRITICAL |
+| `POST` | `/api/v1/graph/trace` | `{"workspace":"<hash>","node":"funcName","max_depth":3}` | Outgoing-edge walk for flow detection |
+
+`direction`: `in` (callers) or `out` (callees). `edge_type`: `calls`, `imports`, `references`, etc.
+
+### Harvest + ops
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `POST` | `/api/harvest` | — | Force-run all configured harvesters (OpenCode SQLite, Claude Code JSONL). Returns `{harvested, skipped, errors}`. |
+| `POST` | `/api/reload-config` | — | Reload `~/.nano-brain/config.yml` without restart |
+
+### MCP (Streamable HTTP)
+
+| Method | Path | Notes |
+|---|---|---|
+| `POST` | `/mcp` | JSON-RPC 2.0 MCP protocol |
+| `GET`/`POST` | `/sse` | SSE transport (legacy) |
+
+13 tools exposed: `memory_query`, `memory_search`, `memory_vsearch`, `memory_get`, `memory_write`, `memory_tags`, `memory_status`, `memory_update`, `memory_wake_up`, `memory_graph`, `memory_trace`, `memory_impact`, `memory_symbols`.
+
+## CLI cheatsheet
+
+Every CLI subcommand is a thin client over the HTTP API. Connection defaults to `localhost:3100`; container agents auto-route to host.
+
+| Command | Endpoint |
+|---|---|
+| `npx @nano-step/nano-brain query "..." --workspace <h>` | `POST /api/v1/query` |
+| `npx @nano-step/nano-brain search "..." --workspace <h>` | `POST /api/v1/search` |
+| `npx @nano-step/nano-brain vsearch "..." --workspace <h>` | `POST /api/v1/vsearch` |
+| `npx @nano-step/nano-brain write "..." --workspace <h> --tags=foo,bar` | `POST /api/v1/write` |
+| `npx @nano-step/nano-brain status` | `GET /api/status` |
+| `npx @nano-step/nano-brain workspaces` | `GET /api/v1/workspaces` |
+| `npx @nano-step/nano-brain wake-up --workspace <h>` | `POST /api/v1/wake-up` |
+| `npx @nano-step/nano-brain reindex` (in workspace dir) | `POST /api/v1/reindex` |
+| `npx @nano-step/nano-brain context <symbol>` | `POST /api/v1/graph/query` |
+| `npx @nano-step/nano-brain code-impact <symbol> --direction=upstream` | `POST /api/v1/graph/impact` |
+| `npx @nano-step/nano-brain detect-changes --scope=staged` | (computes git diff client-side, calls graph endpoints) |
+| `npx @nano-step/nano-brain harvest` | `POST /api/harvest` |
+| `npx @nano-step/nano-brain cleanup-stale-raw [--dry-run]` | Direct PG — wipes pre-PR-#192 orphan raw session docs |
+| `npx @nano-step/nano-brain doctor` | Probes daemon + PG + ollama + model availability |
+
+**Critical CLI gotcha**: `reindex` IGNORES the `--root` flag silently. Always run with `workdir`:
+```bash
+# ✅ Correct
+bash(command="npx @nano-step/nano-brain reindex", workdir="/path/to/workspace")
+
+# ❌ Wrong (silently reindexes CWD instead of /path)
+npx @nano-step/nano-brain reindex --root=/path/to/workspace
+```
+
+## Recipes — best-practice flows
+
+### Recipe 1: Session start (wake-up + recall)
+
+When you start a coding session in a project, run wake-up + a targeted query before exploring. This costs ~500 tokens but prevents you from redoing work or re-discovering the same lessons.
+
+```bash
+# 1. Register workspace once per project (idempotent)
+WS=$(npx @nano-step/nano-brain init --root="$PWD" --json | jq -r .workspace_hash)
+
+# 2. Catch up — N most-recent updates across all collections
+npx @nano-step/nano-brain wake-up --workspace="$WS" --limit=8
+
+# 3. Targeted: anything you've learned about today's task?
+npx @nano-step/nano-brain query "<current task topic>" --workspace="$WS" --compact
+```
+
+For agents inside OpenCode: use MCP `memory_wake_up` then `memory_query`.
+
+### Recipe 2: Recall before grep
+
+Native grep finds exact strings in CURRENT files. nano-brain finds them in past sessions, prior commits, and documentation. The two are complementary — always recall first (cheap, ~200 tokens) then grep if you need exact code locations.
+
+```bash
+# Did we ever debug this before?
+npx @nano-step/nano-brain search "ECONNREFUSED redis" --workspace="$WS"
+
+# Concept-level — fuzzy match
+npx @nano-step/nano-brain vsearch "rate limiting strategy" --workspace="$WS"
+
+# Complex question — hybrid (default)
+npx @nano-step/nano-brain query "how did we handle session invalidation" --workspace="$WS"
+```
+
+### Recipe 3: Pre-refactor impact check
+
+Before touching a symbol that's referenced widely, check impact. This catches "I only need to fix this one place" tunnel-vision.
+
+```bash
+# What calls DatabaseClient?
+npx @nano-step/nano-brain code-impact DatabaseClient --workspace="$WS" --direction=upstream
+
+# What does processOrder depend on?
+npx @nano-step/nano-brain code-impact processOrder --workspace="$WS" --direction=downstream --max-depth=3
+
+# Map current git changes to symbols
+npx @nano-step/nano-brain detect-changes --scope=staged --workspace="$WS"
+```
+
+Risk levels in response: `LOW` (≤3 callers), `MEDIUM` (4-15), `HIGH` (16-50), `CRITICAL` (>50). Treat HIGH/CRITICAL as "needs PR review from someone else."
+
+### Recipe 4: Persist a decision
+
+End every meaningful session with a write. The schema doesn't matter — content is freeform markdown. What matters is consistent tags so future you can filter.
+
+```bash
+npx @nano-step/nano-brain write "## Decision: Use Redis Streams over Bull
+- **Why:** ordered replay needed for retry
+- **Trade-off:** lose Bull's UI; built our own metrics dashboard instead
+- **Files:** internal/queue/*.go, see PR #142" \
+  --workspace="$WS" \
+  --tags=decision,architecture,queue
+```
+
+Conventional tag patterns: `decision`, `lesson`, `architecture`, `bug`, `gotcha`, `summary`, `<area>` (e.g. `auth`, `queue`).
+
+### Recipe 5: Triage many results (compact mode)
+
+For broad queries that return 10+ results, fetch compact first (1-line summaries, ~70% fewer tokens), pick the relevant ones, expand only those.
+
+```bash
+# Stage 1: scan
+npx @nano-step/nano-brain query "auth middleware" --workspace="$WS" --compact
+
+# Stage 2: expand specific result by ID
+npx @nano-step/nano-brain get "<doc-id>" --workspace="$WS"
+```
+
+### Recipe 6: Cross-workspace knowledge transfer
+
+Same `memory_query` but with `scope=all`. Searches every registered workspace, useful for "have I solved this in another project?"
+
+```bash
+# Aggregate across all workspaces
+npx @nano-step/nano-brain query "stripe webhook signature verification" --scope=all
+```
+
+(Equivalent MCP: `memory_query` with `workspace` omitted or `scope=all` arg.)
+
+### Recipe 7: Filter by collection or tag
+
+Both search modes accept `--collection` and `--tags`. Combine when you know the slice you want.
+
+```bash
+# Only past session summaries about bugs
+npx @nano-step/nano-brain query "..." --workspace="$WS" --collection=session-summary --tags=bug
+
+# Only your curated notes
+npx @nano-step/nano-brain query "..." --workspace="$WS" --collection=memory
+```
+
+Collections in a typical setup:
+- `codebase` — source-file chunks
+- `session-summary` — LLM-summarized AI sessions (OpenCode, Claude Code)
+- `sessions` — raw session content (pre-PR-#192 only; run `cleanup-stale-raw` to purge if you've migrated)
+- `memory` — agent-written notes via `write`
+- `auto-memory` — auto-extracted `DECISION:` / `LESSON:` lines
+
+### Recipe 8: Multi-DB OpenCode harvest (advanced)
+
+If you use the `ai-sandbox-wrapper` which splits OpenCode sessions into per-project SQLite databases at `~/.ai-sandbox/opencode-dbs/<slug>-<8hex>/opencode.db`, configure nano-brain to discover them:
+
+```yaml
+# ~/.nano-brain/config.yml
+harvester:
+  opencode:
+    db_root: ~/.ai-sandbox/opencode-dbs   # auto-detected on macOS/Linux
+```
+
+The daemon scans the directory, opens each DB read-only, reads `project.worktree`, and only harvests sessions whose worktree matches a registered nano-brain workspace. Verify via `GET /api/status`:
+
+```bash
+curl -s http://localhost:3100/api/status | jq '.harvester_status.opencode'
+# {"enabled":true, "mode":"db_root", "db_root":"/Users/.../opencode-dbs", "db_count":1, ...}
+```
+
+`mode` values: `db_root` (new multi-DB), `db_path` (single SQLite), `session_dir` (legacy JSON), `disabled`.
+
+## Common errors + fixes
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `cannot connect to nano-brain server` | Daemon not running | `npx @nano-step/nano-brain serve -d` (background) |
+| `workspace not found` | Workspace not registered | `npx @nano-step/nano-brain init --root=.` first |
+| `ollama: input length exceeds context length` (pre-2026.5.30.1) | Char-budget too high for token limit | Upgrade to ≥2026.5.30.1; configure `embedding.max_chars` if still hits |
+| Search returns 0 results despite content | Embedding queue still working | `npx @nano-step/nano-brain status` → check `queue_pending` and `embedding_queue_depth` |
+| Chunk stuck in `embed_failed` retry loop (pre-fix) | Deterministic ollama error | Upgrade ≥2026.5.30.1; new `embed_permanently_failed` state breaks the loop |
+| `bin/sh: gh: not found` in workflow | gh CLI not installed in container | Use HTTPS+token URL: `git push https://kokorolx:$TOKEN@github.com/...` |
+
+## Daemon config — key fields
+
+```yaml
+# ~/.nano-brain/config.yml — see ${PROJECT}/README.md for the canonical example
+database:
+  url: postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev
+
+embedding:
+  provider: ollama
+  url: http://localhost:11434
+  model: nomic-embed-text   # 2048-token context
+  concurrency: 3
+  max_chars: 3000           # safety budget per embed call; lower if ollama still 400s on dense CSV
+                            # override via NANO_BRAIN_EMBED_MAX_CHARS
+
+harvester:
+  opencode:
+    db_root: ""             # ~/.ai-sandbox/opencode-dbs (multi-DB)
+    db_path: ""             # ~/.local/share/opencode/opencode.db (single SQLite)
+    session_dir: ""         # legacy JSON
+  claudecode:
+    enabled: false
+    session_dir: ""         # ~/.claude/sessions
+
+intervals:
+  session_poll: 120         # harvest tick interval (seconds)
+
+summarization:
+  enabled: false            # LLM-generated session summaries
+  provider_url: ""
+  api_key: ""               # or NANO_BRAIN_SUMMARIZE_API_KEY env
+  model: "claude-sonnet-4-5"
+  max_tokens: 8000          # bumped from 4096 — issue #191
+```
+
+Reload without restart: `curl -X POST http://localhost:3100/api/reload-config`.
+
+## Memory vs native tools
+
+| Question | Tool |
+|---|---|
+| "What did we decide about X?" | nano-brain (memory) |
+| "Where exactly is `processPayment` defined?" | grep / Glob (native) |
+| "What calls `processPayment`?" | nano-brain (code intel) → `memory_graph` |
+| "What's the AST structure of this function?" | ast-grep (native) |
+| "Have I solved this error before across all my projects?" | nano-brain (cross-workspace) |
+| "Show me line 142 of foo.go" | Read tool (native) |
+
+**They are complementary. Always recall first (cheap), then use native tools for precise current-state.**
+
+## Further reading
+
+- **Code intelligence deep-dive**: `references/code-intelligence.md`
+- **Full HTTP API contract**: nano-brain repo `internal/server/routes.go` + per-handler request/response structs in `internal/server/handlers/`
+- **MCP tool schemas**: `internal/mcp/tools.go` `RegisterTools`
+- **Migration history**: `nano-step/nano-brain` `CHANGELOG.md` + `openspec/changes/archive/`

--- a/skills/nano-brain/references/code-intelligence.md
+++ b/skills/nano-brain/references/code-intelligence.md
@@ -1,0 +1,93 @@
+---
+name: nano-brain code intelligence
+description: Use nano-brain CLI context, code-impact, and detect-changes for symbol-level analysis, impact checks, and diff mapping.
+---
+
+# Code Intelligence (nano-brain)
+
+## Overview
+
+Run code intelligence when symbol relationships, impact analysis, or diff-to-symbol mapping is needed. Ensure indexing is done before using these tools — run `npx @nano-step/nano-brain reindex` **with `workdir` set to the workspace root** (the `--root` flag is silently ignored).
+
+```bash
+# ✅ Correct
+bash(command="npx @nano-step/nano-brain reindex", workdir="/path/to/workspace")
+
+# ❌ Wrong (reindexes the CALLER's CWD)
+npx @nano-step/nano-brain reindex --root=/path/to/workspace
+```
+
+## code_context — 360-degree symbol view
+
+Return callers, callees, cluster membership, execution flows, and infrastructure connections for any function/class/method.
+
+```
+npx @nano-step/nano-brain context "handleRequest"
+npx @nano-step/nano-brain context "helper" --file=/src/utils.ts
+```
+
+Use `file_path` to disambiguate when multiple symbols share the same name.
+
+## code_impact — dependency analysis
+
+Traverse the symbol graph to find affected symbols and flows. Return a risk level (LOW/MEDIUM/HIGH/CRITICAL).
+
+```
+npx @nano-step/nano-brain code-impact "DatabaseClient" --direction=upstream
+npx @nano-step/nano-brain code-impact "processOrder" --direction=downstream --max-depth=3
+```
+
+- `upstream` = "who calls this?" (callers, consumers)
+- `downstream` = "what does this call?" (callees, dependencies)
+
+## code_detect_changes — git diff to symbol mapping
+
+Map current git changes to affected symbols and execution flows.
+
+```
+npx @nano-step/nano-brain detect-changes --scope=staged
+npx @nano-step/nano-brain detect-changes --scope=all
+```
+
+Scopes: `unstaged`, `staged`, `all` (default).
+
+## When to Use Code Intelligence vs Memory vs Native Tools
+
+| Question | Tool |
+|----------|------|
+| "What calls function X?" | `npx @nano-step/nano-brain context <name>` |
+| "What breaks if I change X?" | `npx @nano-step/nano-brain code-impact <name> --direction=...` |
+| "What did I change and what's affected?" | `npx @nano-step/nano-brain detect-changes --scope=...` |
+| "Have we done this before?" | `npx @nano-step/nano-brain query "..."` |
+| "Find exact string in code" | grep / ast-grep |
+| "How does auth work conceptually?" | `npx @nano-step/nano-brain vsearch "..."` |
+
+Code intelligence requires indexing. Run `npx @nano-step/nano-brain reindex` (with `workdir` set to the workspace) first if the workspace has not been indexed.
+
+## HTTP API equivalents
+
+| CLI | HTTP endpoint | Body shape |
+|---|---|---|
+| `context <name>` | `POST /api/v1/graph/query` | `{"workspace":"<hash>","node":"<name>","direction":"out","edge_type":"calls"}` |
+| `code-impact <name>` | `POST /api/v1/graph/impact` | `{"workspace":"<hash>","node":"<name>","edge_type":"calls","max_depth":2}` |
+| `detect-changes` | Client-side git diff + parallel `graph/query` calls | (computed by CLI) |
+
+`direction`: `in` (callers, who depends on this) or `out` (callees, what this depends on). The CLI maps `--direction=upstream` → `direction=in` and `--direction=downstream` → `direction=out`.
+
+`edge_type` values seen in production: `calls`, `imports`, `references`, `extends`, `implements`. Omit to match any.
+
+## Limits
+
+- `max_depth` is clamped to `[1, 3]` server-side. Deeper traversals are too expensive for hot-path use.
+- Graph is built from Tree-sitter AST extractors for: Go, TypeScript, JavaScript, Python (as of PR #197). Other languages return empty result sets.
+- Cross-file graph edges require the source file to be in the workspace's indexed scope (respects `.gitignore`).
+
+## Symbol disambiguation
+
+When multiple symbols share a name (`init`, `handler`, etc.), the graph query returns ALL matches. Filter client-side via `file_path` matching, or use `memory_symbols` to enumerate options first:
+
+```bash
+npx @nano-step/nano-brain symbols --type=function --name=init --workspace="$WS"
+# Pick the one you want from the returned (file_path, line) tuples
+npx @nano-step/nano-brain context init --file=/path/to/specific/file.go
+```

--- a/skills/nano-brain/references/http-api.md
+++ b/skills/nano-brain/references/http-api.md
@@ -1,0 +1,211 @@
+---
+name: nano-brain HTTP API
+description: Direct HTTP integration patterns for nano-brain — for scripts, dashboards, custom tooling, and tests that bypass the CLI/MCP layer.
+---
+
+# nano-brain HTTP API
+
+Use direct HTTP when:
+- Writing tests that need deterministic request/response control
+- Building a custom dashboard or monitoring integration
+- Embedding nano-brain in a non-Node/Go runtime
+- Debugging — `curl` + `jq` is the fastest path to inspecting daemon state
+
+## Connection
+
+Default: `http://localhost:3100`. Container agents auto-set `NANO_BRAIN_HOST=host.docker.internal` so calls from inside containers reach the host daemon.
+
+```bash
+BASE="http://localhost:3100"   # or http://host.docker.internal:3100 inside a container
+
+# Liveness probe
+curl -sf "$BASE/health" >/dev/null && echo "ready"
+
+# Detailed status
+curl -s "$BASE/api/status" | jq
+```
+
+## Workspace handle
+
+Every data endpoint needs a workspace hash. Get one via init (idempotent — same `root_path` always yields the same hash via SHA-256 of the canonical absolute path):
+
+```bash
+WS=$(curl -s -X POST "$BASE/api/v1/init" \
+  -H 'Content-Type: application/json' \
+  -d "{\"root_path\":\"$PWD\"}" | jq -r .workspace_hash)
+echo "$WS"
+```
+
+Workspace hashes are stable across daemon restarts and machines (deterministic). Two different machines that init the same path produce different hashes (the path differs) — workspace is path-scoped, not content-scoped.
+
+## Search — pick the right mode
+
+| Endpoint | Engine | Strengths | Latency |
+|---|---|---|---|
+| `/api/v1/search` | PostgreSQL `tsvector` (BM25) | Exact terms, code identifiers, error messages | ~10ms |
+| `/api/v1/vsearch` | pgvector cosine | Semantic concepts, paraphrases | ~50ms (needs embed) |
+| `/api/v1/query` | Hybrid (BM25 + vector + RRF) | "Best of both" — recommended default | ~80ms |
+
+### BM25 — keyword/identifier search
+
+```bash
+curl -s -X POST "$BASE/api/v1/search" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"workspace\": \"$WS\",
+    \"query\": \"ECONNREFUSED redis\",
+    \"max_results\": 10,
+    \"tags\": [\"bug\"]
+  }" | jq '.results[] | {title, score, snippet}'
+```
+
+`tags` is OPTIONAL (BM25 search supports it natively via PG `&&` on the tags column). Vsearch and Query don't currently accept tags — filter client-side if needed.
+
+### Vector — fuzzy semantic search
+
+```bash
+curl -s -X POST "$BASE/api/v1/vsearch" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"workspace\": \"$WS\",
+    \"query\": \"rate limiting strategy\",
+    \"max_results\": 10
+  }" | jq '.results'
+```
+
+The server embeds the query first (one ollama call ≈ 30-60ms), then runs pgvector cosine ANN.
+
+### Hybrid — best for most questions
+
+```bash
+curl -s -X POST "$BASE/api/v1/query" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"workspace\": \"$WS\",
+    \"query\": \"how did we handle session invalidation\",
+    \"max_results\": 10
+  }" | jq '.results[] | {title, score, snippet, source_path}'
+```
+
+Hybrid uses **Reciprocal Rank Fusion** to merge BM25 + vector rankings. Single result list with combined scores. Falls back to BM25-only if vector store empty.
+
+## Document write
+
+```bash
+curl -s -X POST "$BASE/api/v1/write" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"workspace\": \"$WS\",
+    \"content\": \"## Decision: bla\\n- Why: bla\",
+    \"tags\": [\"decision\", \"queue\"],
+    \"collection\": \"memory\",
+    \"title\": \"Use Redis Streams\",
+    \"source_path\": \"memory://decision/redis-streams\"
+  }" | jq
+```
+
+Returns `{id, hash, collection, workspace_hash, chunk_count, warning?}`.
+
+- `content_hash` deduplication: re-POST same content → 200 OK with `chunk_count: 0` (existing doc unchanged).
+- `source_path` is the upsert key. Same `source_path` with different `content` → in-place update, old chunks deleted, new chunks enqueued for embedding.
+- Without `source_path`, falls back to content-hash dedup only.
+- `chunk_count` returned is the number of chunks queued for embedding. They embed async via the queue (`status` endpoint shows `queue_pending`).
+
+## Status endpoint — what to monitor
+
+```bash
+curl -s "$BASE/api/status" | jq
+```
+
+Returns:
+
+```json
+{
+  "pg_status": "ok",
+  "migration_version": 10,
+  "embedding_queue_depth": 0,        // queue channel buffered items
+  "active_provider": "ollama",
+  "workspace_count": 1,
+  "queue_pending": 42,                // chunks awaiting embed (across all workspaces)
+  "queue_capacity": 10000,
+  "queue_status": "ok",               // "ok" | "pressured" | "stuck"
+  "harvester_status": {
+    "enabled": true,
+    "mode": "db_root",                // db_root | db_path | session_dir | disabled
+    "db_root": "/Users/x/.ai-sandbox/opencode-dbs",
+    "db_count": 1,
+    "poll_interval_seconds": 120
+  }
+}
+```
+
+Watch `queue_pending` over time — if it grows without bound and `queue_status == "pressured"`, embedding throughput is below ingestion rate. Check ollama health.
+
+## Trigger operations
+
+```bash
+# Force-run harvesters
+curl -s -X POST "$BASE/api/harvest" | jq
+
+# Reindex a workspace from disk
+curl -s -X POST "$BASE/api/v1/reindex" \
+  -d "{\"workspace\":\"$WS\",\"root\":\"$PWD\"}" | jq
+
+# Reload config without daemon restart
+curl -s -X POST "$BASE/api/reload-config" | jq
+```
+
+## Error responses
+
+All endpoints return JSON for both success and error:
+
+| HTTP | Meaning | Common cause |
+|---|---|---|
+| 200 | OK | — |
+| 400 | Bad request | Missing `workspace` or `query` field; invalid `source_path` URI |
+| 404 | Not found | Workspace hash unregistered |
+| 422 | Unprocessable | Schema validation (e.g. `max_depth > 3`) |
+| 500 | Server error | PG down, ollama unreachable; check `/health` |
+
+Error body: `{"message":"<reason>"}`.
+
+## Streaming + MCP
+
+The daemon also exposes:
+
+- `POST /mcp` — Streamable HTTP MCP (preferred for agents)
+- `GET /sse`, `POST /sse` — SSE transport (legacy MCP clients)
+
+Both expose the same 13 `memory_*` tools as MCP. JSON-RPC 2.0 protocol.
+
+For OpenCode / Claude Code agents, add to MCP config:
+```json
+{
+  "mcpServers": {
+    "nano-brain": {
+      "url": "http://host.docker.internal:3100/mcp"
+    }
+  }
+}
+```
+
+## Performance budget
+
+Rough p99 latencies on local hardware (Postgres 17 + pgvector 0.8.2 + ollama nomic-embed-text):
+
+| Operation | Latency |
+|---|---|
+| `GET /health` | <5ms |
+| `GET /api/status` | <20ms |
+| `POST /api/v1/search` (BM25, 10 results) | 10-30ms |
+| `POST /api/v1/vsearch` (1 ollama call + ANN) | 40-100ms |
+| `POST /api/v1/query` (hybrid) | 60-150ms |
+| `POST /api/v1/write` (small doc, sync) | 20-50ms (+ async embedding) |
+| `POST /api/v1/reindex` | seconds to minutes — scales with file count |
+| `POST /api/harvest` | seconds — scales with new sessions since last tick |
+
+If `vsearch` or `query` is slow, ollama is the bottleneck — check `embedding.url` reachability and model load.
+
+## Auth
+
+There is no auth in v1. The daemon binds to `localhost` by default. For multi-user or remote setups, front it with a reverse proxy that adds auth (nginx, Caddy, Cloudflare Tunnel, etc.) — but the standard model is **one daemon per developer machine**, not shared.


### PR DESCRIPTION
Adds a self-contained agent skill at `skills/nano-brain/` teaching AI coding agents (Claude Code, OpenCode, MCP-aware tools) **when** to use nano-brain and **how** to call it correctly.

## Why

As nano-brain matured (multi-DB discovery #199, embed queue fix #208/#209, code intelligence #197, cleanup-stale-raw CLI #190), the agent-facing surface grew faster than the README documented. Agents that try to use nano-brain via trial-and-error waste tokens, hit gotchas, or fall back to grep when nano-brain would be the right tool.

This skill packages the operational knowledge an agent needs in one discoverable place. YAML frontmatter `description` field is tuned to trigger when an agent encounters memory/recall/symbol-trace tasks.

## Files

| File | Lines | Role |
|---|---|---|
| `skills/README.md` | 29 | Directory index + contribute guide |
| `skills/nano-brain/SKILL.md` | 381 | Main skill — install, 3-layer API model, decision matrix, endpoint ref, 8 recipes, errors, config |
| `skills/nano-brain/references/code-intelligence.md` | 93 | `context` / `code-impact` / `detect-changes` deep-dive + HTTP equivalents |
| `skills/nano-brain/references/http-api.md` | 211 | Direct HTTP integration — curl examples, perf budget, auth model |
| `skills/nano-brain/AGENTS_SNIPPET.md` | 48 | Boilerplate injected into project AGENTS.md by `init` |

## CLI convention

All 68 CLI examples use the scoped form `npx @nano-step/nano-brain <subcommand>`. The unscoped alias `nano-brain` is mentioned once explaining it exists for tooling that doesn't handle scoped names.

## Install (for end users)

After this merges:

```bash
# OpenCode user-level
cp -r skills/nano-brain ~/.config/opencode/skills/

# Or one-liner with curl (no clone needed)
curl -sL https://github.com/nano-step/nano-brain/archive/refs/heads/master.tar.gz \
  | tar -xz --strip-components=2 -C ~/.config/opencode/skills nano-brain-master/skills/nano-brain
```

## .gitignore fix

Removed stale `/skills/` entry from `.gitignore` (leftover from `_bmad`-era convention). The new `skills/` directory is canonical agent documentation and must be tracked.

## Test plan

- ✅ YAML frontmatter parses cleanly (verified with `python3 -c "import yaml; yaml.safe_load(...)"`)
- ✅ All CLI invocations use scoped form (68 / 1 unscoped, the 1 is intentional in an explanatory note)
- ✅ Three layers (MCP / CLI / HTTP) documented and cross-referenced
- ✅ Recipes are runnable as written (validated against the actual HTTP endpoints in `internal/server/routes.go`)
- ✅ No code changes — docs-only, can't break the build

## Follow-up ideas

- Consider auto-injecting `AGENTS_SNIPPET.md` content via `npx @nano-step/nano-brain init` into the target project's AGENTS.md (already partially done — verify in code)
- Add a CI step that lints the skill's YAML frontmatter on every PR
- Add reciprocal links from the main README to the skill