### PR TITLE
docs(agents): add Behavioral Guidelines block to project AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,73 @@ curl -s http://host.docker.internal:3100/api/write -d '{"content":"## Summary\n-
 
 <!-- OPENCODE-MEMORY:END -->
 
+<!-- BEHAVIORAL-GUIDELINES:START -->
+# Behavioral Guidelines (Always Apply)
+
+Reduce common LLM coding mistakes. Apply to every task regardless of scope.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+<!-- BEHAVIORAL-GUIDELINES:END -->
+
 ## ⛔ CRITICAL: nano-brain Server Rule
 
 **NEVER start nano-brain server inside the container.** The server runs via Docker compose on the HOST only.


### PR DESCRIPTION
Pulls the **Behavioral Guidelines (Always Apply)** block from the user-level `~/.config/opencode/AGENTS.md` into the repo so it ships with the project.

## Why

Currently the four behavioral rules live only in per-developer user-level config. Contributors (human or AI) cloning the repo don't see them unless they've separately configured their own setup. Adding the block to the repo's `AGENTS.md` makes the rules **project-canonical** and removes the per-user setup dependency.

## What

Inserts a managed `<!-- BEHAVIORAL-GUIDELINES:START/END -->` block at the top of `AGENTS.md` (after `OPENCODE-MEMORY`, before `## ⛔ CRITICAL: nano-brain Server Rule`) containing the four rules verbatim:

1. **Think Before Coding** — surface tradeoffs, don't hide confusion
2. **Simplicity First** — minimum code, no speculation
3. **Surgical Changes** — touch only what's needed
4. **Goal-Driven Execution** — verifiable success criteria

Each rule has bullets explaining behaviors and anti-patterns. The block ends with a self-check ("these guidelines are working if…").

## Notes

- No `CLAUDE.md` header — per user request to drop it
- Marker block lets future syncs update content in place without diff churn
- Content is verbatim copy of the canonical user-level block (single source of truth → repo)
- No code changes; pure docs
- Project AGENTS.md is read AFTER user-level AGENTS.md, so the duplicate text is benign (last write wins is fine since content is identical)

## Test plan

- ✅ Markdown structure parses (headers + bullets render correctly)
- ✅ Markers `BEHAVIORAL-GUIDELINES:START` and `:END` both present at lines 52 and 117
- ✅ No stale `CLAUDE.md` text anywhere in the file (verified with grep)
- ✅ No code touched — build can't break
- ✅ Follows harness rules: feature branch, no direct trunk push