### PR TITLE
fix(ci): revert setup-node v5→v4 to fix npm publish 404

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v5
+      # Pinned to v4 — v5 breaks classic NPM_TOKEN publish with misleading 404
+      # via npm 11.x OIDC auto-detection (actions/setup-node#1551, npm/cli#8730).
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          always-auth: false
 
       - name: Determine npm tag
         id: npm-tag


### PR DESCRIPTION
## Summary

PR #212 fixed the tag scheme but accidentally bumped `actions/setup-node@v4` → `@v5`. With v5, npm 11.x auto-detects an OIDC trusted-publishing context even when only classic `NPM_TOKEN` auth is configured, and surfaces the failure as a misleading **404** from `PUT /@nano-step%2fnano-brain`.

Result: every CI publish since May 30 has failed at the `npm-publish` job — including the otherwise-correct `v2026.5.3001` (binaries + GH release exist, only npm publish failed).

## Evidence

| Tag | setup-node | Result | Notes |
|---|---|---|---|
| v2026.5.2902 | @v4 | ✅ published | Last successful CI publish (May 29) |
| v2026.5.30.{1,2,3} | @v5 | ❌ 404 | Broken tag scheme **and** v5 |
| v2026.5.3001 | @v5 | ❌ 404 | Tag scheme is correct, only v5 is the regression |

Upstream issues confirming the regression:
- [actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551) — v5 writes `_authToken` line that breaks OIDC
- [actions/setup-node#1445](https://github.com/actions/setup-node/issues/1445) — Trusted Publisher 404 with NODE_AUTH_TOKEN
- [npm/cli#8730](https://github.com/npm/cli/issues/8730) — npm 11.x OIDC publish surfaces as E404

## Change

Surgical revert. `always-auth: false` is removed because it only existed to silence a v5-only deprecation warning.

```diff
-      - uses: actions/setup-node@v5
+      # Pinned to v4 — v5 breaks classic NPM_TOKEN publish with misleading 404
+      # via npm 11.x OIDC auto-detection (actions/setup-node#1551, npm/cli#8730).
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          always-auth: false
```

## Follow-up (manual, after merge)

1. Delete tag + GitHub release `v2026.5.3001` (binaries can stay or be re-uploaded by the workflow)
2. Re-push tag `v2026.5.3001` onto the new master HEAD
3. `release.yml` re-fires with the v4 fix → `npm publish` should succeed
4. Verify `npm view @nano-step/nano-brain@2026.5.3001` and `npm view nano-brain@2026.5.3001`

## Validation

- [x] `go build ./...` — unaffected (workflow-only change)
- [x] Diff is 3 inserts, 2 deletes — surgical
- [ ] Republish v2026.5.3001 succeeds (post-merge step)

Change type: `infrastructure` (CI). No new test required, validation is the next `release.yml` run.