### PR TITLE
feat(cli): add wake-up command (#151)

### DIFF
--- a/cmd/nano-brain/cmd_wake_up.go
+++ b/cmd/nano-brain/cmd_wake_up.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/storage"
+)
+
+func runWakeUpCmd(args []string) {
+	cliLog.Info().Str("cmd", "wake-up").Msg("cli command started")
+
+	var workspaceHash, workspacePath string
+	var limit int
+	var jsonFlag bool
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			printWakeUpUsage()
+			return
+		case strings.HasPrefix(arg, "--workspace="):
+			workspaceHash = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspaceHash = args[i]
+		case strings.HasPrefix(arg, "--workspace-path="):
+			workspacePath = strings.TrimPrefix(arg, "--workspace-path=")
+		case arg == "--workspace-path":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace-path requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspacePath = args[i]
+		case strings.HasPrefix(arg, "--limit="):
+			v, err := strconv.Atoi(strings.TrimPrefix(arg, "--limit="))
+			if err != nil || v < 1 {
+				fmt.Fprintf(os.Stderr, "--limit must be a positive integer\n")
+				os.Exit(2)
+			}
+			limit = v
+		case arg == "--limit":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--limit requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			v, err := strconv.Atoi(args[i])
+			if err != nil || v < 1 {
+				fmt.Fprintf(os.Stderr, "--limit must be a positive integer\n")
+				os.Exit(2)
+			}
+			limit = v
+		case arg == "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n\n", arg)
+			printWakeUpUsage()
+			os.Exit(2)
+		}
+	}
+
+	if workspaceHash == "" && workspacePath == "" {
+		fmt.Fprintf(os.Stderr, "must specify --workspace=<hash> or --workspace-path=<path>\n\n")
+		printWakeUpUsage()
+		os.Exit(2)
+	}
+
+	if workspacePath != "" {
+		h, err := storage.WorkspaceHash(workspacePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: could not derive workspace hash from path %q: %v\n", workspacePath, err)
+			os.Exit(1)
+		}
+		workspaceHash = h
+	}
+
+	reqBody := map[string]interface{}{
+		"workspace": workspaceHash,
+	}
+	if limit > 0 {
+		reqBody["limit"] = limit
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		cliLog.Error().Err(err).Str("cmd", "wake-up").Msg("marshal failed")
+		os.Exit(1)
+	}
+
+	resp, _, reqErr := doRequest("POST", getBaseURL()+"/api/v1/wake-up", bytes.NewReader(data))
+	if reqErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", reqErr)
+		cliLog.Error().Err(reqErr).Str("cmd", "wake-up").Msg("request failed")
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "wake-up").Msg("cli command completed")
+		return
+	}
+
+	var result wakeUpResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "wake-up").Msg("cli command completed")
+		return
+	}
+
+	printWakeUpResponse(result)
+	cliLog.Info().Str("cmd", "wake-up").Msg("cli command completed")
+}
+
+type wakeUpResponse struct {
+	Summary           string              `json:"summary"`
+	RecentMemories    []wakeUpMemory      `json:"recent_memories"`
+	ActiveCollections []wakeUpCollection  `json:"active_collections"`
+	Stats             wakeUpStats         `json:"stats"`
+}
+
+type wakeUpMemory struct {
+	ID      string   `json:"id"`
+	Title   string   `json:"title"`
+	Snippet string   `json:"snippet"`
+	Tags    []string `json:"tags"`
+	Date    string   `json:"date"`
+}
+
+type wakeUpCollection struct {
+	Name          string `json:"name"`
+	DocumentCount int64  `json:"document_count"`
+	LastUpdated   string `json:"last_updated"`
+}
+
+type wakeUpStats struct {
+	TotalDocuments int64  `json:"total_documents"`
+	TotalChunks    int64  `json:"total_chunks"`
+	LastActivity   string `json:"last_activity"`
+}
+
+func printWakeUpResponse(r wakeUpResponse) {
+	fmt.Println(r.Summary)
+
+	if len(r.ActiveCollections) > 0 {
+		fmt.Println("\nCollections:")
+		for _, c := range r.ActiveCollections {
+			fmt.Printf("  %-20s  %d docs", c.Name, c.DocumentCount)
+			if c.LastUpdated != "" {
+				fmt.Printf("  (last updated: %s)", c.LastUpdated)
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Printf("\nStats: %d documents, %d chunks", r.Stats.TotalDocuments, r.Stats.TotalChunks)
+	if r.Stats.LastActivity != "" {
+		fmt.Printf("  last activity: %s", r.Stats.LastActivity)
+	}
+	fmt.Println()
+
+	if len(r.RecentMemories) > 0 {
+		fmt.Printf("\nRecent memories (%d):\n", len(r.RecentMemories))
+		for _, m := range r.RecentMemories {
+			fmt.Printf("  [%s] %s\n", m.Date, m.Title)
+			if m.Snippet != "" {
+				snippet := m.Snippet
+				if len(snippet) > 120 {
+					snippet = snippet[:117] + "..."
+				}
+				fmt.Printf("    %s\n", strings.ReplaceAll(snippet, "\n", " "))
+			}
+			if len(m.Tags) > 0 {
+				fmt.Printf("    tags: %s\n", strings.Join(m.Tags, ", "))
+			}
+		}
+	}
+}
+
+func printWakeUpUsage() {
+	fmt.Print(`Usage: nano-brain wake-up --workspace=<hash> [flags]
+       nano-brain wake-up --workspace-path=<path> [flags]
+
+Show a workspace briefing: recent memories, active collections, and stats.
+
+Flags:
+  --workspace=<hash>     Workspace hash (required if --workspace-path not given)
+  --workspace-path=<p>   Derive workspace hash from directory path
+  --limit=<N>            Number of recent memories to show (default: 10, max: 50)
+  --json                 Output raw JSON response
+  -h, --help             Show this help
+`)
+}

--- a/cmd/nano-brain/cmd_wake_up.go
+++ b/cmd/nano-brain/cmd_wake_up.go
@@ -176,8 +176,8 @@ func printWakeUpResponse(r wakeUpResponse) {
 			fmt.Printf("  [%s] %s\n", m.Date, m.Title)
 			if m.Snippet != "" {
 				snippet := m.Snippet
-				if len(snippet) > 120 {
-					snippet = snippet[:117] + "..."
+				if r := []rune(snippet); len(r) > 120 {
+					snippet = string(r[:117]) + "..."
 				}
 				fmt.Printf("    %s\n", strings.ReplaceAll(snippet, "\n", " "))
 			}

--- a/cmd/nano-brain/cmd_wake_up_test.go
+++ b/cmd/nano-brain/cmd_wake_up_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sampleWakeUpResponse() []byte {
+	resp := wakeUpResponse{
+		Summary: "Workspace has 42 documents across 3 collections. Last activity: 5m ago.",
+		RecentMemories: []wakeUpMemory{
+			{
+				ID:      "uuid-1",
+				Title:   "Decision: use PostgreSQL",
+				Snippet: "We decided to use PostgreSQL for its pgvector support.",
+				Tags:    []string{"decision", "architecture"},
+				Date:    "2026-05-30T10:00:00Z",
+			},
+		},
+		ActiveCollections: []wakeUpCollection{
+			{Name: "memory", DocumentCount: 10, LastUpdated: "2026-05-30T09:00:00Z"},
+			{Name: "codebase", DocumentCount: 32, LastUpdated: "2026-05-29T15:00:00Z"},
+		},
+		Stats: wakeUpStats{
+			TotalDocuments: 42,
+			TotalChunks:    180,
+			LastActivity:   "2026-05-30T10:00:00Z",
+		},
+	}
+	data, _ := json.Marshal(resp)
+	return data
+}
+
+func startWakeUpTestServer(t *testing.T, statusCode int, respBody []byte) (*httptest.Server, *[]byte) {
+	t.Helper()
+	captured := &[]byte{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/wake-up" {
+			t.Errorf("expected path /api/v1/wake-up, got %s", r.URL.Path)
+		}
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r.Body)
+		body := buf.Bytes()
+		*captured = body
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(respBody)
+	}))
+	return ts, captured
+}
+
+func pointClientAt(t *testing.T, ts *httptest.Server) {
+	t.Helper()
+	addr := strings.TrimPrefix(ts.URL, "http://")
+	parts := strings.SplitN(addr, ":", 2)
+	t.Setenv("NANO_BRAIN_HOST", parts[0])
+	if len(parts) == 2 {
+		t.Setenv("NANO_BRAIN_PORT", parts[1])
+	}
+}
+
+func TestRunWakeUpCmd_RequestBodyContainsWorkspace(t *testing.T) {
+	ts, captured := startWakeUpTestServer(t, http.StatusOK, sampleWakeUpResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	reqBody := map[string]interface{}{"workspace": "abc123", "limit": 5}
+	data, _ := json.Marshal(reqBody)
+	resp, statusCode, err := doRequest("POST", ts.URL+"/api/v1/wake-up", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(*captured, &body); err != nil {
+		t.Fatalf("could not parse captured body: %v", err)
+	}
+	if body["workspace"] != "abc123" {
+		t.Errorf("workspace = %v, want abc123", body["workspace"])
+	}
+	if body["limit"] != float64(5) {
+		t.Errorf("limit = %v, want 5", body["limit"])
+	}
+
+	var result wakeUpResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		t.Fatalf("could not parse response: %v", err)
+	}
+	if result.Stats.TotalDocuments != 42 {
+		t.Errorf("total_documents = %d, want 42", result.Stats.TotalDocuments)
+	}
+	if len(result.RecentMemories) != 1 {
+		t.Errorf("recent_memories len = %d, want 1", len(result.RecentMemories))
+	}
+}
+
+func TestRunWakeUpCmd_DefaultLimitOmitted(t *testing.T) {
+	ts, captured := startWakeUpTestServer(t, http.StatusOK, sampleWakeUpResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	reqBody := map[string]interface{}{"workspace": "ws-hash"}
+	data, _ := json.Marshal(reqBody)
+	_, _, err := doRequest("POST", ts.URL+"/api/v1/wake-up", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(*captured, &body); err != nil {
+		t.Fatalf("could not parse captured body: %v", err)
+	}
+	if _, hasLimit := body["limit"]; hasLimit {
+		t.Errorf("expected no 'limit' key when using default, got body: %v", body)
+	}
+}
+
+func TestRunWakeUpCmd_ServerError(t *testing.T) {
+	errResp := []byte(`{"message":"workspace not found"}`)
+	ts, _ := startWakeUpTestServer(t, http.StatusBadRequest, errResp)
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	data, _ := json.Marshal(map[string]interface{}{"workspace": "invalid"})
+	_, statusCode, err := doRequest("POST", ts.URL+"/api/v1/wake-up", bytes.NewReader(data))
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", statusCode)
+	}
+	if !strings.Contains(err.Error(), "server returned 400") {
+		t.Errorf("error = %q, want it to contain 'server returned 400'", err.Error())
+	}
+}
+
+func TestPrintWakeUpResponse_NoCollections(t *testing.T) {
+	r := wakeUpResponse{
+		Summary:           "No data yet.",
+		RecentMemories:    []wakeUpMemory{},
+		ActiveCollections: []wakeUpCollection{},
+		Stats:             wakeUpStats{TotalDocuments: 0, TotalChunks: 0},
+	}
+	printWakeUpResponse(r)
+}
+
+func TestPrintWakeUpResponse_SnippetTruncation(t *testing.T) {
+	longSnippet := strings.Repeat("x", 200)
+	r := wakeUpResponse{
+		Summary: "ok",
+		RecentMemories: []wakeUpMemory{
+			{Title: "test", Snippet: longSnippet, Tags: []string{}, Date: "2026-01-01T00:00:00Z"},
+		},
+		ActiveCollections: []wakeUpCollection{},
+		Stats:             wakeUpStats{},
+	}
+	printWakeUpResponse(r)
+}

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -122,6 +122,9 @@ func main() {
 		case "cleanup-stale-raw":
 			runCleanupStaleRawCmd(args[1:])
 			return
+		case "wake-up":
+			runWakeUpCmd(args[1:])
+			return
 		case "version":
 			runVersionCmd(args[1:])
 			return

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -566,6 +566,7 @@ Commands:
    collection         Manage collections (add/remove/list)
    harvest            Trigger session harvesting
    reindex            Queue collection reindex
+   wake-up            Workspace briefing (recent memories, collections, stats)
    logs               View log file (-f to follow, -n <count>)
   docker             Manage Docker Compose (start/stop/status)
   db:migrate         Run database migrations

--- a/docs/evidence/self-review-feat-151-wake-up-cli.md
+++ b/docs/evidence/self-review-feat-151-wake-up-cli.md
@@ -27,3 +27,8 @@ Reviewer: Sisyphus orchestrator
 - Major: 0  
 - Minor: 0
 - E2E verified against real PG
+
+## Gemini PR Review (post-merge fix)
+| Finding | Severity | Verdict | Action |
+|---|---|---|---|
+| Byte-slice snippet truncation may cut multi-byte UTF-8 | Medium | VALID | FIXED: convert to []rune before slicing |

--- a/docs/evidence/self-review-feat-151-wake-up-cli.md
+++ b/docs/evidence/self-review-feat-151-wake-up-cli.md
@@ -1,0 +1,29 @@
+## Self-Review: feat/151-wake-up-cli
+Date: 2026-05-30
+Reviewer: Sisyphus orchestrator
+
+## Findings
+| # | Severity | File | Description | Status |
+|---|----------|------|-------------|--------|
+| - | none | - | Implementation matches existing CLI patterns (cmd_cleanup_stale_raw, cmd_reset_embeddings); workspace resolution mirrors cmd_reset_embeddings.go; HTTP dispatch via doRequest; logging consistent | n/a |
+
+## E2E smoke test (PG via host.docker.internal:5432)
+- Started server with /tmp/nb-test/config.yml
+- Health check: `{"status":"ok","ready":true}`
+- Registered workspace: hash=c98e3a3ea54114f1b91693672f6b1f3a10efebf839cb2195b1176df28e06deff
+- `wake-up --workspace=<hash>` → pretty output: 0 docs, 3 collections (code/memory/sessions), 0 chunks
+- `wake-up --workspace=<hash> --json` → raw JSON with all expected fields
+- Help text and missing-workspace error path verified
+
+## Unit tests
+- 5 tests in cmd_wake_up_test.go all pass
+- `go test -race -short -count=1 ./cmd/nano-brain/...` → ok
+
+## Build
+- `CGO_ENABLED=0 go build ./...` → exit 0
+
+## Summary
+- Critical: 0
+- Major: 0  
+- Minor: 0
+- E2E verified against real PG


### PR DESCRIPTION
Closes #151

## Summary
Thin CLI wrapper around the existing `POST /api/v1/wake-up` REST endpoint. Surfaces a compact workspace briefing at session start.

## Usage
```
nano-brain wake-up --workspace=<hash> [--limit=N] [--json]
nano-brain wake-up --workspace-path=<path> [--limit=N] [--json]
```

## Flags
- `--workspace=<hash>` / `--workspace-path=<path>` — one required (mirrors cmd_reset_embeddings.go pattern)
- `--limit=<N>` — default 10, max 50
- `--json` — raw response; default = pretty-printed

## Verification
- `go build ./...` → pass
- `go test -race -short ./cmd/nano-brain/...` → 5 new tests + all existing pass
- **E2E smoke (PG @ host.docker.internal:5432):**
  - Server up, health OK, workspace registered
  - `wake-up` pretty output: 0 docs, 3 collections (code/memory/sessions), 0 chunks
  - `wake-up --json` returns proper JSON shape
  - Missing-workspace error path verified

Evidence: `docs/evidence/self-review-feat-151-wake-up-cli.md`