### PR TITLE
feat(cli): add --scope=all for cross-workspace search (#156)

### DIFF
--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -234,42 +234,77 @@ func runWriteCmd(args []string) {
 	cliLog.Info().Str("cmd", "write").Str("document_id", result.ID).Msg("cli command completed")
 }
 
-func runStubCmd(endpoint string, args []string) {
-	cliLog.Info().Str("cmd", endpoint).Msg("cli command started")
-	var query, workspace string
-	var jsonFlag bool
+type stubFlags struct {
+	query     string
+	workspace string
+	scope     string
+	jsonFlag  bool
+}
+
+func parseStubFlags(args []string) (stubFlags, string) {
+	f := stubFlags{scope: "workspace"}
 	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--workspace":
+		arg := args[i]
+		switch {
+		case arg == "--workspace":
 			if i+1 >= len(args) {
-				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
-				os.Exit(1)
+				return f, "--workspace requires a value"
 			}
 			i++
-			workspace = args[i]
-		case "--json":
-			jsonFlag = true
-		default:
-			if strings.HasPrefix(args[i], "--") {
-				fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
-				os.Exit(1)
+			f.workspace = args[i]
+		case strings.HasPrefix(arg, "--workspace="):
+			f.workspace = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--scope":
+			if i+1 >= len(args) {
+				return f, "--scope requires a value"
 			}
-			if query == "" {
-				query = args[i]
+			i++
+			f.scope = args[i]
+		case strings.HasPrefix(arg, "--scope="):
+			f.scope = strings.TrimPrefix(arg, "--scope=")
+		case arg == "--json":
+			f.jsonFlag = true
+		case strings.HasPrefix(arg, "--"):
+			return f, "unknown flag: " + arg
+		default:
+			if f.query == "" {
+				f.query = arg
 			} else {
-				fmt.Fprintf(os.Stderr, "unexpected argument: %s\n", args[i])
-				os.Exit(1)
+				return f, "unexpected argument: " + arg
 			}
 		}
 	}
-	if query == "" || workspace == "" {
-		fmt.Fprintf(os.Stderr, "Usage: nano-brain %s \"<query>\" --workspace <hash> [--json]\n", endpoint)
+
+	if f.scope != "workspace" && f.scope != "all" {
+		return f, fmt.Sprintf("invalid --scope value %q: must be \"workspace\" or \"all\"", f.scope)
+	}
+	return f, ""
+}
+
+func runStubCmd(endpoint string, args []string) {
+	cliLog.Info().Str("cmd", endpoint).Msg("cli command started")
+
+	f, errMsg := parseStubFlags(args)
+	if errMsg != "" {
+		fmt.Fprintf(os.Stderr, "%s\n", errMsg)
+		os.Exit(1)
+	}
+
+	var workspaceVal string
+	if f.scope == "all" {
+		workspaceVal = "all"
+	} else {
+		workspaceVal = f.workspace
+	}
+
+	if f.query == "" || workspaceVal == "" {
+		fmt.Fprintf(os.Stderr, "Usage: nano-brain %s \"<query>\" --workspace <hash> [--scope all|workspace] [--json]\n", endpoint)
 		os.Exit(1)
 	}
 
 	body := map[string]string{
-		"query":     query,
-		"workspace": workspace,
+		"query":     f.query,
+		"workspace": workspaceVal,
 	}
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -290,7 +325,7 @@ func runStubCmd(endpoint string, args []string) {
 		os.Exit(1)
 	}
 
-	if jsonFlag {
+	if f.jsonFlag {
 		fmt.Println(string(resp))
 		cliLog.Info().Str("cmd", endpoint).Msg("cli command completed")
 		return

--- a/cmd/nano-brain/commands_scope_test.go
+++ b/cmd/nano-brain/commands_scope_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseStubFlags_ScopeAll(t *testing.T) {
+	f, errMsg := parseStubFlags([]string{"my query", "--scope", "all"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.scope != "all" {
+		t.Errorf("scope = %q, want %q", f.scope, "all")
+	}
+	if f.query != "my query" {
+		t.Errorf("query = %q, want %q", f.query, "my query")
+	}
+}
+
+func TestParseStubFlags_ScopeAllEquals(t *testing.T) {
+	f, errMsg := parseStubFlags([]string{"q", "--scope=all"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.scope != "all" {
+		t.Errorf("scope = %q, want %q", f.scope, "all")
+	}
+}
+
+func TestParseStubFlags_ScopeWorkspaceDefault(t *testing.T) {
+	f, errMsg := parseStubFlags([]string{"q", "--workspace", "abc"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.scope != "workspace" {
+		t.Errorf("scope = %q, want %q", f.scope, "workspace")
+	}
+	if f.workspace != "abc" {
+		t.Errorf("workspace = %q, want %q", f.workspace, "abc")
+	}
+}
+
+func TestParseStubFlags_ScopeWorkspaceExplicit(t *testing.T) {
+	f, errMsg := parseStubFlags([]string{"q", "--scope", "workspace", "--workspace", "abc"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.scope != "workspace" {
+		t.Errorf("scope = %q, want %q", f.scope, "workspace")
+	}
+}
+
+func TestParseStubFlags_ScopeInvalid(t *testing.T) {
+	_, errMsg := parseStubFlags([]string{"q", "--scope", "foo"})
+	if errMsg == "" {
+		t.Fatal("expected error for invalid scope, got none")
+	}
+}
+
+func TestParseStubFlags_ScopeMissingValue(t *testing.T) {
+	_, errMsg := parseStubFlags([]string{"q", "--scope"})
+	if errMsg == "" {
+		t.Fatal("expected error for missing --scope value")
+	}
+}
+
+func TestParseStubFlags_ScopeAllOverridesWorkspace(t *testing.T) {
+	f, errMsg := parseStubFlags([]string{"q", "--scope", "all", "--workspace", "abc"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.scope != "all" {
+		t.Errorf("scope = %q, want %q", f.scope, "all")
+	}
+	if f.workspace != "abc" {
+		t.Errorf("workspace = %q, want %q", f.workspace, "abc")
+	}
+}
+
+func TestStubCmd_ScopeAll(t *testing.T) {
+	var capturedBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer ts.Close()
+	pointHTTPClientAt(t, ts)
+
+	f, errMsg := parseStubFlags([]string{"test query", "--scope", "all"})
+	if errMsg != "" {
+		t.Fatalf("parse error: %s", errMsg)
+	}
+
+	workspaceVal := f.workspace
+	if f.scope == "all" {
+		workspaceVal = "all"
+	}
+
+	body, _ := json.Marshal(map[string]string{"query": f.query, "workspace": workspaceVal})
+	_, _, err := doRequest("POST", ts.URL+"/api/v1/query", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if capturedBody["workspace"] != "all" {
+		t.Errorf("workspace in body = %q, want %q", capturedBody["workspace"], "all")
+	}
+	if capturedBody["query"] != "test query" {
+		t.Errorf("query in body = %q, want %q", capturedBody["query"], "test query")
+	}
+}
+
+func TestStubCmd_ScopeWorkspace(t *testing.T) {
+	var capturedBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer ts.Close()
+	pointHTTPClientAt(t, ts)
+
+	f, errMsg := parseStubFlags([]string{"test query", "--scope", "workspace", "--workspace", "abc"})
+	if errMsg != "" {
+		t.Fatalf("parse error: %s", errMsg)
+	}
+
+	body, _ := json.Marshal(map[string]string{"query": f.query, "workspace": f.workspace})
+	_, _, err := doRequest("POST", ts.URL+"/api/v1/query", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if capturedBody["workspace"] != "abc" {
+		t.Errorf("workspace in body = %q, want %q", capturedBody["workspace"], "abc")
+	}
+}
+
+func TestStubCmd_ScopeAllOverridesWorkspace(t *testing.T) {
+	var capturedBody map[string]string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer ts.Close()
+	pointHTTPClientAt(t, ts)
+
+	f, errMsg := parseStubFlags([]string{"test query", "--scope", "all", "--workspace", "abc"})
+	if errMsg != "" {
+		t.Fatalf("parse error: %s", errMsg)
+	}
+
+	workspaceVal := f.workspace
+	if f.scope == "all" {
+		workspaceVal = "all"
+	}
+
+	body, _ := json.Marshal(map[string]string{"query": f.query, "workspace": workspaceVal})
+	_, _, err := doRequest("POST", ts.URL+"/api/v1/query", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	if capturedBody["workspace"] != "all" {
+		t.Errorf("workspace in body = %q, want %q (--scope=all should override --workspace)", capturedBody["workspace"], "all")
+	}
+}

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -558,9 +558,9 @@ Commands:
   version            Show version
   config show        Show current configuration
   config check       Validate configuration
-  query              Hybrid search (BM25 + vector)
-  search             BM25 keyword search
-  vsearch            Vector similarity search
+  query              Hybrid search (BM25 + vector)    [--scope all|workspace] [--workspace <hash>]
+  search             BM25 keyword search               [--scope all|workspace] [--workspace <hash>]
+  vsearch            Vector similarity search          [--scope all|workspace] [--workspace <hash>]
   workspaces         List registered workspaces (alias: ls)
   write              Write a document
    collection         Manage collections (add/remove/list)

--- a/docs/evidence/self-review-feat-156-scope-all.md
+++ b/docs/evidence/self-review-feat-156-scope-all.md
@@ -1,0 +1,25 @@
+## Self-Review: feat/156-scope-all-cli
+Date: 2026-05-30
+Reviewer: Sisyphus orchestrator
+
+## Findings
+| # | Severity | File | Description | Status |
+|---|----------|------|-------------|--------|
+| - | none | - | Backend already supported workspace="all" (middleware accepts it; service dispatches to BM25SearchAll/VectorSearchAll). Pure CLI wrapper. | n/a |
+
+## E2E smoke (PG @ host.docker.internal:5432, 11 existing workspaces)
+- `query "test query" --scope=all --json` → returned 20 cross-workspace results spanning multiple workspace hashes (verified `workspace_hash` field differs across results)
+- `search "anything" --scope=all` (no --workspace) → 200 OK with empty results (search index returned nothing for that term, no error)
+- `query "x" --scope=invalid --workspace=abc` → exits with usage error: `invalid --scope value "invalid": must be "workspace" or "all"`
+- Default behavior preserved: `query "x" --workspace=abc` still works without --scope
+
+## Unit tests
+- 10 new tests in commands_scope_test.go (7 parseStubFlags + 3 httptest integration)
+- All pass under `go test -race -short -count=1 ./cmd/nano-brain/...`
+
+## Build
+- `CGO_ENABLED=0 go build ./...` → exit 0
+
+## Summary
+- Critical: 0, Major: 0, Minor: 0
+- E2E cross-workspace search verified working with real data


### PR DESCRIPTION
Closes #156

## Summary
Backend already supported `workspace="all"` (middleware + service + SQL via BM25SearchAll/VectorSearchAll). This PR exposes it via a new `--scope` flag on query/search/vsearch commands.

## Usage
```
nano-brain query "..." --scope=all
nano-brain query "..." --scope=workspace --workspace=<hash>
nano-brain query "..." --workspace=<hash>   # default scope
```

`--scope=all` makes `--workspace` optional and overrides it if both given.

## Implementation
- Extracted `parseStubFlags()` helper struct (testable; minimal surgical change)
- `runStubCmd` validates `scope ∈ {workspace, all}`
- `printUsage()` mentions `--scope all|workspace`

## Verification
- `go build ./...` → pass
- `go test -race -short ./cmd/nano-brain/...` → 10 new tests + all existing pass
- **E2E (PG @ host.docker.internal:5432, 11 workspaces):**
  - `query "test query" --scope=all --json` → 20 results spanning multiple workspace_hash values
  - `search "anything" --scope=all` (no --workspace) → 200 OK
  - `query "x" --scope=invalid` → `invalid --scope value "invalid": must be "workspace" or "all"`

Evidence: `docs/evidence/self-review-feat-156-scope-all.md`