### PR TITLE
feat(cli): workspaces remove command (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Features
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(cli): wake-up command — pretty/JSON workspace briefing at session start (#151, PR #216)
 - feat(cli): `--scope=all` flag on query/search/vsearch for cross-workspace search (#156, PR #217)
 - feat(config): `NANO_BRAIN_CONFIG` env var support — precedence `--config` flag > env var > `~/.nano-brain/config.yml`. Enables Docker/k8s deployments to point at a container-specific config without mounting over the host's default.
@@ -21,6 +22,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.5.267] — 2026-05-26
 
 ### Features
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(summarize): session summarization pipeline — LLM-powered structured summaries for harvested sessions
 - feat(summarize): map-reduce pipeline with strip, parallel map, hierarchical reduce for sessions up to 1M tokens
 - feat(summarize): OpenAI-compatible LLM client with SSE streaming, retry (3x backoff for 429/5xx)
@@ -41,6 +43,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-25
 
 ### Features
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat: nano-brain v2 — complete greenfield rewrite (Go + PostgreSQL + pgvector)
 - feat: interactive first-run setup wizard (closes #43)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
@@ -95,6 +98,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-16
 
 ### Features
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat: interactive first-run setup wizard (closes #43)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
 - feat(graph): focus mode on node click + fix node overlap (#37)
@@ -147,6 +151,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-16
 
 ### Features
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
 - feat(graph): focus mode on node click + fix node overlap (#37)
 - feat(obsidian,db): excludeFolders, frontmatter tags, db:clean --list-only (closes #34)
@@ -197,6 +202,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-16
 
 ### Features
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
 - feat(graph): focus mode on node click + fix node overlap (#37)
 - feat(obsidian,db): excludeFolders, frontmatter tags, db:clean --list-only (closes #34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Features
-- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
+- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with `--dry-run` preview and `--force` safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint wrapped in a single transaction (#155)
 - feat(cli): wake-up command — pretty/JSON workspace briefing at session start (#151, PR #216)
 - feat(cli): `--scope=all` flag on query/search/vsearch for cross-workspace search (#156, PR #217)
 - feat(config): `NANO_BRAIN_CONFIG` env var support — precedence `--config` flag > env var > `~/.nano-brain/config.yml`. Enables Docker/k8s deployments to point at a container-specific config without mounting over the host's default.
@@ -22,7 +22,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.5.267] — 2026-05-26
 
 ### Features
-- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(summarize): session summarization pipeline — LLM-powered structured summaries for harvested sessions
 - feat(summarize): map-reduce pipeline with strip, parallel map, hierarchical reduce for sessions up to 1M tokens
 - feat(summarize): OpenAI-compatible LLM client with SSE streaming, retry (3x backoff for 429/5xx)
@@ -43,7 +42,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-25
 
 ### Features
-- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat: nano-brain v2 — complete greenfield rewrite (Go + PostgreSQL + pgvector)
 - feat: interactive first-run setup wizard (closes #43)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
@@ -98,7 +96,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-16
 
 ### Features
-- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat: interactive first-run setup wizard (closes #43)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
 - feat(graph): focus mode on node click + fix node overlap (#37)
@@ -151,7 +148,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-16
 
 ### Features
-- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
 - feat(graph): focus mode on node click + fix node overlap (#37)
 - feat(obsidian,db): excludeFolders, frontmatter tags, db:clean --list-only (closes #34)
@@ -202,7 +198,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [2026.8.19] — 2026-05-16
 
 ### Features
-- feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with --dry-run preview + --force safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint (#155)
 - feat(graph): auto-zoom to selected node + neighbors on focus mode
 - feat(graph): focus mode on node click + fix node overlap (#37)
 - feat(obsidian,db): excludeFolders, frontmatter tags, db:clean --list-only (closes #34)

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ docker run -d \
 | GET | `/api/status` | Server status with version, uptime, workspace stats |
 | POST | `/api/v1/init` | Register workspace |
 | GET | `/api/v1/workspaces` | List all workspaces (with doc counts) |
+| DELETE | `/api/v1/workspaces/:hash` | Permanently delete a workspace + cascade docs/chunks/embeddings |
 | GET | `/api/v1/wake-up` | Workspace briefing |
 | POST | `/api/harvest` | Trigger session harvesting |
 | POST | `/api/reload-config` | Hot-reload configuration |
@@ -243,6 +244,8 @@ Workspace is passed in the JSON body for POST, query param for GET.
 |---------|-------------|
 | `nano-brain` (no args) | Start HTTP server (default: port 3100) |
 | `nano-brain init --root=<path>` | Register workspace |
+| `nano-brain workspaces list` | List registered workspaces with doc counts |
+| `nano-brain workspaces remove --workspace=<hash> [--dry-run\|--force]` | Permanently delete a workspace + all its documents/chunks/embeddings |
 | `nano-brain write` | Write document via CLI |
 | `nano-brain query` | Hybrid search |
 | `nano-brain search` | BM25 keyword search |

--- a/cmd/nano-brain/cmd_workspace_remove.go
+++ b/cmd/nano-brain/cmd_workspace_remove.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/storage"
+)
+
+type workspaceRemoveFlags struct {
+	workspace     string
+	workspacePath string
+	force         bool
+	dryRun        bool
+	jsonFlag      bool
+}
+
+func parseWorkspaceRemoveFlags(args []string) (workspaceRemoveFlags, string) {
+	var f workspaceRemoveFlags
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			return f, "help"
+		case arg == "--force":
+			f.force = true
+		case arg == "--dry-run":
+			f.dryRun = true
+		case arg == "--json":
+			f.jsonFlag = true
+		case strings.HasPrefix(arg, "--workspace="):
+			f.workspace = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--workspace":
+			if i+1 >= len(args) {
+				return f, "--workspace requires a value"
+			}
+			i++
+			f.workspace = args[i]
+		case strings.HasPrefix(arg, "--workspace-path="):
+			f.workspacePath = strings.TrimPrefix(arg, "--workspace-path=")
+		case arg == "--workspace-path":
+			if i+1 >= len(args) {
+				return f, "--workspace-path requires a value"
+			}
+			i++
+			f.workspacePath = args[i]
+		default:
+			return f, "unknown flag: " + arg
+		}
+	}
+	return f, ""
+}
+
+func runWorkspacesRemove(args []string) {
+	exit := runWorkspacesRemoveWithIO(args, os.Stdout, os.Stderr)
+	if exit != 0 {
+		os.Exit(exit)
+	}
+}
+
+func runWorkspacesRemoveWithIO(args []string, stdout, stderr io.Writer) int {
+	cliLog.Info().Str("cmd", "workspaces remove").Msg("cli command started")
+
+	f, errMsg := parseWorkspaceRemoveFlags(args)
+	if errMsg == "help" {
+		printWorkspaceRemoveUsage(stdout)
+		return 0
+	}
+	if errMsg != "" {
+		fmt.Fprintln(stderr, errMsg)
+		printWorkspaceRemoveUsage(stderr)
+		return 2
+	}
+
+	if f.workspace == "" && f.workspacePath == "" {
+		fmt.Fprintln(stderr, "must specify --workspace=<hash> or --workspace-path=<path>")
+		printWorkspaceRemoveUsage(stderr)
+		return 2
+	}
+
+	hash := f.workspace
+	if f.workspacePath != "" {
+		h, err := storage.WorkspaceHash(f.workspacePath)
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: could not derive workspace hash from path %q: %v\n", f.workspacePath, err)
+			return 1
+		}
+		hash = h
+	}
+
+	if f.dryRun {
+		return workspaceRemoveDryRun(hash, f.jsonFlag, stdout, stderr)
+	}
+
+	if !f.force {
+		docCount, ok := fetchDocCount(hash, stderr)
+		if !ok {
+			return 1
+		}
+		fmt.Fprintf(stderr, "Refusing to remove workspace %s (%d document(s)). Use --force to confirm deletion.\n", hash, docCount)
+		return 2
+	}
+
+	return workspaceRemoveExecute(hash, f.jsonFlag, stdout, stderr)
+}
+
+func fetchDocCount(hash string, stderr io.Writer) (int64, bool) {
+	resp, statusCode, err := doRequest("GET", getBaseURL()+"/api/v1/workspaces", nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error fetching workspace info: %v\n", err)
+		return 0, false
+	}
+	if statusCode != 200 {
+		fmt.Fprintf(stderr, "Error: server returned status %d\n", statusCode)
+		return 0, false
+	}
+	var items []struct {
+		WorkspaceHash string `json:"workspace_hash"`
+		DocumentCount int64  `json:"document_count"`
+	}
+	if err := json.Unmarshal(resp, &items); err != nil {
+		return 0, true
+	}
+	for _, it := range items {
+		if it.WorkspaceHash == hash {
+			return it.DocumentCount, true
+		}
+	}
+	return 0, true
+}
+
+func workspaceRemoveDryRun(hash string, jsonFlag bool, stdout, stderr io.Writer) int {
+	docCount, ok := fetchDocCount(hash, stderr)
+	if !ok {
+		return 1
+	}
+	if jsonFlag {
+		out, _ := json.Marshal(map[string]interface{}{
+			"workspace":    hash,
+			"deleted_docs": docCount,
+			"dry_run":      true,
+		})
+		fmt.Fprintln(stdout, string(out))
+		return 0
+	}
+	fmt.Fprintf(stdout, "Dry run: workspace %s would be removed (%d document(s) deleted).\n", hash, docCount)
+	fmt.Fprintln(stdout, "No changes written.")
+	cliLog.Info().Str("cmd", "workspaces remove").Str("workspace", hash).Int64("doc_count", docCount).Bool("dry_run", true).Msg("cli command completed")
+	return 0
+}
+
+func workspaceRemoveExecute(hash string, jsonFlag bool, stdout, stderr io.Writer) int {
+	resp, statusCode, err := doRequest("DELETE", getBaseURL()+"/api/v1/workspaces/"+hash, nil)
+	if err != nil {
+		if statusCode == 404 {
+			fmt.Fprintf(stderr, "Error: workspace %s not found\n", hash)
+			return 1
+		}
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		cliLog.Error().Err(err).Str("cmd", "workspaces remove").Msg("remove request failed")
+		return 1
+	}
+
+	if jsonFlag {
+		fmt.Fprintln(stdout, string(resp))
+		cliLog.Info().Str("cmd", "workspaces remove").Str("workspace", hash).Msg("cli command completed")
+		return 0
+	}
+
+	var result struct {
+		Workspace    string `json:"workspace"`
+		DeletedDocs  int64  `json:"deleted_docs"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Fprintln(stdout, string(resp))
+		return 0
+	}
+	fmt.Fprintf(stdout, "Workspace %s removed. %d document(s) deleted.\n", result.Workspace, result.DeletedDocs)
+	cliLog.Info().Str("cmd", "workspaces remove").Str("workspace", hash).Int64("deleted_docs", result.DeletedDocs).Msg("cli command completed")
+	return 0
+}
+
+func printWorkspaceRemoveUsage(w io.Writer) {
+	fmt.Fprint(w, `Usage: nano-brain workspaces remove --workspace=<hash> [flags]
+       nano-brain workspaces remove --workspace-path=<path> [flags]
+
+Permanently remove a workspace and all its documents, chunks, and embeddings.
+
+Flags:
+  --workspace=<hash>     Workspace hash to remove
+  --workspace-path=<p>   Derive workspace hash from directory path
+  --force                Confirm deletion (required without --dry-run)
+  --dry-run              Show what would be deleted; make no changes
+  --json                 Output raw JSON response
+  -h, --help             Show this help
+`)
+}

--- a/cmd/nano-brain/cmd_workspace_remove.go
+++ b/cmd/nano-brain/cmd_workspace_remove.go
@@ -80,6 +80,11 @@ func runWorkspacesRemoveWithIO(args []string, stdout, stderr io.Writer) int {
 		printWorkspaceRemoveUsage(stderr)
 		return 2
 	}
+	if f.workspace != "" && f.workspacePath != "" {
+		fmt.Fprintln(stderr, "--workspace and --workspace-path are mutually exclusive")
+		printWorkspaceRemoveUsage(stderr)
+		return 2
+	}
 
 	hash := f.workspace
 	if f.workspacePath != "" {
@@ -122,7 +127,8 @@ func fetchDocCount(hash string, stderr io.Writer) (int64, bool) {
 		DocumentCount int64  `json:"document_count"`
 	}
 	if err := json.Unmarshal(resp, &items); err != nil {
-		return 0, true
+		fmt.Fprintf(stderr, "Error: could not parse workspaces list: %v\n", err)
+		return 0, false
 	}
 	for _, it := range items {
 		if it.WorkspaceHash == hash {
@@ -175,8 +181,10 @@ func workspaceRemoveExecute(hash string, jsonFlag bool, stdout, stderr io.Writer
 		DeletedDocs  int64  `json:"deleted_docs"`
 	}
 	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Fprintf(stderr, "Warning: server returned malformed JSON; printing raw response: %v\n", err)
 		fmt.Fprintln(stdout, string(resp))
-		return 0
+		cliLog.Warn().Err(err).Str("cmd", "workspaces remove").Str("workspace", hash).Msg("response unmarshal failed")
+		return 1
 	}
 	fmt.Fprintf(stdout, "Workspace %s removed. %d document(s) deleted.\n", result.Workspace, result.DeletedDocs)
 	cliLog.Info().Str("cmd", "workspaces remove").Str("workspace", hash).Int64("deleted_docs", result.DeletedDocs).Msg("cli command completed")

--- a/cmd/nano-brain/cmd_workspace_remove_test.go
+++ b/cmd/nano-brain/cmd_workspace_remove_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newRemoveServer(t *testing.T, hash string, respPayload interface{}, status int) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspaces":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"workspace_hash": hash, "document_count": 5},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/workspaces/"+hash:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(respPayload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestParseWorkspaceRemoveFlags_Basic(t *testing.T) {
+	f, errMsg := parseWorkspaceRemoveFlags([]string{"--workspace=abc123", "--force"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.workspace != "abc123" {
+		t.Errorf("workspace = %q, want abc123", f.workspace)
+	}
+	if !f.force {
+		t.Error("expected force=true")
+	}
+}
+
+func TestParseWorkspaceRemoveFlags_DryRun(t *testing.T) {
+	f, errMsg := parseWorkspaceRemoveFlags([]string{"--workspace=abc123", "--dry-run"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if !f.dryRun {
+		t.Error("expected dryRun=true")
+	}
+	if f.force {
+		t.Error("expected force=false")
+	}
+}
+
+func TestParseWorkspaceRemoveFlags_WorkspaceSplit(t *testing.T) {
+	f, errMsg := parseWorkspaceRemoveFlags([]string{"--workspace", "abc123"})
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if f.workspace != "abc123" {
+		t.Errorf("workspace = %q, want abc123", f.workspace)
+	}
+}
+
+func TestParseWorkspaceRemoveFlags_UnknownFlag(t *testing.T) {
+	_, errMsg := parseWorkspaceRemoveFlags([]string{"--workspace=abc", "--bad-flag"})
+	if errMsg == "" {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
+func TestParseWorkspaceRemoveFlags_Help(t *testing.T) {
+	_, errMsg := parseWorkspaceRemoveFlags([]string{"-h"})
+	if errMsg != "help" {
+		t.Errorf("expected errMsg=help, got %q", errMsg)
+	}
+}
+
+func TestWorkspaceRemoveCLI_MissingWorkspace(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := runWorkspacesRemoveWithIO(nil, &out, &errOut)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for missing workspace")
+	}
+	if !strings.Contains(errOut.String(), "--workspace") {
+		t.Errorf("expected usage hint in stderr; got %q", errOut.String())
+	}
+}
+
+func TestWorkspaceRemoveCLI_RefusesWithoutForce(t *testing.T) {
+	ts := newRemoveServer(t, "abc123", nil, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesRemoveWithIO([]string{"--workspace=abc123"}, &out, &errOut)
+	if code == 0 {
+		t.Fatal("expected non-zero exit without --force")
+	}
+	if !strings.Contains(errOut.String(), "--force") {
+		t.Errorf("expected --force hint in stderr; got %q", errOut.String())
+	}
+}
+
+func TestWorkspaceRemoveCLI_DryRun(t *testing.T) {
+	ts := newRemoveServer(t, "abc123", nil, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesRemoveWithIO([]string{"--workspace=abc123", "--dry-run"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0; stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "Dry run") {
+		t.Errorf("expected 'Dry run' in stdout; got %q", out.String())
+	}
+	if !strings.Contains(out.String(), "No changes written") {
+		t.Errorf("expected 'No changes written' in stdout; got %q", out.String())
+	}
+}
+
+func TestWorkspaceRemoveCLI_ForceSuccess(t *testing.T) {
+	payload := map[string]interface{}{
+		"workspace":         "abc123",
+		"deleted_docs":      float64(5),
+		"workspace_removed": true,
+	}
+	ts := newRemoveServer(t, "abc123", payload, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesRemoveWithIO([]string{"--workspace=abc123", "--force"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0; stderr=%q stderr=%q", code, errOut.String(), errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "abc123") {
+		t.Errorf("expected workspace hash in output; got %q", got)
+	}
+	if !strings.Contains(got, "removed") {
+		t.Errorf("expected 'removed' in output; got %q", got)
+	}
+}
+
+func TestWorkspaceRemoveCLI_ForceJSON(t *testing.T) {
+	payload := map[string]interface{}{
+		"workspace":         "abc123",
+		"deleted_docs":      float64(5),
+		"workspace_removed": true,
+	}
+	ts := newRemoveServer(t, "abc123", payload, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesRemoveWithIO([]string{"--workspace=abc123", "--force", "--json"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0; stderr=%q", code, errOut.String())
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimRight(out.String(), "\n")), &got); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, out.String())
+	}
+	if got["workspace"] != "abc123" {
+		t.Errorf("workspace = %v, want abc123", got["workspace"])
+	}
+}
+
+func TestWorkspaceRemoveCLI_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspaces":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		case r.Method == http.MethodDelete:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"workspace not found"}`))
+		}
+	}))
+	t.Cleanup(ts.Close)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesRemoveWithIO([]string{"--workspace=nonexistent", "--force"}, &out, &errOut)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for 404")
+	}
+}

--- a/cmd/nano-brain/workspaces.go
+++ b/cmd/nano-brain/workspaces.go
@@ -12,7 +12,7 @@ import (
 )
 
 func workspacesUsage() {
-	fmt.Fprintln(os.Stderr, "Usage: nano-brain workspaces [list|ls] [--json]")
+	fmt.Fprintln(os.Stderr, "Usage: nano-brain workspaces [list|ls|remove] [flags]")
 	os.Exit(1)
 }
 
@@ -24,6 +24,8 @@ func runWorkspacesCmd(args []string) {
 	switch args[0] {
 	case "list", "ls":
 		runWorkspacesList(args[1:])
+	case "remove", "rm":
+		runWorkspacesRemove(args[1:])
 	default:
 		workspacesUsage()
 	}

--- a/docs/evidence/self-review-feat-155-workspace-remove.md
+++ b/docs/evidence/self-review-feat-155-workspace-remove.md
@@ -1,0 +1,35 @@
+## Self-Review: feat/155-workspace-remove
+Date: 2026-05-30
+Reviewer: Sisyphus orchestrator
+
+## Findings
+| # | Severity | File | Description | Status |
+|---|----------|------|-------------|--------|
+| - | none | - | Mirrors existing ResetWorkspace destructive op pattern: explicit DeleteDocumentsByWorkspace before DeleteWorkspace (no FK cascade from docs → workspaces). | n/a |
+
+## E2E smoke (PG @ host.docker.internal:5432, env var configured)
+1. Created disposable workspace: `fe8b6d471fa2325f4d8f3efd90a6702497981af50f3404a836247f7b8e199bea`
+2. `workspaces remove --workspace=$WS --dry-run` → "would be removed (0 document(s) deleted). No changes written."
+3. `workspaces remove --workspace=$WS` (no --force) → "Refusing to remove ... Use --force to confirm deletion." (exit 2)
+4. `workspaces remove --workspace=$WS --force` → "Workspace ... removed. 0 document(s) deleted." (200 OK)
+5. `workspaces remove --workspace=$WS --force` again → "Error: workspace ... not found" (404)
+
+All 4 user paths verified working with real PG. INFO logs include workspace + doc count + dry-run flag.
+
+## Unit tests
+- 4 handler tests in workspace_remove_test.go: Success, NotFound, CascadeStats, MissingHash
+- 10 CLI tests in cmd_workspace_remove_test.go: parseWorkspaceRemoveFlags + runWorkspacesRemoveWithIO mock-server tests
+- Full suite: `go test -race -short ./...` → all 20 packages OK
+
+## Build
+- `CGO_ENABLED=0 go build ./...` → exit 0
+
+## Design notes
+- REST: `DELETE /api/v1/workspaces/:hash` (consistent with `DELETE /api/v1/collections/:name`)
+- CLI: `workspaces remove` subcommand (consistent with `workspaces list`); also accepts `rm` alias
+- Safety: refuses without --force OR --dry-run; --dry-run fetches doc count via existing list endpoint
+- Cascade: docs→chunks→embeddings via FK ON DELETE CASCADE; workspace→docs uses explicit DeleteDocumentsByWorkspace (no FK)
+
+## Summary
+- Critical: 0, Major: 0, Minor: 0
+- E2E end-to-end destructive flow verified

--- a/docs/evidence/self-review-feat-155-workspace-remove.md
+++ b/docs/evidence/self-review-feat-155-workspace-remove.md
@@ -33,3 +33,20 @@ All 4 user paths verified working with real PG. INFO logs include workspace + do
 ## Summary
 - Critical: 0, Major: 0, Minor: 0
 - E2E end-to-end destructive flow verified
+
+## Gemini PR #222 Review — Findings Addressed (2026-05-30)
+
+| # | Finding | Severity | Verdict | Fix |
+|---|---------|----------|---------|-----|
+| 1 | Sequential DeleteDocs + DeleteWorkspace not transactional → orphaned state on partial failure | Major | VALID | Wrapped in `db.BeginTx` + `tx.Commit`; rollback on either error. Falls back to non-tx path if `db == nil` (test injection). Server log includes `transactional: true/false` field. |
+| 2 | CLI silently proceeds on JSON unmarshal failure (stats lost) | Major | VALID | Both `fetchDocCount` and `workspaceRemoveExecute` now print a warning + return exit code 1 |
+| 3 | No validation when both `--workspace` and `--workspace-path` provided | Major | VALID | Added explicit `mutually exclusive` check after presence check; returns exit 2 |
+| 4 | CHANGELOG entry duplicated across historical release sections | Medium | VALID | Restored CHANGELOG from clean `origin/b-main` baseline and re-applied a single entry under `[Unreleased] ### Features` |
+
+## Note on ResetWorkspace
+`internal/server/handlers/reset_workspace.go` has the same non-transactional pattern. Out of scope for #155 (separate handler, separate endpoint). Should be filed as follow-up issue.
+
+## Re-verified E2E
+- Conflict flags `--workspace=abc --workspace-path=/tmp/x` → "mutually exclusive" error, exit 2
+- Full delete cycle with disposable workspace → server log shows `"transactional":true`
+- All 4 handler tests + 10 CLI tests still pass

--- a/internal/server/handlers/workspace_remove.go
+++ b/internal/server/handlers/workspace_remove.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type RemoveWorkspaceQuerier interface {
+	GetWorkspaceByHash(ctx context.Context, hash string) (sqlc.Workspace, error)
+	CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error)
+	DeleteDocumentsByWorkspace(ctx context.Context, workspaceHash string) error
+	DeleteWorkspace(ctx context.Context, hash string) error
+}
+
+type removeWorkspaceResponse struct {
+	Workspace    string `json:"workspace"`
+	DeletedDocs  int64  `json:"deleted_docs"`
+	WorkspaceRemoved bool `json:"workspace_removed"`
+}
+
+func RemoveWorkspace(q RemoveWorkspaceQuerier, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		hash := c.Param("hash")
+		if hash == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "workspace hash is required")
+		}
+
+		ctx := c.Request().Context()
+
+		if _, err := q.GetWorkspaceByHash(ctx, hash); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return echo.NewHTTPError(http.StatusNotFound, "workspace not found")
+			}
+			logger.Error().Err(err).Str("workspace", hash).Msg("get workspace failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to look up workspace")
+		}
+
+		docCount, err := q.CountDocumentsByWorkspace(ctx, hash)
+		if err != nil {
+			logger.Error().Err(err).Str("workspace", hash).Msg("count documents failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to count documents")
+		}
+
+		if err := q.DeleteDocumentsByWorkspace(ctx, hash); err != nil {
+			logger.Error().Err(err).Str("workspace", hash).Msg("delete documents failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
+		}
+
+		if err := q.DeleteWorkspace(ctx, hash); err != nil {
+			logger.Error().Err(err).Str("workspace", hash).Msg("delete workspace failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+		}
+
+		reqLog := LoggerFromCtx(c, logger)
+		reqLog.Info().
+			Str("workspace", hash).
+			Int64("deleted_docs", docCount).
+			Msg("workspace removed")
+
+		return c.JSON(http.StatusOK, removeWorkspaceResponse{
+			Workspace:    hash,
+			DeletedDocs:  docCount,
+			WorkspaceRemoved: true,
+		})
+	}
+}
+
+var _ RemoveWorkspaceQuerier = (*sqlc.Queries)(nil)

--- a/internal/server/handlers/workspace_remove.go
+++ b/internal/server/handlers/workspace_remove.go
@@ -18,13 +18,17 @@ type RemoveWorkspaceQuerier interface {
 	DeleteWorkspace(ctx context.Context, hash string) error
 }
 
-type removeWorkspaceResponse struct {
-	Workspace    string `json:"workspace"`
-	DeletedDocs  int64  `json:"deleted_docs"`
-	WorkspaceRemoved bool `json:"workspace_removed"`
+type removeWorkspaceTxBeginner interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 }
 
-func RemoveWorkspace(q RemoveWorkspaceQuerier, logger zerolog.Logger) echo.HandlerFunc {
+type removeWorkspaceResponse struct {
+	Workspace        string `json:"workspace"`
+	DeletedDocs      int64  `json:"deleted_docs"`
+	WorkspaceRemoved bool   `json:"workspace_removed"`
+}
+
+func RemoveWorkspace(q RemoveWorkspaceQuerier, db removeWorkspaceTxBeginner, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		hash := c.Param("hash")
 		if hash == "" {
@@ -47,25 +51,48 @@ func RemoveWorkspace(q RemoveWorkspaceQuerier, logger zerolog.Logger) echo.Handl
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to count documents")
 		}
 
-		if err := q.DeleteDocumentsByWorkspace(ctx, hash); err != nil {
-			logger.Error().Err(err).Str("workspace", hash).Msg("delete documents failed")
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
-		}
-
-		if err := q.DeleteWorkspace(ctx, hash); err != nil {
-			logger.Error().Err(err).Str("workspace", hash).Msg("delete workspace failed")
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+		if db == nil {
+			if err := q.DeleteDocumentsByWorkspace(ctx, hash); err != nil {
+				logger.Error().Err(err).Str("workspace", hash).Msg("delete documents failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
+			}
+			if err := q.DeleteWorkspace(ctx, hash); err != nil {
+				logger.Error().Err(err).Str("workspace", hash).Msg("delete workspace failed (docs already deleted)")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+			}
+		} else {
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				logger.Error().Err(err).Str("workspace", hash).Msg("begin transaction failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction")
+			}
+			txq := sqlc.New(tx)
+			if err := txq.DeleteDocumentsByWorkspace(ctx, hash); err != nil {
+				_ = tx.Rollback()
+				logger.Error().Err(err).Str("workspace", hash).Msg("delete documents failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
+			}
+			if err := txq.DeleteWorkspace(ctx, hash); err != nil {
+				_ = tx.Rollback()
+				logger.Error().Err(err).Str("workspace", hash).Msg("delete workspace failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+			}
+			if err := tx.Commit(); err != nil {
+				logger.Error().Err(err).Str("workspace", hash).Msg("commit transaction failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit transaction")
+			}
 		}
 
 		reqLog := LoggerFromCtx(c, logger)
 		reqLog.Info().
 			Str("workspace", hash).
 			Int64("deleted_docs", docCount).
+			Bool("transactional", db != nil).
 			Msg("workspace removed")
 
 		return c.JSON(http.StatusOK, removeWorkspaceResponse{
-			Workspace:    hash,
-			DeletedDocs:  docCount,
+			Workspace:        hash,
+			DeletedDocs:      docCount,
 			WorkspaceRemoved: true,
 		})
 	}

--- a/internal/server/handlers/workspace_remove_test.go
+++ b/internal/server/handlers/workspace_remove_test.go
@@ -1,0 +1,187 @@
+package handlers_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockRemoveQuerier struct {
+	getWorkspaceFn           func(ctx context.Context, hash string) (sqlc.Workspace, error)
+	countDocumentsFn         func(ctx context.Context, workspaceHash string) (int64, error)
+	deleteDocumentsFn        func(ctx context.Context, workspaceHash string) error
+	deleteWorkspaceFn        func(ctx context.Context, hash string) error
+}
+
+func (m *mockRemoveQuerier) GetWorkspaceByHash(ctx context.Context, hash string) (sqlc.Workspace, error) {
+	return m.getWorkspaceFn(ctx, hash)
+}
+
+func (m *mockRemoveQuerier) CountDocumentsByWorkspace(ctx context.Context, workspaceHash string) (int64, error) {
+	return m.countDocumentsFn(ctx, workspaceHash)
+}
+
+func (m *mockRemoveQuerier) DeleteDocumentsByWorkspace(ctx context.Context, workspaceHash string) error {
+	return m.deleteDocumentsFn(ctx, workspaceHash)
+}
+
+func (m *mockRemoveQuerier) DeleteWorkspace(ctx context.Context, hash string) error {
+	return m.deleteWorkspaceFn(ctx, hash)
+}
+
+func newDefaultRemoveQuerier() *mockRemoveQuerier {
+	return &mockRemoveQuerier{
+		getWorkspaceFn: func(_ context.Context, hash string) (sqlc.Workspace, error) {
+			return sqlc.Workspace{ID: uuid.New(), Hash: hash, Name: "test", Path: "/tmp/test", CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+		},
+		countDocumentsFn: func(_ context.Context, _ string) (int64, error) {
+			return 42, nil
+		},
+		deleteDocumentsFn: func(_ context.Context, _ string) error {
+			return nil
+		},
+		deleteWorkspaceFn: func(_ context.Context, _ string) error {
+			return nil
+		},
+	}
+}
+
+func TestWorkspaceRemove_Success(t *testing.T) {
+	q := newDefaultRemoveQuerier()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/workspaces/abc123", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("hash")
+	c.SetParamValues("abc123")
+
+	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp["workspace"] != "abc123" {
+		t.Errorf("expected workspace=abc123, got %v", resp["workspace"])
+	}
+	if resp["deleted_docs"] != float64(42) {
+		t.Errorf("expected deleted_docs=42, got %v", resp["deleted_docs"])
+	}
+	if resp["workspace_removed"] != true {
+		t.Errorf("expected workspace_removed=true, got %v", resp["workspace_removed"])
+	}
+}
+
+func TestWorkspaceRemove_NotFound(t *testing.T) {
+	q := newDefaultRemoveQuerier()
+	q.getWorkspaceFn = func(_ context.Context, _ string) (sqlc.Workspace, error) {
+		return sqlc.Workspace{}, sql.ErrNoRows
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/workspaces/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("hash")
+	c.SetParamValues("nonexistent")
+
+	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing workspace")
+	}
+
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", he.Code)
+	}
+}
+
+func TestWorkspaceRemove_CascadeStats(t *testing.T) {
+	var deletedDocs, deletedWorkspaces int
+
+	q := newDefaultRemoveQuerier()
+	q.countDocumentsFn = func(_ context.Context, _ string) (int64, error) {
+		return 7, nil
+	}
+	q.deleteDocumentsFn = func(_ context.Context, _ string) error {
+		deletedDocs++
+		return nil
+	}
+	q.deleteWorkspaceFn = func(_ context.Context, _ string) error {
+		deletedWorkspaces++
+		return nil
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/workspaces/ws1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("hash")
+	c.SetParamValues("ws1")
+
+	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if deletedDocs != 1 {
+		t.Errorf("expected DeleteDocumentsByWorkspace called once, got %d", deletedDocs)
+	}
+	if deletedWorkspaces != 1 {
+		t.Errorf("expected DeleteWorkspace called once, got %d", deletedWorkspaces)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["deleted_docs"] != float64(7) {
+		t.Errorf("expected deleted_docs=7, got %v", resp["deleted_docs"])
+	}
+}
+
+func TestWorkspaceRemove_MissingHash(t *testing.T) {
+	q := newDefaultRemoveQuerier()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/workspaces/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing hash")
+	}
+
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}

--- a/internal/server/handlers/workspace_remove_test.go
+++ b/internal/server/handlers/workspace_remove_test.go
@@ -66,7 +66,7 @@ func TestWorkspaceRemove_Success(t *testing.T) {
 	c.SetParamNames("hash")
 	c.SetParamValues("abc123")
 
-	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	h := handlers.RemoveWorkspace(q, nil, zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestWorkspaceRemove_NotFound(t *testing.T) {
 	c.SetParamNames("hash")
 	c.SetParamValues("nonexistent")
 
-	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	h := handlers.RemoveWorkspace(q, nil, zerolog.Nop())
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
@@ -142,7 +142,7 @@ func TestWorkspaceRemove_CascadeStats(t *testing.T) {
 	c.SetParamNames("hash")
 	c.SetParamValues("ws1")
 
-	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	h := handlers.RemoveWorkspace(q, nil, zerolog.Nop())
 	if err := h(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestWorkspaceRemove_MissingHash(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	h := handlers.RemoveWorkspace(q, zerolog.Nop())
+	h := handlers.RemoveWorkspace(q, nil, zerolog.Nop())
 	err := h(c)
 	if err == nil {
 		t.Fatal("expected error for missing hash")

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -25,7 +25,7 @@ func registerRoutes(s *Server) {
 	api := s.echo.Group("/api/v1", contentTypeMiddleware())
 	api.POST("/init", handlers.InitWorkspace(s.queries, s.db, s.watcher, s.currentConfig().Watcher, s.logger))
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
-	api.DELETE("/workspaces/:hash", handlers.RemoveWorkspace(s.queries, s.logger))
+	api.DELETE("/workspaces/:hash", handlers.RemoveWorkspace(s.queries, s.db, s.logger))
 	api.POST("/reset-workspace", handlers.ResetWorkspace(s.queries, s.logger))
 
 	var enqueuer handlers.ChunkEnqueuer

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -25,6 +25,7 @@ func registerRoutes(s *Server) {
 	api := s.echo.Group("/api/v1", contentTypeMiddleware())
 	api.POST("/init", handlers.InitWorkspace(s.queries, s.db, s.watcher, s.currentConfig().Watcher, s.logger))
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
+	api.DELETE("/workspaces/:hash", handlers.RemoveWorkspace(s.queries, s.logger))
 	api.POST("/reset-workspace", handlers.ResetWorkspace(s.queries, s.logger))
 
 	var enqueuer handlers.ChunkEnqueuer


### PR DESCRIPTION
Closes #155

## Summary
Destructive workspace deletion via CLI subcommand + REST endpoint. Cascades to all docs/chunks/embeddings. Explicit safety gates (--force required; --dry-run for preview).

## Usage
```
nano-brain workspaces remove --workspace=<hash>           # refuses without --force
nano-brain workspaces remove --workspace=<hash> --dry-run # preview
nano-brain workspaces remove --workspace=<hash> --force   # actually delete
nano-brain workspaces rm    --workspace-path=<path> --force
```

## REST
`DELETE /api/v1/workspaces/:hash` → 200 `{deleted_docs, workspace_removed}` or 404.

## Cascade strategy
- docs → chunks → embeddings: FK `ON DELETE CASCADE`
- workspaces → docs: **no FK** (schema choice), so handler explicitly calls `DeleteDocumentsByWorkspace` before `DeleteWorkspace` — mirrors `ResetWorkspace` pattern

## Verification
- `go build ./...` → pass
- `go test -race -short ./...` → 20 packages OK (4 handler + 10 CLI tests)
- **E2E against PG @ host.docker.internal:5432:**
  - Created disposable workspace → dry-run shows 0 docs → no-force refuses → --force deletes 200 OK → re-run returns 404

## Docs
- README CLI table: `workspaces list` + `workspaces remove` row
- README REST endpoints: `DELETE /api/v1/workspaces/:hash` row
- CHANGELOG `[Unreleased]` entry

Evidence: `docs/evidence/self-review-feat-155-workspace-remove.md`