### PR TITLE
fix: warn on missing NANO_BRAIN_CONFIG path and support env var

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"os/signal"
 	"syscall"
 	"time"
@@ -47,6 +48,13 @@ func main() {
 	flag.IntVar(&verbose, "v", 0, "verbosity: 0=info, 1=debug, 2=trace")
 	flag.IntVar(&verbose, "verbose", 0, "")
 	flag.Parse()
+	// Support NANO_BRAIN_CONFIG env var when --config flag is not set.
+	// Trim whitespace to avoid silent path mismatches.
+	if configPath == "" {
+		if envPath := os.Getenv("NANO_BRAIN_CONFIG"); envPath != "" {
+			configPath = strings.TrimSpace(envPath)
+		}
+	}
 
 	initCLILog(configPath)
 
@@ -185,11 +193,18 @@ func startServer(configPath string) {
 		os.Exit(1)
 	}
 
+	explicit := configPath != ""
 	if configPath == "" {
 		configPath = config.DefaultConfigPath()
 	}
 
-	cfg, err := config.Load(configPath)
+	var cfg *config.Config
+	var err error
+	if explicit {
+		cfg, err = config.LoadExplicit(configPath)
+	} else {
+		cfg, err = config.Load(configPath)
+	}
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,18 @@ type SummarizationConfig struct {
 // Config file path can be overridden via NANO_BRAIN_CONFIG env var.
 // If no file is provided, defaults are used and merged with env vars.
 func Load(configPath string) (*Config, error) {
+	return loadInternal(configPath, false)
+}
+
+// LoadExplicit loads configuration and returns an error if the config file
+// does not exist. Use this when the caller knows the path was explicitly set
+// (e.g., via --config flag or NANO_BRAIN_CONFIG env var) so that typos and
+// misconfigurations are never silent.
+func LoadExplicit(configPath string) (*Config, error) {
+	return loadInternal(configPath, true)
+}
+
+func loadInternal(configPath string, errorOnMissing bool) (*Config, error) {
 	k := koanf.New(".")
 
 	// Load defaults first
@@ -158,11 +170,14 @@ func Load(configPath string) (*Config, error) {
 			configPath = filepath.Join(home, configPath[1:])
 		}
 
-		// Only try to load if file exists
 		if _, err := os.Stat(configPath); err == nil {
 			if err := k.Load(file.Provider(configPath), yaml.Parser()); err != nil {
 				return nil, fmt.Errorf("failed to load config file %s: %w", configPath, err)
 			}
+		} else if errorOnMissing {
+			return nil, fmt.Errorf("config file not found: %s", configPath)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: config file %s not found, using defaults\n", configPath)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -575,3 +575,34 @@ func TestResolveFilterForPath_NoMatch(t *testing.T) {
 		t.Errorf("expected no extensions for unmatched path, got %v", exts)
 	}
 }
+
+func TestLoadExplicitErrorsOnMissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "nonexistent.yml")
+
+	_, err := LoadExplicit(configPath)
+	if err == nil {
+		t.Fatal("LoadExplicit() should fail when config file does not exist")
+	}
+	if !strings.Contains(err.Error(), "config file not found") {
+		t.Errorf("expected 'config file not found' error, got: %v", err)
+	}
+}
+
+func TestLoadExplicitSucceedsWithExistingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+
+	yaml := "server:\n  host: 0.0.0.0\n  port: 8080\n"
+	if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadExplicit(configPath)
+	if err != nil {
+		t.Fatalf("LoadExplicit() failed: %v", err)
+	}
+	if cfg.Server.Host != "0.0.0.0" {
+		t.Errorf("expected Server.Host=0.0.0.0, got %q", cfg.Server.Host)
+	}
+}


### PR DESCRIPTION
## Summary

When `NANO_BRAIN_CONFIG` points to a non-existent file, nano-brain silently falls back to defaults with exit code 0. A typo in the env var path is invisible to the operator. This PR fixes that.

## Changes

### 1. `NANO_BRAIN_CONFIG` env var support
The env var is now actually read in `main.go` (it was only mentioned in comments before). Whitespace is trimmed to avoid silent path mismatches.

### 2. `LoadExplicit()` — errors on missing file
New function for callers that know the path was explicitly set (via `--config` flag or `NANO_BRAIN_CONFIG` env var). Returns `config file not found: <path>` error.

### 3. `Load()` — warns on missing file
Now prints a warning to stderr when the config file doesn't exist, instead of silently continuing.

### 4. `startServer()` — uses appropriate loader
- Explicit path (flag or env var) → `LoadExplicit()` → errors on missing
- Default path → `Load()` → warns on missing (first-run scenario)

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `NANO_BRAIN_CONFIG=/tmp/typo.yml` | Silent defaults | **Error: config file not found** |
| `NANO_BRAIN_CONFIG=" /tmp/path "` | Silent defaults (whitespace) | **Error** (trimmed path) |
| `--config /tmp/typo.yml` | Silent defaults | **Error: config file not found** |
| No config, first run | Silent defaults | **Warning on stderr**, defaults used |
| Config exists | Works | Works (unchanged) |

## Testing
- Added `TestLoadExplicitErrorsOnMissingFile` — verifies error on missing file
- Added `TestLoadExplicitSucceedsWithExistingFile` — verifies success with valid file
- Existing `TestLoadDefaults` still passes (Load warns but succeeds)

Fixes #224