### PR TITLE
feat(cli): get, tags, multi-get commands (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Features
+- feat(cli): `get`, `tags`, `multi-get` commands — fetch a single document by source_path or UUID, list all tags with counts, and batch-fetch multiple documents in one round-trip; backed by `POST /api/v1/get`, `GET /api/v1/tags` (existing), and `POST /api/v1/multi-get` REST endpoints (#152)
 - feat(cli): `--tags=t1,t2,t3` filter on query/search/vsearch — filters results to docs whose tags overlap (PostgreSQL `&&` array op) with the given set; works in --workspace= or --scope=all mode (#160)
 - feat(cli): `workspaces remove --workspace=<hash>` — destructive workspace deletion with `--dry-run` preview and `--force` safety gate; backed by `DELETE /api/v1/workspaces/:hash` REST endpoint wrapped in a single transaction (#155)
 - feat(cli): wake-up command — pretty/JSON workspace briefing at session start (#151, PR #216)

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Workspace is passed in the JSON body for POST, query param for GET.
 | PUT | `/api/v1/collections/:name` | Rename collection |
 | DELETE | `/api/v1/collections/:name` | Remove collection |
 | GET | `/api/v1/tags` | List tags with counts |
+| POST | `/api/v1/get` | Get single document by source_path or id |
+| POST | `/api/v1/multi-get` | Batch fetch documents by paths or ids |
 | POST | `/api/v1/reindex` | Queue reindex (202) |
 | POST | `/api/v1/update` | Queue update (202) |
 | POST | `/api/v1/summarize` | Trigger LLM summarization of harvested sessions |
@@ -251,6 +253,9 @@ Workspace is passed in the JSON body for POST, query param for GET.
 | `nano-brain search [--scope=all] [--tags=t1,t2]` | BM25 keyword search |
 | `nano-brain vsearch [--scope=all] [--tags=t1,t2]` | Vector similarity search |
 | `nano-brain wake-up --workspace=<hash>` | Workspace briefing (collections, stats, recent memories) |
+| `nano-brain get <source_path\|uuid> --workspace=<hash>` | Fetch a single document by source_path or UUID |
+| `nano-brain tags --workspace=<hash>` | List all tags with document counts |
+| `nano-brain multi-get --workspace=<hash> --paths=p1,p2` | Fetch multiple documents in one round-trip |
 | `nano-brain collection add\|remove\|list` | Manage collections |
 | `nano-brain harvest` | Trigger session harvesting |
 | `nano-brain cleanup-stale-raw [--dry-run]` | Delete pre-#192 raw OpenCode session docs superseded by summaries |

--- a/cmd/nano-brain/cmd_get.go
+++ b/cmd/nano-brain/cmd_get.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/storage"
+)
+
+func runGetCmd(args []string) {
+	cliLog.Info().Str("cmd", "get").Msg("cli command started")
+
+	var workspaceHash, workspacePath string
+	var byID bool
+	var jsonFlag bool
+	var target string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			printGetUsage()
+			return
+		case strings.HasPrefix(arg, "--workspace="):
+			workspaceHash = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspaceHash = args[i]
+		case strings.HasPrefix(arg, "--workspace-path="):
+			workspacePath = strings.TrimPrefix(arg, "--workspace-path=")
+		case arg == "--workspace-path":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace-path requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspacePath = args[i]
+		case arg == "--by-id":
+			byID = true
+		case arg == "--json":
+			jsonFlag = true
+		case strings.HasPrefix(arg, "--"):
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n\n", arg)
+			printGetUsage()
+			os.Exit(2)
+		default:
+			if target == "" {
+				target = arg
+			} else {
+				fmt.Fprintf(os.Stderr, "unexpected argument: %s\n\n", arg)
+				printGetUsage()
+				os.Exit(2)
+			}
+		}
+	}
+
+	if target == "" {
+		fmt.Fprintf(os.Stderr, "source_path or id argument is required\n\n")
+		printGetUsage()
+		os.Exit(2)
+	}
+	if workspaceHash == "" && workspacePath == "" {
+		fmt.Fprintf(os.Stderr, "must specify --workspace=<hash> or --workspace-path=<path>\n\n")
+		printGetUsage()
+		os.Exit(2)
+	}
+
+	if workspacePath != "" {
+		h, err := storage.WorkspaceHash(workspacePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: could not derive workspace hash from path %q: %v\n", workspacePath, err)
+			os.Exit(1)
+		}
+		workspaceHash = h
+	}
+
+	reqBody := map[string]interface{}{
+		"workspace": workspaceHash,
+	}
+	if byID {
+		reqBody["id"] = target
+	} else {
+		reqBody["path"] = target
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	resp, _, reqErr := doRequest("POST", getBaseURL()+"/api/v1/get", bytes.NewReader(data))
+	if reqErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", reqErr)
+		cliLog.Error().Err(reqErr).Str("cmd", "get").Msg("request failed")
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "get").Msg("cli command completed")
+		return
+	}
+
+	var result getDocResult
+	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "get").Msg("cli command completed")
+		return
+	}
+
+	printGetResult(result)
+	cliLog.Info().Str("cmd", "get").Str("id", result.ID).Msg("cli command completed")
+}
+
+type getDocResult struct {
+	ID            string   `json:"id"`
+	Title         string   `json:"title"`
+	Content       string   `json:"content"`
+	SourcePath    string   `json:"source_path"`
+	Collection    string   `json:"collection"`
+	Tags          []string `json:"tags"`
+	WorkspaceHash string   `json:"workspace_hash"`
+	SupersedesID  string   `json:"supersedes_id,omitempty"`
+	CreatedAt     string   `json:"created_at"`
+	UpdatedAt     string   `json:"updated_at"`
+}
+
+func printGetResult(r getDocResult) {
+	fmt.Printf("ID:         %s\n", r.ID)
+	if r.Title != "" {
+		fmt.Printf("Title:      %s\n", r.Title)
+	}
+	fmt.Printf("Path:       %s\n", r.SourcePath)
+	fmt.Printf("Collection: %s\n", r.Collection)
+	if len(r.Tags) > 0 {
+		fmt.Printf("Tags:       %s\n", strings.Join(r.Tags, ", "))
+	}
+	fmt.Printf("Updated:    %s\n", r.UpdatedAt)
+	fmt.Println()
+	fmt.Println(r.Content)
+}
+
+func printGetUsage() {
+	fmt.Print(`Usage: nano-brain get <source_path> --workspace=<hash> [flags]
+       nano-brain get <uuid>       --workspace=<hash> --by-id [flags]
+
+Fetch a single document by source_path or ID.
+
+Arguments:
+  <source_path>          Document source_path (e.g., memory://decision.md)
+  <uuid>                 Document UUID (requires --by-id)
+
+Flags:
+  --workspace=<hash>     Workspace hash (required if --workspace-path not given)
+  --workspace-path=<p>   Derive workspace hash from directory path
+  --by-id                Treat the positional argument as a document UUID
+  --json                 Output raw JSON response
+  -h, --help             Show this help
+`)
+}

--- a/cmd/nano-brain/cmd_get_test.go
+++ b/cmd/nano-brain/cmd_get_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sampleGetDocResponse() []byte {
+	r := getDocResult{
+		ID:            "11111111-1111-1111-1111-111111111111",
+		Title:         "Decision: use PostgreSQL",
+		Content:       "We chose PostgreSQL for pgvector.",
+		SourcePath:    "memory://decision.md",
+		Collection:    "memory",
+		Tags:          []string{"decision", "architecture"},
+		WorkspaceHash: "ws-abc",
+		CreatedAt:     "2026-05-01T00:00:00Z",
+		UpdatedAt:     "2026-05-30T10:00:00Z",
+	}
+	data, _ := json.Marshal(r)
+	return data
+}
+
+func startGetTestServer(t *testing.T, statusCode int, respBody []byte) (*httptest.Server, *[]byte) {
+	t.Helper()
+	captured := &[]byte{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/get" {
+			t.Errorf("expected path /api/v1/get, got %s", r.URL.Path)
+		}
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r.Body)
+		*captured = buf.Bytes()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(respBody)
+	}))
+	return ts, captured
+}
+
+func TestRunGetCmd_BySourcePath(t *testing.T) {
+	ts, captured := startGetTestServer(t, http.StatusOK, sampleGetDocResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	reqBody := map[string]interface{}{
+		"workspace": "ws-abc",
+		"path":      "memory://decision.md",
+	}
+	data, _ := json.Marshal(reqBody)
+	resp, statusCode, err := doRequest("POST", ts.URL+"/api/v1/get", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(*captured, &body); err != nil {
+		t.Fatalf("could not parse captured body: %v", err)
+	}
+	if body["workspace"] != "ws-abc" {
+		t.Errorf("workspace = %v, want ws-abc", body["workspace"])
+	}
+	if body["path"] != "memory://decision.md" {
+		t.Errorf("path = %v, want memory://decision.md", body["path"])
+	}
+
+	var result getDocResult
+	if err := json.Unmarshal(resp, &result); err != nil {
+		t.Fatalf("could not parse response: %v", err)
+	}
+	if result.ID != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("id = %q, want 11111111-1111-1111-1111-111111111111", result.ID)
+	}
+	if result.SourcePath != "memory://decision.md" {
+		t.Errorf("source_path = %q, want memory://decision.md", result.SourcePath)
+	}
+}
+
+func TestRunGetCmd_ByID(t *testing.T) {
+	ts, captured := startGetTestServer(t, http.StatusOK, sampleGetDocResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	docID := "11111111-1111-1111-1111-111111111111"
+	reqBody := map[string]interface{}{
+		"workspace": "ws-abc",
+		"id":        docID,
+	}
+	data, _ := json.Marshal(reqBody)
+	_, statusCode, err := doRequest("POST", ts.URL+"/api/v1/get", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(*captured, &body); err != nil {
+		t.Fatalf("could not parse captured body: %v", err)
+	}
+	if body["id"] != docID {
+		t.Errorf("id = %v, want %s", body["id"], docID)
+	}
+}
+
+func TestRunGetCmd_NotFound(t *testing.T) {
+	errResp := []byte(`{"message":"document not found"}`)
+	ts, _ := startGetTestServer(t, http.StatusNotFound, errResp)
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	data, _ := json.Marshal(map[string]interface{}{"workspace": "ws-abc", "path": "missing"})
+	_, statusCode, err := doRequest("POST", ts.URL+"/api/v1/get", bytes.NewReader(data))
+	if err == nil {
+		t.Fatal("expected error for 404 response, got nil")
+	}
+	if statusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", statusCode)
+	}
+	if !strings.Contains(err.Error(), "server returned 404") {
+		t.Errorf("error = %q, want it to contain 'server returned 404'", err.Error())
+	}
+}
+
+func TestPrintGetResult(t *testing.T) {
+	r := getDocResult{
+		ID:         "uuid-1",
+		Title:      "My Doc",
+		Content:    "Some content here",
+		SourcePath: "memory://doc.md",
+		Collection: "memory",
+		Tags:       []string{"tag1"},
+		UpdatedAt:  "2026-05-30T10:00:00Z",
+	}
+	printGetResult(r)
+}
+
+func TestPrintGetResult_NoTitle(t *testing.T) {
+	r := getDocResult{
+		ID:         "uuid-1",
+		Content:    "content",
+		SourcePath: "memory://doc.md",
+		Collection: "memory",
+		Tags:       []string{},
+		UpdatedAt:  "2026-05-30T10:00:00Z",
+	}
+	printGetResult(r)
+}

--- a/cmd/nano-brain/cmd_multi_get.go
+++ b/cmd/nano-brain/cmd_multi_get.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/storage"
+)
+
+func runMultiGetCmd(args []string) {
+	cliLog.Info().Str("cmd", "multi-get").Msg("cli command started")
+
+	var workspaceHash, workspacePath string
+	var rawPaths, rawIDs string
+	var jsonFlag bool
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			printMultiGetUsage()
+			return
+		case strings.HasPrefix(arg, "--workspace="):
+			workspaceHash = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspaceHash = args[i]
+		case strings.HasPrefix(arg, "--workspace-path="):
+			workspacePath = strings.TrimPrefix(arg, "--workspace-path=")
+		case arg == "--workspace-path":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace-path requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspacePath = args[i]
+		case strings.HasPrefix(arg, "--paths="):
+			rawPaths = strings.TrimPrefix(arg, "--paths=")
+		case arg == "--paths":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--paths requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			rawPaths = args[i]
+		case strings.HasPrefix(arg, "--ids="):
+			rawIDs = strings.TrimPrefix(arg, "--ids=")
+		case arg == "--ids":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--ids requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			rawIDs = args[i]
+		case arg == "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n\n", arg)
+			printMultiGetUsage()
+			os.Exit(2)
+		}
+	}
+
+	if workspaceHash == "" && workspacePath == "" {
+		fmt.Fprintf(os.Stderr, "must specify --workspace=<hash> or --workspace-path=<path>\n\n")
+		printMultiGetUsage()
+		os.Exit(2)
+	}
+	if rawPaths == "" && rawIDs == "" {
+		fmt.Fprintf(os.Stderr, "must specify --paths=<p1,p2,...> or --ids=<id1,id2,...>\n\n")
+		printMultiGetUsage()
+		os.Exit(2)
+	}
+
+	if workspacePath != "" {
+		h, err := storage.WorkspaceHash(workspacePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: could not derive workspace hash from path %q: %v\n", workspacePath, err)
+			os.Exit(1)
+		}
+		workspaceHash = h
+	}
+
+	reqBody := map[string]interface{}{
+		"workspace": workspaceHash,
+	}
+	if rawPaths != "" {
+		reqBody["paths"] = splitCSV(rawPaths)
+	}
+	if rawIDs != "" {
+		reqBody["ids"] = splitCSV(rawIDs)
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	resp, _, reqErr := doRequest("POST", getBaseURL()+"/api/v1/multi-get", bytes.NewReader(data))
+	if reqErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", reqErr)
+		cliLog.Error().Err(reqErr).Str("cmd", "multi-get").Msg("request failed")
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "multi-get").Msg("cli command completed")
+		return
+	}
+
+	var result multiGetResult
+	if err := json.Unmarshal(resp, &result); err != nil {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "multi-get").Msg("cli command completed")
+		return
+	}
+
+	printMultiGetResult(result)
+	cliLog.Info().Str("cmd", "multi-get").
+		Int("found", len(result.Results)).
+		Int("not_found", len(result.NotFound)).
+		Msg("cli command completed")
+}
+
+type multiGetResult struct {
+	Results  []getDocResult `json:"results"`
+	NotFound []string       `json:"not_found"`
+}
+
+func printMultiGetResult(r multiGetResult) {
+	for i, doc := range r.Results {
+		if i > 0 {
+			fmt.Println("---")
+		}
+		printGetResult(doc)
+	}
+	if len(r.NotFound) > 0 {
+		fmt.Printf("\nNot found (%d): %s\n", len(r.NotFound), strings.Join(r.NotFound, ", "))
+	}
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func printMultiGetUsage() {
+	fmt.Print(`Usage: nano-brain multi-get --workspace=<hash> --paths=<p1,p2,...> [flags]
+       nano-brain multi-get --workspace=<hash> --ids=<id1,id2,...>   [flags]
+
+Fetch multiple documents in one round-trip.
+
+Flags:
+  --workspace=<hash>     Workspace hash (required if --workspace-path not given)
+  --workspace-path=<p>   Derive workspace hash from directory path
+  --paths=<p1,p2,...>    Comma-separated source_paths to fetch
+  --ids=<id1,id2,...>    Comma-separated UUIDs to fetch
+  --json                 Output raw JSON response
+  -h, --help             Show this help
+`)
+}

--- a/cmd/nano-brain/cmd_multi_get_test.go
+++ b/cmd/nano-brain/cmd_multi_get_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sampleMultiGetResponse() []byte {
+	r := multiGetResult{
+		Results: []getDocResult{
+			{
+				ID:         "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				Title:      "Doc A",
+				Content:    "Content A",
+				SourcePath: "memory://a.md",
+				Collection: "memory",
+				Tags:       []string{"tag1"},
+				UpdatedAt:  "2026-05-30T10:00:00Z",
+			},
+			{
+				ID:         "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+				Title:      "Doc B",
+				Content:    "Content B",
+				SourcePath: "memory://b.md",
+				Collection: "memory",
+				Tags:       []string{},
+				UpdatedAt:  "2026-05-29T10:00:00Z",
+			},
+		},
+		NotFound: []string{"memory://missing.md"},
+	}
+	data, _ := json.Marshal(r)
+	return data
+}
+
+func startMultiGetTestServer(t *testing.T, statusCode int, respBody []byte) (*httptest.Server, *[]byte) {
+	t.Helper()
+	captured := &[]byte{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/multi-get" {
+			t.Errorf("expected path /api/v1/multi-get, got %s", r.URL.Path)
+		}
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r.Body)
+		*captured = buf.Bytes()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(respBody)
+	}))
+	return ts, captured
+}
+
+func TestRunMultiGetCmd_PathsPassedInBody(t *testing.T) {
+	ts, captured := startMultiGetTestServer(t, http.StatusOK, sampleMultiGetResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	reqBody := map[string]interface{}{
+		"workspace": "ws-abc",
+		"paths":     []string{"memory://a.md", "memory://b.md", "memory://missing.md"},
+	}
+	data, _ := json.Marshal(reqBody)
+	resp, statusCode, err := doRequest("POST", ts.URL+"/api/v1/multi-get", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(*captured, &body); err != nil {
+		t.Fatalf("could not parse captured body: %v", err)
+	}
+	if body["workspace"] != "ws-abc" {
+		t.Errorf("workspace = %v, want ws-abc", body["workspace"])
+	}
+	paths, ok := body["paths"].([]interface{})
+	if !ok {
+		t.Fatalf("paths not a slice: %T", body["paths"])
+	}
+	if len(paths) != 3 {
+		t.Errorf("paths len = %d, want 3", len(paths))
+	}
+
+	var result multiGetResult
+	if err := json.Unmarshal(resp, &result); err != nil {
+		t.Fatalf("could not parse response: %v", err)
+	}
+	if len(result.Results) != 2 {
+		t.Errorf("results len = %d, want 2", len(result.Results))
+	}
+	if len(result.NotFound) != 1 {
+		t.Errorf("not_found len = %d, want 1", len(result.NotFound))
+	}
+	if result.NotFound[0] != "memory://missing.md" {
+		t.Errorf("not_found[0] = %q, want memory://missing.md", result.NotFound[0])
+	}
+}
+
+func TestRunMultiGetCmd_IDsPassedInBody(t *testing.T) {
+	ts, captured := startMultiGetTestServer(t, http.StatusOK, sampleMultiGetResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	ids := []string{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}
+	reqBody := map[string]interface{}{
+		"workspace": "ws-abc",
+		"ids":       ids,
+	}
+	data, _ := json.Marshal(reqBody)
+	_, statusCode, err := doRequest("POST", ts.URL+"/api/v1/multi-get", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(*captured, &body); err != nil {
+		t.Fatalf("could not parse captured body: %v", err)
+	}
+	bodyIDs, ok := body["ids"].([]interface{})
+	if !ok {
+		t.Fatalf("ids not a slice: %T", body["ids"])
+	}
+	if len(bodyIDs) != 2 {
+		t.Errorf("ids len = %d, want 2", len(bodyIDs))
+	}
+}
+
+func TestRunMultiGetCmd_ServerError(t *testing.T) {
+	errResp := []byte(`{"message":"workspace not found"}`)
+	ts, _ := startMultiGetTestServer(t, http.StatusBadRequest, errResp)
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	data, _ := json.Marshal(map[string]interface{}{"workspace": "bad", "paths": []string{"x"}})
+	_, statusCode, err := doRequest("POST", ts.URL+"/api/v1/multi-get", bytes.NewReader(data))
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", statusCode)
+	}
+	if !strings.Contains(err.Error(), "server returned 400") {
+		t.Errorf("error = %q, want it to contain 'server returned 400'", err.Error())
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a , b ", []string{"a", "b"}},
+		{"single", []string{"single"}},
+		{"a,,b", []string{"a", "b"}},
+		{"", []string{}},
+	}
+	for _, tt := range tests {
+		got := splitCSV(tt.input)
+		if len(got) != len(tt.expected) {
+			t.Errorf("splitCSV(%q) len = %d, want %d", tt.input, len(got), len(tt.expected))
+			continue
+		}
+		for i, v := range got {
+			if v != tt.expected[i] {
+				t.Errorf("splitCSV(%q)[%d] = %q, want %q", tt.input, i, v, tt.expected[i])
+			}
+		}
+	}
+}
+
+func TestPrintMultiGetResult(t *testing.T) {
+	r := multiGetResult{
+		Results: []getDocResult{
+			{ID: "a", Content: "c1", SourcePath: "p1", Collection: "memory", Tags: []string{}, UpdatedAt: "2026-05-30"},
+			{ID: "b", Content: "c2", SourcePath: "p2", Collection: "memory", Tags: []string{}, UpdatedAt: "2026-05-29"},
+		},
+		NotFound: []string{"p3"},
+	}
+	printMultiGetResult(r)
+}

--- a/cmd/nano-brain/cmd_tags.go
+++ b/cmd/nano-brain/cmd_tags.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/storage"
+)
+
+func runTagsCmd(args []string) {
+	cliLog.Info().Str("cmd", "tags").Msg("cli command started")
+
+	var workspaceHash, workspacePath string
+	var jsonFlag bool
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help":
+			printTagsUsage()
+			return
+		case strings.HasPrefix(arg, "--workspace="):
+			workspaceHash = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--workspace":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspaceHash = args[i]
+		case strings.HasPrefix(arg, "--workspace-path="):
+			workspacePath = strings.TrimPrefix(arg, "--workspace-path=")
+		case arg == "--workspace-path":
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "--workspace-path requires a value\n")
+				os.Exit(2)
+			}
+			i++
+			workspacePath = args[i]
+		case arg == "--json":
+			jsonFlag = true
+		default:
+			fmt.Fprintf(os.Stderr, "unknown flag: %s\n\n", arg)
+			printTagsUsage()
+			os.Exit(2)
+		}
+	}
+
+	if workspaceHash == "" && workspacePath == "" {
+		fmt.Fprintf(os.Stderr, "must specify --workspace=<hash> or --workspace-path=<path>\n\n")
+		printTagsUsage()
+		os.Exit(2)
+	}
+
+	if workspacePath != "" {
+		h, err := storage.WorkspaceHash(workspacePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: could not derive workspace hash from path %q: %v\n", workspacePath, err)
+			os.Exit(1)
+		}
+		workspaceHash = h
+	}
+
+	u := getBaseURL() + "/api/v1/tags?workspace=" + url.QueryEscape(workspaceHash)
+	resp, _, reqErr := doRequest("GET", u, nil)
+	if reqErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", reqErr)
+		cliLog.Error().Err(reqErr).Str("cmd", "tags").Msg("request failed")
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "tags").Msg("cli command completed")
+		return
+	}
+
+	var items []tagItem
+	if err := json.Unmarshal(resp, &items); err != nil {
+		fmt.Println(string(resp))
+		cliLog.Info().Str("cmd", "tags").Msg("cli command completed")
+		return
+	}
+
+	if len(items) == 0 {
+		fmt.Println("(no tags)")
+		cliLog.Info().Str("cmd", "tags").Msg("cli command completed")
+		return
+	}
+
+	for _, t := range items {
+		fmt.Printf("%-30s  %d\n", t.Tag, t.Count)
+	}
+	cliLog.Info().Str("cmd", "tags").Int("count", len(items)).Msg("cli command completed")
+}
+
+type tagItem struct {
+	Tag   string `json:"tag"`
+	Count int64  `json:"count"`
+}
+
+func printTagsUsage() {
+	fmt.Print(`Usage: nano-brain tags --workspace=<hash> [flags]
+
+List all tags in the workspace with their document counts.
+
+Flags:
+  --workspace=<hash>     Workspace hash (required if --workspace-path not given)
+  --workspace-path=<p>   Derive workspace hash from directory path
+  --json                 Output raw JSON response
+  -h, --help             Show this help
+`)
+}

--- a/cmd/nano-brain/cmd_tags_test.go
+++ b/cmd/nano-brain/cmd_tags_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sampleTagsResponse() []byte {
+	items := []tagItem{
+		{Tag: "decision", Count: 5},
+		{Tag: "architecture", Count: 3},
+		{Tag: "bug", Count: 1},
+	}
+	data, _ := json.Marshal(items)
+	return data
+}
+
+func startTagsTestServer(t *testing.T, statusCode int, respBody []byte) (*httptest.Server, *string) {
+	t.Helper()
+	capturedWS := new(string)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/tags" {
+			t.Errorf("expected path /api/v1/tags, got %s", r.URL.Path)
+		}
+		*capturedWS = r.URL.Query().Get("workspace")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(respBody)
+	}))
+	return ts, capturedWS
+}
+
+func TestRunTagsCmd_WorkspacePassedAsQueryParam(t *testing.T) {
+	ts, capturedWS := startTagsTestServer(t, http.StatusOK, sampleTagsResponse())
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	resp, statusCode, err := doRequest("GET", ts.URL+"/api/v1/tags?workspace=ws-abc", nil)
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+	if *capturedWS != "ws-abc" {
+		t.Errorf("workspace query param = %q, want ws-abc", *capturedWS)
+	}
+
+	var items []tagItem
+	if err := json.Unmarshal(resp, &items); err != nil {
+		t.Fatalf("could not parse response: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 tags, got %d", len(items))
+	}
+	if items[0].Tag != "decision" || items[0].Count != 5 {
+		t.Errorf("unexpected first tag: %+v", items[0])
+	}
+}
+
+func TestRunTagsCmd_EmptyResponse(t *testing.T) {
+	ts, _ := startTagsTestServer(t, http.StatusOK, []byte("[]"))
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	resp, statusCode, err := doRequest("GET", ts.URL+"/api/v1/tags?workspace=ws-empty", nil)
+	if err != nil {
+		t.Fatalf("doRequest error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", statusCode)
+	}
+
+	var items []tagItem
+	if err := json.Unmarshal(resp, &items); err != nil {
+		t.Fatalf("could not parse response: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 tags, got %d", len(items))
+	}
+}
+
+func TestRunTagsCmd_ServerError(t *testing.T) {
+	errResp := []byte(`{"message":"workspace not found"}`)
+	ts, _ := startTagsTestServer(t, http.StatusBadRequest, errResp)
+	defer ts.Close()
+	pointClientAt(t, ts)
+
+	_, statusCode, err := doRequest("GET", ts.URL+"/api/v1/tags?workspace=bad", nil)
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", statusCode)
+	}
+	if !strings.Contains(err.Error(), "server returned 400") {
+		t.Errorf("error = %q, want it to contain 'server returned 400'", err.Error())
+	}
+}

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -125,6 +125,15 @@ func main() {
 		case "wake-up":
 			runWakeUpCmd(args[1:])
 			return
+		case "get":
+			runGetCmd(args[1:])
+			return
+		case "tags":
+			runTagsCmd(args[1:])
+			return
+		case "multi-get":
+			runMultiGetCmd(args[1:])
+			return
 		case "version":
 			runVersionCmd(args[1:])
 			return

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -567,6 +567,9 @@ Commands:
    harvest            Trigger session harvesting
    reindex            Queue collection reindex
    wake-up            Workspace briefing (recent memories, collections, stats)
+   get                Fetch a single document by source_path or ID
+   tags               List all tags with counts
+   multi-get          Fetch multiple documents in one round-trip
    logs               View log file (-f to follow, -n <count>)
   docker             Manage Docker Compose (start/stop/status)
   db:migrate         Run database migrations

--- a/docs/evidence/self-review-feat-152-get-tags-multiget.md
+++ b/docs/evidence/self-review-feat-152-get-tags-multiget.md
@@ -1,0 +1,32 @@
+## Self-Review: feat/152-get-tags-multiget
+Date: 2026-05-30
+Reviewer: Sisyphus orchestrator
+
+## E2E (PG @ host.docker.internal:5432, 13 workspaces, 8+ tags)
+- `nano-brain tags --workspace=<hash>` → pretty: `tag\tcount` aligned; JSON returns array
+- `nano-brain get <path> --workspace=<hash>` → ID/Title/Path/Collection/Updated + content body
+- `nano-brain get <path> --workspace=<hash> --json` → full document JSON
+- `nano-brain get /nonexistent --workspace=<hash>` → "server returned 404: document not found" (exit non-zero)
+- `nano-brain multi-get --workspace=<hash> --paths=p1,p2,/missing` → `{results:[...], not_found:["/missing"]}` correctly
+
+## New endpoints
+- POST /api/v1/get — body `{workspace, path?, id?}` → single document or 404
+- POST /api/v1/multi-get — body `{workspace, paths:[]}` or `{workspace, ids:[]}` → `{results, not_found}` (sequential lookup, no parallelism v1)
+
+## Existing endpoints reused
+- GET /api/v1/tags — already exists (just wrapped CLI)
+
+## Tests
+- 22 new unit tests across 3 cmd_*_test.go + 2 handler_*_test.go files
+- Full suite: `go test -race -short ./...` → 20 packages OK
+
+## Build
+- `CGO_ENABLED=0 go build ./...` → exit 0
+
+## Docs
+- README CLI table: 3 new rows (`get`, `tags`, `multi-get`)
+- CHANGELOG `[Unreleased] ### Features`: single combined entry
+
+## Summary
+- Critical: 0, Major: 0, Minor: 0
+- E2E end-to-end verified for all 3 commands incl. 404 path + not_found array

--- a/internal/server/handlers/get_document.go
+++ b/internal/server/handlers/get_document.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type GetDocumentQuerier interface {
+	GetDocumentByID(ctx context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error)
+	GetDocumentBySourcePath(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error)
+}
+
+type getDocumentRequest struct {
+	Path string `json:"path"`
+	ID   string `json:"id"`
+}
+
+type getDocumentResponse struct {
+	ID            string   `json:"id"`
+	Title         string   `json:"title"`
+	Content       string   `json:"content"`
+	SourcePath    string   `json:"source_path"`
+	Collection    string   `json:"collection"`
+	Tags          []string `json:"tags"`
+	WorkspaceHash string   `json:"workspace_hash"`
+	SupersedesID  string   `json:"supersedes_id,omitempty"`
+	CreatedAt     string   `json:"created_at"`
+	UpdatedAt     string   `json:"updated_at"`
+}
+
+func GetDocument(q GetDocumentQuerier, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		workspace := c.Get("workspace").(string)
+
+		var req getDocumentRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+
+		lookupPath := strings.TrimSpace(req.Path)
+		lookupID := strings.TrimSpace(req.ID)
+
+		if lookupPath == "" && lookupID == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "path or id is required")
+		}
+
+		var doc sqlc.Document
+		var err error
+
+		switch {
+		case strings.HasPrefix(lookupPath, "#"):
+			parsed, parseErr := uuid.Parse(strings.TrimPrefix(lookupPath, "#"))
+			if parseErr != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid document ID in path")
+			}
+			doc, err = q.GetDocumentByID(c.Request().Context(), sqlc.GetDocumentByIDParams{
+				ID:            parsed,
+				WorkspaceHash: workspace,
+			})
+		case lookupPath != "":
+			doc, err = q.GetDocumentBySourcePath(c.Request().Context(), sqlc.GetDocumentBySourcePathParams{
+				SourcePath:    lookupPath,
+				WorkspaceHash: workspace,
+			})
+		default:
+			parsed, parseErr := uuid.Parse(lookupID)
+			if parseErr != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid document id")
+			}
+			doc, err = q.GetDocumentByID(c.Request().Context(), sqlc.GetDocumentByIDParams{
+				ID:            parsed,
+				WorkspaceHash: workspace,
+			})
+		}
+
+		if err != nil {
+			if isNotFound(err) {
+				return echo.NewHTTPError(http.StatusNotFound, "document not found")
+			}
+			logger.Error().Err(err).Str("workspace", workspace).Msg("get document failed")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get document")
+		}
+
+		supersedes := ""
+		if doc.SupersedesID.Valid {
+			supersedes = doc.SupersedesID.UUID.String()
+		}
+
+		tags := doc.Tags
+		if tags == nil {
+			tags = []string{}
+		}
+
+		return c.JSON(http.StatusOK, getDocumentResponse{
+			ID:            doc.ID.String(),
+			Title:         doc.Title,
+			Content:       doc.Content,
+			SourcePath:    doc.SourcePath,
+			Collection:    doc.Collection,
+			Tags:          tags,
+			WorkspaceHash: doc.WorkspaceHash,
+			SupersedesID:  supersedes,
+			CreatedAt:     doc.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:     doc.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+}
+
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, sql.ErrNoRows)
+}

--- a/internal/server/handlers/get_document_test.go
+++ b/internal/server/handlers/get_document_test.go
@@ -1,0 +1,199 @@
+package handlers_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+	"github.com/sqlc-dev/pqtype"
+)
+
+type mockGetDocQuerier struct {
+	getByID         func(ctx context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error)
+	getBySourcePath func(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error)
+}
+
+func (m *mockGetDocQuerier) GetDocumentByID(ctx context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error) {
+	return m.getByID(ctx, arg)
+}
+
+func (m *mockGetDocQuerier) GetDocumentBySourcePath(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+	return m.getBySourcePath(ctx, arg)
+}
+
+func sampleDoc(id uuid.UUID, sourcePath string) sqlc.Document {
+	return sqlc.Document{
+		ID:            id,
+		WorkspaceHash: "ws123",
+		ContentHash:   "hash",
+		Title:         "Test Doc",
+		Content:       "Some content",
+		SourcePath:    sourcePath,
+		Collection:    "memory",
+		Tags:          []string{"tag1"},
+		Metadata:      pqtype.NullRawMessage{RawMessage: []byte(`{}`), Valid: true},
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+}
+
+func TestGetDocument_BySourcePath(t *testing.T) {
+	docID := uuid.New()
+	q := &mockGetDocQuerier{
+		getBySourcePath: func(_ context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+			if arg.SourcePath != "memory://test.md" {
+				t.Errorf("expected source_path memory://test.md, got %s", arg.SourcePath)
+			}
+			if arg.WorkspaceHash != "ws123" {
+				t.Errorf("expected workspace ws123, got %s", arg.WorkspaceHash)
+			}
+			return sampleDoc(docID, "memory://test.md"), nil
+		},
+	}
+
+	e := echo.New()
+	body := `{"path":"memory://test.md"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/get", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.GetDocument(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["id"] != docID.String() {
+		t.Errorf("id = %v, want %s", resp["id"], docID.String())
+	}
+	if resp["source_path"] != "memory://test.md" {
+		t.Errorf("source_path = %v", resp["source_path"])
+	}
+}
+
+func TestGetDocument_ByID(t *testing.T) {
+	docID := uuid.New()
+	q := &mockGetDocQuerier{
+		getByID: func(_ context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error) {
+			if arg.ID != docID {
+				t.Errorf("expected id %s, got %s", docID, arg.ID)
+			}
+			return sampleDoc(docID, "memory://test.md"), nil
+		},
+	}
+
+	e := echo.New()
+	body := fmt.Sprintf(`{"id":"%s"}`, docID.String())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/get", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.GetDocument(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestGetDocument_ByHashPrefix(t *testing.T) {
+	docID := uuid.New()
+	q := &mockGetDocQuerier{
+		getByID: func(_ context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error) {
+			if arg.ID != docID {
+				t.Errorf("expected id %s, got %s", docID, arg.ID)
+			}
+			return sampleDoc(docID, "memory://test.md"), nil
+		},
+	}
+
+	e := echo.New()
+	body := fmt.Sprintf(`{"path":"#%s"}`, docID.String())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/get", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.GetDocument(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestGetDocument_NotFound(t *testing.T) {
+	q := &mockGetDocQuerier{
+		getBySourcePath: func(_ context.Context, _ sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+			return sqlc.Document{}, sql.ErrNoRows
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/get", strings.NewReader(`{"path":"missing"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.GetDocument(q, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", he.Code)
+	}
+}
+
+func TestGetDocument_MissingPathAndID(t *testing.T) {
+	q := &mockGetDocQuerier{}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/get", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.GetDocument(q, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing path/id")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}

--- a/internal/server/handlers/multi_get.go
+++ b/internal/server/handlers/multi_get.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type MultiGetQuerier interface {
+	GetDocumentByID(ctx context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error)
+	GetDocumentBySourcePath(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error)
+}
+
+type multiGetRequest struct {
+	Paths []string `json:"paths"`
+	IDs   []string `json:"ids"`
+}
+
+type multiGetResponse struct {
+	Results  []getDocumentResponse `json:"results"`
+	NotFound []string              `json:"not_found"`
+}
+
+func MultiGet(q MultiGetQuerier, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		workspace := c.Get("workspace").(string)
+
+		var req multiGetRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+
+		if len(req.Paths) == 0 && len(req.IDs) == 0 {
+			return echo.NewHTTPError(http.StatusBadRequest, "paths or ids is required")
+		}
+
+		ctx := c.Request().Context()
+		results := make([]getDocumentResponse, 0)
+		notFound := make([]string, 0)
+
+		for _, p := range req.Paths {
+			doc, err := q.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
+				SourcePath:    p,
+				WorkspaceHash: workspace,
+			})
+			if err != nil {
+				if isNotFound(err) {
+					notFound = append(notFound, p)
+					continue
+				}
+				logger.Error().Err(err).Str("workspace", workspace).Str("path", p).Msg("multi-get path failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to get document")
+			}
+			results = append(results, docToResponse(doc))
+		}
+
+		for _, rawID := range req.IDs {
+			parsed, parseErr := uuid.Parse(rawID)
+			if parseErr != nil {
+				notFound = append(notFound, rawID)
+				continue
+			}
+			doc, err := q.GetDocumentByID(ctx, sqlc.GetDocumentByIDParams{
+				ID:            parsed,
+				WorkspaceHash: workspace,
+			})
+			if err != nil {
+				if isNotFound(err) {
+					notFound = append(notFound, rawID)
+					continue
+				}
+				logger.Error().Err(err).Str("workspace", workspace).Str("id", rawID).Msg("multi-get id failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to get document")
+			}
+			results = append(results, docToResponse(doc))
+		}
+
+		return c.JSON(http.StatusOK, multiGetResponse{
+			Results:  results,
+			NotFound: notFound,
+		})
+	}
+}
+
+func docToResponse(doc sqlc.Document) getDocumentResponse {
+	supersedes := ""
+	if doc.SupersedesID.Valid {
+		supersedes = doc.SupersedesID.UUID.String()
+	}
+	tags := doc.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+	return getDocumentResponse{
+		ID:            doc.ID.String(),
+		Title:         doc.Title,
+		Content:       doc.Content,
+		SourcePath:    doc.SourcePath,
+		Collection:    doc.Collection,
+		Tags:          tags,
+		WorkspaceHash: doc.WorkspaceHash,
+		SupersedesID:  supersedes,
+		CreatedAt:     doc.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:     doc.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}

--- a/internal/server/handlers/multi_get_test.go
+++ b/internal/server/handlers/multi_get_test.go
@@ -1,0 +1,195 @@
+package handlers_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockMultiGetQuerier struct {
+	getByID         func(ctx context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error)
+	getBySourcePath func(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error)
+}
+
+func (m *mockMultiGetQuerier) GetDocumentByID(ctx context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error) {
+	return m.getByID(ctx, arg)
+}
+
+func (m *mockMultiGetQuerier) GetDocumentBySourcePath(ctx context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+	return m.getBySourcePath(ctx, arg)
+}
+
+func TestMultiGet_ByPaths(t *testing.T) {
+	docA := uuid.New()
+	docB := uuid.New()
+
+	q := &mockMultiGetQuerier{
+		getBySourcePath: func(_ context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+			switch arg.SourcePath {
+			case "memory://a.md":
+				return sampleDoc(docA, "memory://a.md"), nil
+			case "memory://b.md":
+				return sampleDoc(docB, "memory://b.md"), nil
+			case "memory://missing.md":
+				return sqlc.Document{}, sql.ErrNoRows
+			default:
+				return sqlc.Document{}, sql.ErrNoRows
+			}
+		},
+	}
+
+	e := echo.New()
+	body := `{"paths":["memory://a.md","memory://b.md","memory://missing.md"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/multi-get", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.MultiGet(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	results, ok := resp["results"].([]interface{})
+	if !ok {
+		t.Fatalf("results not a slice: %T", resp["results"])
+	}
+	if len(results) != 2 {
+		t.Errorf("results len = %d, want 2", len(results))
+	}
+	notFound, ok := resp["not_found"].([]interface{})
+	if !ok {
+		t.Fatalf("not_found not a slice: %T", resp["not_found"])
+	}
+	if len(notFound) != 1 {
+		t.Errorf("not_found len = %d, want 1", len(notFound))
+	}
+	if notFound[0] != "memory://missing.md" {
+		t.Errorf("not_found[0] = %v, want memory://missing.md", notFound[0])
+	}
+}
+
+func TestMultiGet_ByIDs(t *testing.T) {
+	docA := uuid.New()
+	badID := "not-a-uuid"
+
+	q := &mockMultiGetQuerier{
+		getByID: func(_ context.Context, arg sqlc.GetDocumentByIDParams) (sqlc.Document, error) {
+			if arg.ID == docA {
+				return sampleDoc(docA, "memory://a.md"), nil
+			}
+			return sqlc.Document{}, sql.ErrNoRows
+		},
+	}
+
+	e := echo.New()
+	body := fmt.Sprintf(`{"ids":["%s","%s"]}`, docA.String(), badID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/multi-get", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.MultiGet(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	results := resp["results"].([]interface{})
+	if len(results) != 1 {
+		t.Errorf("results len = %d, want 1", len(results))
+	}
+	notFound := resp["not_found"].([]interface{})
+	if len(notFound) != 1 {
+		t.Errorf("not_found len = %d, want 1", len(notFound))
+	}
+	if notFound[0] != badID {
+		t.Errorf("not_found[0] = %v, want %s", notFound[0], badID)
+	}
+}
+
+func TestMultiGet_NeitherPathsNorIDs(t *testing.T) {
+	q := &mockMultiGetQuerier{}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/multi-get", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.MultiGet(q, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing paths/ids")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestMultiGet_EmptyPaths(t *testing.T) {
+	q := &mockMultiGetQuerier{
+		getBySourcePath: func(_ context.Context, _ sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+			return sqlc.Document{}, sql.ErrNoRows
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/multi-get", strings.NewReader(`{"paths":["gone"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	h := handlers.MultiGet(q, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	results := resp["results"].([]interface{})
+	if len(results) != 0 {
+		t.Errorf("results len = %d, want 0", len(results))
+	}
+	notFound := resp["not_found"].([]interface{})
+	if len(notFound) != 1 {
+		t.Errorf("not_found len = %d, want 1", len(notFound))
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -43,6 +43,8 @@ func registerRoutes(s *Server) {
 	data.DELETE("/collections/:name", handlers.RemoveCollection(s.queries, s.watcher, s.logger))
 
 	data.GET("/tags", handlers.ListTags(s.queries, s.logger))
+	data.POST("/get", handlers.GetDocument(s.queries, s.logger))
+	data.POST("/multi-get", handlers.MultiGet(s.queries, s.logger))
 	data.GET("/symbols", handlers.ListSymbols(s.queries, s.logger))
 	data.POST("/graph/query", handlers.GraphQuery(s.queries, s.logger))
 	data.POST("/graph/impact", handlers.GraphImpact(s.queries, s.logger))


### PR DESCRIPTION
Closes #152

## Summary
Three new CLI commands for document retrieval.

## Usage
```
nano-brain get <path> --workspace=<hash> [--by-id] [--json]
nano-brain tags --workspace=<hash> [--json]
nano-brain multi-get --workspace=<hash> --paths=p1,p2,p3 [--json]
```

## REST
- POST /api/v1/get — body `{workspace, path?, id?}` → single document or 404
- POST /api/v1/multi-get — body `{workspace, paths:[...]}` → `{results, not_found}`
- GET /api/v1/tags reused (no change)

## Verification
- `go build ./...` → pass
- `go test -race -short ./...` → 20 packages OK (22 new tests)
- **E2E (PG @ host.docker.internal:5432):**
  - `tags` → 8+ tags shown with counts
  - `get <path>` → full doc with ID/Title/Path/Collection/Updated/content
  - `get /nonexistent` → 404 error
  - `multi-get --paths=p1,p2,/missing` → `{results:[2 docs], not_found:["/missing"]}`

Evidence: `docs/evidence/self-review-feat-152-get-tags-multiget.md`