### PR TITLE
fix(handler): wrap ResetWorkspace in a transaction (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixes
+- fix(handler): wrap `ResetWorkspace` document+workspace deletion in a single transaction with rollback — matches the pattern already shipped in `RemoveWorkspace` (#155). Prevents orphaned documents if the workspace delete fails after docs are already removed (#225)
+
 ### Features
 - feat(cli): `get`, `tags`, `multi-get` commands — fetch a single document by source_path or UUID, list all tags with counts, and batch-fetch multiple documents in one round-trip; backed by `POST /api/v1/get`, `GET /api/v1/tags` (existing), and `POST /api/v1/multi-get` REST endpoints (#152)
 - feat(cli): `--tags=t1,t2,t3` filter on query/search/vsearch — filters results to docs whose tags overlap (PostgreSQL `&&` array op) with the given set; works in --workspace= or --scope=all mode (#160)

--- a/docs/evidence/self-review-fix-225-reset-tx.md
+++ b/docs/evidence/self-review-fix-225-reset-tx.md
@@ -1,0 +1,21 @@
+## Self-Review: fix/225-reset-workspace-tx
+Date: 2026-05-30
+Reviewer: Sisyphus orchestrator
+
+## Findings
+Direct port of the pattern shipped in #155 (RemoveWorkspace). Same shape:
+- Accept `db removeWorkspaceTxBeginner`-style interface
+- Wrap deletes in BeginTx + Commit/Rollback
+- Fallback non-tx path when db == nil (test injection)
+- Server log gains `transactional: true/false` field
+
+## Unit tests
+- 2 new tests in reset_workspace_test.go (was missing before): NonTxPath success, MissingWorkspace 400
+- Full suite: `go test -race -short ./...` → 20 packages OK
+
+## Build
+- `CGO_ENABLED=0 go build ./...` → exit 0
+
+## Summary
+- Critical: 0, Major: 0, Minor: 0
+- Closes #225 (follow-up from Gemini PR #222 review)

--- a/internal/server/handlers/reset_workspace.go
+++ b/internal/server/handlers/reset_workspace.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -15,6 +16,10 @@ type ResetWorkspaceQuerier interface {
 	DeleteWorkspace(ctx context.Context, hash string) error
 }
 
+type resetWorkspaceTxBeginner interface {
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
 type resetWorkspaceRequest struct {
 	Workspace string `json:"workspace"`
 }
@@ -24,7 +29,7 @@ type resetWorkspaceResponse struct {
 	Workspace        string `json:"workspace"`
 }
 
-func ResetWorkspace(q ResetWorkspaceQuerier, logger zerolog.Logger) echo.HandlerFunc {
+func ResetWorkspace(q ResetWorkspaceQuerier, db resetWorkspaceTxBeginner, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var req resetWorkspaceRequest
 		if err := c.Bind(&req); err != nil {
@@ -42,18 +47,44 @@ func ResetWorkspace(q ResetWorkspaceQuerier, logger zerolog.Logger) echo.Handler
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to count documents")
 		}
 
-		if err := q.DeleteDocumentsByWorkspace(ctx, req.Workspace); err != nil {
-			logger.Error().Err(err).Str("workspace", req.Workspace).Msg("delete documents failed")
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
-		}
-
-		if err := q.DeleteWorkspace(ctx, req.Workspace); err != nil {
-			logger.Error().Err(err).Str("workspace", req.Workspace).Msg("delete workspace failed")
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+		if db == nil {
+			if err := q.DeleteDocumentsByWorkspace(ctx, req.Workspace); err != nil {
+				logger.Error().Err(err).Str("workspace", req.Workspace).Msg("delete documents failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
+			}
+			if err := q.DeleteWorkspace(ctx, req.Workspace); err != nil {
+				logger.Error().Err(err).Str("workspace", req.Workspace).Msg("delete workspace failed (docs already deleted)")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+			}
+		} else {
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				logger.Error().Err(err).Str("workspace", req.Workspace).Msg("begin transaction failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction")
+			}
+			txq := sqlc.New(tx)
+			if err := txq.DeleteDocumentsByWorkspace(ctx, req.Workspace); err != nil {
+				_ = tx.Rollback()
+				logger.Error().Err(err).Str("workspace", req.Workspace).Msg("delete documents failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete documents")
+			}
+			if err := txq.DeleteWorkspace(ctx, req.Workspace); err != nil {
+				_ = tx.Rollback()
+				logger.Error().Err(err).Str("workspace", req.Workspace).Msg("delete workspace failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete workspace")
+			}
+			if err := tx.Commit(); err != nil {
+				logger.Error().Err(err).Str("workspace", req.Workspace).Msg("commit transaction failed")
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit transaction")
+			}
 		}
 
 		reqLog := LoggerFromCtx(c, logger)
-		reqLog.Info().Str("workspace", req.Workspace).Int64("deleted_documents", count).Msg("workspace reset")
+		reqLog.Info().
+			Str("workspace", req.Workspace).
+			Int64("deleted_documents", count).
+			Bool("transactional", db != nil).
+			Msg("workspace reset")
 
 		return c.JSON(http.StatusOK, resetWorkspaceResponse{
 			DeletedDocuments: count,

--- a/internal/server/handlers/reset_workspace_test.go
+++ b/internal/server/handlers/reset_workspace_test.go
@@ -1,0 +1,90 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/rs/zerolog"
+)
+
+type mockResetQuerier struct {
+	countFn      func(ctx context.Context, hash string) (int64, error)
+	delDocsFn    func(ctx context.Context, hash string) error
+	delWsFn      func(ctx context.Context, hash string) error
+	docDelCalled bool
+	wsDelCalled  bool
+}
+
+func (m *mockResetQuerier) CountDocumentsByWorkspace(ctx context.Context, hash string) (int64, error) {
+	if m.countFn != nil {
+		return m.countFn(ctx, hash)
+	}
+	return 5, nil
+}
+
+func (m *mockResetQuerier) DeleteDocumentsByWorkspace(ctx context.Context, hash string) error {
+	m.docDelCalled = true
+	if m.delDocsFn != nil {
+		return m.delDocsFn(ctx, hash)
+	}
+	return nil
+}
+
+func (m *mockResetQuerier) DeleteWorkspace(ctx context.Context, hash string) error {
+	m.wsDelCalled = true
+	if m.delWsFn != nil {
+		return m.delWsFn(ctx, hash)
+	}
+	return nil
+}
+
+func TestResetWorkspace_NonTxPath(t *testing.T) {
+	q := &mockResetQuerier{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/reset", strings.NewReader(`{"workspace":"ws1"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.ResetWorkspace(q, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if !q.docDelCalled || !q.wsDelCalled {
+		t.Errorf("expected both deletes called: docs=%v ws=%v", q.docDelCalled, q.wsDelCalled)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["workspace"] != "ws1" {
+		t.Errorf("workspace mismatch: %v", resp["workspace"])
+	}
+}
+
+func TestResetWorkspace_MissingWorkspace(t *testing.T) {
+	q := &mockResetQuerier{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/reset", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.ResetWorkspace(q, nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for missing workspace")
+	}
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %v", err)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -26,7 +26,7 @@ func registerRoutes(s *Server) {
 	api.POST("/init", handlers.InitWorkspace(s.queries, s.db, s.watcher, s.currentConfig().Watcher, s.logger))
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
 	api.DELETE("/workspaces/:hash", handlers.RemoveWorkspace(s.queries, s.db, s.logger))
-	api.POST("/reset-workspace", handlers.ResetWorkspace(s.queries, s.logger))
+	api.POST("/reset-workspace", handlers.ResetWorkspace(s.queries, s.db, s.logger))
 
 	var enqueuer handlers.ChunkEnqueuer
 	if s.embedQueue != nil {


### PR DESCRIPTION
Closes #225

## Summary
Follow-up from Gemini's review of #155 (PR #222). ResetWorkspace had the same non-transactional pattern: sequential `DeleteDocumentsByWorkspace` then `DeleteWorkspace` outside a transaction. If the workspace delete failed after docs were already removed, the system was left inconsistent.

Direct port of the RemoveWorkspace pattern from PR #222:
- New `resetWorkspaceTxBeginner` interface
- Wrap both deletes in `db.BeginTx` + `tx.Commit` + rollback on error
- Fallback non-tx path when `db == nil` (test injection)
- Server log includes `transactional` boolean field

## Verification
- `go build ./...` → pass
- `go test -race -short ./...` → 20 packages OK
- 2 new tests added to reset_workspace_test.go (handler had none before)

Evidence: `docs/evidence/self-review-fix-225-reset-tx.md`