### PR TITLE
fix(config): warn when NANO_BRAIN_CONFIG points to missing file (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixes
+- fix(config): `NANO_BRAIN_CONFIG` (and `--config`) now strip leading/trailing whitespace, and a `WARNING:` is printed to stderr when the explicitly-set path does not exist (previously silently fell back to defaults — a production footgun for typos in container env values) (#224)
+
 ### Features
 - feat(cli): `get`, `tags`, `multi-get` commands — fetch a single document by source_path or UUID, list all tags with counts, and batch-fetch multiple documents in one round-trip; backed by `POST /api/v1/get`, `GET /api/v1/tags` (existing), and `POST /api/v1/multi-get` REST endpoints (#152)
 - feat(cli): `--tags=t1,t2,t3` filter on query/search/vsearch — filters results to docs whose tags overlap (PostgreSQL `&&` array op) with the given set; works in --workspace= or --scope=all mode (#160)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Large sessions (100K+ tokens) are handled via map-reduce chunking — no session
 
 | Variable | Description |
 |----------|-------------|
-| `NANO_BRAIN_CONFIG` | Path to YAML config file (12-factor; useful in Docker/k8s). Precedence: `--config` flag > `NANO_BRAIN_CONFIG` > `~/.nano-brain/config.yml` |
+| `NANO_BRAIN_CONFIG` | Path to YAML config file (12-factor; useful in Docker/k8s). Precedence: `--config` flag > `NANO_BRAIN_CONFIG` > `~/.nano-brain/config.yml`. Leading/trailing whitespace is stripped. If the env-pointed file does not exist, a `WARNING:` is printed to stderr and defaults are used (operator can spot typos). |
 | `DATABASE_URL` | PostgreSQL connection string |
 | `VOYAGE_API_KEY` | Voyage AI API key |
 | `OPENCODE_DB_ROOT` | OpenCode per-project DB root directory (multi-DB mode) |

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -185,7 +185,11 @@ func startServer(configPath string) {
 		os.Exit(1)
 	}
 
-	configPath = config.ResolveConfigPath(configPath)
+	var configWarning string
+	configPath, configWarning = config.ResolveConfigPathStrict(configPath)
+	if configWarning != "" {
+		fmt.Fprintln(os.Stderr, configWarning)
+	}
 
 	cfg, err := config.Load(configPath)
 	if err != nil {

--- a/docs/evidence/self-review-fix-224-config-validation.md
+++ b/docs/evidence/self-review-fix-224-config-validation.md
@@ -1,0 +1,30 @@
+## Self-Review: fix/224-config-env-validation
+Date: 2026-05-30
+Reviewer: Sisyphus orchestrator
+
+## E2E
+- `NANO_BRAIN_CONFIG=/tmp/does-not-exist.yml ./nano-brain` → stderr line:
+  `WARNING: NANO_BRAIN_CONFIG env points to "/tmp/does-not-exist.yml" but that file does not exist — defaults will be used.`
+  Server continues on defaults (port 3100).
+- `NANO_BRAIN_CONFIG=" /tmp/nb-test/config.yml "` (whitespace) → server starts on port 3199 from that config (whitespace trimmed before stat check).
+- `--config /missing.yml` → same warning prefixed with `--config flag` instead of `NANO_BRAIN_CONFIG env`.
+
+## Unit tests (5 new in internal/config/config_test.go)
+- TestResolveConfigPath_TrimsWhitespace
+- TestResolveConfigPathStrict_WarnsOnMissingFile (env)
+- TestResolveConfigPathStrict_WarnsOnFlagMissingFile (flag)
+- TestResolveConfigPathStrict_NoWarnWhenDefault
+- TestResolveConfigPathStrict_NoWarnWhenFlagPathExists
+
+## Design notes
+- Backward-compat: existing `ResolveConfigPath(flagValue)` kept; new `ResolveConfigPathStrict` returns `(path, warning)`.
+- Warning is non-fatal — server still starts. This was the explicit design choice in the issue ("Log a WARNING on stderr ... OR exit non-zero"). WARNING was chosen because in production, falling back to defaults is often what the user wants when the explicit config is mid-rollout.
+- Trim happens BEFORE stat check so " /path/file.yml " resolves correctly.
+
+## Build + tests
+- `CGO_ENABLED=0 go build ./...` → exit 0
+- `go test -race -short ./...` → 20 packages OK
+
+## Summary
+- Critical: 0, Major: 0, Minor: 0
+- Closes #224

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -362,18 +362,49 @@ func DefaultConfigPath() string {
 }
 
 // ResolveConfigPath returns the effective config file path with precedence:
-//  1. explicit --config flag value (non-empty)
-//  2. NANO_BRAIN_CONFIG environment variable (non-empty)
+//  1. explicit --config flag value (non-empty, after TrimSpace)
+//  2. NANO_BRAIN_CONFIG environment variable (non-empty, after TrimSpace)
 //  3. DefaultConfigPath() (~/.nano-brain/config.yml)
 //
-// This lets containerized deployments override the host's default config
-// without modifying CLI invocations (12-factor app pattern).
+// Whitespace is trimmed from both sources. Existence is not checked — use
+// ResolveConfigPathStrict when the caller needs a warning on missing files.
 func ResolveConfigPath(flagValue string) string {
-	if flagValue != "" {
-		return flagValue
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v
 	}
-	if env := os.Getenv("NANO_BRAIN_CONFIG"); env != "" {
-		return env
+	if v := strings.TrimSpace(os.Getenv("NANO_BRAIN_CONFIG")); v != "" {
+		return v
 	}
 	return DefaultConfigPath()
+}
+
+// ResolveConfigPathStrict behaves like ResolveConfigPath but ALSO emits a
+// warning to stderr (and returns the warning) when --config flag or
+// NANO_BRAIN_CONFIG env was set explicitly but the resolved file does not
+// exist. The path is still returned so the caller can fall through to
+// defaults — this is a warning, not a fatal error.
+//
+// Returns (path, warning). warning is "" when no problem detected.
+func ResolveConfigPathStrict(flagValue string) (string, string) {
+	flagTrimmed := strings.TrimSpace(flagValue)
+	envTrimmed := strings.TrimSpace(os.Getenv("NANO_BRAIN_CONFIG"))
+
+	var path string
+	var source string
+	switch {
+	case flagTrimmed != "":
+		path, source = flagTrimmed, "--config flag"
+	case envTrimmed != "":
+		path, source = envTrimmed, "NANO_BRAIN_CONFIG env"
+	default:
+		return DefaultConfigPath(), ""
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return path, fmt.Sprintf("WARNING: %s points to %q but that file does not exist — defaults will be used.", source, path)
+		}
+		return path, fmt.Sprintf("WARNING: %s = %q: %v", source, path, err)
+	}
+	return path, ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -607,3 +607,55 @@ func TestResolveConfigPath_EmptyEnvFallsBackToDefault(t *testing.T) {
 		t.Errorf("expected default when env is empty string, got %q", got)
 	}
 }
+
+func TestResolveConfigPath_TrimsWhitespace(t *testing.T) {
+	t.Setenv("NANO_BRAIN_CONFIG", "  /from/env.yml  ")
+	got := ResolveConfigPath("")
+	if got != "/from/env.yml" {
+		t.Errorf("expected trimmed env value, got %q", got)
+	}
+}
+
+func TestResolveConfigPathStrict_WarnsOnMissingFile(t *testing.T) {
+	t.Setenv("NANO_BRAIN_CONFIG", "/tmp/nano-brain-test-does-not-exist.yml")
+	_, warn := ResolveConfigPathStrict("")
+	if warn == "" {
+		t.Fatal("expected warning for non-existent env-pointed file")
+	}
+	if !strings.Contains(warn, "NANO_BRAIN_CONFIG") {
+		t.Errorf("warning should mention env var name, got %q", warn)
+	}
+	if !strings.Contains(warn, "does not exist") {
+		t.Errorf("warning should explain why, got %q", warn)
+	}
+}
+
+func TestResolveConfigPathStrict_NoWarnWhenDefault(t *testing.T) {
+	t.Setenv("NANO_BRAIN_CONFIG", "")
+	_, warn := ResolveConfigPathStrict("")
+	if warn != "" {
+		t.Errorf("default path should not warn, got %q", warn)
+	}
+}
+
+func TestResolveConfigPathStrict_NoWarnWhenFlagPathExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "cfg.yml")
+	if err := os.WriteFile(cfgPath, []byte("server: {host: localhost}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, warn := ResolveConfigPathStrict(cfgPath)
+	if warn != "" {
+		t.Errorf("existing flag path should not warn, got %q", warn)
+	}
+}
+
+func TestResolveConfigPathStrict_WarnsOnFlagMissingFile(t *testing.T) {
+	_, warn := ResolveConfigPathStrict("/tmp/no-such-flag-path.yml")
+	if warn == "" {
+		t.Fatal("expected warning for non-existent flag-pointed file")
+	}
+	if !strings.Contains(warn, "--config") {
+		t.Errorf("warning should mention --config, got %q", warn)
+	}
+}


### PR DESCRIPTION
Closes #224

## Summary
Previously, a typo in `NANO_BRAIN_CONFIG` (or `--config`) silently fell back to defaults with exit 0. In production this is a footgun: a typo in Dockerfile/k8s env started nano-brain on default port/creds with no signal to the operator.

## Changes
- `ResolveConfigPath` now `TrimSpace()`s both flag and env values (trailing newlines from container env files now work)
- New `ResolveConfigPathStrict` returns `(path, warning)`; warning is non-empty when an explicitly-set path does not exist. `startServer` prints it to stderr and continues on defaults.

## Verification
- `go build ./...` → pass
- `go test -race -short ./...` → 20 packages OK (5 new TestResolveConfigPath* tests)
- **E2E:**
  - `NANO_BRAIN_CONFIG=/nonexistent.yml ./nano-brain` → `WARNING: NANO_BRAIN_CONFIG env points to "/nonexistent.yml" but that file does not exist — defaults will be used.` (server still starts on defaults)
  - `NANO_BRAIN_CONFIG=' /tmp/cfg.yml ' ./nano-brain` → server starts on env-pointed config (whitespace trimmed before stat check)

## Design decision
Warning, not fatal error. The issue offered both as alternatives; warning was chosen because falling-back-to-defaults is often what the user wants during a partial rollout. The loud stderr line ensures the typo is visible.

Evidence: `docs/evidence/self-review-fix-224-config-validation.md`