### PR TITLE
openspec(#158): proposal for incremental reindex

### DIFF
--- a/openspec/changes/incremental-reindex/.openspec.yaml
+++ b/openspec/changes/incremental-reindex/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/incremental-reindex/design.md
+++ b/openspec/changes/incremental-reindex/design.md
@@ -1,0 +1,82 @@
+# Design — Incremental Reindex
+
+## Approach: content-hash tracking on `documents`
+
+Reuse the existing `documents.content_hash` (SHA-256, already populated by `UpsertDocument`). The dedup is already there at the document level. The gap is that `reindex` doesn't *use* it — it currently deletes all chunks unconditionally.
+
+### Current flow (full wipe)
+```
+POST /api/v1/reindex
+ → DeleteChunksByWorkspace(workspace)
+ → DeleteDocumentsByWorkspace(workspace)
+ → Walk root directory
+ → For each file: read → hash → UpsertDocument → chunk → embed → InsertChunks
+```
+
+### New flow (incremental)
+```
+POST /api/v1/reindex
+ → Walk root directory (collect {path, content_hash} for every file)
+ → Compute set: { current_paths } = paths found on disk
+ → Query: SELECT source_path, content_hash FROM documents WHERE workspace_hash = $1
+   → indexed_paths_by_hash = { source_path -> content_hash }
+ → For each file (path, hash) on disk:
+     - if path not in indexed_paths_by_hash → NEW: chunk + embed + insert
+     - if path in indexed_paths_by_hash AND hash == stored → UNCHANGED: skip
+     - if path in indexed_paths_by_hash AND hash != stored → CHANGED: delete old chunks for this document_id, re-chunk + re-embed
+ → For each (path, hash) in indexed_paths_by_hash where path NOT in current_paths → DELETED: cascade delete (documents → chunks via FK)
+```
+
+## Schema impact
+
+**Zero new columns.** `documents.content_hash` already exists and is already populated. The change is purely in handler logic — the `reindex.go` handler shifts from "DELETE then INSERT" to "DIFF then patch".
+
+If telemetry is desired (count of skipped vs embedded files per reindex), add a new sibling table `reindex_runs` (timestamp, workspace_hash, scanned, skipped, embedded, deleted). This is OPTIONAL and can be deferred.
+
+## Watcher integration
+
+The watcher already detects file changes via fsnotify and calls `UpsertDocument` → which already short-circuits when the content_hash matches existing. So watcher-driven incremental indexing already works. This change brings the **explicit `reindex` button** in line with that behavior.
+
+## Trade-offs
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **A. Content-hash diff (chosen)** | Zero schema change. Reuses existing `content_hash`. Easy to test. | Re-reads + hashes every file on disk — disk I/O bound for huge trees. |
+| B. Track mtime per file | Faster (no read+hash; just stat). | mtime is unreliable (touch -t, container layer copy, git checkout all bump it without content change). Skews "changed" set. |
+| C. Use fsnotify-only (incremental from watcher events) | Zero disk scan. Real-time. | Misses changes that happen while server is down (e.g. git pull during downtime). Reindex is meant to be the recovery from this. |
+
+**Recommendation:** A (content-hash). C is already covered by the watcher. B is a footgun.
+
+## API shape (no change to the wire contract)
+
+Request body unchanged. Response gains optional counters:
+
+```json
+{
+  "workspace": "abc...",
+  "scanned": 1024,
+  "skipped": 1020,
+  "embedded": 4,
+  "deleted": 0,
+  "duration_ms": 87
+}
+```
+
+These are additive fields — existing clients that ignore them keep working.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Hash computation cost dominates on large repos | Mitigation: stream-hash with `io.Copy` into a `sha256.New()` hasher (already how `UpsertDocument` does it). Single pass, no full buffer. |
+| Race: file mutated during walk | Accepted. Next reindex picks it up. The watcher path handles real-time. |
+| Stale chunks if migration interrupted mid-flight | Transaction wrapping per-document: delete old chunks + insert new chunks in single tx (mirror PR #222 #229 pattern). |
+| Reindex with `--force` flag for full wipe is preserved | New flag `--force-wipe` on the reindex CLI; default behavior becomes incremental. |
+| Watcher latency regression | Watcher is unchanged. Only `reindex.go` handler logic changes. |
+
+## Test plan
+
+1. **Unit (handler):** mock `Queries` interface; verify diff-skip-vs-embed branches.
+2. **Integration:** reindex on empty workspace → adds N docs. Reindex again unchanged → 0 embeds. Touch one file (no content change) → 0 embeds. Modify one file → 1 embed. Delete one file from disk → that doc's chunks gone.
+3. **E2E:** run twice on nano-brain repo itself; second run completes in < 5% of first run's duration.
+4. **Watcher regression:** `internal/watcher/watcher_test.go` continues to pass (no changes there).

--- a/openspec/changes/incremental-reindex/proposal.md
+++ b/openspec/changes/incremental-reindex/proposal.md
@@ -1,0 +1,32 @@
+# Incremental Reindex
+
+## Issue
+[#158 — feat(indexing): incremental reindex — only re-index changed files](https://github.com/nano-step/nano-brain/issues/158)
+
+## Lane
+high-risk — touches data-model (new column/table on `chunks`), indexing core, watcher integration.
+
+## Why
+Current `reindex` wipes ALL chunks for a workspace and re-embeds every file. On the nano-brain repo itself this is ~2700+ documents × N chunks each × Ollama embedding round-trip. Slow + wasteful + hits embedding API rate limits.
+
+## Desired Outcome
+Repeated `POST /api/v1/reindex` on an unchanged codebase should be effectively a no-op (no embeddings generated, no chunks rewritten). On a partially-changed codebase, only the changed files are re-chunked + re-embedded; unchanged files are preserved.
+
+## Constraints
+- Backward compatible: existing chunks/embeddings stay valid.
+- No new external dependencies.
+- Watcher hot-path (fsnotify event → debounce → upsert) must not regress in latency.
+- The full-wipe behavior of `POST /api/v1/reset-workspace` must remain — that's intentionally distinct from reindex.
+
+## Out of Scope
+- Cross-workspace dedup (different feature).
+- Reindex parallelism / sharding (separate perf work).
+- File deletion handling beyond "delete chunks for removed files" (covered here, not extended).
+
+## Acceptance Criteria
+1. **Unchanged file**: `reindex` on a workspace where nothing changed → 0 embeddings generated, 0 chunks rewritten. Visible via `/api/status` embed counters before/after.
+2. **Modified file**: changing 1 file out of 1000 → exactly that file's chunks are re-embedded; other 999 untouched.
+3. **Deleted file**: removing a file from disk + reindex → chunks for that file are deleted; orphan rows = 0.
+4. **New file**: adding 1 file + reindex → that file's chunks are embedded; existing 1000 untouched.
+5. **Schema migration is reversible** (down migration provided) AND additive (no breaking change to existing chunks/documents tables — only adds columns or a sibling table).
+6. **No regression** to watcher latency (fsnotify event → DB upsert): p95 must not increase by more than 5%.

--- a/openspec/changes/incremental-reindex/specs/cli-reindex/spec.md
+++ b/openspec/changes/incremental-reindex/specs/cli-reindex/spec.md
@@ -1,0 +1,43 @@
+# cli-reindex Delta — Incremental Reindex
+
+## MODIFIED Requirements
+
+### Requirement: reindex CLI command
+The CLI SHALL expose a `reindex` command that runs codebase indexing only — scanning files, updating chunks, and rebuilding the tree-sitter symbol graph. It SHALL NOT harvest sessions, index collections, or generate embeddings unnecessarily. By default it SHALL operate **incrementally**: only re-chunk + re-embed files whose `content_hash` has changed since last index. It SHALL accept `--root=<path>` to specify workspace root and `--force-wipe` to fall back to the previous full-wipe behavior.
+
+#### Scenario: Incremental reindex skips unchanged files
+- **WHEN** user runs `nano-brain reindex --root=<path>` on a workspace where no files changed since last index
+- **THEN** the response counters report `embedded: 0, skipped: N` where N is the number of indexed documents
+- **AND** no calls are made to the embedding provider (Ollama/Voyage)
+
+#### Scenario: Incremental reindex re-embeds changed files only
+- **WHEN** the user modifies 1 file out of 1000 indexed and runs `nano-brain reindex`
+- **THEN** the response reports `embedded: 1, skipped: 999`
+- **AND** only the chunks for the modified file are deleted + reinserted
+- **AND** chunks for the other 999 files are untouched
+
+#### Scenario: Incremental reindex deletes orphan documents
+- **WHEN** a file is removed from disk and the user runs `nano-brain reindex`
+- **THEN** the response reports `deleted: 1` for that document
+- **AND** the chunks for that document are removed via FK cascade
+
+#### Scenario: --force-wipe restores legacy behavior
+- **WHEN** user runs `nano-brain reindex --force-wipe`
+- **THEN** ALL chunks + documents for the workspace are deleted before re-indexing
+- **AND** the response reports `embedded: N, deleted: M` (matching the previous full-wipe semantics)
+
+#### Scenario: Reindex with explicit root (unchanged behavior)
+- **WHEN** user runs `nano-brain reindex --root=/path/to/project`
+- **THEN** CLI indexes the specified workspace root
+
+### Requirement: reindex returns incremental counters
+The `POST /api/v1/reindex` REST endpoint and the CLI `reindex` command SHALL return counters describing the operation: `scanned` (files seen on disk), `skipped` (unchanged), `embedded` (chunked + embedded), `deleted` (orphan docs cleaned up), and `duration_ms` (wall-clock time).
+
+#### Scenario: Counters reported in JSON response
+- **WHEN** the `reindex` REST endpoint completes
+- **THEN** the response body contains all five counters as integer fields
+- **AND** `scanned == skipped + embedded` (excluding deletes which are independent)
+
+#### Scenario: CLI prints counters in pretty mode
+- **WHEN** user runs `nano-brain reindex` without `--json`
+- **THEN** the CLI prints a one-line summary: `Reindex: N scanned, N skipped, N embedded, N deleted in NN ms`

--- a/openspec/changes/incremental-reindex/tasks.md
+++ b/openspec/changes/incremental-reindex/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — Incremental Reindex (#158)
+
+## Pre-implementation
+- [ ] Run deep-design with Metis + Oracle on `proposal.md` + `design.md`. Revise until clean pass.
+- [ ] Confirm `documents.content_hash` is populated for ALL existing rows (one-time validation query): `SELECT count(*) FROM documents WHERE content_hash IS NULL OR content_hash = ''` → must be 0.
+
+## Implementation
+
+### Backend
+- [ ] Add `ListDocumentsByWorkspace` sqlc query returning `(source_path, content_hash, id)` rows.
+- [ ] Refactor `internal/server/handlers/reindex.go` (or wherever the handler lives):
+  - [ ] Replace full-wipe with diff loop described in design.md.
+  - [ ] Wrap per-document delete-old + insert-new in single transaction.
+  - [ ] Return counters `{scanned, skipped, embedded, deleted, duration_ms}` in response body.
+- [ ] CLI: `cmd/nano-brain/commands.go runReindexCmd` — accept new `--force-wipe` flag for the old full-wipe behavior; default = incremental. Update `printUsage()`.
+- [ ] Logging: structured log at INFO with counters, at DEBUG with per-file decision.
+
+### Tests
+- [ ] Unit: `reindex_test.go` covering 4 cases (new / unchanged / changed / deleted file) with mock querier.
+- [ ] Integration (build tag `integration`): live PG, populate workspace, reindex twice, assert counters.
+- [ ] CLI test: `runReindexCmd` with `--force-wipe` triggers old path; default triggers new.
+
+### Docs
+- [ ] Update CHANGELOG `[Unreleased] ### Features` and `### Breaking` if any.
+- [ ] Update README CLI table for reindex flag.
+- [ ] Update README REST section if response shape documented there.
+
+### Self-review evidence
+- [ ] `docs/evidence/self-review-feat-158-incremental-reindex.md` with E2E proof (timing comparison full vs incremental on nano-brain repo).
+
+## Post-merge
+- [ ] `openspec archive incremental-reindex`
+- [ ] Close issue #158 with link to PR


### PR DESCRIPTION
Tracks #158

## Summary
OpenSpec proposal + design + tasks + cli-reindex delta spec for incremental reindex. Per harness rules, this is a HIGH-RISK change (touches indexing core + data semantics) so it requires a proposal before implementation.

## Approach (from design.md)
**Content-hash diff loop, zero schema change.** `documents.content_hash` is already populated by every `UpsertDocument`; the reindex handler is what's not using it. New flow:

```
walk disk → collect {path, hash}
query db → indexed_paths_by_hash
diff:
  hash unchanged → skip
  hash changed   → delete old chunks + re-chunk + re-embed (single tx)
  path on disk, not in db → new: insert + embed
  path in db, not on disk → delete (cascade via FK)
```

## Why this approach (rejected alternatives in design.md)
- **B. mtime-based**: unreliable (touch/git checkout/container layer copy bump mtime without content change).
- **C. fsnotify-only**: already done. reindex is the recovery path for events missed while server was down.

## Acceptance Criteria
Six numbered criteria in proposal.md covering unchanged/modified/deleted/new files, additive migration, and zero watcher regression.

## What this PR ships
- `openspec/changes/incremental-reindex/proposal.md`
- `openspec/changes/incremental-reindex/design.md`
- `openspec/changes/incremental-reindex/tasks.md`
- `openspec/changes/incremental-reindex/specs/cli-reindex/spec.md` (delta)
- `openspec validate incremental-reindex --strict` → passes

## What this PR does NOT ship
- Any code change to `internal/server/handlers/reindex.go` or sqlc queries
- Tests / evidence
- README / CHANGELOG entry (saves that for the impl PR)

## Next steps
1. Deep-design with Metis + Oracle on this proposal (per harness HIGH-RISK lane)
2. Revise proposal/design until clean pass
3. Implementation PR closes #158