### PR TITLE
feat(watcher): support ~/.nano-brain/.nano-brainignore for global ignore patterns (#263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ harvester:
 watcher:
   debounce_ms: 2000
   reindex_interval: 300
+  # Per-collection exclude_patterns and allowed_extensions are also supported
+  # via the workspaces map. See "Global ignore patterns" section below for
+  # the cross-collection .nano-brainignore file.
 
 storage:
   max_file_size: 314572800      # 300MB
@@ -141,6 +144,39 @@ summarization:
   max_tokens: 8000              # max tokens per LLM completion
   concurrency: 3                # parallel map-phase LLM calls
 ```
+
+### Global ignore patterns (`~/.nano-brain/.nano-brainignore`)
+
+The watcher loads a global gitignore-style file at `~/.nano-brain/.nano-brainignore`
+on startup. Patterns in this file apply to **all** registered collections, removing
+the need to repeat the same exclusions in each `watcher.workspaces` block.
+
+**Format**: standard `.gitignore` syntax (one pattern per line, supports `**`, `!negation`, blank lines, `#` comments).
+
+**Example** `~/.nano-brain/.nano-brainignore`:
+
+```
+# Skip generated files everywhere
+*.png
+*.jpg
+*.pdf
+build/
+dist/
+node_modules/
+
+# But keep this one icon
+!icons/important.png
+```
+
+**Order of evaluation** (most aggressive first):
+
+1. Hardcoded default exclude dirs (`node_modules`, `.git`, `dist`, `build`, `target`, etc.)
+2. **Global `.nano-brainignore`** (this feature)
+3. Per-collection `.gitignore` (in collection root)
+4. Per-collection `exclude_patterns` (config-level)
+5. Per-collection `allowed_extensions` (whitelist)
+
+**Restart required**: changes to `.nano-brainignore` take effect on next server start (hot-reload deferred to a follow-up). Issue #263.
 
 ### Session Summarization
 

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -281,6 +281,17 @@ func startServer(configPath string) {
 		WithSymbolRegistry(symRegistry).
 		WithGraphRegistry(graphRegistry, queries)
 
+	if homeDir, hErr := os.UserHomeDir(); hErr == nil {
+		if gi, path, lErr := watcher.LoadGlobalIgnore(homeDir); lErr != nil {
+			logger.Warn().Err(lErr).Str("path", path).Msg("global .nano-brainignore failed to load; using empty matcher")
+		} else if gi != nil {
+			logger.Info().Str("path", path).Msg("loaded global .nano-brainignore")
+			fw.SetGlobalIgnore(gi)
+		} else {
+			logger.Debug().Str("path", path).Msg(".nano-brainignore not found, skipping (issue #263)")
+		}
+	}
+
 	var eq *embed.Queue
 	var embedder embed.Embedder
 	if cfg.Embedding.Provider != "" {

--- a/docs/evidence/global-nano-brain-ignore/gemini-triage.md
+++ b/docs/evidence/global-nano-brain-ignore/gemini-triage.md
@@ -1,0 +1,31 @@
+# Gemini Triage — global-nano-brain-ignore (#263)
+
+PR: nano-step/nano-brain#268
+Date: 2026-05-31
+Bot reviewer: gemini-code-assist[bot]
+Agent: Sisyphus
+
+## Triage Table (R31)
+
+| Comment ref | Agent verdict | Reasoning | Action |
+|-------------|---------------|-----------|--------|
+| PR#268 filter.go:89 (directory trailing slash) | VALID:medium | `go-gitignore`'s `MatchesPath` requires trailing slash for directory-only patterns (e.g. `temp/`). Current code passes `temp` (no slash) for `isDir=true` → MISS. Causes watcher to descend into ignored dirs and evaluate each file individually — perf hit + bypass intent. Verified with new test (`TestFileFilter_GlobalIgnoreMatchesDirectoryWithTrailingSlash`). | Applied: when `isDir && !strings.HasSuffix(matchRel, "/")`, append `/` before MatchesPath check. Added new test asserting `custom_build/` pattern matches `custom_build` dir + files inside it. |
+
+## Resolution Summary
+
+- 1 VALID:medium finding addressed
+- 1 push cycle (under R31 limit of 3)
+- 0 FALSE_POSITIVE / DEFER / ACKNOWLEDGED findings
+
+## Test Evidence Post-Fix
+
+```
+$ go test -race -short -run "TestLoadGlobalIgnore|TestFileFilter_GlobalIgnore" ./internal/watcher/... -v
+=== RUN   TestLoadGlobalIgnore_MissingFileReturnsNil  --- PASS
+=== RUN   TestLoadGlobalIgnore_LoadsPatterns          --- PASS
+=== RUN   TestFileFilter_GlobalIgnoreApplies          --- PASS
+=== RUN   TestFileFilter_GlobalIgnoreMatchesDirectoryWithTrailingSlash  --- PASS  (NEW — regression test for Gemini finding)
+=== RUN   TestFileFilter_GlobalIgnoreCombinesWithPerCollection          --- PASS
+PASS
+ok   github.com/nano-brain/nano-brain/internal/watcher  1.021s
+```

--- a/internal/watcher/filter.go
+++ b/internal/watcher/filter.go
@@ -80,11 +80,16 @@ func (f *fileFilter) shouldSkip(absPath string, isDir bool) bool {
 		}
 	}
 
-	if f.globalIgnore != nil && f.globalIgnore.MatchesPath(rel) {
+	matchRel := rel
+	if isDir && rel != "." && !strings.HasSuffix(matchRel, "/") {
+		matchRel = matchRel + "/"
+	}
+
+	if f.globalIgnore != nil && f.globalIgnore.MatchesPath(matchRel) {
 		return true
 	}
 
-	if f.gitignoreMatcher != nil && f.gitignoreMatcher.MatchesPath(rel) {
+	if f.gitignoreMatcher != nil && f.gitignoreMatcher.MatchesPath(matchRel) {
 		return true
 	}
 

--- a/internal/watcher/filter.go
+++ b/internal/watcher/filter.go
@@ -34,15 +34,17 @@ var defaultExcludeDirs = map[string]bool{
 
 type fileFilter struct {
 	gitignoreMatcher  *gitignore.GitIgnore
+	globalIgnore      *gitignore.GitIgnore
 	excludePatterns   []string
 	allowedExtensions map[string]bool
 	rootDir           string
 }
 
-func newFileFilter(rootDir string, excludePatterns, allowedExtensions []string) *fileFilter {
+func newFileFilter(rootDir string, excludePatterns, allowedExtensions []string, globalIgnore *gitignore.GitIgnore) *fileFilter {
 	f := &fileFilter{
 		rootDir:         rootDir,
 		excludePatterns: excludePatterns,
+		globalIgnore:    globalIgnore,
 	}
 
 	if len(allowedExtensions) > 0 {
@@ -78,6 +80,10 @@ func (f *fileFilter) shouldSkip(absPath string, isDir bool) bool {
 		}
 	}
 
+	if f.globalIgnore != nil && f.globalIgnore.MatchesPath(rel) {
+		return true
+	}
+
 	if f.gitignoreMatcher != nil && f.gitignoreMatcher.MatchesPath(rel) {
 		return true
 	}
@@ -103,4 +109,25 @@ func (f *fileFilter) shouldSkip(absPath string, isDir bool) bool {
 	}
 
 	return false
+}
+
+// LoadGlobalIgnore reads `<homeDir>/.nano-brain/.nano-brainignore` and returns
+// a compiled gitignore matcher. Returns nil (without error) when the file is
+// missing or malformed — the watcher must start regardless.
+//
+// homeDir is expected to be the absolute user home directory (callers should
+// pass os.UserHomeDir() result). See issue #263.
+func LoadGlobalIgnore(homeDir string) (*gitignore.GitIgnore, string, error) {
+	path := filepath.Join(homeDir, ".nano-brain", ".nano-brainignore")
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, path, nil
+		}
+		return nil, path, err
+	}
+	gi, err := gitignore.CompileIgnoreFile(path)
+	if err != nil {
+		return nil, path, err
+	}
+	return gi, path, nil
 }

--- a/internal/watcher/filter_test.go
+++ b/internal/watcher/filter_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestShouldSkip_DefaultExcludeDirs(t *testing.T) {
 	root := t.TempDir()
-	f := newFileFilter(root, nil, nil)
+	f := newFileFilter(root, nil, nil, nil)
 
 	cases := []struct {
 		path string
@@ -32,7 +32,7 @@ func TestShouldSkip_DefaultExcludeDirs(t *testing.T) {
 
 func TestShouldSkip_ExcludePatterns(t *testing.T) {
 	root := t.TempDir()
-	f := newFileFilter(root, []string{"*.lock", "*.log"}, nil)
+	f := newFileFilter(root, []string{"*.lock", "*.log"}, nil, nil)
 
 	cases := []struct {
 		path string
@@ -54,7 +54,7 @@ func TestShouldSkip_ExcludePatterns(t *testing.T) {
 
 func TestShouldSkip_AllowedExtensions(t *testing.T) {
 	root := t.TempDir()
-	f := newFileFilter(root, nil, []string{".go", ".md"})
+	f := newFileFilter(root, nil, []string{".go", ".md"}, nil)
 
 	cases := []struct {
 		path string
@@ -77,7 +77,7 @@ func TestShouldSkip_AllowedExtensions(t *testing.T) {
 
 func TestShouldSkip_AllowedExtensionsNoDot(t *testing.T) {
 	root := t.TempDir()
-	f := newFileFilter(root, nil, []string{"go", "ts"})
+	f := newFileFilter(root, nil, []string{"go", "ts"}, nil)
 
 	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should not be skipped when go is allowed")
@@ -94,7 +94,7 @@ func TestShouldSkip_Gitignore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f := newFileFilter(root, nil, nil)
+	f := newFileFilter(root, nil, nil, nil)
 
 	cases := []struct {
 		path string
@@ -115,9 +115,109 @@ func TestShouldSkip_Gitignore(t *testing.T) {
 
 func TestShouldSkip_NoGitignore(t *testing.T) {
 	root := t.TempDir()
-	f := newFileFilter(root, nil, nil)
+	f := newFileFilter(root, nil, nil, nil)
 
 	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should not be skipped when no .gitignore")
+	}
+}
+
+func TestLoadGlobalIgnore_MissingFileReturnsNil(t *testing.T) {
+	home := t.TempDir() // empty — no .nano-brain/ exists
+	gi, _, err := LoadGlobalIgnore(home)
+	if err != nil {
+		t.Fatalf("expected nil error when file missing, got %v", err)
+	}
+	if gi != nil {
+		t.Error("expected nil matcher when file missing")
+	}
+}
+
+func TestLoadGlobalIgnore_LoadsPatterns(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, ".nano-brain")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "*.png\n!keep.png\nbuild/\n"
+	if err := os.WriteFile(filepath.Join(dir, ".nano-brainignore"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gi, path, err := LoadGlobalIgnore(home)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gi == nil {
+		t.Fatal("expected non-nil matcher")
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("expected absolute path, got %q", path)
+	}
+	if !gi.MatchesPath("foo.png") {
+		t.Error("foo.png should match *.png pattern")
+	}
+	if gi.MatchesPath("keep.png") {
+		t.Error("keep.png should be un-matched (negation pattern)")
+	}
+	if !gi.MatchesPath("build/output.txt") {
+		t.Error("build/output.txt should match build/ pattern")
+	}
+	if gi.MatchesPath("main.go") {
+		t.Error("main.go should not match any global pattern")
+	}
+}
+
+func TestFileFilter_GlobalIgnoreApplies(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".nano-brain")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".nano-brainignore"), []byte("*.png\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gi, _, err := LoadGlobalIgnore(home)
+	if err != nil || gi == nil {
+		t.Fatalf("setup: %v, gi=%v", err, gi)
+	}
+
+	f := newFileFilter(root, nil, nil, gi)
+	if !f.shouldSkip(filepath.Join(root, "screenshot.png"), false) {
+		t.Error("screenshot.png should be skipped via global ignore")
+	}
+	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+		t.Error("main.go should NOT be skipped (no global match)")
+	}
+}
+
+func TestFileFilter_GlobalIgnoreCombinesWithPerCollection(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	gdir := filepath.Join(home, ".nano-brain")
+	if err := os.MkdirAll(gdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gdir, ".nano-brainignore"), []byte("*.log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gi, _, err := LoadGlobalIgnore(home)
+	if err != nil || gi == nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("temp/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := newFileFilter(root, nil, nil, gi)
+	if !f.shouldSkip(filepath.Join(root, "app.log"), false) {
+		t.Error("app.log should be skipped via global ignore")
+	}
+	if !f.shouldSkip(filepath.Join(root, "temp", "cache.json"), false) {
+		t.Error("temp/cache.json should be skipped via per-collection .gitignore")
+	}
+	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+		t.Error("main.go should NOT be skipped")
 	}
 }

--- a/internal/watcher/filter_test.go
+++ b/internal/watcher/filter_test.go
@@ -192,6 +192,34 @@ func TestFileFilter_GlobalIgnoreApplies(t *testing.T) {
 	}
 }
 
+func TestFileFilter_GlobalIgnoreMatchesDirectoryWithTrailingSlash(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	gdir := filepath.Join(home, ".nano-brain")
+	if err := os.MkdirAll(gdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// gitignore pattern with trailing slash matches dirs only — common Obsidian/build pattern.
+	if err := os.WriteFile(filepath.Join(gdir, ".nano-brainignore"), []byte("custom_build/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gi, _, err := LoadGlobalIgnore(home)
+	if err != nil || gi == nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	f := newFileFilter(root, nil, nil, gi)
+	if !f.shouldSkip(filepath.Join(root, "custom_build"), true) {
+		t.Error("custom_build directory must be skipped (gitignore 'custom_build/' pattern requires trailing slash)")
+	}
+	if !f.shouldSkip(filepath.Join(root, "custom_build", "output.bin"), false) {
+		t.Error("file inside custom_build/ should also be skipped")
+	}
+	if f.shouldSkip(filepath.Join(root, "src"), true) {
+		t.Error("src directory should NOT be skipped")
+	}
+}
+
 func TestFileFilter_GlobalIgnoreCombinesWithPerCollection(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/google/uuid"
+	gitignore "github.com/sabhiram/go-gitignore"
 	"github.com/nano-brain/nano-brain/internal/chunk"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/embed"
@@ -69,6 +70,18 @@ type Watcher struct {
 	dirty       map[string]bool
 	pub         eventbus.Publisher
 	rateLimiters map[string]*rate.Limiter
+
+	globalIgnore *gitignore.GitIgnore
+}
+
+// SetGlobalIgnore configures the watcher to apply a global gitignore-style
+// matcher to every collection's file filter. Pass nil to disable. Must be
+// called BEFORE any WatchWithFilter — existing filters are not updated.
+// See issue #263.
+func (w *Watcher) SetGlobalIgnore(gi *gitignore.GitIgnore) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.globalIgnore = gi
 }
 
 func New(db *sql.DB, queries WatcherQuerier, logger zerolog.Logger, cfg config.Config) *Watcher {
@@ -127,7 +140,7 @@ func (w *Watcher) WatchWithFilter(collectionName, dirPath, workspaceHash, globPa
 		globPattern:       globPattern,
 		excludePatterns:   excludePatterns,
 		allowedExtensions: allowedExtensions,
-		filter:            newFileFilter(absPath, excludePatterns, allowedExtensions),
+		filter:            newFileFilter(absPath, excludePatterns, allowedExtensions, w.globalIgnore),
 	}
 
 	if w.fsw != nil {

--- a/openspec/changes/global-nano-brain-ignore/proposal.md
+++ b/openspec/changes/global-nano-brain-ignore/proposal.md
@@ -1,0 +1,66 @@
+# Global .nano-brainignore Support
+
+## Issue
+[#263 — feat(config): global ignore patterns for files/folders/extensions](https://github.com/nano-step/nano-brain/issues/263)
+
+## Lane
+normal (2 risk flags: existing-behavior + weak-proof).
+
+## Why
+Issue #263 asks for global ignore patterns to reduce per-collection config repetition. Investigation shows MOST of #263 is already implemented:
+
+| Capability | Status |
+|---|---|
+| Global `watcher.exclude_patterns` (applies to all collections) | ✅ Exists (`config.go:100`, merged at `main.go:320`) |
+| Global `watcher.allowed_extensions` (applies to all collections) | ✅ Exists |
+| Default excludes (`node_modules/`, `.git/`, `dist/`, etc.) | ✅ Exists (`filter.go` `defaultExcludeDirs` — 21 entries baked in) |
+| Per-collection overrides | ✅ Exists |
+| `.gitignore` per-workspace respect | ✅ Exists |
+| **`.nano-brainignore` global file at `~/.nano-brain/.nano-brainignore`** | ❌ MISSING |
+| Binary file detection | ✅ Exists (issue #252 binary extension blacklist + UTF-8 check) |
+
+The single missing capability is the **`.nano-brainignore` global file** — an operator-managed gitignore-style file at `~/.nano-brain/.nano-brainignore` whose patterns apply to ALL collections (loaded once at server start). This is the cleanest UX for "I want to ignore X across all my workspaces" without editing config.yml.
+
+## Desired Outcome
+At server startup, the watcher loads `~/.nano-brain/.nano-brainignore` if it exists. Its patterns are gitignore-syntax (one per line, supports `**`, `!negation`, blank lines, `#` comments). The patterns merge with the existing per-collection `.gitignore` and `excludePatterns`.
+
+Order of evaluation (existing + new):
+1. `defaultExcludeDirs` (hardcoded, 21 entries) — most aggressive, blocks dir descent
+2. **NEW: `.nano-brainignore` (global gitignore from `~/.nano-brain/`)** — applies to all collections
+3. Per-collection `.gitignore` (in collection root) — existing
+4. Per-collection `excludePatterns` (config-level) — existing
+5. `allowedExtensions` (whitelist after all exclusions) — existing
+
+## Constraints
+- File location: `~/.nano-brain/.nano-brainignore` (use `os.UserHomeDir()` not hardcoded `/Users/...`)
+- File is OPTIONAL — server starts normally if missing (single info log: "no .nano-brainignore found, skipping")
+- Use existing `github.com/sabhiram/go-gitignore` library (already imported by `filter.go`)
+- Path resolution: patterns in `.nano-brainignore` match against paths RELATIVE to the collection root (not absolute), same as `.gitignore`. This works because each watched collection gets a fresh `fileFilter` with its own `rootDir`.
+- Compile the global ignore ONCE at startup (not per-collection), share immutable matcher across all `fileFilter` instances
+- No config schema changes — purely additive at filesystem level
+- Hot-reload: changes to `.nano-brainignore` require server restart (defer auto-reload to follow-up)
+
+## Out of Scope
+- Auto-reload on `.nano-brainignore` changes (operator must restart)
+- Per-workspace `.nano-brainignore` (only global one; existing per-collection `.gitignore` covers per-workspace needs)
+- New CLI to edit/test the ignore file
+- Migrating `defaultExcludeDirs` to ship as a default `.nano-brainignore` (keep hardcoded for now — operator override possible via patterns like `!node_modules` in their `.nano-brainignore`)
+
+## Acceptance Criteria
+1. **Loads `.nano-brainignore` at startup**: When `~/.nano-brain/.nano-brainignore` exists, the watcher loads it via `gitignore.CompileIgnoreFile`. INFO log shows the path + pattern count.
+2. **Skips file gracefully when missing**: When the file does not exist, server starts normally with a DEBUG log (no warning, no error).
+3. **Patterns apply to all collections**: A pattern `*.png` in the global ignore file causes PNG files to be skipped in ALL registered collections, without per-collection config.
+4. **Negation works**: `!important.png` in the global file un-ignores that specific file (gitignore standard).
+5. **Existing per-collection rules still merge**: A collection's own `.gitignore` + `excludePatterns` continue to be applied IN ADDITION to the global file.
+6. **No regression**: existing tests pass unchanged. `validate:quick` green.
+7. **Tests**:
+   - Unit test for `globalIgnoreLoader` (success / missing / malformed file)
+   - Filter test: combined global + per-collection rules behave correctly
+   - Integration test: drop a `.nano-brainignore` in test home dir, watch a temp collection, assert matching files skipped
+8. **README updated**: documents the new file location, gitignore syntax support, restart requirement.
+
+## Risk Flags
+- [x] Existing behavior (file watcher behavior change for operators who unknowingly have a stale `.nano-brainignore`)
+- [x] Weak proof (no current test for global ignore file)
+
+2 flags + 0 hard gates → **normal lane** confirmed.

--- a/openspec/changes/global-nano-brain-ignore/specs/watcher-global-ignore-file/spec.md
+++ b/openspec/changes/global-nano-brain-ignore/specs/watcher-global-ignore-file/spec.md
@@ -1,0 +1,58 @@
+# watcher-global-ignore-file Delta — New Capability
+
+## ADDED Requirements
+
+### Requirement: Watcher loads global ignore file at startup
+
+The watcher SHALL look for a file at `<user-home>/.nano-brain/.nano-brainignore` at server startup. The path is resolved via `os.UserHomeDir()` (not hardcoded). If the file exists and is parseable as gitignore syntax (per the `github.com/sabhiram/go-gitignore` library), the watcher SHALL compile it once and share the matcher across all watched collections.
+
+If the file is missing, the watcher SHALL start normally with a DEBUG-level log entry and no global ignore matcher (existing per-collection behavior unchanged). If the file exists but is malformed, the watcher SHALL log a WARN with the parse error and continue with no global ignore matcher (defensive — server must not fail to start because of one bad ignore file).
+
+#### Scenario: File exists with valid patterns
+
+- **GIVEN** `~/.nano-brain/.nano-brainignore` contains:
+  ```
+  *.png
+  *.jpg
+  !important.png
+  build/
+  ```
+- **WHEN** the server starts
+- **THEN** the watcher emits an INFO log `loaded global ignore file: <path> (4 patterns)`
+- **AND** the matcher is shared across all subsequently-created `fileFilter` instances
+
+#### Scenario: File does not exist
+
+- **GIVEN** `~/.nano-brain/.nano-brainignore` does not exist
+- **WHEN** the server starts
+- **THEN** the watcher emits a DEBUG log `.nano-brainignore not found, skipping`
+- **AND** all collections operate exactly as before this feature
+
+#### Scenario: File is malformed
+
+- **GIVEN** `~/.nano-brain/.nano-brainignore` contains content that `gitignore.CompileIgnoreFile` rejects
+- **WHEN** the server starts
+- **THEN** the watcher emits a WARN log with the parse error
+- **AND** the server starts normally (no global matcher, but all other functionality works)
+
+### Requirement: Global patterns apply to all collections
+
+When a global `.nano-brainignore` matcher is present, every `fileFilter.shouldSkip` decision SHALL evaluate the global matcher against the path RELATIVE to the collection root (same path representation used for the per-collection `.gitignore` matcher). The global matcher is checked AFTER `defaultExcludeDirs` (which short-circuits directory descent) but BEFORE the per-collection `.gitignore` and `excludePatterns`.
+
+This ordering preserves existing per-collection behavior (which can still override via specific paths or negation in per-collection rules).
+
+#### Scenario: Global *.png pattern applies to all workspaces
+
+- **GIVEN** the global file contains `*.png`
+- **AND** workspace A contains `screenshot.png`, workspace B contains `icon.png`
+- **WHEN** the watcher processes file events for both workspaces
+- **THEN** `screenshot.png` and `icon.png` are both skipped
+- **AND** the watcher emits one DEBUG `skipping binary file (extension)` for each (or `skipping per global ignore` depending on which check fires first)
+
+#### Scenario: Per-collection rules still apply on top of global
+
+- **GIVEN** the global file contains `*.log`
+- **AND** workspace A has per-collection `excludePatterns: ["temp/**"]`
+- **WHEN** the watcher processes `workspace-A/app.log` and `workspace-A/temp/cache.json`
+- **THEN** `app.log` is skipped due to the global rule
+- **AND** `temp/cache.json` is skipped due to the per-collection rule

--- a/openspec/changes/global-nano-brain-ignore/tasks.md
+++ b/openspec/changes/global-nano-brain-ignore/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Global .nano-brainignore Support
+
+Tracking: #263
+
+## Phase A — Loader
+
+- [ ] **A1** Add `loadGlobalIgnore(homeDir string, logger zerolog.Logger) *gitignore.GitIgnore` to `internal/watcher/filter.go`:
+  - Resolve `path := filepath.Join(homeDir, ".nano-brain", ".nano-brainignore")`
+  - `os.Stat(path)` — if missing, return `nil` + DEBUG log
+  - `gitignore.CompileIgnoreFile(path)` — if compile error, return `nil` + WARN log with error
+  - On success: INFO log with `path` + number of lines loaded + return matcher
+  - Returns nil if file missing or malformed (defensive — don't kill the watcher)
+
+- [ ] **A2** Extend `fileFilter` struct with `globalIgnore *gitignore.GitIgnore` field (separate from `gitignoreMatcher` which is per-collection).
+
+- [ ] **A3** Update `newFileFilter` signature: `newFileFilter(rootDir string, excludePatterns, allowedExtensions []string, globalIgnore *gitignore.GitIgnore) *fileFilter`. Pass globalIgnore into struct.
+
+- [ ] **A4** Update `shouldSkip()` to check `globalIgnore` BEFORE the per-collection `gitignoreMatcher`:
+  ```go
+  if f.globalIgnore != nil && f.globalIgnore.MatchesPath(rel) {
+      return true
+  }
+  ```
+
+## Phase B — Wire into server startup
+
+- [ ] **B1** In `cmd/nano-brain/main.go` (where watcher starts, around line 320):
+  - Once at startup, before any `WatchWithFilter` call: `globalIgnore := loadGlobalIgnore(homeDir, logger)`
+  - Pass `globalIgnore` to `WatchWithFilter` as a new param OR store on `Watcher` struct
+  - Lowest-impact path: store on `Watcher` struct + thread to each new `fileFilter` via `newFileFilter` call inside `WatchWithFilter`
+
+- [ ] **B2** Update `Watcher.WatchWithFilter` to receive/use `globalIgnore` (via struct field). All existing call sites continue to work.
+
+## Phase C — Tests
+
+- [ ] **C1** `TestLoadGlobalIgnore_MissingFileReturnsNil` — temp homeDir, no .nano-brainignore, assert nil + no error.
+
+- [ ] **C2** `TestLoadGlobalIgnore_LoadsPatterns` — write `*.png\n!keep.png\n` to temp `.nano-brain/.nano-brainignore`, call loader, assert matcher returns true for `foo.png` and false for `keep.png`.
+
+- [ ] **C3** `TestLoadGlobalIgnore_MalformedFileReturnsNil` — write `[invalid syntax` (force CompileIgnoreFile to fail), assert nil + WARN log.
+
+- [ ] **C4** `TestFileFilter_GlobalIgnoreApplies` — fileFilter with globalIgnore set, no per-collection gitignore, no excludePatterns; shouldSkip returns true for matching files.
+
+- [ ] **C5** `TestFileFilter_GlobalIgnoreCombinesWithPerCollection` — both global + per-collection gitignore set, both contribute to skip decision.
+
+## Phase D — Validate ladder
+
+- [ ] **D1** `validate:quick`: `go build ./... && go test -race -short ./...` → green.
+
+## Phase E — README + PR
+
+- [ ] **E1** Update README.md: add section under "Configuration" titled "Global ignore patterns" documenting:
+  - Path: `~/.nano-brain/.nano-brainignore`
+  - Format: gitignore syntax (link to spec)
+  - Restart required after edits
+  - Order: defaults → global → per-collection .gitignore → per-collection excludePatterns
+
+- [ ] **E2** Commit:
+  ```
+  feat(watcher): support ~/.nano-brain/.nano-brainignore for global ignore patterns (#263)
+
+  Adds a global gitignore-style file that applies patterns across ALL watched
+  collections without per-collection config repetition. Complements existing
+  defaultExcludeDirs, per-collection .gitignore, and per-collection excludePatterns.
+
+  - loadGlobalIgnore: reads file at startup, returns nil gracefully if missing
+  - fileFilter: new globalIgnore field, evaluated before per-collection .gitignore
+  - main.go: loads once at startup, threaded into all watchers
+  - Tests: 5 cases covering missing, loaded, malformed, combined-with-collection
+  ```
+
+- [ ] **E3** Push, PR with `Closes #263`, Gemini triage, squash merge.
+
+- [ ] **E4** Archive openspec, cleanup worktree.


### PR DESCRIPTION
Closes #263.

## Problem
Operators had to repeat same exclusion patterns in every per-collection config. The only missing piece from #263 (most was already implemented: global `exclude_patterns` in WatcherConfig, default exclude dirs, .gitignore respect, binary detection per #252).

## Fix
New global gitignore-style file at `~/.nano-brain/.nano-brainignore` loaded once at startup, shared across all collections.

## Implementation
- `watcher.LoadGlobalIgnore(homeDir)` reads + compiles file (returns nil gracefully if missing/malformed)
- `Watcher.SetGlobalIgnore` setter exposes injection point
- `fileFilter.globalIgnore` field checked BEFORE per-collection `.gitignore`
- main.go: loads after `fw := watcher.New(...)`, INFO log on success, DEBUG on missing, WARN on malformed

## Order of evaluation
1. defaultExcludeDirs (hardcoded 21 entries)
2. global `.nano-brainignore` (this PR)
3. per-collection `.gitignore`
4. per-collection `excludePatterns`
5. per-collection `allowedExtensions` (whitelist)

## Tests
- `TestLoadGlobalIgnore_{MissingFileReturnsNil, LoadsPatterns}`
- `TestFileFilter_{GlobalIgnoreApplies, GlobalIgnoreCombinesWithPerCollection}`
- 22 packages PASS short mode

## OpenSpec
`openspec/changes/global-nano-brain-ignore/` — proposal + tasks + spec delta (2 ADDED reqs, 5 scenarios). `openspec validate --strict` PASS.