### PR TITLE
feat(server): add serve_only mode flag to disable background workers (#282)

### DIFF
--- a/cmd/nano-brain/bindsafety.go
+++ b/cmd/nano-brain/bindsafety.go
@@ -9,6 +9,10 @@ import (
 // unsafeNoAuth is set by the --unsafe-no-auth flag on the serve subcommand.
 var unsafeNoAuth bool
 
+// serveOnlyFlag is set by the --serve-only flag on the serve subcommand and
+// overrides cfg.Server.ServeOnly at startup. See issue #282.
+var serveOnlyFlag bool
+
 func isLoopback(host string) bool {
 	h := strings.ToLower(strings.Trim(host, "[]"))
 	if h == "" || h == "localhost" || h == "127.0.0.1" || h == "::1" {

--- a/cmd/nano-brain/daemon.go
+++ b/cmd/nano-brain/daemon.go
@@ -45,9 +45,11 @@ func runServeCmd(args []string, configPath string) {
 			daemon = true
 		case "--unsafe-no-auth":
 			unsafeNoAuth = true
+		case "--serve-only":
+			serveOnlyFlag = true
 		default:
 			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", a)
-			fmt.Fprintln(os.Stderr, "Usage: nano-brain serve [-d] [--unsafe-no-auth]")
+			fmt.Fprintln(os.Stderr, "Usage: nano-brain serve [-d] [--unsafe-no-auth] [--serve-only]")
 			os.Exit(1)
 		}
 	}

--- a/cmd/nano-brain/daemon.go
+++ b/cmd/nano-brain/daemon.go
@@ -95,6 +95,12 @@ func runServeDaemon(configPath string) {
 	if configPath != "" {
 		childArgs = append(childArgs, "--config", configPath)
 	}
+	if unsafeNoAuth {
+		childArgs = append(childArgs, "--unsafe-no-auth")
+	}
+	if serveOnlyFlag {
+		childArgs = append(childArgs, "--serve-only")
+	}
 
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -217,6 +217,10 @@ func startServer(configPath string) {
 
 	applyVerbose(&cfg.Logging)
 
+	if serveOnlyFlag {
+		cfg.Server.ServeOnly = true
+	}
+
 	if err := checkBindSafety(cfg.Server.Host, cfg.Server.Auth.Enabled); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
@@ -230,6 +234,10 @@ func startServer(configPath string) {
 
 	if unsafeNoAuth && !isLoopback(cfg.Server.Host) && !cfg.Server.Auth.Enabled {
 		logger.Warn().Str("host", cfg.Server.Host).Msg("bound to non-loopback without auth (--unsafe-no-auth set)")
+	}
+
+	if cfg.Server.ServeOnly {
+		logger.Info().Msg("serve_only mode enabled — embed queue + file watcher + harvester will NOT start (issue #282)")
 	}
 
 	logger.Info().
@@ -343,7 +351,9 @@ func startServer(configPath string) {
 
 	srv := server.New(cfg, configPath, pool, db, queries, fw, eq, embedder, bus, logger, Version, migrationVersion)
 
-	if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
+	if cfg.Server.ServeOnly {
+		logger.Info().Msg("serve_only mode — skipping collection watcher registration")
+	} else if workspaces, err := queries.ListWorkspaces(ctx); err == nil {
 		for _, ws := range workspaces {
 			collections, err := queries.ListCollections(ctx, ws.Hash)
 			if err != nil {
@@ -377,87 +387,97 @@ func startServer(configPath string) {
 		return nil
 	})
 
-	g.Go(func() error {
-		return fw.Run(gctx)
-	})
+	if cfg.Server.ServeOnly {
+		logger.Info().Msg("serve_only mode — file watcher goroutine disabled")
+	} else {
+		g.Go(func() error {
+			return fw.Run(gctx)
+		})
+	}
 
-	if eq != nil {
+	if cfg.Server.ServeOnly {
+		logger.Info().Msg("serve_only mode — embed queue worker disabled")
+	} else if eq != nil {
 		g.Go(func() error {
 			return eq.Run(gctx)
 		})
 	}
 
-	var hr *harvest.Runner
-	interval := time.Duration(cfg.Intervals.SessionPoll) * time.Second
+	if cfg.Server.ServeOnly {
+		logger.Info().Msg("serve_only mode — harvester + summarizer disabled")
+	} else {
+		var hr *harvest.Runner
+		interval := time.Duration(cfg.Intervals.SessionPoll) * time.Second
 
-	if cfg.Harvester.OpenCode.SessionDir == "" {
-		if detected := detectOpenCodeStorageDir(); detected != "" {
-			cfg.Harvester.OpenCode.SessionDir = detected
-			logger.Info().Str("path", detected).Msg("auto-detected opencode storage dir")
-		}
-	}
-
-	if cfg.Harvester.OpenCode.DBPath == "" {
-		if detected := detectOpenCodeDBPath(); detected != "" {
-			cfg.Harvester.OpenCode.DBPath = detected
-			logger.Info().Str("path", detected).Msg("auto-detected opencode sqlite db")
-		}
-	}
-
-	if cfg.Harvester.OpenCode.DBRoot == "" {
-		if detected := detectOpenCodeDBRoot(); detected != "" {
-			cfg.Harvester.OpenCode.DBRoot = detected
-			logger.Info().Str("path", detected).Msg("auto-detected opencode db root")
-		}
-	}
-
-	var harvestSummarizer *summarize.HarvestSummarizer
-	if cfg.Summarization.Enabled {
-		harvestSummarizer = buildHarvestSummarizer(cfg, db, eq, logger)
-		if harvestSummarizer == nil {
-			logger.Warn().Msg("summarization enabled but init failed — falling back to raw harvest")
-		} else {
-			logger.Info().Str("model", cfg.Summarization.Model).Msg("session summarization enabled")
-		}
-	}
-
-	ocHarvesters, ocMode := buildOpenCodeHarvesters(ctx, cfg, db, queries, logger)
-	for i, oh := range ocHarvesters {
-		if i == 0 {
-			hr = harvest.NewRunner(oh, eq, interval, logger)
-		} else {
-			hr.AddHarvester(oh)
-		}
-	}
-	srv.SetHarvestStatus(ocMode, cfg.Harvester.OpenCode.DBRoot, cfg.Harvester.OpenCode.DBPath, cfg.Harvester.OpenCode.SessionDir, len(ocHarvesters))
-
-	if ch, ccErr := initClaudeCodeHarvester(ctx, cfg.Harvester.ClaudeCode, db, logger); ccErr != nil {
-		logger.Error().Err(ccErr).Msg("claude code harvester init failed")
-	} else if ch != nil {
-		if hr == nil {
-			hr = harvest.NewRunner(ch, eq, interval, logger)
-		} else {
-			hr.AddHarvester(ch)
-		}
-		logger.Info().
-			Str("session_dir", cfg.Harvester.ClaudeCode.SessionDir).
-			Dur("interval", interval).
-			Msg("claude code session harvester started")
-	}
-
-	if hr != nil {
-		hr.WithPublisher(bus)
-		if harvestSummarizer != nil {
-			hr.WithSummarizer(harvestSummarizer)
-			srv.SetSummarizer(harvestSummarizer)
-			if res, ext := srv.LinkDeps(); res != nil && ext != nil {
-				harvestSummarizer.SetLinkExtractor(res, ext)
+		if cfg.Harvester.OpenCode.SessionDir == "" {
+			if detected := detectOpenCodeStorageDir(); detected != "" {
+				cfg.Harvester.OpenCode.SessionDir = detected
+				logger.Info().Str("path", detected).Msg("auto-detected opencode storage dir")
 			}
 		}
-		srv.SetHarvestRunner(hr)
-		g.Go(func() error {
-			return hr.Run(gctx)
-		})
+
+		if cfg.Harvester.OpenCode.DBPath == "" {
+			if detected := detectOpenCodeDBPath(); detected != "" {
+				cfg.Harvester.OpenCode.DBPath = detected
+				logger.Info().Str("path", detected).Msg("auto-detected opencode sqlite db")
+			}
+		}
+
+		if cfg.Harvester.OpenCode.DBRoot == "" {
+			if detected := detectOpenCodeDBRoot(); detected != "" {
+				cfg.Harvester.OpenCode.DBRoot = detected
+				logger.Info().Str("path", detected).Msg("auto-detected opencode db root")
+			}
+		}
+
+		var harvestSummarizer *summarize.HarvestSummarizer
+		if cfg.Summarization.Enabled {
+			harvestSummarizer = buildHarvestSummarizer(cfg, db, eq, logger)
+			if harvestSummarizer == nil {
+				logger.Warn().Msg("summarization enabled but init failed — falling back to raw harvest")
+			} else {
+				logger.Info().Str("model", cfg.Summarization.Model).Msg("session summarization enabled")
+			}
+		}
+
+		ocHarvesters, ocMode := buildOpenCodeHarvesters(ctx, cfg, db, queries, logger)
+		for i, oh := range ocHarvesters {
+			if i == 0 {
+				hr = harvest.NewRunner(oh, eq, interval, logger)
+			} else {
+				hr.AddHarvester(oh)
+			}
+		}
+		srv.SetHarvestStatus(ocMode, cfg.Harvester.OpenCode.DBRoot, cfg.Harvester.OpenCode.DBPath, cfg.Harvester.OpenCode.SessionDir, len(ocHarvesters))
+
+		if ch, ccErr := initClaudeCodeHarvester(ctx, cfg.Harvester.ClaudeCode, db, logger); ccErr != nil {
+			logger.Error().Err(ccErr).Msg("claude code harvester init failed")
+		} else if ch != nil {
+			if hr == nil {
+				hr = harvest.NewRunner(ch, eq, interval, logger)
+			} else {
+				hr.AddHarvester(ch)
+			}
+			logger.Info().
+				Str("session_dir", cfg.Harvester.ClaudeCode.SessionDir).
+				Dur("interval", interval).
+				Msg("claude code session harvester started")
+		}
+
+		if hr != nil {
+			hr.WithPublisher(bus)
+			if harvestSummarizer != nil {
+				hr.WithSummarizer(harvestSummarizer)
+				srv.SetSummarizer(harvestSummarizer)
+				if res, ext := srv.LinkDeps(); res != nil && ext != nil {
+					harvestSummarizer.SetLinkExtractor(res, ext)
+				}
+			}
+			srv.SetHarvestRunner(hr)
+			g.Go(func() error {
+				return hr.Run(gctx)
+			})
+		}
 	}
 
 	g.Go(func() error {

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -45,6 +45,8 @@ func main() {
 	var daemonChild bool
 	flag.StringVar(&configPath, "config", "", "path to config file (default: ~/.nano-brain/config.yml)")
 	flag.BoolVar(&daemonChild, "daemon-child", false, "")
+	flag.BoolVar(&unsafeNoAuth, "unsafe-no-auth", false, "allow binding to non-loopback without auth")
+	flag.BoolVar(&serveOnlyFlag, "serve-only", false, "disable background workers (embed queue, watcher, harvester) — issue #282")
 	flag.IntVar(&verbose, "v", 0, "verbosity: 0=info, 1=debug, 2=trace")
 	flag.IntVar(&verbose, "verbose", 0, "")
 	flag.Parse()
@@ -335,10 +337,13 @@ func startServer(configPath string) {
 			logger.Error().Err(embedErr).Str("provider", cfg.Embedding.Provider).Str("url", cfg.Embedding.URL).Msg("embedding provider init failed")
 		} else {
 			embedder = e
-			eq = embed.NewQueue(embedder, queries, logger, cfg.Embedding.Provider, cfg.Embedding.Model, cfg.Embedding.Concurrency).
-				WithMaxChars(cfg.Embedding.MaxChars)
-			fw.WithEmbedQueue(eq)
-			// Publisher is wired after bus creation below.
+			if cfg.Server.ServeOnly {
+				logger.Info().Msg("serve_only mode — embedder constructed but queue skipped (write handler will be no-op for enqueue)")
+			} else {
+				eq = embed.NewQueue(embedder, queries, logger, cfg.Embedding.Provider, cfg.Embedding.Model, cfg.Embedding.Concurrency).
+					WithMaxChars(cfg.Embedding.MaxChars)
+				fw.WithEmbedQueue(eq)
+			}
 		}
 	}
 

--- a/docs/evidence/serve-only-mode/gemini-triage.md
+++ b/docs/evidence/serve-only-mode/gemini-triage.md
@@ -1,0 +1,36 @@
+# Gemini Triage — serve-only-mode (#282)
+
+PR: nano-step/nano-brain#283
+Date: 2026-06-01
+Bot reviewer: gemini-code-assist[bot]
+Agent: Sisyphus
+
+## Triage Table (R31)
+
+| Comment ref | Verdict | Reasoning | Action |
+|-------------|---------|-----------|--------|
+| daemon.go:L49 (flags not forwarded to child) | VALID:high | When `serve -d` spawns child via `os.StartProcess`, child only gets `--daemon-child --config X` args. `unsafeNoAuth` and `serveOnlyFlag` package globals in parent process don't propagate. Child runs with defaults → silent breakage. | Applied: forward both flags to childArgs in `runServeDaemon`. Also register them as `flag.BoolVar` in `main()` so child process can parse them on the `--daemon-child` invocation. |
+| main.go:L400 (embed queue worker disabled but Enqueue may block) | VALID:medium | When serve_only=true, eq.Run goroutine is not started. If `eq != nil` and routes.go passes it as ChunkEnqueuer to /api/v1/write, calling `eq.Enqueue` writes to a channel with no draining worker. Channel fills to cap=10000, then `select default` branch drops chunks silently. Worse: scan worker also disabled, so dropped chunks never recover. | Applied: skip queue construction entirely when serve_only. `eq = nil` → routes.go check `s.embedQueue != nil` falls through, handler enqueuer is nil, WriteDocument's `if enqueuer != nil` guard skips embed enqueue. Documents still saved; embedding happens later when host instance scans. |
+
+## Resolution Summary
+
+- 2 findings addressed in 1 push cycle (R31 limit: 3)
+- 0 FALSE_POSITIVE / DEFER
+
+## Verification Post-Fix
+
+```
+$ go build ./...                    exit 0
+$ go test -race -short ./cmd/nano-brain/...    PASS
+```
+
+Live test on dev server (port 3199, serve_only=true):
+- Startup log: "serve_only mode — embedder constructed but queue skipped (write handler will be no-op for enqueue)"
+- `/api/v1/workspaces` returns 19 workspaces
+- `/health` returns 200 OK
+
+Daemon mode flag forwarding tested logically:
+- `nano-brain serve --serve-only -d` → parent sets serveOnlyFlag=true → runServeDaemon called → childArgs now includes "--serve-only" → child process flag.BoolVar parses it → child startServer() sees serveOnlyFlag=true → cfg.Server.ServeOnly = true
+
+## Loop count
+1/3 push cycles.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,10 +47,16 @@ type Config struct {
 }
 
 // ServerConfig holds server configuration.
+//
+// ServeOnly disables ALL background workers (embed queue, file watcher,
+// harvester) so the binary only serves HTTP requests. Useful for proxy
+// containers that share a DB with a primary host instance running the
+// workers — prevents duplicate work and races. See issue #282.
 type ServerConfig struct {
-	Host string     `koanf:"host" json:"host"`
-	Port int        `koanf:"port" json:"port"`
-	Auth AuthConfig `koanf:"auth" json:"auth"`
+	Host      string     `koanf:"host" json:"host"`
+	Port      int        `koanf:"port" json:"port"`
+	Auth      AuthConfig `koanf:"auth" json:"auth"`
+	ServeOnly bool       `koanf:"serve_only" json:"serve_only"`
 }
 
 // AuthConfig holds authentication configuration for VPS/remote deployments.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -947,3 +947,51 @@ func TestConfig_JSONUsesSnakeCase(t *testing.T) {
 		}
 	}
 }
+
+func TestServeOnlyConfigFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+
+	t.Run("default is false", func(t *testing.T) {
+		yaml := "server:\n  host: localhost\n  port: 3100\n"
+		if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Server.ServeOnly {
+			t.Errorf("ServeOnly default should be false, got true")
+		}
+	})
+
+	t.Run("yaml serve_only: true is honored", func(t *testing.T) {
+		yaml := "server:\n  host: localhost\n  port: 3100\n  serve_only: true\n"
+		if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.Server.ServeOnly {
+			t.Errorf("ServeOnly should be true from YAML, got false")
+		}
+	})
+
+	t.Run("env NANO_BRAIN_SERVER_SERVE_ONLY overrides yaml", func(t *testing.T) {
+		yaml := "server:\n  host: localhost\n  port: 3100\n  serve_only: false\n"
+		if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("NANO_BRAIN_SERVER_SERVE_ONLY", "true")
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.Server.ServeOnly {
+			t.Errorf("ServeOnly should be true from env, got false")
+		}
+	})
+}


### PR DESCRIPTION
Closes #282.

## Problem

Running nano-brain inside a container that proxies to a host-side DB+ollama caused duplicate work (and race conditions on DB writes) because background workers (embed queue, file watcher, harvester, summarizer) still started despite the host instance already running them.

## Fix

Add `server.serve_only` config flag (and `--serve-only` CLI flag). When true, the server starts HTTP listener only — all background goroutines are skipped at startup.

## Usage

3 ways to enable:

```yaml
# config.yml
server:
  serve_only: true
```

```bash
export NANO_BRAIN_SERVER_SERVE_ONLY=true
```

```bash
nano-brain serve --serve-only
```

## What's Disabled

- File watcher (fw.Run goroutine + collection registration loop)
- Embed queue worker (eq.Run goroutine)
- Harvester (hr.Run goroutine + summarizer build)

## What Still Works

- HTTP server (echo handlers)
- All API endpoints (/api/v1/*, /api/status, /health, /mcp, /ui)
- DB reads + writes (when triggered by API requests)

## E2E Verification

Built dev binary, ran on port 3199 with `serve_only: true`:

Startup logs (4 explicit disabled markers):
```
serve_only mode enabled — embed queue + file watcher + harvester will NOT start (issue #282)
serve_only mode — skipping collection watcher registration
serve_only mode — file watcher goroutine disabled
serve_only mode — embed queue worker disabled
serve_only mode — harvester + summarizer disabled
HTTP server listening on 0.0.0.0:3199
```

Tests against running server:
- `curl /health` → 200 OK
- `curl /api/v1/workspaces` → returns 19 workspaces
- `curl /api/v1/stats` → docs_total=8812, chunks_total=12704, embed queue depth=0
- Browser /ui/dashboard → renders 6 cards correctly, EMBED QUEUE 0 idle
- **Embed/watcher events in 30s window: 0** (zero background activity)

## Tests

```
go build ./...                    exit 0
go vet ./...                      clean
go test -race -short ./...        ALL PASS
```

3 new sub-tests in TestServeOnlyConfigFlag:
- default is false
- yaml `serve_only: true` is honored
- env `NANO_BRAIN_SERVER_SERVE_ONLY` overrides yaml

## Lane

tiny — config additions + boolean guards. Additive only. No risk flags. Existing default behavior unchanged (all workers run when serve_only is unset/false).