### PR TITLE
chore: collapse b-main into master single-trunk model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, b-main]
+    branches: [master]
   pull_request:
-    branches: [master, b-main]
+    branches: [master]
 
 jobs:
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,10 +155,10 @@ Why: keeps worktree state co-located with the repo, avoids polluting the parent 
 
 ```bash
 # CORRECT — worktree inside the repo
-git worktree add .opencode/worktrees/feat-NNN-short-name b-main
+git worktree add .opencode/worktrees/feat-NNN-short-name master
 
 # WRONG — pollutes parent dir, hard to track
-git worktree add ../nano-brain-foo b-main
+git worktree add ../nano-brain-foo master
 ```
 
 After PR merge, clean up:
@@ -312,9 +312,9 @@ This project uses an engineering harness for risk-classified, spec-driven develo
 - **No starting work without a GitHub issue.**
 - **No archiving without Review Verdict = PASS.**
 - **No modifying harness rules without user approval.**
-- **No direct commits to `master` or `b-main`.** Always work on a feature branch (`feat/`, `fix/`, `chore/`, `docs/`) and open a PR. The only exception is a merge commit produced by resolving an existing PR's conflicts — and even then the resolution should normally happen on the PR's head branch, not on the target.
+- **No direct commits to `master`.** Always work on a feature branch (`feat/`, `fix/`, `chore/`, `docs/`) and open a PR. The only exception is a merge commit produced by resolving an existing PR's conflicts — and even then the resolution should normally happen on the PR's head branch, not on the target.
 - **No `git push origin <branch>` without first verifying you are ON `<branch>`.** Always run `git branch --show-current` (or check `git status` header) before pushing. Pushing while on the wrong branch silently returns "Everything up-to-date" without error. Use `git push` (no args, relies on upstream tracking) when in doubt.
-- **No merging trunk-into-trunk locally.** If a PR's base needs to absorb its head (e.g. `b-main → master`), let the GitHub merge button handle it after conflicts are resolved on the PR head. Local `git merge origin/<other-trunk>` followed by `push origin <this-trunk>` bypasses CI gates and PR review history.
+- **Single-trunk model: `master` only.** All feature branches branch from `master` and PR back to `master`. The `b-main` staging branch was retired on 2026-06-01 — no more `b-main → master` promotion step. Every merge to `master` triggers `auto-tag.yml` → `release.yml` → npm publish.
 
 ### Git push workflow (container environment)
 
@@ -352,7 +352,7 @@ Date-based auto-release pipeline (master push → tag → binaries + npm publish
 | `master` push | `.github/workflows/auto-tag.yml` | Compute next tag `v{YYYY}.{M}.{D}.{N}` (e.g. `v2026.5.30.1`) → push tag via `RELEASE_PAT` |
 | `v*` tag push | `.github/workflows/release.yml` | Cross-build 4-platform Go binaries (linux/darwin × amd64/arm64) → create GH Release with binaries → `npm publish --tag latest` both `@nano-step/nano-brain` and `nano-brain` (unscoped alias) |
 | PR opened/sync | `.github/workflows/gemini-review.yml` → shared `gemini-review.yml@v1` | Gemini code review comment on PR |
-| `master` / `b-main` push, PR | `.github/workflows/ci.yml` | `go build` + `go test -race -short` against ephemeral PG service |
+| `master` push, PR | `.github/workflows/ci.yml` | `go build` + `go test -race -short` against ephemeral PG service |
 
 Required repo secrets (set via `gh secret set --repo nano-step/nano-brain`):
 

--- a/docs/harness-state.json
+++ b/docs/harness-state.json
@@ -3,7 +3,7 @@
   "position": {
     "epic": 10,
     "story": "next",
-    "branch": "b-main",
+    "branch": "master",
     "base_commit": "bda265f",
     "note": "Epic 9 complete: 8/8 stories merged, openspec web-ui archived (2026-05-30-web-ui), Epic #239 closed"
   },

--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -167,13 +167,13 @@ phase_pre_work() {
         fi
     fi
     
-    # 1.4 Branch b-main up-to-date
+    # 1.4 Branch master up-to-date
     if git fetch origin &>/dev/null; then
-        unpushed=$(git log origin/b-main..b-main --oneline 2>/dev/null || echo "")
+        unpushed=$(git log origin/master..master --oneline 2>/dev/null || echo "")
         if [[ -n "$unpushed" ]]; then
-            add_check "FAIL" "1.4 b-main has unpushed commits"
+            add_check "FAIL" "1.4 master has unpushed commits"
         else
-            add_check "PASS" "1.4 b-main is up-to-date"
+            add_check "PASS" "1.4 master is up-to-date"
         fi
     else
         add_check "SKIP" "1.4 Cannot fetch origin"
@@ -190,29 +190,29 @@ phase_pre_work() {
         add_check "SKIP" "1.5 Go not installed"
     fi
     
-    # 1.6 Feature branch created off b-main (NOT master)
+    # 1.6 Feature branch created off master
     current_branch=$(git branch --show-current 2>/dev/null || echo "")
-    if [[ -n "$current_branch" && "$current_branch" != "b-main" ]]; then
-        parent_is_bmain=$(git merge-base --is-ancestor b-main "$current_branch" 2>/dev/null && echo "yes" || echo "no")
-        if [[ "$parent_is_bmain" == "yes" ]]; then
-            add_check "PASS" "1.6 Branch '$current_branch' is based on b-main"
+    if [[ -n "$current_branch" && "$current_branch" != "master" ]]; then
+        parent_is_master=$(git merge-base --is-ancestor master "$current_branch" 2>/dev/null && echo "yes" || echo "no")
+        if [[ "$parent_is_master" == "yes" ]]; then
+            add_check "PASS" "1.6 Branch '$current_branch' is based on master"
         else
-            add_check "FAIL" "1.6 Branch '$current_branch' is NOT based on b-main"
+            add_check "FAIL" "1.6 Branch '$current_branch' is NOT based on master"
         fi
     else
-        add_check "SKIP" "1.6 On b-main or branch unknown (check after creating feature branch)"
+        add_check "SKIP" "1.6 On master or branch unknown (check after creating feature branch)"
     fi
 }
 
 phase_in_progress() {
     echo "─ IN-PROGRESS checks"
     
-    # 2.1 On feature branch, not b-main
+    # 2.1 On feature branch, not master
     current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-    if [[ "$current_branch" != "b-main" ]]; then
+    if [[ "$current_branch" != "master" ]]; then
         add_check "PASS" "2.1 On feature branch: $current_branch"
     else
-        add_check "FAIL" "2.1 Still on b-main (should be on feature branch)"
+        add_check "FAIL" "2.1 Still on master (should be on feature branch)"
     fi
     
     # 2.2 OpenSpec change active
@@ -409,13 +409,13 @@ phase_pre_merge() {
         add_check "SKIP" "3.8 gh CLI not installed"
     fi
     
-    # 3.9 PR targets b-main (NOT master)
+    # 3.9 PR targets master
     if cmd_exists gh; then
         base_ref=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "")
-        if [[ "$base_ref" == "b-main" ]]; then
-            add_check "PASS" "3.9 PR targets b-main"
+        if [[ "$base_ref" == "master" ]]; then
+            add_check "PASS" "3.9 PR targets master"
         elif [[ -n "$base_ref" ]]; then
-            add_check "FAIL" "3.9 PR targets '$base_ref' — MUST target b-main"
+            add_check "FAIL" "3.9 PR targets '$base_ref' — MUST target master"
         else
             add_check "SKIP" "3.9 No open PR found"
         fi
@@ -485,7 +485,7 @@ phase_pre_merge() {
     if ! cmd_exists git; then
         add_check "SKIP" "3.13 git not installed"
     else
-        web_touched=$(git diff --name-only origin/b-main...HEAD 2>/dev/null \
+        web_touched=$(git diff --name-only origin/master...HEAD 2>/dev/null \
             | grep -E '^(web/src/|web/package\.json|internal/server/handlers/|internal/server/webui/|internal/server/routes\.go)' || true)
         if [[ -z "$web_touched" ]]; then
             add_check "SKIP" "3.13 no web change in PR diff (smoke:ui not required)"
@@ -576,18 +576,18 @@ phase_post_merge() {
     
     # 4.4 Feature branch deleted
     current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-    if [[ "$current_branch" == "b-main" ]]; then
-        add_check "PASS" "4.4 On b-main (feature branch cleaned up)"
+    if [[ "$current_branch" == "master" ]]; then
+        add_check "PASS" "4.4 On master (feature branch cleaned up)"
     else
         add_check "FAIL" "4.4 Still on feature branch: $current_branch"
     fi
     
-    # 4.5 Validation on b-main
+    # 4.5 Validation on master
     if cmd_exists go; then
-        if git checkout b-main &>/dev/null && go build ./... &>/dev/null && go test -race -short ./... >/dev/null 2>&1; then
-            add_check "PASS" "4.5 b-main validation passes"
+        if git checkout master &>/dev/null && go build ./... &>/dev/null && go test -race -short ./... >/dev/null 2>&1; then
+            add_check "PASS" "4.5 master validation passes"
         else
-            add_check "FAIL" "4.5 Validation failed on b-main"
+            add_check "FAIL" "4.5 Validation failed on master"
         fi
     else
         add_check "SKIP" "4.5 Go not installed"
@@ -653,15 +653,15 @@ phase_retro() {
         add_check "SKIP" "6.2 No merged PRs to compute avg cycles"
     fi
 
-    # 6.3 CI failure count on b-main during epic window
-    if gh run list --branch b-main --limit 100 --json conclusion &>/dev/null; then
-        ci_fails=$(gh run list --branch b-main --limit 100 \
+    # 6.3 CI failure count on master during epic window
+    if gh run list --branch master --limit 100 --json conclusion &>/dev/null; then
+        ci_fails=$(gh run list --branch master --limit 100 \
             --json conclusion --jq '[.[] | select(.conclusion == "failure")] | length' \
             2>/dev/null || echo "0")
         if [[ "$ci_fails" -gt 5 ]]; then
-            add_check "FAIL" "6.3 CI failures on b-main: $ci_fails (> 5 — investigate)"
+            add_check "FAIL" "6.3 CI failures on master: $ci_fails (> 5 — investigate)"
         else
-            add_check "PASS" "6.3 CI failures on b-main: $ci_fails"
+            add_check "PASS" "6.3 CI failures on master: $ci_fails"
         fi
     else
         add_check "SKIP" "6.3 gh run list not accessible"


### PR DESCRIPTION
## Summary

Retire the `b-main` staging branch in favor of a single-trunk model. All feature branches will now branch from `master` and PR back to `master`. Every merge to master triggers `auto-tag.yml` → `release.yml` → npm publish.

## Why

The b-main → master promotion was a manual step (PR #274, PR #290) that gated releases. Today (2026-06-01) all 7 feature PRs merged into b-main and then sat there for ~13 hours unreleased because the promotion step was forgotten. Releases ONLY happened once b-main → master was manually triggered. Single-trunk eliminates this footgun.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Drop `b-main` from CI push/PR trigger branches |
| `AGENTS.md` | Rewrite git workflow rules — feature branches now base off `master`; retire `b-main → master` rule; update CI triggers table |
| `scripts/harness-check.sh` | 6 gate checks updated: 1.4 (up-to-date), 1.6 (parent branch), 2.1 (not-on-trunk), 3.9 (PR target), 4.4/4.5 (cleanup+validation), 3.13 (web diff base), 6.3 (CI failure window) |
| `docs/harness-state.json` | `position.branch`: `b-main` → `master` |

## What's NOT touched

- `docs/evidence/`, `ai/test-case/`, `openspec/changes/archive/`, `CHANGELOG.md`, `.decision-log.md`, `docs/HARNESS_BACKLOG.md`, `docs/HARNESS_GATES.md` — append-only history with references to b-main left as-is.

## Post-merge cleanup steps

1. Delete `origin/b-main` from GitHub.
2. Update GitHub branch protection rules (remove b-main protection if any exists).
3. Locally: `git branch -D b-main` + `git remote prune origin`.

## Verification

- `go build ./...` exit 0
- `bash -n scripts/harness-check.sh` — syntax clean
- Diff is minimal (4 files, 38 lines changed)

[skip-release]