### PR TITLE
fix(npm): handle npm semver normalization of zero-padded tag patch (#292)

### DIFF
--- a/docs/evidence/fix-292-postinstall-tag-mismatch/gemini-triage.md
+++ b/docs/evidence/fix-292-postinstall-tag-mismatch/gemini-triage.md
@@ -1,0 +1,41 @@
+# Gemini Review Triage — PR #293
+
+## Cycle 1 (push 4eb16fb)
+
+### Finding 1 — HIGH — `npm/postinstall.js:105` (API fallback normalization)
+**Verdict: ACCEPTED**
+
+`r.tag_name.replace(/^v/, "").replace(/^0+/, "") === version` only strips leading zeros from the start of the entire string, not from each version component. Comparing `v2026.6.0101` (→ `2026.6.0101`) against `2026.6.101` fails because there are no leading zeros at position 0.
+
+**Fix:** Extracted `normalizeVersion()` helper that strips leading zeros from EACH component independently. Now `v2026.6.0101` and `2026.6.101` both normalize to `2026.6.101` → match.
+
+### Finding 2 — MEDIUM — `npm/postinstall.js:76` (prerelease patch handling)
+**Verdict: ACCEPTED**
+
+`parseInt("1-beta", 10)` returns `1`, then `.padStart(4, "0")` → `"0001"`, silently dropping the `-beta` suffix and producing a wrong candidate tag `v2026.6.0001` instead of `v2026.6.1-beta`.
+
+**Fix:** Replaced `parseInt + isNaN` with `/^\d+$/` regex test. Only pad when the patch is purely numeric. Verified: `2026.6.1-beta` now produces `["v2026.6.1-beta"]` (no spurious padded candidate).
+
+### Finding 3 — MEDIUM — `npm/postinstall.js:83` (socket leak on non-200)
+**Verdict: ACCEPTED**
+
+Per Node.js docs, response streams must be consumed even when returning early on non-200. Otherwise the underlying socket isn't freed and can lead to slow connection-pool exhaustion.
+
+**Fix:** Added `res.resume()` before reject in the non-200 branch.
+
+## Cycle 1 verification
+
+- `node -c npm/postinstall.js` syntax OK
+- Unit-test against all historic patch widths PASS:
+  - `2026.6.101` → `["v2026.6.101", "v2026.6.0101"]` ✓
+  - `2026.6.8` → `["v2026.6.8", "v2026.6.0008"]` ✓
+  - `2026.5.3105` → `["v2026.5.3105"]` (no padding for 4-digit) ✓
+  - `2026.6.1-beta` → `["v2026.6.1-beta"]` (no padding for prerelease) ✓
+- `normalizeVersion` test: all (tag, npm-version) pairs match correctly
+- End-to-end against live npm package `2026.6.101`:
+  ```
+  Downloading nano-brain v2026.6.101 for linux-arm64...
+  nano-brain v2026.6.101 installed successfully from v2026.6.0101.
+  ```
+
+All 3 Gemini findings real and useful — accepted in 1 cycle.

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -55,6 +55,55 @@ function download(url, dest) {
   });
 }
 
+// npm normalizes leading zeros in semver numeric identifiers (e.g. tag
+// v2026.6.0101 publishes as 2026.6.101). Auto-tag uses a fixed-width 4-digit
+// patch {DD}{NN} for new tags, but older history has 1-3 digit patches. Try
+// the canonical form first, then a zero-padded reconstruction, then API.
+function candidateTagsForVersion(version) {
+  const parts = version.split(".");
+  const candidates = [`v${version}`];
+  if (parts.length === 3) {
+    const patch = parts[2];
+    const patchNum = parseInt(patch, 10);
+    if (!isNaN(patchNum) && patch.length < 4) {
+      const padded = String(patchNum).padStart(4, "0");
+      if (padded !== patch) {
+        candidates.push(`v${parts[0]}.${parts[1]}.${padded}`);
+      }
+    }
+  }
+  return candidates;
+}
+
+function httpGetJSON(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, { headers: { "User-Agent": "nano-brain-postinstall" } }, (res) => {
+      if (res.statusCode !== 200) {
+        return reject(new Error(`API ${url} returned HTTP ${res.statusCode}`));
+      }
+      let body = "";
+      res.on("data", (chunk) => { body += chunk; });
+      res.on("end", () => {
+        try { resolve(JSON.parse(body)); } catch (e) { reject(e); }
+      });
+    }).on("error", reject);
+  });
+}
+
+async function resolveTagFromAPI(version, assetName) {
+  const api = `https://api.github.com/repos/${REPO}/releases`;
+  const releases = await httpGetJSON(`${api}?per_page=30`);
+  for (const r of releases) {
+    if (!r.tag_name) continue;
+    if (r.tag_name === `v${version}` || r.tag_name.replace(/^v/, "").replace(/^0+/, "") === version) {
+      if (r.assets && r.assets.some((a) => a.name === assetName)) {
+        return r.tag_name;
+      }
+    }
+  }
+  return null;
+}
+
 async function main() {
   const platformKey = getPlatformKey();
   const binName = os.platform() === "win32" ? "nano-brain.exe" : "nano-brain";
@@ -72,18 +121,38 @@ async function main() {
     }
   }
 
-  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/nano-brain-${platformKey}`;
   console.log(`Downloading nano-brain v${VERSION} for ${platformKey}...`);
 
-  try {
-    await download(url, binPath);
-    fs.chmodSync(binPath, 0o755);
-    console.log(`nano-brain v${VERSION} installed successfully.`);
-  } catch (err) {
-    console.error(`Failed to download binary: ${err.message}`);
-    console.error("Build from source: CGO_ENABLED=0 go build -o npm/nano-brain ./cmd/nano-brain");
-    process.exit(0);
+  const assetName = `nano-brain-${platformKey}`;
+  let lastErr;
+  for (const tag of candidateTagsForVersion(VERSION)) {
+    const url = `https://github.com/${REPO}/releases/download/${tag}/${assetName}`;
+    try {
+      await download(url, binPath);
+      fs.chmodSync(binPath, 0o755);
+      console.log(`nano-brain v${VERSION} installed successfully from ${tag}.`);
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
   }
+
+  try {
+    const tag = await resolveTagFromAPI(VERSION, assetName);
+    if (tag) {
+      const url = `https://github.com/${REPO}/releases/download/${tag}/${assetName}`;
+      await download(url, binPath);
+      fs.chmodSync(binPath, 0o755);
+      console.log(`nano-brain v${VERSION} installed successfully from ${tag} (API fallback).`);
+      return;
+    }
+  } catch (err) {
+    lastErr = err;
+  }
+
+  console.error(`Failed to download binary: ${lastErr && lastErr.message}`);
+  console.error("Build from source: CGO_ENABLED=0 go build -o npm/nano-brain ./cmd/nano-brain");
+  process.exit(0);
 }
 
 main();

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -64,21 +64,23 @@ function candidateTagsForVersion(version) {
   const candidates = [`v${version}`];
   if (parts.length === 3) {
     const patch = parts[2];
-    const patchNum = parseInt(patch, 10);
-    if (!isNaN(patchNum) && patch.length < 4) {
-      const padded = String(patchNum).padStart(4, "0");
-      if (padded !== patch) {
-        candidates.push(`v${parts[0]}.${parts[1]}.${padded}`);
-      }
+    if (/^\d+$/.test(patch) && patch.length < 4) {
+      const padded = patch.padStart(4, "0");
+      candidates.push(`v${parts[0]}.${parts[1]}.${padded}`);
     }
   }
   return candidates;
+}
+
+function normalizeVersion(v) {
+  return v.replace(/^v/, "").split(".").map((p) => p.replace(/^0+/, "") || "0").join(".");
 }
 
 function httpGetJSON(url) {
   return new Promise((resolve, reject) => {
     https.get(url, { headers: { "User-Agent": "nano-brain-postinstall" } }, (res) => {
       if (res.statusCode !== 200) {
+        res.resume();
         return reject(new Error(`API ${url} returned HTTP ${res.statusCode}`));
       }
       let body = "";
@@ -93,9 +95,10 @@ function httpGetJSON(url) {
 async function resolveTagFromAPI(version, assetName) {
   const api = `https://api.github.com/repos/${REPO}/releases`;
   const releases = await httpGetJSON(`${api}?per_page=30`);
+  const normalizedTarget = normalizeVersion(version);
   for (const r of releases) {
     if (!r.tag_name) continue;
-    if (r.tag_name === `v${version}` || r.tag_name.replace(/^v/, "").replace(/^0+/, "") === version) {
+    if (normalizeVersion(r.tag_name) === normalizedTarget) {
       if (r.assets && r.assets.some((a) => a.name === assetName)) {
         return r.tag_name;
       }

--- a/npm/run.js
+++ b/npm/run.js
@@ -10,7 +10,9 @@ const binName = os.platform() === "win32" ? "nano-brain.exe" : "nano-brain";
 const binPath = path.join(__dirname, binName);
 
 if (!fs.existsSync(binPath)) {
-  console.error("nano-brain binary not found. Run: npx nano-brain (it will download automatically)");
+  console.error("nano-brain binary not found at " + binPath + ".");
+  console.error("The postinstall script may have failed during npm install.");
+  console.error("Try: npm install -g @nano-step/nano-brain --foreground-scripts");
   console.error("Or build from source: CGO_ENABLED=0 go build -o npm/nano-brain ./cmd/nano-brain");
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Fixes #292 — `npx @nano-step/nano-brain@latest` silently fails on the v2026.6.0101 release because npm normalizes the version `2026.6.0101` → `2026.6.101` (semver strips leading zeros from numeric identifiers), but the GitHub tag is still `v2026.6.0101`. The postinstall download URL hits 404 → install silently fails → `run.js` shows misleading 'Run: npx nano-brain'.

## Reproduction

```
$ npx @nano-step/nano-brain@latest serve
Need to install the following packages:
@nano-step/nano-brain@2026.6.101
nano-brain binary not found. Run: npx nano-brain (it will download automatically)
```

## Fix

`npm/postinstall.js`:
- Try `v${version}` first (canonical form, works for older 1-3 digit patches like v2026.6.8).
- If 404, try `v${YYYY}.${M}.${patch.padStart(4,'0')}` (the auto-tag's actual format).
- If still missing, query the GitHub Releases API (`/repos/\:owner/\:repo/releases`) and match by normalized version comparison.

`npm/run.js`:
- Replace misleading 'Run: npx nano-brain (it will download automatically)' — the user IS running npx nano-brain. Replace with: 'postinstall may have failed; retry with `--foreground-scripts`'.

## Verification

Tested locally with the broken `2026.6.101` npm package — fix downloads from `v2026.6.0101` automatically:
```
Downloading nano-brain v2026.6.101 for linux-arm64...
nano-brain v2026.6.101 installed successfully from v2026.6.0101.
```

Algorithm tested against all historic tag patch widths:
```
2026.6.101  → ["v2026.6.101", "v2026.6.0101"]
2026.6.8    → ["v2026.6.8", "v2026.6.0008"]
2026.5.30   → ["v2026.5.30", "v2026.5.0030"]
2026.5.3105 → ["v2026.5.3105"]
```
All existing tags resolve on the first candidate (no extra network round-trip).

## Lane

Tiny (1 risk flag — touches release-publishing path). Direct patch.

## Follow-ups (separate issues)

- Long-term: change auto-tag scheme to `v{YYYY}.{M}.{D}{NN}` (no D zero-pad) so npm normalization stops mangling tags entirely.

Closes #292