### PR TITLE
fix(search): add snake_case JSON tags to Result struct — fixes memory_query MCP empty title + score=0 (#303)

### DIFF
--- a/docs/evidence/fix-303-memory-query-mcp/gemini-triage.md
+++ b/docs/evidence/fix-303-memory-query-mcp/gemini-triage.md
@@ -1,0 +1,29 @@
+# Gemini Review Triage — PR #311
+
+## Cycle 1 — both MEDIUM findings accepted
+
+### Finding 1 MEDIUM — unused strings import after refactor
+**Verdict: ACCEPTED**
+
+Gemini suggested removing strings.Contains in favor of map-key lookups → strings import would become unused → Go compile error.
+
+**Fix:** Removed `strings` from imports as part of refactor below.
+
+### Finding 2 MEDIUM — fragile string-matching in test assertions
+**Verdict: ACCEPTED**
+
+`strings.Contains(json, "\"Title\"")` produces false positives if a field VALUE contains the string `"Title"`. Better: unmarshal JSON to map[string]any, check map keys directly.
+
+**Fix:**
+- Unmarshal JSON output to map[string]any
+- Check key presence via map lookup (`if _, ok := m[k]; !ok`)
+- Expanded forbidden-key list to all 12 PascalCase variants
+- Added mapKeys helper for diagnostic output
+
+## Cycle 1 verification
+
+- go test PASS for new behavior
+- go vet clean
+- Full suite still green
+
+Both findings real, accepted, ~25 LOC refactor of the test only (production code unchanged).

--- a/internal/search/result_test.go
+++ b/internal/search/result_test.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 )
@@ -26,23 +25,32 @@ func TestResult_JSONFieldsUseSnakeCase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := string(raw)
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
 	wantKeys := []string{
-		`"id"`, `"document_id"`, `"workspace_hash"`, `"title"`, `"snippet"`,
-		`"content"`, `"score"`, `"tags"`, `"collection"`, `"source_path"`,
-		`"created_at"`, `"updated_at"`,
+		"id", "document_id", "workspace_hash", "title", "snippet",
+		"content", "score", "tags", "collection", "source_path",
+		"created_at", "updated_at",
 	}
 	for _, k := range wantKeys {
-		if !strings.Contains(s, k) {
-			t.Errorf("expected snake_case key %s in JSON, got: %s", k, s)
+		if _, ok := m[k]; !ok {
+			t.Errorf("expected snake_case key %q in JSON map, got keys: %v", k, mapKeys(m))
 		}
 	}
-	forbiddenKeys := []string{
-		`"ID"`, `"DocumentID"`, `"WorkspaceHash"`, `"Title"`,
-	}
+	forbiddenKeys := []string{"ID", "DocumentID", "WorkspaceHash", "Title", "Snippet", "Content", "Score", "Tags", "Collection", "SourcePath", "CreatedAt", "UpdatedAt"}
 	for _, k := range forbiddenKeys {
-		if strings.Contains(s, k) {
-			t.Errorf("forbidden PascalCase key %s present in JSON (issue #303 regression): %s", k, s)
+		if _, ok := m[k]; ok {
+			t.Errorf("forbidden PascalCase key %q present in JSON map (issue #303 regression)", k)
 		}
 	}
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/internal/search/result_test.go
+++ b/internal/search/result_test.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResult_JSONFieldsUseSnakeCase(t *testing.T) {
+	r := Result{
+		ID:            "uuid-1",
+		DocumentID:    "doc-2",
+		WorkspaceHash: "ws-3",
+		Title:         "test title",
+		Snippet:       "snip",
+		Content:       "body",
+		Score:         0.75,
+		Tags:          []string{"a"},
+		Collection:    "memory",
+		SourcePath:    "memory://x",
+		CreatedAt:     time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+	raw, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(raw)
+	wantKeys := []string{
+		`"id"`, `"document_id"`, `"workspace_hash"`, `"title"`, `"snippet"`,
+		`"content"`, `"score"`, `"tags"`, `"collection"`, `"source_path"`,
+		`"created_at"`, `"updated_at"`,
+	}
+	for _, k := range wantKeys {
+		if !strings.Contains(s, k) {
+			t.Errorf("expected snake_case key %s in JSON, got: %s", k, s)
+		}
+	}
+	forbiddenKeys := []string{
+		`"ID"`, `"DocumentID"`, `"WorkspaceHash"`, `"Title"`,
+	}
+	for _, k := range forbiddenKeys {
+		if strings.Contains(s, k) {
+			t.Errorf("forbidden PascalCase key %s present in JSON (issue #303 regression): %s", k, s)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -4,17 +4,20 @@ package search
 import "time"
 
 // Result represents a single search result from any search method.
+// JSON tags use snake_case to match the public API + MCP tool response contract.
+// Without these tags Go marshals fields as PascalCase (ID, Title, Score) which
+// breaks MCP clients that expect snake_case (id, title, score). See issue #303.
 type Result struct {
-	ID            string
-	DocumentID    string
-	WorkspaceHash string
-	Title         string
-	Snippet       string
-	Content       string
-	Score         float64
-	Tags          []string
-	Collection    string
-	SourcePath    string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID            string    `json:"id"`
+	DocumentID    string    `json:"document_id"`
+	WorkspaceHash string    `json:"workspace_hash"`
+	Title         string    `json:"title"`
+	Snippet       string    `json:"snippet"`
+	Content       string    `json:"content"`
+	Score         float64   `json:"score"`
+	Tags          []string  `json:"tags"`
+	Collection    string    `json:"collection"`
+	SourcePath    string    `json:"source_path"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary

Fixes #303 — `memory_query` MCP tool returned results with empty title and score=0 because `internal/search.Result` struct had no `json:` tags. Go's default marshaling uses PascalCase field names (`Title`, `Score`), but the MCP client + skill docs expect snake_case (`title`, `score`).

## Why memory_query was affected but memory_search/memory_vsearch were not

memory_search and memory_vsearch in tools.go manually map rows to a local `resultRow` struct that already has snake_case json tags. memory_query just calls `textResult(results)` on the raw `[]search.Result` slice, exposing the missing tags.

## Fix

Add 12 explicit `json:` tags to `search.Result`. Single-source-of-truth fix that also benefits any future consumer (HTTP handlers serializing the same struct).

## Test

`TestResult_JSONFieldsUseSnakeCase` (new) asserts:
- All 12 expected snake_case keys present in JSON output
- Zero PascalCase keys (ID, DocumentID, WorkspaceHash, Title) ever appear

## Verification

```
go build ./...   exit 0
go vet ./...     clean
go test -race -short ./internal/search/...   PASS (incl new regression test)
go test -race -short ./internal/mcp/...      PASS
go test -race -short ./...                   PASS
```

Live re-test of TC-API-04 will be performed after deploy.

## Discovered via

RRI-T testing today (2026-06-01) — see `ai/test-case/rri-t/2026-06-01-session-qa/04-execute.md` for the failure observation that led to filing #303.

## Lane: normal
## Change type: bug-fix

Closes #303