### PR TITLE
fix(watcher): scan existing files when workspace registered at runtime (#308)

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -68,8 +68,12 @@ type Watcher struct {
 	mu          sync.Mutex
 	collections map[string]watchedCollection
 	dirty       map[string]bool
-	pub         eventbus.Publisher
-	rateLimiters map[string]*rate.Limiter
+	// hotRegisterCh signals Run() that a workspace was registered at runtime so
+	// the dirty map should be processed without waiting for fsnotify events.
+	// Buffered=1 so WatchWithFilter never blocks. See issue #308.
+	hotRegisterCh chan struct{}
+	pub           eventbus.Publisher
+	rateLimiters  map[string]*rate.Limiter
 
 	globalIgnore *gitignore.GitIgnore
 }
@@ -92,14 +96,15 @@ func (w *Watcher) CollectionsWatched() int {
 
 func New(db *sql.DB, queries WatcherQuerier, logger zerolog.Logger, cfg config.Config) *Watcher {
 	return &Watcher{
-		db:           db,
-		queries:      queries,
-		logger:       logger.With().Str("component", "watcher").Logger(),
-		debounceMs:   cfg.Watcher.DebounceMs,
-		pollInterval: cfg.Watcher.ReindexInterval,
-		maxFileSize:  cfg.Storage.MaxFileSize,
-		collections:  make(map[string]watchedCollection),
-		dirty:        make(map[string]bool),
+		db:            db,
+		queries:       queries,
+		logger:        logger.With().Str("component", "watcher").Logger(),
+		debounceMs:    cfg.Watcher.DebounceMs,
+		pollInterval:  cfg.Watcher.ReindexInterval,
+		maxFileSize:   cfg.Storage.MaxFileSize,
+		collections:   make(map[string]watchedCollection),
+		dirty:         make(map[string]bool),
+		hotRegisterCh: make(chan struct{}, 1),
 	}
 }
 
@@ -156,6 +161,15 @@ func (w *Watcher) WatchWithFilter(collectionName, dirPath, workspaceHash, globPa
 		}
 		if err := w.fsw.Add(absPath); err != nil {
 			return fmt.Errorf("watch dir %s: %w", absPath, err)
+		}
+		// Mark dirty + nudge Run() so processDirty runs an immediate scan.
+		// Without this, fsnotify only fires on FUTURE changes — existing files in a
+		// freshly-registered workspace never get queued for embedding until server
+		// restart (issue #308).
+		w.dirty[absPath] = true
+		select {
+		case w.hotRegisterCh <- struct{}{}:
+		default:
 		}
 		w.logger.Info().Str("dir", absPath).Str("collection", collectionName).Msg("watching directory")
 	}
@@ -261,6 +275,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 		case <-pollTicker.C:
 			w.processAll(ctx)
+
+		case <-w.hotRegisterCh:
+			w.processDirty(ctx)
 		}
 	}
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -396,3 +396,48 @@ func TestProcessFile_AcceptsValidUTF8(t *testing.T) {
 		t.Fatalf("expected valid UTF-8 markdown to be indexed, got %d upserts", mq.upsertDocCalls.Load())
 	}
 }
+
+func TestHotRegister_WatchAfterRunScansExistingFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing-sensitive test in short mode")
+	}
+
+	// Start the watcher with no collections, then "hot-register" a new
+	// workspace by calling Watch after Run is already going. The pre-existing
+	// files in that directory MUST be picked up via the dirty-mark mechanism
+	// (issue #308 regression guard).
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 100, 3600)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("# A\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.md"), []byte("# B\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Watch("hotreg", dir, "ws-hotreg", "*.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	calls := mq.upsertDocCalls.Load()
+	if calls < 2 {
+		t.Fatalf("expected at least 2 upserts for pre-existing files after hot-register, got %d", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #308. After server starts, POST /api/v1/init registers the workspace and calls fw.WatchWithFilter, which subscribes fsnotify. But fsnotify only fires on FUTURE file changes — existing files in the new dir were never queued for embedding until server restart.

## Reproduction (before fix)

```bash
nano-brain serve -d
# Register new workspace
curl -X POST /api/v1/init -d '{"root_path":"/path/with/files"}'
sleep 30
curl /api/v1/workspaces  # → doc_count=0 for new workspace
nano-brain stop && nano-brain serve -d
sleep 30
curl /api/v1/workspaces  # → doc_count > 0 only AFTER restart
```

Confirmed in RRI-T test TC-EDGE-03 (2026-06-01): doc_count=0 after 30s on hot-registered workspace.

## Fix

1. Add buffered hotRegisterCh (cap 1) to Watcher struct
2. WatchWithFilter sets path dirty + non-blocking send to hotRegisterCh when fsw is alive
3. Run()'s select loop has new case <-hotRegisterCh that calls processDirty(ctx) immediately

The non-blocking send pattern (`select { case w.hotRegisterCh <- struct{}{}: default: }`) ensures WatchWithFilter never blocks even if Run isn't draining (e.g. processing a long scan).

## Test

`TestHotRegister_WatchAfterRunScansExistingFiles` (new):
1. Start watcher with no collections, run it
2. Wait 50ms for setup
3. Create new dir with 2 pre-existing .md files
4. Call Watch on that dir (the hot-register path)
5. Wait 500ms
6. Assert upsertDocCalls >= 2

PASS on 1.59s. Full suite + vet still clean.

## Severity

MED-HIGH — every user registering a workspace via running daemon hits this. Workaround was always 'restart'. Now hot-register works as expected.

## Lane: normal
## Change type: bug-fix

Closes #308