### PR TITLE
fix(security): redact postgres DSN password in CLI error messages (#307)

### DIFF
--- a/cmd/nano-brain/bench.go
+++ b/cmd/nano-brain/bench.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/embed"
 	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/rs/zerolog"
@@ -142,13 +143,13 @@ func runBenchGenerate(args []string) {
 
 	db, err := sql.Open("pgx", cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to open database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer db.Close()
 
 	if err := db.PingContext(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to connect to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to connect to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	queries := sqlc.New(db)
@@ -236,13 +237,13 @@ func runBenchRun(args []string) {
 
 	db, err := sql.Open("pgx", cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to open database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer db.Close()
 
 	if err := db.PingContext(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to connect to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to connect to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 
@@ -446,13 +447,13 @@ func runBenchStress(args []string) {
 
 	db, err := sql.Open("pgx", cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to open database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer db.Close()
 
 	if err := db.PingContext(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to connect to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to connect to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 

--- a/cmd/nano-brain/cmd_backfill_summaries.go
+++ b/cmd/nano-brain/cmd_backfill_summaries.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/summarize"
 )
@@ -80,7 +81,7 @@ func runBackfillSummariesCmd(args []string) {
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer pool.Close()

--- a/cmd/nano-brain/cmd_cleanup_orphan_workspaces.go
+++ b/cmd/nano-brain/cmd_cleanup_orphan_workspaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 )
 
@@ -43,7 +44,7 @@ func runCleanupOrphanWorkspacesCmd(args []string) {
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer pool.Close()

--- a/cmd/nano-brain/cmd_cleanup_stale_raw.go
+++ b/cmd/nano-brain/cmd_cleanup_stale_raw.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 )
 
@@ -39,7 +40,7 @@ func runCleanupStaleRawCmd(args []string) {
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer pool.Close()

--- a/cmd/nano-brain/cmd_reset_embeddings.go
+++ b/cmd/nano-brain/cmd_reset_embeddings.go
@@ -76,7 +76,7 @@ func runResetEmbeddingsCmd(args []string) {
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer pool.Close()

--- a/cmd/nano-brain/migrate.go
+++ b/cmd/nano-brain/migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/migrate"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/sqlc-dev/pqtype"
 )
@@ -69,7 +70,7 @@ func runDBMigrateCmd(args []string) {
 
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer pool.Close()
@@ -82,7 +83,7 @@ func runDBMigrateCmd(args []string) {
 
 	m, err := migrate.NewV1Migrator(fromV1, writer)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening v1 database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error opening v1 database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer m.Close()

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/migrations"
 	"github.com/pressly/goose/v3"
 )
@@ -482,7 +483,7 @@ func runGooseMigrateCmd(jsonFlag bool) {
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error connecting to database: %s\n", storage.RedactError(err))
 		os.Exit(1)
 	}
 	defer pool.Close()

--- a/docs/evidence/fix-307-redact-db-url/gemini-triage.md
+++ b/docs/evidence/fix-307-redact-db-url/gemini-triage.md
@@ -1,0 +1,36 @@
+# Gemini Review Triage — PR #315
+
+## Cycle 1 — security-HIGH finding accepted
+
+### Finding 1 security-HIGH — url.Parse fallback leaks password
+**Verdict: ACCEPTED**
+
+When a DSN contains raw special chars in the password (e.g. `{`, `}`, `\`),
+url.Parse returns an error and the previous code returned the unredacted
+match. The dsnRegex matched the entire URI, so this silently leaked the
+password rather than redacting it.
+
+**Fix:** Add a regex-based fallback `pwdInDSN` that runs only when url.Parse
+fails. It uses simple character classes (no URL semantics required) to
+extract scheme+user, then replaces ':password@' with ':REDACTED@'.
+
+Two-layer design:
+1. url.Parse for well-formed URIs (handles percent-encoded chars correctly)
+2. Regex fallback for malformed URIs (catches what url.Parse rejects)
+
+### Finding 2 MEDIUM — missing test for fallback path
+**Verdict: ACCEPTED**
+
+Added 2 test cases:
+- 'malformed URL fallback path — raw brace in password' → `p{ass}word`
+- 'malformed URL fallback path — backslash in password' → `back\\slash`
+
+Both now PASS with the new fallback.
+
+## Cycle 1 verification
+
+- go build PASS, go vet clean
+- 10/10 test cases PASS (was 8, added 2)
+- No production code changes outside redact.go
+
+Both findings real, accepted, ~10 LOC added to redact.go + 10 LOC of tests.

--- a/internal/storage/redact.go
+++ b/internal/storage/redact.go
@@ -19,19 +19,24 @@ func RedactError(err error) string {
 // embedded anywhere in s, replacing the password portion with "REDACTED".
 // Safe to call on arbitrary strings; non-URL content is returned unchanged.
 //
-// Regex matches the URI from scheme up to the first whitespace or quote
-// boundary (postgres connection strings cannot contain raw whitespace/quotes).
+// Two-layer redaction:
+//  1. url.Parse path — handles well-formed URIs (e.g. percent-encoded passwords).
+//  2. Regex-fallback — handles malformed URIs that url.Parse rejects (e.g. raw
+//     '{', '}', '\\' in password). Without this fallback the secret would leak
+//     unchanged. See #307 / Gemini review on PR #315.
 func RedactString(s string) string {
 	return dsnRegex.ReplaceAllStringFunc(s, func(match string) string {
-		u, err := url.Parse(match)
-		if err != nil || u.User == nil {
-			return match
+		if u, err := url.Parse(match); err == nil {
+			if u.User == nil {
+				return match
+			}
+			if _, hasPwd := u.User.Password(); !hasPwd {
+				return match
+			}
+			u.User = url.UserPassword(u.User.Username(), "REDACTED")
+			return u.String()
 		}
-		if _, hasPwd := u.User.Password(); !hasPwd {
-			return match
-		}
-		u.User = url.UserPassword(u.User.Username(), "REDACTED")
-		return u.String()
+		return pwdInDSN.ReplaceAllString(match, "$1:REDACTED@")
 	})
 }
 
@@ -39,5 +44,10 @@ func RedactString(s string) string {
 // boundary. The character class [^...] explicitly excludes characters that
 // cannot legally appear in a postgres DSN per RFC 3986 / libpq syntax.
 var dsnRegex = regexp.MustCompile(`postgres(?:ql)?://[^\s"'` + "`" + `]+`)
+
+// pwdInDSN extracts username and password from a postgres URI's userinfo.
+// Used only as fallback when url.Parse fails. Captures: $1 = scheme + username
+// up to the colon; $2 = password (discarded). Replaces with "$1:REDACTED@".
+var pwdInDSN = regexp.MustCompile(`(postgres(?:ql)?://[^:/@\s]+):[^@\s]+@`)
 
 

--- a/internal/storage/redact.go
+++ b/internal/storage/redact.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// RedactError returns err.Error() with any embedded postgres connection string
+// (postgres://user:password@host/db) replaced by postgres://user:REDACTED@host/db.
+// Used to scrub passwords from CLI error messages — see issue #307.
+func RedactError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return RedactString(err.Error())
+}
+
+// RedactString scrubs all postgres:// and postgresql:// connection strings
+// embedded anywhere in s, replacing the password portion with "REDACTED".
+// Safe to call on arbitrary strings; non-URL content is returned unchanged.
+//
+// Regex matches the URI from scheme up to the first whitespace or quote
+// boundary (postgres connection strings cannot contain raw whitespace/quotes).
+func RedactString(s string) string {
+	return dsnRegex.ReplaceAllStringFunc(s, func(match string) string {
+		u, err := url.Parse(match)
+		if err != nil || u.User == nil {
+			return match
+		}
+		if _, hasPwd := u.User.Password(); !hasPwd {
+			return match
+		}
+		u.User = url.UserPassword(u.User.Username(), "REDACTED")
+		return u.String()
+	})
+}
+
+// dsnRegex matches postgres connection strings up to a quote/whitespace
+// boundary. The character class [^...] explicitly excludes characters that
+// cannot legally appear in a postgres DSN per RFC 3986 / libpq syntax.
+var dsnRegex = regexp.MustCompile(`postgres(?:ql)?://[^\s"'` + "`" + `]+`)
+
+

--- a/internal/storage/redact_test.go
+++ b/internal/storage/redact_test.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRedactString_ScrubsPasswordInPostgresURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"basic password leak",
+			"failed to connect: postgres://user:secret@localhost:5432/db",
+			"failed to connect: postgres://user:REDACTED@localhost:5432/db",
+		},
+		{
+			"postgresql scheme also scrubbed",
+			"err: postgresql://admin:p%40ssw0rd@host:5432/prod",
+			"err: postgresql://admin:REDACTED@host:5432/prod",
+		},
+		{
+			"no password — leave as-is",
+			"postgres://user@localhost/db",
+			"postgres://user@localhost/db",
+		},
+		{
+			"empty input",
+			"",
+			"",
+		},
+		{
+			"no URL — leave as-is",
+			"random error message about something",
+			"random error message about something",
+		},
+		{
+			"URL inside quotes",
+			`error: "postgres://u:p@h/db"`,
+			`error: "postgres://u:REDACTED@h/db"`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RedactString(c.in)
+			if got != c.want {
+				t.Errorf("\n  in:   %q\n  got:  %q\n  want: %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRedactError_NilSafe(t *testing.T) {
+	if got := RedactError(nil); got != "" {
+		t.Errorf("RedactError(nil) = %q, want empty string", got)
+	}
+}
+
+func TestRedactError_WrapsErrorString(t *testing.T) {
+	err := errors.New("dial tcp postgres://nb:topsecret@host:5432/db: timeout")
+	got := RedactError(err)
+	want := "dial tcp postgres://nb:REDACTED@host:5432/db: timeout"
+	if got != want {
+		t.Errorf("\n  got:  %q\n  want: %q", got, want)
+	}
+}

--- a/internal/storage/redact_test.go
+++ b/internal/storage/redact_test.go
@@ -41,6 +41,16 @@ func TestRedactString_ScrubsPasswordInPostgresURL(t *testing.T) {
 			`error: "postgres://u:p@h/db"`,
 			`error: "postgres://u:REDACTED@h/db"`,
 		},
+		{
+			"malformed URL fallback path — raw brace in password",
+			`failed: postgres://user:p{ass}word@host/db oops`,
+			`failed: postgres://user:REDACTED@host/db oops`,
+		},
+		{
+			"malformed URL fallback path — backslash in password",
+			`postgres://nb:back\\slash@host:5432/db`,
+			`postgres://nb:REDACTED@host:5432/db`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #307 — when CLI commands fail to connect to PG, the error message often echoes the full DSN including the password to stderr. Container logs, journald, CI logs, and shell history then persist the secret.

## Fix

Add `storage.RedactError(err)` / `storage.RedactString(s)` helpers (new file `internal/storage/redact.go`). Match postgres://[postgresql://] URIs via regex up to the first whitespace/quote boundary, replace password portion with 'REDACTED'.

Applied at **9 callsites** across CLI commands. Production code path: every `fmt.Fprintf(os.Stderr, ..., err)` that could embed a DSN now uses `storage.RedactError(err)`.

## Files

- New: `internal/storage/redact.go` (43 lines incl. docs)
- New: `internal/storage/redact_test.go` (68 lines, 8 test cases)
- Updated: 7 `cmd/nano-brain/*.go` files

## Test coverage

| Case | Input | Expected |
|---|---|---|
| basic password leak | `failed: postgres://u:secret@h/db` | `failed: postgres://u:REDACTED@h/db` |
| postgresql:// scheme | `err: postgresql://admin:p%40ssw0rd@h/p` | `err: postgresql://admin:REDACTED@h/p` |
| no password | `postgres://user@localhost/db` | unchanged |
| empty | `""` | `""` |
| non-URL | `random error` | unchanged |
| URL in quotes | `error: "postgres://u:p@h/db"` | `error: "postgres://u:REDACTED@h/db"` |
| nil error | `nil` | empty string |
| error.Error() | `errors.New(... postgres://nb:topsecret@h/db ...)` | password replaced |

All 8 cases PASS.

## Verification

```
go build ./...       exit 0
go vet ./...         clean
go test -race -short ./...  PASS
grep 'fmt.Fprintf.*database.*%v.*err)' cmd/ internal/  → 0 leaky sites
```

## Lane: tiny
Security helper (43 LOC) + 9 callsite updates + 8 test cases. No data migration, no schema change. Reversible by single revert.

## Change type: bug-fix (security)

Closes #307