### PR TITLE
feat(workspace-resolve): add POST /api/v1/workspaces/resolve + CLI + MCP + phase-based skill rewrite (#316)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,77 @@
 <!-- OPENCODE-MEMORY:START -->
-<!-- Managed block - do not edit manually. Updated by: npx nano-brain init -->
+<!-- Managed block - do not edit manually. Updated by: npx @nano-step/nano-brain init -->
 
 ## Memory System (nano-brain)
 
-This project uses **nano-brain** for persistent context across sessions.
+This project uses **nano-brain** for persistent context across sessions. Server runs on the host at port 3100; agents inside containers reach it at `host.docker.internal:3100`.
 
-> **Container setup required:** Each agent container must install the wrapper script to avoid
-> SQLite conflicts. See your project's nano-brain setup guide.
+### Bootstrap (once per shell session)
 
-### Quick Reference
+```bash
+eval "$(npx @nano-step/nano-brain workspaces current --export)"
+```
 
-All commands use HTTP API (nano-brain runs as Docker service on port 3100):
+This exports `NANO_BRAIN_WORKSPACE` so subsequent CLI calls do not need `--workspace=...`. If the workspace is not yet registered:
 
-> **Container agents:** server is on the HOST — always use `http://host.docker.internal:3100` inside containers. `localhost:3100` only works on the host itself.
+```bash
+npx @nano-step/nano-brain workspaces current --check 2>/dev/null \
+  || npx @nano-step/nano-brain init --root="$PWD"
+```
+
+### Quick Reference (CLI)
 
 | I want to... | Command |
-|--------------|---------|
-| Recall past work on a topic | `curl -s http://host.docker.internal:3100/api/query -d '{"query":"topic"}'` |
-| Find exact error/function name | `curl -s http://host.docker.internal:3100/api/search -d '{"query":"exact term"}'` |
-| Explore a concept semantically | `curl -s http://host.docker.internal:3100/api/query -d '{"query":"concept"}'` |
-| Save a decision for future sessions | `curl -s http://host.docker.internal:3100/api/write -d '{"content":"...","tags":"decision"}'` |
-| Check index health | `curl -s http://host.docker.internal:3100/api/status` |
-| Write a note with tags | `curl -s http://host.docker.internal:3100/api/write -d '{"content":"...","tags":"decision,auth"}'` |
-| Supersede old info | `curl -s http://host.docker.internal:3100/api/write -d '{"content":"new info","supersedes":"<path>"}'` |
-| See file dependencies | Use MCP tool: `memory_focus` with `{"filePath":"src/server.ts"}` |
-| Find cross-repo Redis usage | Use MCP tool: `memory_symbols` with `{"type":"redis_key","pattern":"sinv:*"}` |
-| Analyze cross-repo impact | Use MCP tool: `memory_impact` with `{"type":"redis_key","pattern":"sinv:*:compressed"}` |
-| Search across all workspaces | `curl -s http://host.docker.internal:3100/api/query -d '{"query":"topic","scope":"all"}'` |
-| Filter by tags | `curl -s http://host.docker.internal:3100/api/query -d '{"query":"topic","tags":"decision"}'` |
+|---|---|
+| Recall past work | `npx @nano-step/nano-brain query "topic"` |
+| Find exact term/identifier | `npx @nano-step/nano-brain search "FunctionName"` |
+| Semantic search | `npx @nano-step/nano-brain vsearch "concept"` |
+| Save a decision | `npx @nano-step/nano-brain write --tags=decision --title="..." --content="..."` |
+| Workspace briefing | `npx @nano-step/nano-brain wake-up` |
+| Cross-workspace search | `npx @nano-step/nano-brain query --scope=all "topic"` |
+| Tag-filtered search | `npx @nano-step/nano-brain query --tags=decision "topic"` |
+| Server health | `npx @nano-step/nano-brain status` |
+
+### HTTP API (for non-CLI agents)
+
+Base URL inside containers: `http://host.docker.internal:3100`. On the host: `http://localhost:3100`.
+
+All `POST /api/v1/*` workspace-scoped endpoints require a `workspace` field in the JSON body. Get the hash via:
+
+```bash
+curl -fsS -X POST $BASE/api/v1/workspaces/resolve \
+  -H 'Content-Type: application/json' \
+  -d "{\"path\":\"$PWD\"}" | jq -r .workspace_hash
+```
+
+Endpoint contract: `POST /api/v1/workspaces/resolve` body `{"path":"<abs>"}` → `{"workspace_hash","root_path","name","registered"}`. Read-only — never auto-registers; use `POST /api/v1/init` for that.
+
+Example query:
+
+```bash
+curl -fsS -X POST $BASE/api/v1/query \
+  -H 'Content-Type: application/json' \
+  -d "{\"workspace\":\"$NANO_BRAIN_WORKSPACE\",\"query\":\"topic\",\"max_results\":10}"
+```
 
 ### Session Workflow
 
-**Start of session:** Check memory for relevant past context before exploring the codebase.
-```
-curl -s http://host.docker.internal:3100/api/query -d '{"query":"what have we done regarding {current task topic}"}'
-```
+- **Start of session:** `npx @nano-step/nano-brain query "what have we done about <task>"` before exploring the codebase.
+- **End of session:** Persist key decisions and learnings:
 
-**End of session:** Save key decisions, patterns discovered, and debugging insights.
 ```bash
-curl -s http://host.docker.internal:3100/api/write -d '{"content":"## Summary\n- Decision: ...\n- Why: ...\n- Files: ...","tags":"summary"}'
+npx @nano-step/nano-brain write --tags=summary,decision \
+  --title="Session: <topic>" \
+  --content="## Summary\n- Decision: ...\n- Why: ...\n- Files: ..."
 ```
 
 ### When to Search Memory vs Codebase
 
-- **"Have we done this before?"** → `curl -s http://host.docker.internal:3100/api/query` (searches past sessions)
-- **"Where is this in the code?"** → grep / ast-grep (searches current files)
-- **"How does this concept work here?"** → Both (memory for past context + grep for current code)
+- **"Have we done this before?"** → `npx @nano-step/nano-brain query "..."` (past sessions)
+- **"Where is this in the code right now?"** → grep / ast-grep
+- **"How does this concept work here?"** → both
+- **"What calls this function / what breaks if I change Y?"** → `nano-brain` code intelligence (`POST /api/v1/graph/query`, `/api/v1/graph/impact`, `/api/v1/graph/trace`)
+
+See `skills/nano-brain/SKILL.md` for the full reference (phases, error recovery, all endpoints).
 
 <!-- OPENCODE-MEMORY:END -->
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ docker run -d \
 | GET | `/api/status` | Server status with version, uptime, workspace stats |
 | POST | `/api/v1/init` | Register workspace |
 | GET | `/api/v1/workspaces` | List all workspaces (with doc counts) |
+| POST | `/api/v1/workspaces/resolve` | Resolve path → workspace hash + `registered` status (read-only) |
 | DELETE | `/api/v1/workspaces/:hash` | Permanently delete a workspace + cascade docs/chunks/embeddings |
 | GET | `/api/v1/wake-up` | Workspace briefing |
 | POST | `/api/harvest` | Trigger session harvesting |
@@ -353,6 +354,7 @@ Workspace is passed in the JSON body for POST, query param for GET.
 | `nano-brain` (no args) | Start HTTP server (default: port 3100) |
 | `nano-brain init --root=<path>` | Register workspace |
 | `nano-brain workspaces list` | List registered workspaces with doc counts |
+| `nano-brain workspaces current [--path=<p>] [--export\|--json\|--check]` | Resolve current/path workspace hash. `--export` prints `export NANO_BRAIN_WORKSPACE=<hash>` for `eval`; `--check` exits 2 if not registered |
 | `nano-brain workspaces remove --workspace=<hash> [--dry-run\|--force]` | Permanently delete a workspace + all its documents/chunks/embeddings |
 | `nano-brain write` | Write document via CLI |
 | `nano-brain query [--scope=all] [--tags=t1,t2]` | Hybrid search (BM25 + vector + RRF + recency) |
@@ -379,7 +381,7 @@ Workspace is passed in the JSON body for POST, query param for GET.
 
 ## MCP Tools
 
-nano-brain exposes 13 tools via MCP (Model Context Protocol):
+nano-brain exposes 14 tools via MCP (Model Context Protocol):
 
 | Tool | Description |
 |------|-------------|
@@ -396,6 +398,7 @@ nano-brain exposes 13 tools via MCP (Model Context Protocol):
 | `memory_trace` | Call chain trace from entry point |
 | `memory_impact` | Cross-file change impact analysis |
 | `memory_symbols` | Symbol search (functions, types, constants) |
+| `memory_workspaces_resolve` | Resolve filesystem path → workspace hash + registered status (read-only) |
 
 ### MCP Configuration
 

--- a/cmd/nano-brain/workspaces.go
+++ b/cmd/nano-brain/workspaces.go
@@ -12,7 +12,7 @@ import (
 )
 
 func workspacesUsage() {
-	fmt.Fprintln(os.Stderr, "Usage: nano-brain workspaces [list|ls|remove] [flags]")
+	fmt.Fprintln(os.Stderr, "Usage: nano-brain workspaces [list|ls|current|remove] [flags]")
 	os.Exit(1)
 }
 
@@ -24,6 +24,8 @@ func runWorkspacesCmd(args []string) {
 	switch args[0] {
 	case "list", "ls":
 		runWorkspacesList(args[1:])
+	case "current":
+		runWorkspacesCurrent(args[1:])
 	case "remove", "rm":
 		runWorkspacesRemove(args[1:])
 	default:
@@ -149,4 +151,84 @@ func truncateLeft(s string, max int) string {
 		return s
 	}
 	return ".." + s[len(s)-(max-2):]
+}
+
+func runWorkspacesCurrent(args []string) {
+	exit := runWorkspacesCurrentWithIO(args, os.Stdout, os.Stderr)
+	if exit != 0 {
+		os.Exit(exit)
+	}
+}
+
+func runWorkspacesCurrentWithIO(args []string, stdout, stderr io.Writer) int {
+	var (
+		pathFlag   string
+		exportFlag bool
+		jsonFlag   bool
+		checkFlag  bool
+	)
+	for _, a := range args {
+		switch {
+		case a == "--export":
+			exportFlag = true
+		case a == "--json":
+			jsonFlag = true
+		case a == "--check":
+			checkFlag = true
+		case strings.HasPrefix(a, "--path="):
+			pathFlag = strings.TrimPrefix(a, "--path=")
+		default:
+			fmt.Fprintf(stderr, "unknown flag: %s\n", a)
+			return 1
+		}
+	}
+
+	path := pathFlag
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(stderr, "failed to detect current directory: %v\n", err)
+			return 1
+		}
+		path = cwd
+	}
+
+	reqBody, _ := json.Marshal(map[string]string{"path": path})
+	body, _, err := doRequest("POST", getBaseURL()+"/api/v1/workspaces/resolve", bytes.NewReader(reqBody))
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+
+	if jsonFlag {
+		trimmed := bytes.TrimRight(body, "\n")
+		_, _ = stdout.Write(trimmed)
+		fmt.Fprintln(stdout)
+	}
+
+	var resp struct {
+		WorkspaceHash string `json:"workspace_hash"`
+		RootPath      string `json:"root_path"`
+		Name          string `json:"name"`
+		Registered    bool   `json:"registered"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		fmt.Fprintf(stderr, "failed to parse server response: %v\n", err)
+		return 1
+	}
+
+	if !jsonFlag {
+		switch {
+		case exportFlag:
+			fmt.Fprintf(stdout, "export NANO_BRAIN_WORKSPACE=%s\n", resp.WorkspaceHash)
+		default:
+			fmt.Fprintln(stdout, resp.WorkspaceHash)
+		}
+	}
+
+	if checkFlag && !resp.Registered {
+		fmt.Fprintf(stderr, "workspace not registered: %s\n", resp.RootPath)
+		return 2
+	}
+	return 0
 }

--- a/cmd/nano-brain/workspaces.go
+++ b/cmd/nano-brain/workspaces.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -191,6 +192,13 @@ func runWorkspacesCurrentWithIO(args []string, stdout, stderr io.Writer) int {
 			return 1
 		}
 		path = cwd
+	} else if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			fmt.Fprintf(stderr, "failed to resolve path %q: %v\n", path, err)
+			return 1
+		}
+		path = abs
 	}
 
 	reqBody, _ := json.Marshal(map[string]string{"path": path})

--- a/cmd/nano-brain/workspaces_test.go
+++ b/cmd/nano-brain/workspaces_test.go
@@ -435,3 +435,40 @@ func TestWorkspacesCurrent_UnknownFlag_ExitsOne(t *testing.T) {
 		t.Errorf("stderr should mention unknown flag; got %q", errOut.String())
 	}
 }
+
+func TestWorkspacesCurrent_RelativePathNormalized_ClientSide(t *testing.T) {
+	var receivedPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workspaces/resolve" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var body struct {
+			Path string `json:"path"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		receivedPath = body.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"workspace_hash": "h",
+			"root_path":      body.Path,
+			"name":           "x",
+			"registered":     false,
+		})
+	}))
+	t.Cleanup(ts.Close)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--path=./relative/subdir"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, errOut.String())
+	}
+	if !strings.HasPrefix(receivedPath, "/") {
+		t.Errorf("server received non-absolute path %q — CLI must normalize relative paths client-side (Gemini review F2)", receivedPath)
+	}
+	if strings.Contains(receivedPath, "./") {
+		t.Errorf("server received unresolved path components %q — filepath.Abs should clean dots", receivedPath)
+	}
+}

--- a/cmd/nano-brain/workspaces_test.go
+++ b/cmd/nano-brain/workspaces_test.go
@@ -274,3 +274,164 @@ func TestWorkspacesFlagOnlyDefaultsToList(t *testing.T) {
 		t.Errorf("expected JSON object output; got:\n%s", out.String())
 	}
 }
+
+func newResolveServer(t *testing.T, response map[string]interface{}, status int) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workspaces/resolve" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestWorkspacesCurrent_Default_PrintsHash(t *testing.T) {
+	resp := map[string]interface{}{
+		"workspace_hash": "abc123",
+		"root_path":      "/tmp/x",
+		"name":           "x",
+		"registered":     true,
+	}
+	ts := newResolveServer(t, resp, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--path=/tmp/x"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, errOut.String())
+	}
+	if strings.TrimSpace(out.String()) != "abc123" {
+		t.Errorf("stdout: got %q want %q", out.String(), "abc123\n")
+	}
+}
+
+func TestWorkspacesCurrent_Export_PrintsExportLine(t *testing.T) {
+	resp := map[string]interface{}{
+		"workspace_hash": "deadbeef",
+		"root_path":      "/tmp/y",
+		"name":           "y",
+		"registered":     true,
+	}
+	ts := newResolveServer(t, resp, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--export", "--path=/tmp/y"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, errOut.String())
+	}
+	if strings.TrimSpace(out.String()) != "export NANO_BRAIN_WORKSPACE=deadbeef" {
+		t.Errorf("stdout: got %q", out.String())
+	}
+}
+
+func TestWorkspacesCurrent_JSON_PrintsFullBody(t *testing.T) {
+	resp := map[string]interface{}{
+		"workspace_hash": "h",
+		"root_path":      "/p",
+		"name":           "n",
+		"registered":     true,
+	}
+	ts := newResolveServer(t, resp, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--json", "--path=/p"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, errOut.String())
+	}
+	if !strings.HasPrefix(out.String(), "{") {
+		t.Errorf("expected JSON output, got %q", out.String())
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out.String()), &parsed); err != nil {
+		t.Fatalf("decode: %v output=%q", err, out.String())
+	}
+	if parsed["workspace_hash"] != "h" {
+		t.Errorf("workspace_hash: got %v want h", parsed["workspace_hash"])
+	}
+}
+
+func TestWorkspacesCurrent_Check_Registered_ExitsZero(t *testing.T) {
+	resp := map[string]interface{}{
+		"workspace_hash": "h",
+		"root_path":      "/p",
+		"name":           "n",
+		"registered":     true,
+	}
+	ts := newResolveServer(t, resp, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--check", "--path=/p"}, &out, &errOut)
+	if code != 0 {
+		t.Errorf("exit=%d want 0; stderr=%q", code, errOut.String())
+	}
+}
+
+func TestWorkspacesCurrent_Check_NotRegistered_ExitsTwo(t *testing.T) {
+	resp := map[string]interface{}{
+		"workspace_hash": "h",
+		"root_path":      "/p",
+		"name":           "n",
+		"registered":     false,
+	}
+	ts := newResolveServer(t, resp, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--check", "--path=/p"}, &out, &errOut)
+	if code != 2 {
+		t.Errorf("exit=%d want 2; stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "not registered") {
+		t.Errorf("stderr should mention 'not registered', got %q", errOut.String())
+	}
+}
+
+func TestWorkspacesCurrent_CombinedExportCheck(t *testing.T) {
+	resp := map[string]interface{}{
+		"workspace_hash": "x",
+		"root_path":      "/p",
+		"name":           "n",
+		"registered":     true,
+	}
+	ts := newResolveServer(t, resp, http.StatusOK)
+	setHostPort(t, ts)
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--export", "--check", "--path=/p"}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "export NANO_BRAIN_WORKSPACE=x") {
+		t.Errorf("stdout should contain export line; got %q", out.String())
+	}
+}
+
+func TestWorkspacesCurrent_ServerUnreachable_ExitsOne(t *testing.T) {
+	t.Setenv("NANO_BRAIN_HOST", "127.0.0.1")
+	t.Setenv("NANO_BRAIN_PORT", "1")
+
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--path=/p"}, &out, &errOut)
+	if code != 1 {
+		t.Errorf("exit=%d want 1; stderr=%q", code, errOut.String())
+	}
+}
+
+func TestWorkspacesCurrent_UnknownFlag_ExitsOne(t *testing.T) {
+	var out, errOut bytes.Buffer
+	code := runWorkspacesCurrentWithIO([]string{"--bogus"}, &out, &errOut)
+	if code != 1 {
+		t.Errorf("exit=%d want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "unknown flag") {
+		t.Errorf("stderr should mention unknown flag; got %q", errOut.String())
+	}
+}

--- a/docs/evidence/add-workspace-resolve-endpoint/gemini-triage.md
+++ b/docs/evidence/add-workspace-resolve-endpoint/gemini-triage.md
@@ -1,0 +1,93 @@
+# Gemini code review triage — PR #319
+
+**PR:** [nano-step/nano-brain#319](https://github.com/nano-step/nano-brain/pull/319)
+**Issue:** #316
+**Reviewer:** gemini-code-assist[bot]
+**Review submitted:** 2026-06-02T05:28:15Z
+**Commit reviewed:** `baef491`
+**Triage cycle:** 1 of 3 (≤3 push cycles per harness rule)
+
+## Findings
+
+### F1 (medium) — Non-idiomatic loop in integration test
+
+**File:** `internal/server/handlers/workspace_resolve_integration_test.go:80`
+
+**Original code:**
+
+```go
+for i := 0; i < 3; i++ {
+    if _, _ = doResolve(t, resolveHandler, projectPath); false {
+    }
+}
+```
+
+**Reviewer feedback:** The `if` statement with constant `false` condition is non-idiomatic and confusing.
+
+**Decision:** **Accept.** Replace with the suggested form. The `if ...; false {}` wrapper was a workaround for "call function for side-effects only, ignore return values" that I wrote when working around test-infra schema isolation issues. The cleaner form expresses intent directly.
+
+**Fix:**
+
+```go
+for i := 0; i < 3; i++ {
+    _, _ = doResolve(t, resolveHandler, projectPath)
+}
+```
+
+---
+
+### F2 (medium) — CLI does not convert relative path to absolute client-side
+
+**File:** `cmd/nano-brain/workspaces.go:194` (inside `runWorkspacesCurrentWithIO`)
+
+**Reviewer feedback:** If `--path` is passed as a relative path (e.g., `--path=.` or `--path=sub/dir`), the CLI sends it directly to the server. Since the server's working directory may differ from the client's (especially in container/host scenarios), the server will resolve the relative path against its own CWD — producing the wrong workspace hash.
+
+**Decision:** **Accept.** This is a real bug. The skill explicitly documents that the CLI should resolve `$PWD` to the project — relative paths must be normalized client-side because the server has no knowledge of where the user invoked the CLI from.
+
+**Design choice:** apply `filepath.Abs(path)` (which uses `os.Getwd()` internally when the input is relative) for the `--path` branch, mirroring the default branch's `os.Getwd()` call. This is simpler than the suggested `filepath.Join(cwd, path)` and handles edge cases like `--path=./foo/../bar` correctly.
+
+**Fix:**
+
+```go
+path := pathFlag
+if path == "" {
+    cwd, err := os.Getwd()
+    if err != nil {
+        fmt.Fprintf(stderr, "failed to detect current directory: %v\n", err)
+        return 1
+    }
+    path = cwd
+} else if !filepath.IsAbs(path) {
+    abs, err := filepath.Abs(path)
+    if err != nil {
+        fmt.Fprintf(stderr, "failed to resolve path %q: %v\n", path, err)
+        return 1
+    }
+    path = abs
+}
+```
+
+Plus adding `path/filepath` to imports.
+
+---
+
+## Items NOT raised by Gemini but worth flagging
+
+None. The review covered the two most significant client-side correctness issues.
+
+## Items intentionally NOT addressed (out of scope)
+
+- Smoke:e2e via long-running server (env-blocked as documented in PR body). No change here.
+- Schema isolation leak in `testutil.SetupTestDB` (pre-existing test-infra bug; tracked separately).
+
+## Verification after fix
+
+- `go build ./...` → expect exit 0
+- `go vet ./...` → expect no warnings
+- `go test -race -short ./cmd/nano-brain/... ./internal/server/handlers/...` → expect PASS
+- `go test -race -tags=integration -run "TestResolveWorkspaceE2E" ./internal/server/handlers/...` → expect 3 PASS
+- New CLI test added to cover relative-path normalization
+
+## Outcome
+
+Both findings accepted and fixed. No findings disputed. Cycle 1/3 complete.

--- a/internal/mcp/concurrent_test.go
+++ b/internal/mcp/concurrent_test.go
@@ -155,8 +155,8 @@ func TestToolRegistration_ListToolsUnderRaceDetector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
-	if len(result.Tools) != 13 {
-		t.Errorf("expected 13 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 14 {
+		t.Errorf("expected 14 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,12 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/nano-brain/nano-brain/internal/chunk"
+	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	pgvector_go "github.com/pgvector/pgvector-go"
 	"github.com/sqlc-dev/pqtype"
@@ -33,6 +35,7 @@ func RegisterTools(server *mcpsdk.Server, a *Adapter) {
 	registerMemoryGraph(server, a)
 	registerMemoryImpact(server, a)
 	registerMemoryTrace(server, a)
+	registerMemoryWorkspacesResolve(server, a)
 }
 
 func toolSchema(props map[string]map[string]any, required []string) json.RawMessage {
@@ -1218,6 +1221,55 @@ func registerMemorySymbols(server *mcpsdk.Server, a *Adapter) {
 				"symbols": results,
 				"count":   len(results),
 			})
+		},
+	)
+}
+
+func registerMemoryWorkspacesResolve(server *mcpsdk.Server, a *Adapter) {
+	server.AddTool(
+		&mcpsdk.Tool{
+			Name:        "memory_workspaces_resolve",
+			Description: "Resolve a filesystem path to a deterministic workspace hash and report whether it is registered. Read-only — does not register the workspace; use POST /api/v1/init for that.",
+			InputSchema: toolSchema(map[string]map[string]any{
+				"path": {"type": "string", "description": "Absolute filesystem path to the project root"},
+			}, []string{"path"}),
+		},
+		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			args, err := parseArgs(req.Params.Arguments)
+			if err != nil {
+				return errResult("invalid arguments"), nil
+			}
+			path, _ := args["path"].(string)
+			if path == "" {
+				return errResult("path is required"), nil
+			}
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return errResult("invalid path"), nil
+			}
+			hash, err := storage.WorkspaceHash(absPath)
+			if err != nil {
+				return errResult("invalid path"), nil
+			}
+
+			ws, err := a.queries.GetWorkspaceByHash(ctx, hash)
+			if err == nil {
+				return textResult(map[string]any{
+					"workspace_hash": ws.Hash,
+					"root_path":      ws.Path,
+					"name":           ws.Name,
+					"registered":     true,
+				})
+			}
+			if errors.Is(err, sql.ErrNoRows) {
+				return textResult(map[string]any{
+					"workspace_hash": hash,
+					"root_path":      absPath,
+					"name":           filepath.Base(absPath),
+					"registered":     false,
+				})
+			}
+			return errResult(fmt.Sprintf("resolve workspace failed: %v", err)), nil
 		},
 	)
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -35,8 +35,8 @@ func TestRegisterTools_CountAndNames(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 
-	if len(result.Tools) != 13 {
-		t.Errorf("expected 13 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 14 {
+		t.Errorf("expected 14 tools, got %d", len(result.Tools))
 		for _, tool := range result.Tools {
 			t.Logf("  - %s", tool.Name)
 		}
@@ -56,6 +56,7 @@ func TestRegisterTools_CountAndNames(t *testing.T) {
 		"memory_graph",
 		"memory_impact",
 		"memory_trace",
+		"memory_workspaces_resolve",
 	}
 	sort.Strings(expected)
 
@@ -368,4 +369,55 @@ func TestKeepAliveInterval_Is30Seconds(t *testing.T) {
 	if internalmcp.KeepAliveInterval != 30*time.Second {
 		t.Errorf("KeepAliveInterval = %v, want 30s", internalmcp.KeepAliveInterval)
 	}
+}
+
+func TestMemoryWorkspacesResolve_EmptyPath(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name: "memory_workspaces_resolve",
+		Arguments: map[string]any{
+			"path": "",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected error result for empty path")
+	}
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(text, "path is required") {
+		t.Errorf("expected 'path is required' in error, got: %s", text)
+	}
+}
+
+func TestMemoryWorkspacesResolve_MissingPath(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "memory_workspaces_resolve",
+		Arguments: map[string]any{},
+	})
+	if err == nil && !result.IsError {
+		t.Fatal("expected error for missing path argument")
+	}
+}
+
+func TestMemoryWorkspacesResolve_ToolRegistered(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	list, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	for _, tool := range list.Tools {
+		if tool.Name == "memory_workspaces_resolve" {
+			if tool.Description == "" {
+				t.Error("memory_workspaces_resolve has empty description")
+			}
+			return
+		}
+	}
+	t.Fatal("memory_workspaces_resolve not found in tool list")
 }

--- a/internal/server/handlers/workspace_resolve.go
+++ b/internal/server/handlers/workspace_resolve.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"path/filepath"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/storage"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type WorkspaceResolver interface {
+	GetWorkspaceByHash(ctx context.Context, hash string) (sqlc.Workspace, error)
+}
+
+type workspaceResolveRequest struct {
+	Path string `json:"path"`
+}
+
+type WorkspaceResolveResponse struct {
+	WorkspaceHash string `json:"workspace_hash"`
+	RootPath      string `json:"root_path"`
+	Name          string `json:"name"`
+	Registered    bool   `json:"registered"`
+}
+
+func ResolveWorkspace(q WorkspaceResolver, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		var req workspaceResolveRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+		resp, err := ResolveWorkspacePath(c.Request().Context(), q, req.Path, logger)
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, resp)
+	}
+}
+
+func ResolveWorkspacePath(ctx context.Context, q WorkspaceResolver, path string, logger zerolog.Logger) (WorkspaceResolveResponse, error) {
+	if path == "" {
+		return WorkspaceResolveResponse{}, echo.NewHTTPError(http.StatusBadRequest, "path is required")
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return WorkspaceResolveResponse{}, echo.NewHTTPError(http.StatusBadRequest, "invalid path")
+	}
+	hash, err := storage.WorkspaceHash(absPath)
+	if err != nil {
+		return WorkspaceResolveResponse{}, echo.NewHTTPError(http.StatusBadRequest, "invalid path")
+	}
+
+	ws, err := q.GetWorkspaceByHash(ctx, hash)
+	if err == nil {
+		return WorkspaceResolveResponse{
+			WorkspaceHash: ws.Hash,
+			RootPath:      ws.Path,
+			Name:          ws.Name,
+			Registered:    true,
+		}, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkspaceResolveResponse{
+			WorkspaceHash: hash,
+			RootPath:      absPath,
+			Name:          filepath.Base(absPath),
+			Registered:    false,
+		}, nil
+	}
+	logger.Error().Err(err).Str("hash", hash).Msg("resolve workspace lookup failed")
+	return WorkspaceResolveResponse{}, echo.NewHTTPError(http.StatusInternalServerError, "failed to resolve workspace")
+}

--- a/internal/server/handlers/workspace_resolve_integration_test.go
+++ b/internal/server/handlers/workspace_resolve_integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage"
+	"github.com/rs/zerolog"
+)
+
+func doResolve(t *testing.T, h echo.HandlerFunc, path string) (int, map[string]interface{}) {
+	t.Helper()
+	e := echo.New()
+	body, _ := json.Marshal(map[string]string{"path": path})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/resolve", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h(c); err != nil {
+		if he, ok := err.(*echo.HTTPError); ok {
+			return he.Code, nil
+		}
+		t.Fatalf("resolve handler: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode resolve response: %v", err)
+	}
+	return rec.Code, resp
+}
+
+func TestResolveWorkspaceE2E_RegisteredAfterInit(t *testing.T) {
+	q := newQueries(t)
+	const projectPath = "/tmp/e2e-resolve-registered"
+	doInit(t, q, projectPath)
+
+	resolveHandler := handlers.ResolveWorkspace(q, zerolog.Nop())
+	code, resp := doResolve(t, resolveHandler, projectPath)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+
+	wantHash, err := storage.WorkspaceHash(projectPath)
+	if err != nil {
+		t.Fatalf("WorkspaceHash: %v", err)
+	}
+	if resp["workspace_hash"] != wantHash {
+		t.Errorf("workspace_hash: got %v want %s", resp["workspace_hash"], wantHash)
+	}
+	if resp["registered"] != true {
+		t.Errorf("registered: got %v want true", resp["registered"])
+	}
+	if resp["name"] != filepath.Base(projectPath) {
+		t.Errorf("name: got %v want %s", resp["name"], filepath.Base(projectPath))
+	}
+	if resp["root_path"] != projectPath {
+		t.Errorf("root_path: got %v want %s", resp["root_path"], projectPath)
+	}
+
+	ctx := context.Background()
+	rowsAfter, err := q.ListWorkspacesWithStats(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkspacesWithStats: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, _ = doResolve(t, resolveHandler, projectPath); false {
+		}
+	}
+	rowsAfterResolve, err := q.ListWorkspacesWithStats(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkspacesWithStats: %v", err)
+	}
+	if len(rowsAfter) != len(rowsAfterResolve) {
+		t.Errorf("resolve must be read-only: count changed from %d to %d after 3 resolves", len(rowsAfter), len(rowsAfterResolve))
+	}
+}
+
+func TestResolveWorkspaceE2E_UnregisteredPath(t *testing.T) {
+	q := newQueries(t)
+	resolveHandler := handlers.ResolveWorkspace(q, zerolog.Nop())
+
+	const unregistered = "/tmp/e2e-resolve-never-init-xyz"
+
+	ctx := context.Background()
+	rowsBefore, err := q.ListWorkspacesWithStats(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkspacesWithStats baseline: %v", err)
+	}
+
+	code, resp := doResolve(t, resolveHandler, unregistered)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+
+	wantHash, _ := storage.WorkspaceHash(unregistered)
+	if resp["workspace_hash"] != wantHash {
+		t.Errorf("workspace_hash: got %v want %s", resp["workspace_hash"], wantHash)
+	}
+	if resp["registered"] != false {
+		t.Errorf("registered: got %v want false", resp["registered"])
+	}
+
+	rowsAfter, err := q.ListWorkspacesWithStats(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkspacesWithStats post-resolve: %v", err)
+	}
+	if len(rowsBefore) != len(rowsAfter) {
+		t.Errorf("resolve must be read-only: count changed from %d to %d", len(rowsBefore), len(rowsAfter))
+	}
+	for _, r := range rowsAfter {
+		if r.Hash == wantHash {
+			t.Errorf("resolve should NOT have inserted hash %s", wantHash)
+		}
+	}
+}
+
+func TestResolveWorkspaceE2E_HashDeterministic(t *testing.T) {
+	q := newQueries(t)
+	resolveHandler := handlers.ResolveWorkspace(q, zerolog.Nop())
+
+	const path = "/tmp/e2e-resolve-determinism"
+	_, r1 := doResolve(t, resolveHandler, path)
+	_, r2 := doResolve(t, resolveHandler, path)
+	if r1["workspace_hash"] != r2["workspace_hash"] {
+		t.Errorf("hash should be deterministic across calls: got %v then %v", r1["workspace_hash"], r2["workspace_hash"])
+	}
+}

--- a/internal/server/handlers/workspace_resolve_integration_test.go
+++ b/internal/server/handlers/workspace_resolve_integration_test.go
@@ -75,8 +75,7 @@ func TestResolveWorkspaceE2E_RegisteredAfterInit(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		if _, _ = doResolve(t, resolveHandler, projectPath); false {
-		}
+		_, _ = doResolve(t, resolveHandler, projectPath)
 	}
 	rowsAfterResolve, err := q.ListWorkspacesWithStats(ctx)
 	if err != nil {

--- a/internal/server/handlers/workspace_resolve_test.go
+++ b/internal/server/handlers/workspace_resolve_test.go
@@ -1,0 +1,251 @@
+package handlers_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockResolver struct {
+	fn func(ctx context.Context, hash string) (sqlc.Workspace, error)
+}
+
+func (m *mockResolver) GetWorkspaceByHash(ctx context.Context, hash string) (sqlc.Workspace, error) {
+	return m.fn(ctx, hash)
+}
+
+func newResolveRequest(t *testing.T, body string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/resolve", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func decodeResolveResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v\nbody=%s", err, rec.Body.String())
+	}
+	return got
+}
+
+func TestResolveWorkspace_Registered(t *testing.T) {
+	absPath, err := filepath.Abs("/tmp/registered-project")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	wantHash, err := storage.WorkspaceHash(absPath)
+	if err != nil {
+		t.Fatalf("WorkspaceHash: %v", err)
+	}
+
+	q := &mockResolver{
+		fn: func(_ context.Context, hash string) (sqlc.Workspace, error) {
+			if hash != wantHash {
+				t.Fatalf("expected hash %q, got %q", wantHash, hash)
+			}
+			return sqlc.Workspace{
+				ID:        uuid.New(),
+				Hash:      wantHash,
+				Name:      "custom-display-name",
+				Path:      absPath,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}, nil
+		},
+	}
+
+	c, rec := newResolveRequest(t, `{"path":"/tmp/registered-project"}`)
+	if err := handlers.ResolveWorkspace(q, zerolog.Nop())(c); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeResolveResponse(t, rec)
+	if got["workspace_hash"] != wantHash {
+		t.Errorf("workspace_hash: got %v want %s", got["workspace_hash"], wantHash)
+	}
+	if got["root_path"] != absPath {
+		t.Errorf("root_path: got %v want %s", got["root_path"], absPath)
+	}
+	if got["name"] != "custom-display-name" {
+		t.Errorf("name: got %v want %s", got["name"], "custom-display-name")
+	}
+	if got["registered"] != true {
+		t.Errorf("registered: got %v want true", got["registered"])
+	}
+}
+
+func TestResolveWorkspace_NotRegistered(t *testing.T) {
+	absPath, _ := filepath.Abs("/tmp/never-registered")
+	wantHash, _ := storage.WorkspaceHash(absPath)
+
+	q := &mockResolver{
+		fn: func(_ context.Context, _ string) (sqlc.Workspace, error) {
+			return sqlc.Workspace{}, sql.ErrNoRows
+		},
+	}
+
+	c, rec := newResolveRequest(t, `{"path":"/tmp/never-registered"}`)
+	if err := handlers.ResolveWorkspace(q, zerolog.Nop())(c); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	got := decodeResolveResponse(t, rec)
+	if got["workspace_hash"] != wantHash {
+		t.Errorf("workspace_hash: got %v want %s", got["workspace_hash"], wantHash)
+	}
+	if got["root_path"] != absPath {
+		t.Errorf("root_path: got %v want %s", got["root_path"], absPath)
+	}
+	if got["name"] != "never-registered" {
+		t.Errorf("name: got %v want never-registered (filepath.Base)", got["name"])
+	}
+	if got["registered"] != false {
+		t.Errorf("registered: got %v want false", got["registered"])
+	}
+}
+
+func TestResolveWorkspace_MissingPathField(t *testing.T) {
+	q := &mockResolver{fn: func(_ context.Context, _ string) (sqlc.Workspace, error) {
+		t.Fatal("mock should not be called when path is empty")
+		return sqlc.Workspace{}, nil
+	}}
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", `{}`},
+		{"empty path string", `{"path":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newResolveRequest(t, tc.body)
+			err := handlers.ResolveWorkspace(q, zerolog.Nop())(c)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			he, ok := err.(*echo.HTTPError)
+			if !ok {
+				t.Fatalf("expected *echo.HTTPError, got %T: %v", err, err)
+			}
+			if he.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d", he.Code)
+			}
+		})
+	}
+}
+
+func TestResolveWorkspace_InvalidJSON(t *testing.T) {
+	q := &mockResolver{fn: func(_ context.Context, _ string) (sqlc.Workspace, error) {
+		t.Fatal("mock should not be called on invalid JSON")
+		return sqlc.Workspace{}, nil
+	}}
+	c, _ := newResolveRequest(t, `{bad json`)
+	err := handlers.ResolveWorkspace(q, zerolog.Nop())(c)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected *echo.HTTPError, got %T: %v", err, err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+}
+
+func TestResolveWorkspace_RelativePathNormalized(t *testing.T) {
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	wantHash, err := storage.WorkspaceHash(cwd)
+	if err != nil {
+		t.Fatalf("WorkspaceHash: %v", err)
+	}
+
+	q := &mockResolver{
+		fn: func(_ context.Context, hash string) (sqlc.Workspace, error) {
+			if hash != wantHash {
+				t.Errorf("expected normalized hash %q, got %q", wantHash, hash)
+			}
+			return sqlc.Workspace{}, sql.ErrNoRows
+		},
+	}
+
+	c, rec := newResolveRequest(t, `{"path":"."}`)
+	if err := handlers.ResolveWorkspace(q, zerolog.Nop())(c); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got := decodeResolveResponse(t, rec)
+	if got["root_path"] != cwd {
+		t.Errorf("root_path: got %v want %s", got["root_path"], cwd)
+	}
+	if got["workspace_hash"] != wantHash {
+		t.Errorf("workspace_hash: got %v want %s", got["workspace_hash"], wantHash)
+	}
+}
+
+func TestResolveWorkspace_DBError(t *testing.T) {
+	q := &mockResolver{
+		fn: func(_ context.Context, _ string) (sqlc.Workspace, error) {
+			return sqlc.Workspace{}, errors.New("connection refused")
+		},
+	}
+	c, _ := newResolveRequest(t, `{"path":"/tmp/x"}`)
+	err := handlers.ResolveWorkspace(q, zerolog.Nop())(c)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected *echo.HTTPError, got %T: %v", err, err)
+	}
+	if he.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", he.Code)
+	}
+}
+
+func TestResolveWorkspacePath_DirectCall(t *testing.T) {
+	absPath, _ := filepath.Abs("/tmp/direct-call-test")
+	wantHash, _ := storage.WorkspaceHash(absPath)
+	q := &mockResolver{
+		fn: func(_ context.Context, _ string) (sqlc.Workspace, error) {
+			return sqlc.Workspace{}, sql.ErrNoRows
+		},
+	}
+	resp, err := handlers.ResolveWorkspacePath(context.Background(), q, "/tmp/direct-call-test", zerolog.Nop())
+	if err != nil {
+		t.Fatalf("ResolveWorkspacePath: %v", err)
+	}
+	if resp.WorkspaceHash != wantHash {
+		t.Errorf("hash: got %s want %s", resp.WorkspaceHash, wantHash)
+	}
+	if resp.RootPath != absPath {
+		t.Errorf("root_path: got %s want %s", resp.RootPath, absPath)
+	}
+	if resp.Registered {
+		t.Error("expected registered=false")
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -31,6 +31,7 @@ func registerRoutes(s *Server) {
 	api := s.echo.Group("/api/v1", contentTypeMiddleware())
 	api.POST("/init", handlers.InitWorkspace(s.queries, s.db, s.watcher, s.currentConfig().Watcher, s.logger))
 	api.GET("/workspaces", handlers.ListWorkspaces(s.queries, s.logger))
+	api.POST("/workspaces/resolve", handlers.ResolveWorkspace(s.queries, s.logger))
 	api.DELETE("/workspaces/:hash", handlers.RemoveWorkspace(s.queries, s.db, s.logger))
 	api.POST("/reset-workspace", handlers.ResetWorkspace(s.queries, s.db, s.logger))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -164,9 +165,33 @@ func TestRouteRegistration(t *testing.T) {
 		paths[r.Path] = true
 	}
 
-	for _, path := range []string{"/health", "/api/status", "/api/v1/init", "/api/v1/workspaces", "/api/v1/embed", "/api/v1/collections", "/api/v1/collections/:name"} {
+	for _, path := range []string{"/health", "/api/status", "/api/v1/init", "/api/v1/workspaces", "/api/v1/workspaces/resolve", "/api/v1/embed", "/api/v1/collections", "/api/v1/collections/:name"} {
 		if !paths[path] {
 			t.Errorf("route %s not registered", path)
 		}
+	}
+}
+
+// TestResolveWorkspaceRouteSkipsWorkspaceMiddleware confirms that
+// POST /api/v1/workspaces/resolve is NOT subject to workspaceMiddleware:
+// it must reject empty path with "path is required" (handler), not with
+// "workspace_required" (middleware). See issue #316.
+func TestResolveWorkspaceRouteSkipsWorkspaceMiddleware(t *testing.T) {
+	s := newTestServer(&mockPool{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/resolve", strings.NewReader(`{"path":""}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "workspace_required") {
+		t.Errorf("workspace middleware leaked onto resolve route — body should mention 'path is required', got: %s", body)
+	}
+	if !strings.Contains(body, "path is required") {
+		t.Errorf("expected 'path is required' from handler, got: %s", body)
 	}
 }

--- a/openspec/changes/add-workspace-resolve-endpoint/design.md
+++ b/openspec/changes/add-workspace-resolve-endpoint/design.md
@@ -1,0 +1,184 @@
+## Context
+
+The workspace_hash is a deterministic SHA-256 of the absolute project path (`internal/storage/workspace.go:9-16`). Every workspace-scoped HTTP/CLI/MCP call requires this hash, but agents have no path-to-hash lookup endpoint.
+
+**Today's options for an agent in a fresh shell:**
+
+```bash
+# Option A — wasteful re-register
+WS=$(curl -sX POST $BASE/api/v1/init -d "{\"root_path\":\"$PWD\"}" | jq -r .workspace_hash)
+
+# Option B — list + filter (O(N) over all workspaces)
+WS=$(curl -s $BASE/api/v1/workspaces \
+  | jq -r ".workspaces[] | select(.root_path == \"$PWD\") | .hash")
+```
+
+Both are documented inconsistently across `SKILL.md`, `AGENTS_SNIPPET.md`, and `AGENTS.md`. The `AGENTS.md` examples are also broken (wrong endpoint, missing field) — see proposal.md.
+
+The Anthropic Skills 2026 guideline (progressive disclosure: SKILL.md body + references/) and industry patterns (kubectl `current-context`, AWS `sts get-caller-identity`, gcloud `current-config`) all converge on a **dedicated "resolve current context" endpoint** rather than overloading list/init.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One HTTP call: path in → hash + registration status out. No side effects.
+- One CLI call: `nano-brain workspaces current` auto-detects CWD, prints hash (or `export` line).
+- One MCP tool: same surface for MCP-only agents.
+- Fix the broken `AGENTS.md` snippet and rewrite the skill phase-based.
+
+**Non-Goals:**
+- Auto-register on resolve (`init` already idempotent — separate intent).
+- Implicit `NANO_BRAIN_WORKSPACE` env reading in middleware (Phương án C, separate proposal).
+- Multi-project / "active workspace" persisted state.
+- Symlink resolution beyond `filepath.Abs`.
+- Path canonicalization across host/container (the agent's `$PWD` is its own truth; if host and container see different paths, that's deployment config, not our problem).
+
+## Decisions
+
+### D1: Read-only `POST` endpoint (not `GET`)
+
+**Decision:** `POST /api/v1/workspaces/resolve` with JSON body `{path: string}`, NOT `GET /api/v1/workspaces/resolve?path=...`.
+
+**Rationale:**
+- Paths can contain characters that need URL-encoding (spaces, unicode, `?`, `#`). POST body avoids the encoding mess.
+- Consistent with `POST /api/v1/init` which also takes `{root_path}` in body.
+- Frontend/CLI/MCP all use `application/json` body — uniform.
+- POST is semantically fine for read-only operations when the input is rich/structured (RFC 9110 §9.3.3 allows it; common for search endpoints).
+
+**Alternative considered:** `GET` with query param. Rejected for encoding fragility.
+
+### D2: Public route group (no `workspaceMiddleware`)
+
+**Decision:** Register at `api.POST("/workspaces/resolve", ...)` in the public group at `routes.go:32-35`, NOT through `data := api.Group("", workspaceMiddleware(s.db))` at line 60.
+
+**Rationale:**
+- `workspaceMiddleware` extracts `workspace` from body and validates registration. This endpoint's input is `path`, not `workspace`. Middleware would reject every call.
+- Same group as `/init` (`/init` also doesn't go through workspace middleware — it CREATES workspaces).
+
+### D3: Compute hash even if not registered
+
+**Decision:** Always return `workspace_hash` field, even when `registered: false`. Use `filepath.Abs` + `storage.WorkspaceHash` (same logic as `init`).
+
+**Rationale:**
+- Hash is a pure function of absolute path. Server can compute it without DB lookup. Returning it always means the agent can later call `init` with the path it already used — no second hash derivation needed client-side.
+- Lets the CLI's `--export` flag work even pre-registration (agent can `export NANO_BRAIN_WORKSPACE=<hash>` then call `init` separately).
+
+**Alternative considered:** Return 404 if not registered. Rejected — forces client to handle two response shapes; loses the "one call gives you everything" UX.
+
+### D4: `name` field from DB if registered, from `filepath.Base` if not
+
+**Decision:** When `registered: true`, return `name` from `workspaces.name` column. When `false`, fallback to `filepath.Base(absPath)`.
+
+**Rationale:**
+- Display-only field. Frontend/CLI uses it for human-readable workspace identification.
+- Consistent fallback so the response shape is stable.
+
+### D5: Response shape — flat object, no envelope
+
+**Decision:** Return flat `{workspace_hash, root_path, name, registered}`. Not `{workspace: {...}}` wrapper.
+
+**Rationale:**
+- Single-object responses don't need wrapping (only list endpoints benefit from envelopes for pagination — see `fix-workspaces-api-contract` proposal).
+- Matches existing `initResponse` shape (also flat).
+
+```go
+type workspaceResolveResponse struct {
+    WorkspaceHash string `json:"workspace_hash"`
+    RootPath      string `json:"root_path"`
+    Name          string `json:"name"`
+    Registered    bool   `json:"registered"`
+}
+```
+
+### D6: CLI flags — `--path`, `--export`, `--json`, `--check`
+
+**Decision:** Add to `runWorkspacesCmd` switch:
+
+```bash
+nano-brain workspaces current                  # bare hash to stdout
+nano-brain workspaces current --path=/abs/path # override CWD
+nano-brain workspaces current --export         # "export NANO_BRAIN_WORKSPACE=<hash>"
+nano-brain workspaces current --json           # full JSON response
+nano-brain workspaces current --check          # exit 2 if registered=false
+```
+
+**Exit codes:**
+- `0` — resolved successfully (regardless of `registered`)
+- `1` — HTTP error / server unreachable / `--path` invalid
+- `2` — `--check` set AND `registered=false`
+
+Flags are independent; can combine (e.g., `--export --check`).
+
+### D7: MCP tool parity
+
+**Decision:** Register `memory_workspaces_resolve` in `internal/mcp/tools.go` alongside other workspace tools. Args schema: `{path: string (required)}`. Response: same JSON shape as HTTP handler.
+
+**Rationale:**
+- MCP is a first-class consumer (per `internal/mcp/AGENTS.md`). Parity prevents "MCP agent has fewer capabilities than HTTP agent".
+- Implementation can share the handler logic — extract to internal function, MCP tool wraps it.
+
+### D8: Skill rewrite structure (Anthropic 2026 progressive disclosure)
+
+**Decision:** `skills/nano-brain/SKILL.md` restructured into 4 phases:
+
+| Phase | Purpose | Length |
+|---|---|---|
+| Phase 1 DISCOVER | Verify server, resolve workspace, register if needed. **Success criterion: `$NANO_BRAIN_WORKSPACE` is set and registered.** | ~50 lines |
+| Phase 2 SELECT | User intent → operation decision tree (table). | ~50 lines |
+| Phase 3 EXECUTE | Each of 7 operations (query/search/vsearch/write/wake-up/graph/symbols) with request, response, error table. | ~200 lines |
+| Phase 4 RECOVER | Error catalog: HTTP code → meaning → recovery action. Retry limits (max 2). | ~30 lines |
+| References | Pointer to `references/*.md` for deep dives. | ~10 lines |
+
+**Rationale:**
+- Anthropic guideline: skill body <500 lines, decision tree over prose, imperative voice.
+- Phase-based reduces cognitive load for first-time agents.
+- Each phase has explicit success criterion (testable by the agent itself).
+
+### D9: AGENTS_SNIPPET.md is the agent's TLDR
+
+**Decision:** AGENTS_SNIPPET.md (~40 lines) injected into project AGENTS.md must contain a working bootstrap one-liner and a minimal cheatsheet. Anything deeper points to `skills/nano-brain/SKILL.md`.
+
+```markdown
+### Bootstrap (once per shell)
+eval "$(npx nano-brain workspaces current --export)"
+```
+
+**Rationale:**
+- AGENTS.md is the first thing agents see. It must work out of the box.
+- Current snippet has wrong endpoints + missing workspace field — agents fail before they start.
+
+### D10: `--check` semantics for shell guards
+
+**Decision:** `--check` makes the command exit 2 (distinct from 0/1) when `registered=false`. Enables shell guards:
+
+```bash
+npx nano-brain workspaces current --check 2>/dev/null \
+  || npx nano-brain init --root="$PWD"
+```
+
+Exit code 2 (not 1) so users can distinguish "server unreachable" (1) from "valid path but not registered" (2).
+
+**Rationale:**
+- Standard convention: 0=success, 1=error, 2=specific condition (cf. grep no-match=1, jq no-match=1, but tools like `diff` use 0/1/2).
+- The bash `||` chain works for either 1 or 2; users wanting fine-grained handling check `$?` explicitly.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| Endpoint leaks workspace metadata (name, doc count) | Already exposed by `GET /api/v1/workspaces`. No new attack surface. Auth middleware applies if enabled. |
+| Path traversal via `path` field | `filepath.Abs` normalizes but doesn't restrict. Server returns hash regardless — there's no file read. Adversary already controls the path string; computing SHA-256 of arbitrary strings is not a vulnerability. |
+| Agent uses `--export` then shell escapes the hash | Hash is 64 hex chars `[0-9a-f]`, safe in shell. Use `"$NANO_BRAIN_WORKSPACE"` quoting in skill examples. |
+| MCP tool name collision | `memory_workspaces_resolve` — new name, no conflict (other tools: `memory_query`, `memory_search`, etc.) |
+| CLI `--path` could be a relative path | Server handles `filepath.Abs` — same as `init`. Client doesn't need to pre-normalize. |
+| Skill drift between canonical `skills/nano-brain/` and the 2 install paths (`.opencode/` + `~/.config/opencode/`) | Manual sync in this PR. Follow-up issue for `nano-brain skill sync` command. |
+| Existing `AGENTS.md` is hand-written, not auto-generated from snippet | Manual edit this PR. Document the snippet→AGENTS.md sync responsibility in backlog. |
+
+## Migration
+
+- No DB migration.
+- No config change.
+- No API version bump.
+- New endpoint is purely additive. Existing endpoints unchanged.
+- Existing agents using `init`+filter or `list`+filter continue to work.
+- New skill bootstrap one-liner requires the new CLI subcommand — only works after binary upgrade.
+- For users on stale CLI: skill includes a fallback HTTP-direct bootstrap that uses `curl` against the new endpoint.

--- a/openspec/changes/add-workspace-resolve-endpoint/proposal.md
+++ b/openspec/changes/add-workspace-resolve-endpoint/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+Every nano-brain operation (HTTP, CLI, MCP) requires a `workspace_hash`, but agents have no clean way to discover the hash for the current project. Today the only options are:
+
+1. **Hardcode** the hash — brittle, breaks across machines and containers
+2. **Call `POST /api/v1/init` every session** — works (UPSERT is idempotent) but conflates "register" with "look up" and is wasteful
+3. **Call `GET /api/v1/workspaces` and filter client-side** — works but requires listing every workspace
+
+An audit of the agent-facing docs (`AGENTS.md` OPENCODE-MEMORY block, `skills/nano-brain/AGENTS_SNIPPET.md`) also found:
+
+- Wrong endpoint path (`/api/query` instead of `/api/v1/query`) — agents get 404 following the snippet
+- Missing `workspace` field in every `curl` example — agents get 400 `workspace_required`
+- No first-time-user bootstrap flow documented — agents have to grep code to figure out the init step
+
+A QA round (RRI-T) flagged the same gap as a recurring UX problem.
+
+## What Changes
+
+This change adds a small, **read-only** workspace resolution surface and rewrites the agent-facing skill to use a clear phase-based onboarding flow.
+
+### Backend
+- **`internal/server/handlers/workspace_resolve.go`** (new) — `POST /api/v1/workspaces/resolve` handler. Pure read-only. Computes hash via existing `storage.WorkspaceHash` (SHA-256 of absolute path), checks DB for registration, returns `{workspace_hash, root_path, name, registered}`. Never auto-registers.
+- **`internal/server/routes.go`** — register route in the public group (alongside `/init`, `/workspaces`). NOT through `workspaceMiddleware` (input is a path, not a hash).
+- **`internal/storage/queries/workspaces.sql`** — add `GetWorkspaceByHash` query if not already present (re-uses existing UPSERT, only needs lookup-by-PK).
+- **`internal/server/handlers/workspace_resolve_test.go`** (new) — table-driven unit tests (registered/unregistered/empty path/relative path/abs path).
+- **`internal/server/handlers/workspace_resolve_integration_test.go`** (new) — `//go:build integration` real-PG test against `testutil.SetupTestDB`.
+
+### CLI
+- **`cmd/nano-brain/workspaces.go`** — add `current` subcommand to the existing `runWorkspacesCmd` dispatcher. Auto-detects CWD via `os.Getwd()` (or `--path=<p>`), calls `/api/v1/workspaces/resolve`, prints result.
+  - Default: print hash to stdout
+  - `--export`: print `export NANO_BRAIN_WORKSPACE=<hash>` for shell `eval`
+  - `--json`: print full response
+  - `--check`: exit 2 if `registered=false`
+- **`cmd/nano-brain/workspaces_test.go`** — add tests using `httptest.NewServer` (same pattern as `runWorkspacesListWithIO`).
+
+### MCP
+- **`internal/mcp/tools.go`** — register `memory_workspaces_resolve` tool. Args: `{path: string}`. Same response shape as HTTP. Validates path is non-empty.
+- **`internal/mcp/tools_test.go`** — add unit test for new tool.
+
+### Documentation (skill rewrite — Anthropic 2026 progressive disclosure)
+- **`skills/nano-brain/SKILL.md`** — rewrite as 4-phase structure:
+  - Phase 1 DISCOVER — verify server up, resolve workspace, register if needed
+  - Phase 2 SELECT — user intent → operation decision tree
+  - Phase 3 EXECUTE — each operation with error handling block
+  - Phase 4 RECOVER — fallback patterns + retry limits
+- **`skills/nano-brain/AGENTS_SNIPPET.md`** — rewrite (~40 lines, used by `npx nano-brain init` to inject into project AGENTS.md). New bootstrap one-liner: `eval "$(npx nano-brain workspaces current --export)"`.
+- **`AGENTS.md`** (project root) — sync OPENCODE-MEMORY block from new snippet; fix wrong endpoint paths + add `workspace` field to all examples.
+- **`.opencode/skills/nano-brain/*`** and **`~/.config/opencode/skills/nano-brain/*`** — mirror from canonical `skills/nano-brain/`.
+- **`README.md`** — add new endpoint + CLI command to the tables.
+
+## Capabilities
+
+### New Capabilities
+- **`workspace-resolve-endpoint`** — defines the contract for `POST /api/v1/workspaces/resolve`, the matching CLI subcommand `nano-brain workspaces current`, and the MCP tool `memory_workspaces_resolve`. All three share the same request (`{path}`) and response (`{workspace_hash, root_path, name, registered}`) shape.
+
+### Modified Capabilities
+None — `/api/v1/init` and `GET /api/v1/workspaces` keep current behavior.
+
+## Impact
+
+- **Code**: 4 new files (handler + 2 tests + sqlc query addition), ~3 edits (routes.go, workspaces.go CLI, tools.go MCP), plus 5 docs files.
+- **Behavior additive**: existing endpoints unchanged. New endpoint is purely additive. No client breakage.
+- **Risk**: Low — read-only, no middleware/auth touched, no schema migration.
+- **Performance**: Single PK lookup (`SELECT * FROM workspaces WHERE hash=$1`). <5ms typical.
+- **Security**: Returns workspace metadata (path, name, doc count). Same surface as `GET /api/v1/workspaces` which already exposes this. No new leak.
+
+## Out of Scope (separate issues)
+
+- Implicit `NANO_BRAIN_WORKSPACE` env-var reading in `workspaceMiddleware` (Phương án C — high-risk lane, touches middleware + auth surface). Will be its own proposal.
+- `nano-brain skill sync` command to regenerate `AGENTS.md` OPENCODE-MEMORY block from `AGENTS_SNIPPET.md` (manual sync this PR).
+- Fix for #234 CLI `--config` precedence bug (separate issue already open).
+- `.nano-brain` per-project marker file pattern.
+- Symlink resolution (`filepath.EvalSymlinks`) — server uses `filepath.Abs` only, consistent with existing `init` handler. Different behavior between host/container would be a footgun.

--- a/openspec/changes/add-workspace-resolve-endpoint/specs/workspace-resolve-endpoint/spec.md
+++ b/openspec/changes/add-workspace-resolve-endpoint/specs/workspace-resolve-endpoint/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Workspace path-to-hash resolution endpoint
+The server SHALL expose `POST /api/v1/workspaces/resolve` that accepts a filesystem path and returns the deterministic workspace hash plus registration status. The endpoint SHALL be public (no `workspaceMiddleware`) and read-only (no DB writes, no side effects).
+
+#### Scenario: Resolve registered workspace
+- **WHEN** `POST /api/v1/workspaces/resolve` is called with body `{"path": "/abs/path/to/registered/project"}`
+- **AND** the workspace at that path is already registered via `POST /api/v1/init`
+- **THEN** the response is HTTP 200 with `Content-Type: application/json`
+- **AND** the body is `{"workspace_hash": "<64-char-hex>", "root_path": "/abs/path/to/registered/project", "name": "<workspaces.name>", "registered": true}`
+- **AND** `workspace_hash` equals `sha256(absolute_path)` rendered as lowercase hex
+
+#### Scenario: Resolve unregistered path
+- **WHEN** `POST /api/v1/workspaces/resolve` is called with body `{"path": "/abs/path/never/registered"}`
+- **THEN** the response is HTTP 200 with the same shape
+- **AND** `workspace_hash` is computed from `filepath.Abs(path)` via `storage.WorkspaceHash`
+- **AND** `name` is `filepath.Base(absolute_path)` (no DB lookup needed)
+- **AND** `registered` is `false`
+- **AND** no row is inserted into the `workspaces` table
+
+#### Scenario: Resolve relative path
+- **WHEN** the request body contains a relative path (e.g., `{"path": "."}` or `{"path": "../foo"}`)
+- **THEN** the server normalizes it via `filepath.Abs` (relative to the SERVER'S working directory, not the client's)
+- **AND** the response `root_path` field contains the absolute path
+
+> Note: Clients SHOULD send absolute paths since the server's CWD is not the client's CWD. The CLI subcommand handles this by calling `os.Getwd()` client-side before posting.
+
+#### Scenario: Missing path field
+- **WHEN** `POST /api/v1/workspaces/resolve` is called with body `{}` or `{"path": ""}`
+- **THEN** the response is HTTP 400 with error message indicating `path is required`
+
+#### Scenario: Invalid JSON body
+- **WHEN** the request body is malformed JSON
+- **THEN** the response is HTTP 400 with error message indicating invalid request body
+
+#### Scenario: Read-only — no DB mutation
+- **WHEN** `POST /api/v1/workspaces/resolve` is called any number of times with any path (registered or not)
+- **THEN** the count of rows in `workspaces`, `collections`, `documents`, and `chunks` tables is unchanged
+
+### Requirement: CLI `workspaces current` subcommand
+The CLI SHALL expose `nano-brain workspaces current` which resolves the current shell's working directory (or `--path=<p>`) to a workspace hash by calling `POST /api/v1/workspaces/resolve`.
+
+#### Scenario: Default — bare hash to stdout
+- **WHEN** `nano-brain workspaces current` is invoked in a registered project directory
+- **THEN** stdout contains exactly the 64-character workspace hash followed by a newline
+- **AND** stderr is empty
+- **AND** the exit code is `0`
+
+#### Scenario: `--export` flag
+- **WHEN** `nano-brain workspaces current --export` is invoked
+- **THEN** stdout contains exactly `export NANO_BRAIN_WORKSPACE=<hash>\n`
+- **AND** the exit code is `0`
+- **AND** the line is suitable for `eval "$(nano-brain workspaces current --export)"`
+
+#### Scenario: `--json` flag
+- **WHEN** `nano-brain workspaces current --json` is invoked
+- **THEN** stdout contains the full server JSON response with newline
+- **AND** the JSON parses to an object with keys `workspace_hash`, `root_path`, `name`, `registered`
+
+#### Scenario: `--check` flag with registered workspace
+- **WHEN** `nano-brain workspaces current --check` is invoked in a registered project
+- **THEN** stdout contains the bare hash
+- **AND** the exit code is `0`
+
+#### Scenario: `--check` flag with unregistered path
+- **WHEN** `nano-brain workspaces current --check` is invoked in a directory NOT registered
+- **THEN** the exit code is `2` (distinct from 1=server error and 0=success)
+- **AND** stderr contains a message indicating the workspace is not registered
+
+#### Scenario: `--path` flag overrides CWD
+- **WHEN** `nano-brain workspaces current --path=/some/other/path` is invoked
+- **THEN** the server is called with that path (not `os.Getwd()`)
+- **AND** the response reflects that path's hash and registration status
+
+#### Scenario: Server unreachable
+- **WHEN** the nano-brain server is not running
+- **THEN** the exit code is `1`
+- **AND** stderr contains a connection error message
+
+#### Scenario: Combined flags
+- **WHEN** `nano-brain workspaces current --export --check` is invoked in a registered project
+- **THEN** stdout contains the `export NANO_BRAIN_WORKSPACE=<hash>` line
+- **AND** the exit code is `0`
+
+### Requirement: MCP tool `memory_workspaces_resolve`
+The MCP server SHALL expose a tool named `memory_workspaces_resolve` with the same semantic surface as the HTTP endpoint.
+
+#### Scenario: MCP resolve tool
+- **WHEN** an MCP client calls tool `memory_workspaces_resolve` with arguments `{"path": "/abs/path"}`
+- **THEN** the response contains a JSON object with keys `workspace_hash`, `root_path`, `name`, `registered`
+- **AND** the values match the corresponding HTTP endpoint response for the same path
+
+#### Scenario: MCP resolve with empty path
+- **WHEN** an MCP client calls `memory_workspaces_resolve` with `{"path": ""}` or missing `path`
+- **THEN** the tool returns an error indicating `path is required`
+
+### Requirement: Skill documentation phase-based structure
+The agent-facing documentation in `skills/nano-brain/SKILL.md` SHALL follow a 4-phase structure: DISCOVER → SELECT → EXECUTE → RECOVER. The bootstrap section SHALL document the one-liner `eval "$(npx nano-brain workspaces current --export)"`.
+
+#### Scenario: SKILL.md contains all four phases
+- **WHEN** an agent reads `skills/nano-brain/SKILL.md`
+- **THEN** the file contains headers matching `## Phase 1 — DISCOVER`, `## Phase 2 — SELECT`, `## Phase 3 — EXECUTE`, `## Phase 4 — RECOVER`
+- **AND** the DISCOVER section contains the bootstrap one-liner using `nano-brain workspaces current --export`
+- **AND** the RECOVER section contains an error table with at least the entries: `workspace_required`, `workspace_not_registered`, `connection refused`
+
+#### Scenario: AGENTS_SNIPPET.md bootstrap example
+- **WHEN** an agent reads `skills/nano-brain/AGENTS_SNIPPET.md`
+- **THEN** the file contains the literal bootstrap line `eval "$(npx nano-brain workspaces current --export)"`
+- **AND** all curl examples use endpoint path prefix `/api/v1/` (not `/api/`)
+- **AND** all curl POST examples include a `workspace` field in their request body OR reference `$NANO_BRAIN_WORKSPACE`
+
+#### Scenario: Project AGENTS.md sync
+- **WHEN** an agent reads the `<!-- OPENCODE-MEMORY:START -->` block in the project root `AGENTS.md`
+- **THEN** the block matches the content of `skills/nano-brain/AGENTS_SNIPPET.md`
+- **AND** no `curl` example uses the wrong path `/api/query`
+- **AND** every API example shows the workspace handling

--- a/openspec/changes/add-workspace-resolve-endpoint/tasks.md
+++ b/openspec/changes/add-workspace-resolve-endpoint/tasks.md
@@ -1,0 +1,174 @@
+## 1. SQL query
+
+- [ ] 1.1 Inspect `internal/storage/queries/workspaces.sql` for existing `GetWorkspaceByHash` (or equivalent single-row lookup by hash PK)
+- [ ] 1.2 If missing, add query: `-- name: GetWorkspaceByHash :one\nSELECT * FROM workspaces WHERE hash = $1;`
+- [ ] 1.3 Run `make sqlc-generate` (or `sqlc generate`) to regenerate Go bindings
+- [ ] 1.4 Verify regenerated `sqlc.Queries` includes `GetWorkspaceByHash` method
+
+## 2. HTTP handler — POST /api/v1/workspaces/resolve
+
+- [ ] 2.1 Create `internal/server/handlers/workspace_resolve.go`:
+  - Define `workspaceResolveRequest{Path string json:"path"}`
+  - Define `workspaceResolveResponse{WorkspaceHash, RootPath, Name string; Registered bool}` with snake_case JSON tags
+  - Define `WorkspaceResolver` interface with method `GetWorkspaceByHash(ctx, hash) (sqlc.Workspace, error)`
+  - Implement `ResolveWorkspace(q WorkspaceResolver, logger zerolog.Logger) echo.HandlerFunc` constructor
+  - Handler logic:
+    1. Bind request body → 400 if invalid
+    2. Validate `path != ""` → 400 `path is required`
+    3. `absPath, _ := filepath.Abs(req.Path)` → 400 if error
+    4. `hash, _ := storage.WorkspaceHash(absPath)` → 400 if error
+    5. Look up `q.GetWorkspaceByHash(ctx, hash)`:
+       - If found: response uses DB `Name`, `registered: true`
+       - If `sql.ErrNoRows`: response uses `filepath.Base(absPath)`, `registered: false`
+       - Other error: 500 + log
+    6. Return `c.JSON(200, response)`
+- [ ] 2.2 Register route in `internal/server/routes.go` next to `/init` (public group, NOT through `workspaceMiddleware`):
+  ```go
+  api.POST("/workspaces/resolve", handlers.ResolveWorkspace(s.queries, s.logger))
+  ```
+- [ ] 2.3 Extend `WorkspaceQuerier` interface in `workspace.go` to include `GetWorkspaceByHash` (or use a separate interface for resolve — prefer keeping minimal surface per handler file)
+
+## 3. HTTP handler tests
+
+- [ ] 3.1 Create `internal/server/handlers/workspace_resolve_test.go` with table-driven tests:
+  - `TestResolveWorkspace_Registered` — mock returns row → assert `registered:true`, fields populated from row
+  - `TestResolveWorkspace_NotRegistered` — mock returns `sql.ErrNoRows` → assert `registered:false`, `name` from filepath.Base
+  - `TestResolveWorkspace_MissingPath` — empty body → 400
+  - `TestResolveWorkspace_EmptyPathField` — `{"path":""}` → 400
+  - `TestResolveWorkspace_RelativePath` — `{"path":"."}` → normalized to abs
+  - `TestResolveWorkspace_DBError` — mock returns other error → 500
+- [ ] 3.2 Use inline mock struct implementing `WorkspaceResolver`, no gomock
+- [ ] 3.3 Create `internal/server/handlers/workspace_resolve_integration_test.go` with `//go:build integration` and use `testutil.SetupTestDB`:
+  - Register a workspace via real `InitWorkspace` handler
+  - Call resolve with its path → assert `registered:true`
+  - Call resolve with a DIFFERENT path → assert `registered:false`, hash is deterministic
+
+## 4. CLI subcommand — `workspaces current`
+
+- [ ] 4.1 In `cmd/nano-brain/workspaces.go` extend `runWorkspacesCmd` switch:
+  ```go
+  case "current":
+      runWorkspacesCurrent(args[1:])
+  ```
+- [ ] 4.2 Implement `runWorkspacesCurrent(args []string)` and `runWorkspacesCurrentWithIO(args, stdout, stderr) int`:
+  - Parse flags: `--path=<p>`, `--export`, `--json`, `--check`
+  - Determine path: `--path` value or `os.Getwd()`
+  - Call `POST /api/v1/workspaces/resolve` via existing `doRequest`
+  - Parse response into a struct
+  - Format output based on flags:
+    - `--json`: print body
+    - `--export`: print `export NANO_BRAIN_WORKSPACE=<hash>\n`
+    - default: print `<hash>\n`
+  - Exit code: 0 success; 1 HTTP/server error; 2 `--check` && `!registered`
+- [ ] 4.3 Update `workspacesUsage()` to include `current` in usage line
+
+## 5. CLI tests
+
+- [ ] 5.1 In `cmd/nano-brain/workspaces_test.go` add tests using `httptest.NewServer` (same pattern as `runWorkspacesListWithIO` tests):
+  - `TestRunWorkspacesCurrent_Default_PrintsHash`
+  - `TestRunWorkspacesCurrent_Export_PrintsExportLine`
+  - `TestRunWorkspacesCurrent_JSON_PrintsFullBody`
+  - `TestRunWorkspacesCurrent_Check_RegisteredExitsZero`
+  - `TestRunWorkspacesCurrent_Check_UnregisteredExitsTwo`
+  - `TestRunWorkspacesCurrent_PathOverridesCWD`
+  - `TestRunWorkspacesCurrent_ServerUnreachable_ExitsOne`
+- [ ] 5.2 Use `os.Setenv("NANO_BRAIN_HOST", ...)` + `NANO_BRAIN_PORT` to point `getBaseURL()` at the test server
+
+## 6. MCP tool — memory_workspaces_resolve
+
+- [ ] 6.1 In `internal/mcp/tools.go` register new tool in the same pattern as existing memory_* tools
+- [ ] 6.2 Extract the handler core logic into an unexported function `resolveWorkspaceCore(ctx, q, path) (response, error)` reusable by HTTP and MCP
+- [ ] 6.3 MCP tool wraps core: validate args["path"] is non-empty string → call core → marshal response
+- [ ] 6.4 In `internal/mcp/tools_test.go` add `TestMemoryWorkspacesResolve_*` tests for registered, not_registered, empty_path
+
+## 7. Documentation — SKILL.md (phase-based rewrite)
+
+- [ ] 7.1 Rewrite `skills/nano-brain/SKILL.md` with frontmatter + 4 phases:
+  - Phase 1 DISCOVER — server health check, bootstrap one-liner, registration check
+  - Phase 2 SELECT — user intent → operation table
+  - Phase 3 EXECUTE — sub-sections for query/search/vsearch/write/wake-up/graph/symbols/tags, each with request, response, error table
+  - Phase 4 RECOVER — error catalog + retry policy
+  - References section pointing to `references/*.md`
+- [ ] 7.2 Keep total length ≤500 lines (Anthropic guideline)
+- [ ] 7.3 Verify all curl examples use `/api/v1/*` paths and include `workspace` field or `$NANO_BRAIN_WORKSPACE`
+- [ ] 7.4 Verify all CLI examples use `nano-brain` command names that actually exist (cross-check against `cmd/nano-brain/main.go` switch)
+
+## 8. Documentation — AGENTS_SNIPPET.md (rewrite)
+
+- [ ] 8.1 Rewrite `skills/nano-brain/AGENTS_SNIPPET.md` to ~40 lines:
+  - Bootstrap one-liner: `eval "$(npx nano-brain workspaces current --export)"`
+  - Quick reference table (CLI commands)
+  - HTTP API section showing 1 example with workspace field + correct path
+  - Pointer to `skills/nano-brain/SKILL.md` for full reference
+- [ ] 8.2 Preserve `<!-- OPENCODE-MEMORY:START -->` and `<!-- OPENCODE-MEMORY:END -->` markers
+
+## 9. Documentation — project AGENTS.md sync
+
+- [ ] 9.1 Replace `<!-- OPENCODE-MEMORY:START -->` block in `/Users/tamlh/workspaces/self/AI/Tools/nano-brain/AGENTS.md` with content from new `AGENTS_SNIPPET.md`
+- [ ] 9.2 Verify no other places in `AGENTS.md` reference the wrong `/api/query` path
+
+## 10. Documentation — skill copies sync
+
+- [ ] 10.1 Sync `.opencode/skills/nano-brain/SKILL.md` from canonical
+- [ ] 10.2 Sync `.opencode/skills/nano-brain/references/*.md` from canonical
+- [ ] 10.3 Sync `~/.config/opencode/skills/nano-brain/SKILL.md` from canonical
+- [ ] 10.4 Sync `~/.config/opencode/skills/nano-brain/references/*.md` from canonical
+- [ ] 10.5 Verify all 3 copies (`skills/`, `.opencode/skills/`, `~/.config/`) are byte-identical for SKILL.md + references
+
+## 11. Documentation — README.md update
+
+- [ ] 11.1 Add row to "Public Endpoints" table: `POST /api/v1/workspaces/resolve | Resolve path → workspace hash + registration status`
+- [ ] 11.2 Add row to "CLI Commands" table: `nano-brain workspaces current [--path=<p>] [--export] [--json] [--check] | Resolve current/path workspace hash`
+- [ ] 11.3 Add row to "MCP Tools" table: `memory_workspaces_resolve | Resolve path → workspace hash + registered`
+
+## 12. Verification — validate:quick
+
+- [ ] 12.1 `cd .opencode/worktrees/feat-316-workspace-resolve && go build ./...` → exit 0
+- [ ] 12.2 `go vet ./...` → no warnings
+- [ ] 12.3 `go test -race -short ./internal/server/handlers/... ./cmd/nano-brain/... ./internal/mcp/...` → all PASS
+- [ ] 12.4 `lsp_diagnostics` on all changed Go files → no errors/warnings
+
+## 13. Verification — test:integration
+
+- [ ] 13.1 `go test -race -tags=integration ./internal/server/handlers/...` → PASS
+- [ ] 13.2 Verify the integration test creates + queries a real workspace via real PG
+
+## 14. Verification — smoke:e2e
+
+- [ ] 14.1 Build local binary: `CGO_ENABLED=0 go build -o /tmp/nb-316 ./cmd/nano-brain`
+- [ ] 14.2 Start server on port 3199 (avoid clash with running 3100): `NANO_BRAIN_SERVER_PORT=3199 /tmp/nb-316 &`
+- [ ] 14.3 Curl resolve with current path → assert response shape + `registered:true`
+- [ ] 14.4 Curl resolve with a non-registered path → assert `registered:false`
+- [ ] 14.5 Run `/tmp/nb-316 workspaces current --export` → eval the output → assert `$NANO_BRAIN_WORKSPACE` is set
+- [ ] 14.6 Use the exported env to call `query` via curl with manual `workspace` field — assert search works
+- [ ] 14.7 Run `/tmp/nb-316 workspaces current --check` in a non-registered dir → assert exit code 2
+- [ ] 14.8 Stop server cleanly
+
+## 15. Verification — self-review
+
+- [ ] 15.1 `self-review:response-shape` — read `workspaceResolveResponse` struct + handler mapping → confirm all 4 fields explicitly assigned in both branches (registered/unregistered)
+- [ ] 15.2 `self-review:staged-files` — `git status` → no `.opencode/` files staged, no `package-lock.json`, no worktree metadata
+- [ ] 15.3 Verify no AI-slop: no fabricated paths, no comments like "// implement X here", no unused error variables ignored with `_`
+
+## 16. PR + Review Gate
+
+- [ ] 16.1 Stage only intended files, write conventional commit:
+  `feat(workspace-resolve): add POST /resolve + CLI 'workspaces current' + MCP tool + phase-based skill rewrite (#316)`
+- [ ] 16.2 Push branch `feat/316-workspace-resolve` to origin
+- [ ] 16.3 Open PR via `gh pr create` with body referencing #316 and the OpenSpec change folder
+- [ ] 16.4 STOP — request human/external review per harness rule "no self-review"
+- [ ] 16.5 Address bot review (Gemini) findings, ≤3 push cycles
+- [ ] 16.6 After Review Verdict = PASS, squash merge + delete branch
+
+## 17. Archive + Release
+
+- [ ] 17.1 Pull merged master
+- [ ] 17.2 `openspec archive add-workspace-resolve-endpoint --yes`
+- [ ] 17.3 Commit archive + push (master push triggers auto-tag → release → npm publish)
+- [ ] 17.4 Remove worktree: `git worktree remove .opencode/worktrees/feat-316-workspace-resolve`
+- [ ] 17.5 Delete local branch: `git branch -D feat/316-workspace-resolve`
+- [ ] 17.6 Comment release note on issue #316 + close
+
+## 18. Memory persistence
+
+- [ ] 18.1 Write session summary to nano-brain memory with tags=[decision, skill-rewrite, workspace-resolve] documenting the design choices (D1-D10) for future sessions

--- a/skills/nano-brain/AGENTS_SNIPPET.md
+++ b/skills/nano-brain/AGENTS_SNIPPET.md
@@ -3,46 +3,74 @@
 
 ## Memory System (nano-brain)
 
-This project uses **nano-brain** for persistent context across sessions.
+This project uses **nano-brain** for persistent context across sessions. Server runs on the host at port 3100; agents inside containers reach it at `host.docker.internal:3100`.
 
-### Quick Reference
+### Bootstrap (once per shell session)
 
-All commands use the nano-brain CLI:
+```bash
+eval "$(npx @nano-step/nano-brain workspaces current --export)"
+```
 
-| I want to... | CLI |
-|--------------|-----|
-| Recall past work on a topic | `npx @nano-step/nano-brain query "topic"` |
-| Find exact error/function name | `npx @nano-step/nano-brain search "exact term"` |
-| Explore a concept semantically | `npx @nano-step/nano-brain vsearch "concept"` |
-| Save a decision for future sessions | `npx @nano-step/nano-brain write "decision context" --tags=decision` |
-| Check index health | `npx @nano-step/nano-brain status` |
+This exports `NANO_BRAIN_WORKSPACE` so subsequent CLI calls do not need `--workspace=...`. If the workspace is not yet registered:
+
+```bash
+npx @nano-step/nano-brain workspaces current --check 2>/dev/null \
+  || npx @nano-step/nano-brain init --root="$PWD"
+```
+
+### Quick Reference (CLI)
+
+| I want to... | Command |
+|---|---|
+| Recall past work | `npx @nano-step/nano-brain query "topic"` |
+| Find exact term/identifier | `npx @nano-step/nano-brain search "FunctionName"` |
+| Semantic search | `npx @nano-step/nano-brain vsearch "concept"` |
+| Save a decision | `npx @nano-step/nano-brain write --tags=decision --title="..." --content="..."` |
+| Workspace briefing | `npx @nano-step/nano-brain wake-up` |
+| Cross-workspace search | `npx @nano-step/nano-brain query --scope=all "topic"` |
+| Tag-filtered search | `npx @nano-step/nano-brain query --tags=decision "topic"` |
+| Server health | `npx @nano-step/nano-brain status` |
+
+### HTTP API (for non-CLI agents)
+
+Base URL inside containers: `http://host.docker.internal:3100`. On the host: `http://localhost:3100`.
+
+All `POST /api/v1/*` workspace-scoped endpoints require a `workspace` field in the JSON body. Get the hash via:
+
+```bash
+curl -fsS -X POST $BASE/api/v1/workspaces/resolve \
+  -H 'Content-Type: application/json' \
+  -d "{\"path\":\"$PWD\"}" | jq -r .workspace_hash
+```
+
+Endpoint contract: `POST /api/v1/workspaces/resolve` body `{"path":"<abs>"}` → `{"workspace_hash","root_path","name","registered"}`. Read-only — never auto-registers; use `POST /api/v1/init` for that.
+
+Example query:
+
+```bash
+curl -fsS -X POST $BASE/api/v1/query \
+  -H 'Content-Type: application/json' \
+  -d "{\"workspace\":\"$NANO_BRAIN_WORKSPACE\",\"query\":\"topic\",\"max_results\":10}"
+```
 
 ### Session Workflow
 
-**End of session:** Save key decisions, patterns discovered, and debugging insights.
+- **Start of session:** `npx @nano-step/nano-brain query "what have we done about <task>"` before exploring the codebase.
+- **End of session:** Persist key decisions and learnings:
+
+```bash
+npx @nano-step/nano-brain write --tags=summary,decision \
+  --title="Session: <topic>" \
+  --content="## Summary\n- Decision: ...\n- Why: ...\n- Files: ..."
 ```
-npx @nano-step/nano-brain write "## Summary\n- Decision: ...\n- Why: ...\n- Files: ..." --tags=summary
-```
 
-### Code Intelligence Tools
+### When to Search Memory vs Codebase
 
-nano-brain also provides symbol-level code analysis (requires `npx @nano-step/nano-brain reindex` with `workdir` set to the workspace — the `--root` flag is silently ignored):
+- **"Have we done this before?"** → `npx @nano-step/nano-brain query "..."` (past sessions)
+- **"Where is this in the code right now?"** → grep / ast-grep
+- **"How does this concept work here?"** → both
+- **"What calls this function / what breaks if I change Y?"** → `nano-brain` code intelligence (`POST /api/v1/graph/query`, `/api/v1/graph/impact`, `/api/v1/graph/trace`)
 
-| I want to... | CLI |
-|--------------|-----|
-| Understand a symbol's callers/callees/flows | `npx @nano-step/nano-brain context functionName` |
-| Assess risk of changing a symbol | `npx @nano-step/nano-brain code-impact className --direction=upstream` |
-| Map my git changes to affected symbols | `npx @nano-step/nano-brain detect-changes --scope=all` |
-
-Use `file_path` parameter to disambiguate when multiple symbols share the same name.
-
-### When to Search Memory vs Codebase vs Code Intelligence
-
-- **"Have we done this before?"** → `npx @nano-step/nano-brain query "..."` (searches past sessions)
-- **"Where is this in the code?"** → grep / ast-grep (searches current files)
-- **"How does this concept work here?"** → Both (memory for past context + grep for current code)
-- **"What calls this function?"** → `npx @nano-step/nano-brain context <name>` (symbol graph relationships)
-- **"What breaks if I change X?"** → `npx @nano-step/nano-brain code-impact <name> --direction=...` (dependency + flow analysis)
-- **"What did my changes affect?"** → `npx @nano-step/nano-brain detect-changes --scope=...` (git diff to symbol mapping)
+See `skills/nano-brain/SKILL.md` for the full reference (phases, error recovery, all endpoints).
 
 <!-- OPENCODE-MEMORY:END -->

--- a/skills/nano-brain/SKILL.md
+++ b/skills/nano-brain/SKILL.md
@@ -1,381 +1,278 @@
 ---
 name: nano-brain
-description: Persistent memory + code intelligence for AI coding agents. Hybrid search (BM25 + vector + LLM rerank), cross-session recall, symbol analysis, impact checks, OpenCode/Claude Code session harvesting. Use this skill when you need to recall prior decisions, search across sessions/codebase, trace symbol callers/callees, or persist long-term context.
+description: Persistent memory + code intelligence for AI coding agents. Hybrid search (BM25 + vector + RRF + recency), cross-session recall, symbol analysis, impact checks, knowledge graph, OpenCode/Claude Code session harvesting. Use this skill when you need to recall prior decisions across sessions, search across multiple codebases, trace symbol callers/callees, analyze code impact (what breaks if X changes), persist long-term context, or query the knowledge graph. Triggers — "remember what we did about X", "search across sessions", "find references to X", "what breaks if I change Y", "save this decision", "wake-up briefing".
 compatibility: OpenCode, Claude Code, any MCP-aware agent
 metadata:
   author: nano-step
-  version: 3.0.0
+  version: 3.1.0
   repo: nano-step/nano-brain
 ---
 
-# nano-brain
 
-Persistent memory + code intelligence service for AI coding agents. This skill teaches an agent **when** to use nano-brain and **how** to call its three API layers correctly.
+# nano-brain — Persistent Memory + Code Intelligence
 
-## Install this skill
+A read-mostly knowledge graph + vector DB. Three call surfaces: HTTP, CLI (`npx nano-brain ...`), MCP tools. All operations require a `workspace_hash` that maps to one project root path.
 
-This skill lives at `skills/nano-brain/` in the [nano-brain repo](https://github.com/nano-step/nano-brain). Drop it into your agent's skills root:
-
-```bash
-# OpenCode — user-level (any project)
-mkdir -p ~/.config/opencode/skills
-cp -r /path/to/nano-brain/skills/nano-brain ~/.config/opencode/skills/
-
-# OpenCode — project-level (current project only)
-mkdir -p ./.opencode/skills
-cp -r /path/to/nano-brain/skills/nano-brain ./.opencode/skills/
-
-# Claude Code
-mkdir -p ~/.claude/skills
-cp -r /path/to/nano-brain/skills/nano-brain ~/.claude/skills/
-```
-
-Or one-liner (no clone needed) — fetch the skill directly from GitHub:
+## TL;DR
 
 ```bash
-curl -sL https://github.com/nano-step/nano-brain/archive/refs/heads/master.tar.gz \
-  | tar -xz --strip-components=2 -C ~/.config/opencode/skills nano-brain-master/skills/nano-brain
+# Bootstrap once per shell:
+eval "$(npx nano-brain workspaces current --export)"
+
+# Then query:
+npx nano-brain query "how did we solve auth caching"
 ```
 
-The skill auto-loads on next agent session. To update, repeat the copy (`--delete` if using rsync) — files are idempotent.
+All CLI commands read `$NANO_BRAIN_WORKSPACE` so you do not need to pass `--workspace=...` after bootstrap. For HTTP/MCP direct calls, see Phase 3.
 
 ---
 
-## How to talk to nano-brain
+## Phase 1 — DISCOVER (bootstrap)
 
-| Layer | When | How |
+Run these steps once per shell session. They are idempotent — safe to re-run.
+
+### 1.1 Verify server is reachable
+
+**From a container** (most agents):
+
+```bash
+curl -fsS http://host.docker.internal:3100/api/status | jq -r .pg_status
+```
+
+**From the host directly:**
+
+```bash
+curl -fsS http://localhost:3100/api/status | jq -r .pg_status
+```
+
+**Success criterion:** prints `healthy`.
+
+**Failure recovery:** If `curl` fails, the server is not running. Recovery in order:
+1. On host: `npx nano-brain docker start`
+2. Ask the user to start the server. **Do not** try to start the server yourself inside a container — see "nano-brain Server Rule" in the project AGENTS.md.
+
+### 1.2 Resolve the current workspace hash
+
+**Recommended — CLI bootstrap one-liner:**
+
+```bash
+eval "$(npx nano-brain workspaces current --export)"
+```
+
+This sets `NANO_BRAIN_WORKSPACE` for the rest of the shell. All subsequent `npx nano-brain ...` commands pick it up implicitly.
+
+**HTTP fallback** (for non-CLI agents):
+
+```bash
+HASH=$(curl -fsS -X POST http://host.docker.internal:3100/api/v1/workspaces/resolve \
+  -H 'Content-Type: application/json' \
+  -d "{\"path\":\"$PWD\"}" | jq -r .workspace_hash)
+export NANO_BRAIN_WORKSPACE="$HASH"
+```
+
+The `/api/v1/workspaces/resolve` endpoint is **read-only**: it computes the deterministic SHA-256 hash from your absolute path and reports `registered: true|false`. It does NOT create the workspace.
+
+### 1.3 Ensure the workspace is registered
+
+```bash
+npx nano-brain workspaces current --check 2>/dev/null \
+  || npx nano-brain init --root="$PWD"
+```
+
+`workspaces current --check` exits **2** if the workspace is not yet registered. `init` is idempotent — safe to run multiple times.
+
+**Success criterion:** `$NANO_BRAIN_WORKSPACE` is set AND `npx nano-brain workspaces current --check` exits 0.
+
+---
+
+## Phase 2 — SELECT (decision tree)
+
+Map the user's intent to the right call:
+
+| User intent | Operation | CLI | HTTP endpoint |
+|---|---|---|---|
+| "What did we decide about X?" | hybrid recall | `query "X"` | `POST /api/v1/query` |
+| "Find exact term/identifier" | BM25 only | `search "X"` | `POST /api/v1/search` |
+| "Semantic concept (no exact words)" | vector only | `vsearch "X"` | `POST /api/v1/vsearch` |
+| "Across all my projects" | cross-workspace | `query --scope=all "X"` | `POST /api/v1/query` body `{"workspace":"all", ...}` |
+| "Filter by tag (e.g. decisions)" | tagged search | `query --tags=decision "X"` | body adds `"tags":["decision"]` |
+| "Save a decision/summary" | persist | `write` | `POST /api/v1/write` |
+| "What does my workspace contain?" | briefing | `wake-up` | `GET /api/v1/wake-up?workspace=$NANO_BRAIN_WORKSPACE` |
+| "Find function/type definition" | symbol lookup | `get` + code-intelligence | `POST /api/v1/symbols` |
+| "Who calls FunctionName?" | graph traversal | (HTTP/MCP) | `POST /api/v1/graph/query` |
+| "What breaks if I change Y?" | impact analysis | (HTTP/MCP) | `POST /api/v1/graph/impact` |
+| "Trace call chain from entry" | call trace | (HTTP/MCP) | `POST /api/v1/graph/trace` |
+| "List all tags with counts" | tag inventory | `tags` | `GET /api/v1/tags?workspace=...` |
+
+**Default for ambiguous "find X":** use `query` (hybrid). It combines BM25 + vector + RRF + recency decay and gives the best results.
+
+---
+
+## Phase 3 — EXECUTE
+
+Every example below assumes Phase 1 has set `$NANO_BRAIN_WORKSPACE`.
+
+### 3.1 Hybrid query — `POST /api/v1/query`
+
+```bash
+# CLI:
+npx nano-brain query "redis caching for inv compression" --json
+
+# HTTP:
+curl -fsS -X POST http://host.docker.internal:3100/api/v1/query \
+  -H 'Content-Type: application/json' \
+  -d "{\"workspace\":\"$NANO_BRAIN_WORKSPACE\",\"query\":\"redis caching\",\"max_results\":10}"
+```
+
+Response: `{"results":[{"source_path","excerpt","score","tags",...}, ...]}`.
+
+| Error | Meaning | Recovery |
 |---|---|---|
-| **MCP tools** (`memory_*`) | Preferred. Streamable HTTP at `/mcp`. | Agent auto-discovers; no shell needed |
-| **CLI** (`npx @nano-step/nano-brain ...`) | When MCP not configured, or for one-off shell scripts | Wraps the HTTP API |
-| **HTTP API** directly | Scripts, integration tests, dashboards | `POST /api/v1/*` |
+| 400 `workspace_required` | Missing `workspace` in body | Re-run Phase 1.2 |
+| 400 `workspace_not_registered` | Hash valid but not in DB | Re-run Phase 1.3 (`init`) |
+| 500 | Server error | Read `nano-brain logs -n 50`, retry once |
 
-All three target the same daemon at `http://localhost:3100` (default; container agents auto-set `NANO_BRAIN_HOST=host.docker.internal`).
+### 3.2 BM25 keyword search — `POST /api/v1/search`
 
-> **CLI invocation**: always use the scoped package `@nano-step/nano-brain` for clarity and to avoid name collisions:
-> ```bash
-> npx @nano-step/nano-brain <subcommand> ...
-> ```
-> An unscoped alias `nano-brain` is also published (e.g. `npx nano-brain ...`), but the scoped form is canonical and stable.
+Use when the query is an exact identifier / error message / function name.
 
-## Quick decision matrix
-
-| You need to... | Use |
-|---|---|
-| Recall past work on a topic | `memory_query` / `query "topic"` |
-| Find an exact string (error msg, fn name) | `memory_search` / `search "term"` |
-| Explore a fuzzy concept | `memory_vsearch` / `vsearch "concept"` |
-| Save a decision for future sessions | `memory_write` / `write "..." --tags=decision` |
-| Check daemon health, queue depth, migration | `memory_status` / `status` |
-| Catch up at session start | `memory_wake_up` / `wake-up` |
-| Trace symbol callers/callees | `memory_graph` (CLI: `context <name>`) |
-| Risk-check before refactor | `memory_impact` (CLI: `code-impact <name>`) |
-| Map git diff → affected symbols | CLI: `detect-changes --scope=staged` |
-| List all tags / collections / symbols | `memory_tags` / `memory_symbols` |
-| Reindex after major code changes | CLI: `reindex` (in workspace dir) |
-
-## Endpoint reference
-
-All `POST /api/v1/*` endpoints require a `workspace` field in the JSON body OR an `X-Workspace` header. The workspace hash is returned by `POST /api/v1/init`.
-
-### Health + status
-
-| Method | Path | Body | Returns |
-|---|---|---|---|
-| `GET` | `/health` | — | `{status, ready}` — for liveness/readiness probes |
-| `GET` | `/api/status` | — | `{pg_status, migration_version, queue_*, workspace_count, harvester_status}` — operator dashboard data |
-
-### Workspace lifecycle
-
-| Method | Path | Body | Returns |
-|---|---|---|---|
-| `POST` | `/api/v1/init` | `{"root_path":"/abs/path"}` | `{workspace_hash, root_path, agents_snippet}` — registers a workspace, deterministic SHA-256 hash of normalized path |
-| `GET` | `/api/v1/workspaces` | — | `[{workspace_hash, root_path, document_count, last_indexed_at}]` |
-| `POST` | `/api/v1/reset-workspace` | `{"workspace":"<hash>"}` | `{deleted_documents, workspace}` — wipes all docs+chunks+embeddings for the workspace |
-
-### Search (3 modes — choose by use case)
-
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| `POST` | `/api/v1/search` | `{"workspace":"<hash>","query":"...","max_results":10,"tags":["bug"]}` | **BM25 full-text** — exact keywords/symbols, fastest, free-text English |
-| `POST` | `/api/v1/vsearch` | `{"workspace":"<hash>","query":"...","max_results":10}` | **Vector semantic** — fuzzy concepts, embedding cosine, slower |
-| `POST` | `/api/v1/query` | `{"workspace":"<hash>","query":"...","max_results":10}` | **Hybrid** — BM25 + vector + RRF fusion. Default for most questions. |
-
-Response shape (all three):
-```json
-{"results": [{"id","title","snippet","score","tags","collection","source_path","created_at"}], "took_ms": 42}
+```bash
+npx nano-brain search "EmbedQueue.PendingCount"
 ```
 
-### Document I/O
+### 3.3 Vector semantic search — `POST /api/v1/vsearch`
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| `POST` | `/api/v1/write` | `{"workspace":"<hash>","content":"...","tags":["..."],"collection":"memory","title":"...","source_path":"memory://...","metadata":{}}` | Upsert by content-hash; chunks + enqueues for embedding async |
-| `POST` | `/api/v1/wake-up` | `{"workspace":"<hash>","limit":10}` | Returns the N most-recent updated documents — for session start briefing |
-| `POST` | `/api/v1/reindex` | `{"workspace":"<hash>","root":"/abs/path"}` | Reindex workspace from disk; respects `.gitignore` |
-| `POST` | `/api/v1/embed` | `{"workspace":"<hash>","chunk_id":"<uuid>"}` | Force-embed a specific chunk (debugging) |
-| `POST` | `/api/v1/summarize` | `{"workspace":"<hash>","source":"opencode://session/<id>","limit":1,"force":false}` | Run LLM summarizer on a session |
+Use when the user describes a concept without exact terms.
 
-### Collections + tags + symbols
+```bash
+npx nano-brain vsearch "ways to keep the embedding queue from overflowing"
+```
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| `GET` | `/api/v1/collections?workspace=<hash>` | — | List collections with doc counts |
-| `POST` | `/api/v1/collections` | `{"workspace":"<hash>","name":"my-col"}` | Create |
-| `PUT` | `/api/v1/collections/:name` | `{"workspace":"<hash>","new_name":"..."}` | Rename |
-| `DELETE` | `/api/v1/collections/:name` | `{"workspace":"<hash>"}` | Remove (and all its docs) |
-| `GET` | `/api/v1/tags?workspace=<hash>` | — | All tags with usage counts |
-| `GET` | `/api/v1/symbols?workspace=<hash>&type=function&name=foo` | — | Symbol search by type+name pattern |
+### 3.4 Cross-workspace search
 
-### Code intelligence (graph)
+```bash
+# CLI:
+npx nano-brain query --scope=all "rate limiter pattern"
 
-Powered by Tree-sitter AST parsing. **Requires** a prior `reindex` to populate the symbol graph.
+# HTTP:
+curl -fsS -X POST http://host.docker.internal:3100/api/v1/query \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace":"all","query":"rate limiter pattern"}'
+```
 
-| Method | Path | Body | Returns |
-|---|---|---|---|
-| `POST` | `/api/v1/graph/query` | `{"workspace":"<hash>","node":"funcName","direction":"out","edge_type":"calls"}` | Symbol's neighbors (callers/callees) |
-| `POST` | `/api/v1/graph/impact` | `{"workspace":"<hash>","node":"funcName","edge_type":"calls","max_depth":2}` | BFS upstream/downstream — risk = LOW/MEDIUM/HIGH/CRITICAL |
-| `POST` | `/api/v1/graph/trace` | `{"workspace":"<hash>","node":"funcName","max_depth":3}` | Outgoing-edge walk for flow detection |
+The literal string `"all"` is allowed for read-only endpoints (query/search/vsearch). It is **rejected** by write endpoints (`/api/v1/write`, `/api/v1/update`) — those require a specific registered hash.
 
-`direction`: `in` (callers) or `out` (callees). `edge_type`: `calls`, `imports`, `references`, etc.
+### 3.5 Persist a decision — `POST /api/v1/write`
 
-### Harvest + ops
+```bash
+# CLI:
+npx nano-brain write \
+  --title="Decision: use RRF k=60 for hybrid search" \
+  --tags=decision,search \
+  --content='## Context\n...\n## Decision\n...'
 
-| Method | Path | Body | Notes |
-|---|---|---|---|
-| `POST` | `/api/harvest` | — | Force-run all configured harvesters (OpenCode SQLite, Claude Code JSONL). Returns `{harvested, skipped, errors}`. |
-| `POST` | `/api/reload-config` | — | Reload `~/.nano-brain/config.yml` without restart |
+# HTTP:
+curl -fsS -X POST http://host.docker.internal:3100/api/v1/write \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg ws "$NANO_BRAIN_WORKSPACE" \
+        '{workspace:$ws, source_path:"notes/decision-rrf.md", content:"# Decision\nUse k=60.", tags:["decision"]}')"
+```
 
-### MCP (Streamable HTTP)
+### 3.6 Workspace briefing — `wake-up`
 
-| Method | Path | Notes |
+Use at start of a new task to summarize what's in the workspace.
+
+```bash
+npx nano-brain wake-up
+```
+
+Returns: collections, recent docs, doc/chunk counts, last update times.
+
+### 3.7 Code intelligence — graph / trace / impact / symbols
+
+For deep code analysis, see [`references/code-intelligence.md`](references/code-intelligence.md). Three patterns:
+
+- **Symbol lookup:** `POST /api/v1/symbols` body `{workspace, query, kind, limit}` — find a function/type definition.
+- **Impact analysis:** `POST /api/v1/graph/impact` body `{workspace, node, max_depth, edge_type}` — who depends on this symbol, transitively.
+- **Call trace:** `POST /api/v1/graph/trace` body `{workspace, node, max_depth}` — what does this entry function call.
+
+### 3.8 Tags — `GET /api/v1/tags`
+
+```bash
+npx nano-brain tags
+```
+
+Returns `[{name, count}, ...]` sorted by count desc.
+
+---
+
+## Phase 4 — RECOVER
+
+Error catalog with deterministic recovery actions. Never retry more than 2 times. Never silently fall back without telling the user.
+
+| Symptom | Most likely cause | Recovery |
 |---|---|---|
-| `POST` | `/mcp` | JSON-RPC 2.0 MCP protocol |
-| `GET`/`POST` | `/sse` | SSE transport (legacy) |
+| `curl: (7) connection refused` | Server not running | Phase 1.1 recovery |
+| HTTP 400 `workspace_required` | Missing `workspace` field in body | Re-run Phase 1.2; verify `$NANO_BRAIN_WORKSPACE` is set |
+| HTTP 400 `workspace_not_registered` | Path valid but never `init`'d | `npx nano-brain init --root="$PWD"` |
+| HTTP 400 `path is required` | `/resolve` called with empty `path` | Pass an absolute path; default to `$PWD` |
+| HTTP 400 `invalid path` | Path could not be normalized | Check path exists and is absolute |
+| HTTP 503 | Server restarting / overload | Sleep 5s, retry **once** |
+| HTTP 500 | Server bug | `nano-brain logs -n 100`; report stack to user |
+| `workspace_all_not_supported` on write | Wrote with `workspace:"all"` | Use a specific registered hash |
+| Empty `results: []` | Topic not in memory | Try broader query OR `search` (exact) OR fall back to grep/ast-grep over the codebase |
 
-13 tools exposed: `memory_query`, `memory_search`, `memory_vsearch`, `memory_get`, `memory_write`, `memory_tags`, `memory_status`, `memory_update`, `memory_wake_up`, `memory_graph`, `memory_trace`, `memory_impact`, `memory_symbols`.
+**Last resort fallback:** If nano-brain is unreachable for >2 retries, switch to native tools (grep / ast-grep / Read) and tell the user the limitation.
 
-## CLI cheatsheet
+---
 
-Every CLI subcommand is a thin client over the HTTP API. Connection defaults to `localhost:3100`; container agents auto-route to host.
+## CLI flags reference
 
-| Command | Endpoint |
-|---|---|
-| `npx @nano-step/nano-brain query "..." --workspace <h>` | `POST /api/v1/query` |
-| `npx @nano-step/nano-brain search "..." --workspace <h>` | `POST /api/v1/search` |
-| `npx @nano-step/nano-brain vsearch "..." --workspace <h>` | `POST /api/v1/vsearch` |
-| `npx @nano-step/nano-brain write "..." --workspace <h> --tags=foo,bar` | `POST /api/v1/write` |
-| `npx @nano-step/nano-brain status` | `GET /api/status` |
-| `npx @nano-step/nano-brain workspaces` | `GET /api/v1/workspaces` |
-| `npx @nano-step/nano-brain wake-up --workspace <h>` | `POST /api/v1/wake-up` |
-| `npx @nano-step/nano-brain reindex` (in workspace dir) | `POST /api/v1/reindex` |
-| `npx @nano-step/nano-brain context <symbol>` | `POST /api/v1/graph/query` |
-| `npx @nano-step/nano-brain code-impact <symbol> --direction=upstream` | `POST /api/v1/graph/impact` |
-| `npx @nano-step/nano-brain detect-changes --scope=staged` | (computes git diff client-side, calls graph endpoints) |
-| `npx @nano-step/nano-brain harvest` | `POST /api/harvest` |
-| `npx @nano-step/nano-brain cleanup-stale-raw [--dry-run]` | Direct PG — wipes pre-PR-#192 orphan raw session docs |
-| `npx @nano-step/nano-brain doctor` | Probes daemon + PG + ollama + model availability |
-
-**Critical CLI gotcha**: `reindex` IGNORES the `--root` flag silently. Always run with `workdir`:
-```bash
-# ✅ Correct
-bash(command="npx @nano-step/nano-brain reindex", workdir="/path/to/workspace")
-
-# ❌ Wrong (silently reindexes CWD instead of /path)
-npx @nano-step/nano-brain reindex --root=/path/to/workspace
-```
-
-## Recipes — best-practice flows
-
-### Recipe 1: Session start (wake-up + recall)
-
-When you start a coding session in a project, run wake-up + a targeted query before exploring. This costs ~500 tokens but prevents you from redoing work or re-discovering the same lessons.
-
-```bash
-# 1. Register workspace once per project (idempotent)
-WS=$(npx @nano-step/nano-brain init --root="$PWD" --json | jq -r .workspace_hash)
-
-# 2. Catch up — N most-recent updates across all collections
-npx @nano-step/nano-brain wake-up --workspace="$WS" --limit=8
-
-# 3. Targeted: anything you've learned about today's task?
-npx @nano-step/nano-brain query "<current task topic>" --workspace="$WS" --compact
-```
-
-For agents inside OpenCode: use MCP `memory_wake_up` then `memory_query`.
-
-### Recipe 2: Recall before grep
-
-Native grep finds exact strings in CURRENT files. nano-brain finds them in past sessions, prior commits, and documentation. The two are complementary — always recall first (cheap, ~200 tokens) then grep if you need exact code locations.
-
-```bash
-# Did we ever debug this before?
-npx @nano-step/nano-brain search "ECONNREFUSED redis" --workspace="$WS"
-
-# Concept-level — fuzzy match
-npx @nano-step/nano-brain vsearch "rate limiting strategy" --workspace="$WS"
-
-# Complex question — hybrid (default)
-npx @nano-step/nano-brain query "how did we handle session invalidation" --workspace="$WS"
-```
-
-### Recipe 3: Pre-refactor impact check
-
-Before touching a symbol that's referenced widely, check impact. This catches "I only need to fix this one place" tunnel-vision.
-
-```bash
-# What calls DatabaseClient?
-npx @nano-step/nano-brain code-impact DatabaseClient --workspace="$WS" --direction=upstream
-
-# What does processOrder depend on?
-npx @nano-step/nano-brain code-impact processOrder --workspace="$WS" --direction=downstream --max-depth=3
-
-# Map current git changes to symbols
-npx @nano-step/nano-brain detect-changes --scope=staged --workspace="$WS"
-```
-
-Risk levels in response: `LOW` (≤3 callers), `MEDIUM` (4-15), `HIGH` (16-50), `CRITICAL` (>50). Treat HIGH/CRITICAL as "needs PR review from someone else."
-
-### Recipe 4: Persist a decision
-
-End every meaningful session with a write. The schema doesn't matter — content is freeform markdown. What matters is consistent tags so future you can filter.
-
-```bash
-npx @nano-step/nano-brain write "## Decision: Use Redis Streams over Bull
-- **Why:** ordered replay needed for retry
-- **Trade-off:** lose Bull's UI; built our own metrics dashboard instead
-- **Files:** internal/queue/*.go, see PR #142" \
-  --workspace="$WS" \
-  --tags=decision,architecture,queue
-```
-
-Conventional tag patterns: `decision`, `lesson`, `architecture`, `bug`, `gotcha`, `summary`, `<area>` (e.g. `auth`, `queue`).
-
-### Recipe 5: Triage many results (compact mode)
-
-For broad queries that return 10+ results, fetch compact first (1-line summaries, ~70% fewer tokens), pick the relevant ones, expand only those.
-
-```bash
-# Stage 1: scan
-npx @nano-step/nano-brain query "auth middleware" --workspace="$WS" --compact
-
-# Stage 2: expand specific result by ID
-npx @nano-step/nano-brain get "<doc-id>" --workspace="$WS"
-```
-
-### Recipe 6: Cross-workspace knowledge transfer
-
-Same `memory_query` but with `scope=all`. Searches every registered workspace, useful for "have I solved this in another project?"
-
-```bash
-# Aggregate across all workspaces
-npx @nano-step/nano-brain query "stripe webhook signature verification" --scope=all
-```
-
-(Equivalent MCP: `memory_query` with `workspace` omitted or `scope=all` arg.)
-
-### Recipe 7: Filter by collection or tag
-
-Both search modes accept `--collection` and `--tags`. Combine when you know the slice you want.
-
-```bash
-# Only past session summaries about bugs
-npx @nano-step/nano-brain query "..." --workspace="$WS" --collection=session-summary --tags=bug
-
-# Only your curated notes
-npx @nano-step/nano-brain query "..." --workspace="$WS" --collection=memory
-```
-
-Collections in a typical setup:
-- `codebase` — source-file chunks
-- `session-summary` — LLM-summarized AI sessions (OpenCode, Claude Code)
-- `sessions` — raw session content (pre-PR-#192 only; run `cleanup-stale-raw` to purge if you've migrated)
-- `memory` — agent-written notes via `write`
-- `auto-memory` — auto-extracted `DECISION:` / `LESSON:` lines
-
-### Recipe 8: Multi-DB OpenCode harvest (advanced)
-
-If you use the `ai-sandbox-wrapper` which splits OpenCode sessions into per-project SQLite databases at `~/.ai-sandbox/opencode-dbs/<slug>-<8hex>/opencode.db`, configure nano-brain to discover them:
-
-```yaml
-# ~/.nano-brain/config.yml
-harvester:
-  opencode:
-    db_root: ~/.ai-sandbox/opencode-dbs   # auto-detected on macOS/Linux
-```
-
-The daemon scans the directory, opens each DB read-only, reads `project.worktree`, and only harvests sessions whose worktree matches a registered nano-brain workspace. Verify via `GET /api/status`:
-
-```bash
-curl -s http://localhost:3100/api/status | jq '.harvester_status.opencode'
-# {"enabled":true, "mode":"db_root", "db_root":"/Users/.../opencode-dbs", "db_count":1, ...}
-```
-
-`mode` values: `db_root` (new multi-DB), `db_path` (single SQLite), `session_dir` (legacy JSON), `disabled`.
-
-## Common errors + fixes
-
-| Symptom | Diagnosis | Fix |
+| Flag | On | Effect |
 |---|---|---|
-| `cannot connect to nano-brain server` | Daemon not running | `npx @nano-step/nano-brain serve -d` (background) |
-| `workspace not found` | Workspace not registered | `npx @nano-step/nano-brain init --root=.` first |
-| `ollama: input length exceeds context length` (pre-2026.5.30.1) | Char-budget too high for token limit | Upgrade to ≥2026.5.30.1; configure `embedding.max_chars` if still hits |
-| Search returns 0 results despite content | Embedding queue still working | `npx @nano-step/nano-brain status` → check `queue_pending` and `embedding_queue_depth` |
-| Chunk stuck in `embed_failed` retry loop (pre-fix) | Deterministic ollama error | Upgrade ≥2026.5.30.1; new `embed_permanently_failed` state breaks the loop |
-| `bin/sh: gh: not found` in workflow | gh CLI not installed in container | Use HTTPS+token URL: `git push https://kokorolx:$TOKEN@github.com/...` |
+| `--workspace=<hash>` | query, search, vsearch, write, get, tags, wake-up, multi-get | Override `$NANO_BRAIN_WORKSPACE` |
+| `--scope=all` | query, search, vsearch | Cross-workspace |
+| `--tags=t1,t2` | query, search, vsearch | Filter to docs with any of these tags |
+| `--json` | most commands | Print raw JSON response |
+| `--path=<p>` | workspaces current | Override `$PWD` for resolution |
+| `--export` | workspaces current | Print `export NANO_BRAIN_WORKSPACE=<hash>` |
+| `--check` | workspaces current | Exit 2 if workspace not registered |
+| `--root=<p>` | init | Path to register; required |
+| `--force` | init, workspaces remove | Skip confirmation |
 
-## Daemon config — key fields
+---
 
-```yaml
-# ~/.nano-brain/config.yml — see ${PROJECT}/README.md for the canonical example
-database:
-  url: postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev
+## Anti-patterns (do not do)
 
-embedding:
-  provider: ollama
-  url: http://localhost:11434
-  model: nomic-embed-text   # 2048-token context
-  concurrency: 3
-  max_chars: 3000           # safety budget per embed call; lower if ollama still 400s on dense CSV
-                            # override via NANO_BRAIN_EMBED_MAX_CHARS
+- **Do not** hardcode a workspace hash. Always resolve from `$PWD` via Phase 1.
+- **Do not** call `init` on every query. It is idempotent but wasteful; `resolve` is the read-only check.
+- **Do not** swallow connection errors. If nano-brain is down, tell the user.
+- **Do not** call write endpoints with `workspace:"all"`. They will reject with `workspace_all_not_supported`.
+- **Do not** use `/api/query` or `/api/write` (no `/v1`). Those paths return 404. Always use `/api/v1/*`.
+- **Do not** retry indefinitely. Cap retries at 2 per call.
 
-harvester:
-  opencode:
-    db_root: ""             # ~/.ai-sandbox/opencode-dbs (multi-DB)
-    db_path: ""             # ~/.local/share/opencode/opencode.db (single SQLite)
-    session_dir: ""         # legacy JSON
-  claudecode:
-    enabled: false
-    session_dir: ""         # ~/.claude/sessions
+---
 
-intervals:
-  session_poll: 120         # harvest tick interval (seconds)
+## When to use nano-brain vs native tools
 
-summarization:
-  enabled: false            # LLM-generated session summaries
-  provider_url: ""
-  api_key: ""               # or NANO_BRAIN_SUMMARIZE_API_KEY env
-  model: "claude-sonnet-4-5"
-  max_tokens: 8000          # bumped from 4096 — issue #191
-```
-
-Reload without restart: `curl -X POST http://localhost:3100/api/reload-config`.
-
-## Memory vs native tools
-
-| Question | Tool |
+| Goal | Tool |
 |---|---|
-| "What did we decide about X?" | nano-brain (memory) |
-| "Where exactly is `processPayment` defined?" | grep / Glob (native) |
-| "What calls `processPayment`?" | nano-brain (code intel) → `memory_graph` |
-| "What's the AST structure of this function?" | ast-grep (native) |
-| "Have I solved this error before across all my projects?" | nano-brain (cross-workspace) |
-| "Show me line 142 of foo.go" | Read tool (native) |
+| "Have we discussed X before?" | nano-brain (cross-session memory) |
+| "Where is X defined in this repo right now?" | grep / ast-grep / Read |
+| "What did we decide about X back in March?" | nano-brain (recall) |
+| "Show me line 142 of foo.go" | Read |
+| "What's the AST shape of this function?" | ast-grep |
+| "Has this error appeared in any project before?" | nano-brain `--scope=all` |
+| "Who imports this module across my repos?" | nano-brain `graph/impact` (cross-repo) |
 
-**They are complementary. Always recall first (cheap), then use native tools for precise current-state.**
+**Order:** recall from memory first (cheap, gives context). Then use native tools for precise current-state inspection.
 
-## Further reading
+---
 
-- **Code intelligence deep-dive**: `references/code-intelligence.md`
-- **Full HTTP API contract**: nano-brain repo `internal/server/routes.go` + per-handler request/response structs in `internal/server/handlers/`
-- **MCP tool schemas**: `internal/mcp/tools.go` `RegisterTools`
-- **Migration history**: `nano-step/nano-brain` `CHANGELOG.md` + `openspec/changes/archive/`
+## Reference docs (load on demand)
+
+- [`references/http-api.md`](references/http-api.md) — full HTTP schema, all endpoints, performance budgets
+- [`references/cli-cheatsheet.md`](references/cli-cheatsheet.md) — every CLI command + flag combo
+- [`references/code-intelligence.md`](references/code-intelligence.md) — graph / trace / impact / symbols deep-dive
+- [`references/config-reference.md`](references/config-reference.md) — `config.yml` fields
+- Source contracts: `internal/server/routes.go` (HTTP) + `internal/mcp/tools.go::RegisterTools` (MCP) in the `nano-step/nano-brain` repo


### PR DESCRIPTION
## Summary

Adds a small, read-only workspace path-to-hash resolution surface across all three call layers (HTTP, CLI, MCP) plus a complete rewrite of the agent-facing skill documentation following Anthropic's 2026 progressive-disclosure guideline.

The new endpoint computes the deterministic SHA-256 hash from an absolute filesystem path and reports whether that workspace is registered. **Purely additive** — existing endpoints unchanged.

Closes #316.

## What's new

### Backend
- **`POST /api/v1/workspaces/resolve`** — body `{path}` → `{workspace_hash, root_path, name, registered}`. Read-only. Never auto-registers.
- **`memory_workspaces_resolve`** — MCP tool with parity to HTTP.

### CLI
- **`nano-brain workspaces current [--path=<p>] [--export] [--json] [--check]`**
  - Default: prints hash to stdout
  - `--export`: prints `export NANO_BRAIN_WORKSPACE=<hash>` for shell `eval`
  - `--json`: full response
  - `--check`: exits **2** if `registered=false`

### Skill rewrite (Anthropic 2026 progressive disclosure)
- `skills/nano-brain/SKILL.md` — restructured as 4 phases: DISCOVER → SELECT → EXECUTE → RECOVER (278 lines, under 500-line guideline)
- `skills/nano-brain/AGENTS_SNIPPET.md` — rewritten with bootstrap one-liner + correct `/api/v1/*` paths + workspace field in all curl examples
- `AGENTS.md` OPENCODE-MEMORY block synced — **fixes broken endpoints** (was `/api/query` → now `/api/v1/query`) and **missing `workspace` field** in every curl example
- `README.md` — endpoint, CLI command, MCP tool added to tables

## Bootstrap pattern

One-liner per shell session:

```bash
eval "$(npx nano-brain workspaces current --export)"
```

Sets `$NANO_BRAIN_WORKSPACE` so subsequent CLI calls work without `--workspace=`. The skill teaches this as the canonical entry point and falls back to a direct `curl` to `/api/v1/workspaces/resolve` for non-CLI agents.

## Design decisions

Full design in [`openspec/changes/add-workspace-resolve-endpoint/design.md`](https://github.com/nano-step/nano-brain/blob/feat/316-workspace-resolve/openspec/changes/add-workspace-resolve-endpoint/design.md) (10 decisions D1-D10). Highlights:

- **D1 — POST not GET**: avoids URL-encoding paths with spaces/unicode/special chars
- **D2 — Public route group**: registered alongside `/init`, NOT behind `workspaceMiddleware` (input is path, not hash)
- **D3 — Always return hash**: even when `registered=false`, the agent gets the hash it would need to call `/init` next
- **D5 — Flat response, no envelope**: matches `initResponse` shape
- **D7 — MCP parity**: prevents "MCP agent has fewer capabilities than HTTP agent"
- **D10 — `--check` exit 2**: distinct from `1` (server error) so shell guards can branch precisely

## Validation

- ✅ `validate:quick` — `go build` + `go vet` + `go test -race -short ./...` all PASS
- ✅ `test:integration` — 3 new `TestResolveWorkspaceE2E_*` PASS against real PG (PG running on `host.docker.internal:5432`)
- ✅ Server-level routing pinned by **`TestResolveWorkspaceRouteSkipsWorkspaceMiddleware`** — regression invariant that the resolve route must NOT inherit `workspaceMiddleware` from the `data` group
- ✅ `TestRegisterTools_CountAndNames` and `TestToolRegistration_ListToolsUnderRaceDetector` bumped 13 → 14 tools; both PASS
- ✅ Self-review: `response-shape` (all 4 fields explicitly assigned in both branches of HTTP + MCP), `staged-files` (no `.opencode/`, no `package-lock.json`, no worktree metadata), AI-slop scan clean

### Smoke:e2e note

Full long-running smoke via a separate `nano-brain serve` was blocked in the dev container because the shared production PG contains 11 registered workspaces (including a 4127-doc workspace) whose watchers cascade and crash the smoke server. Coverage is provided by:

1. The new server-level `TestResolveWorkspaceRouteSkipsWorkspaceMiddleware` (pins the routing + middleware-skip behavior end-to-end via `httptest`)
2. The 3 `TestResolveWorkspaceE2E_*` integration tests (real PG, real `InitWorkspace` handler → real `ResolveWorkspace` handler)
3. The 8 CLI tests (`httptest.NewServer` mocking the API)

Recommend the reviewer (or whoever runs CI with a clean PG) run a quick manual smoke:

```bash
curl -sX POST http://localhost:3100/api/v1/workspaces/resolve \
  -H 'Content-Type: application/json' \
  -d '{"path":"/path/to/your/project"}'
```

## Files changed

| Domain | Files |
|---|---|
| HTTP handler | `internal/server/handlers/workspace_resolve.go` (new), `internal/server/handlers/workspace_resolve_test.go` (new, 7 cases), `internal/server/handlers/workspace_resolve_integration_test.go` (new, 3 cases) |
| Server wiring | `internal/server/routes.go`, `internal/server/server_test.go` (new regression test) |
| CLI | `cmd/nano-brain/workspaces.go`, `cmd/nano-brain/workspaces_test.go` (8 new cases) |
| MCP | `internal/mcp/tools.go`, `internal/mcp/tools_test.go` (3 new cases), `internal/mcp/concurrent_test.go` (count bump) |
| Docs | `skills/nano-brain/SKILL.md` (rewrite), `skills/nano-brain/AGENTS_SNIPPET.md` (rewrite), `AGENTS.md` (sync), `README.md` (tables) |
| OpenSpec | `openspec/changes/add-workspace-resolve-endpoint/{proposal,design,tasks}.md` + `specs/workspace-resolve-endpoint/spec.md` (validates `--strict`) |

## Out of scope (deferred)

- Implicit `NANO_BRAIN_WORKSPACE` env-var reading in `workspaceMiddleware` (Phương án C — high-risk lane, touches middleware/auth)
- `nano-brain skill sync` command for AGENTS.md regeneration (manual sync this PR)
- Fix for #234 CLI `--config` precedence
- `.nano-brain` per-project marker file pattern
- Path canonicalization beyond `filepath.Abs` (no symlink follow — would diverge between host and container)

## Lane / Change type

`lane:normal` + `change-type:user-feature` (4 new files, ~7 edits, no middleware/auth/data-model surface touched).

## Review checklist

- [ ] Read `openspec/changes/add-workspace-resolve-endpoint/design.md` for the 10 design decisions
- [ ] Verify `TestResolveWorkspaceRouteSkipsWorkspaceMiddleware` covers the regression invariant
- [ ] Spot-check that the AGENTS_SNIPPET.md rewrite no longer contains `/api/query` or curl examples missing the `workspace` field
- [ ] Confirm SKILL.md ≤500 lines (current: 278)
