### PR TITLE
docs(embed): fix stale 4,000 chars → 3,000 in AGENTS.md

### DIFF
--- a/internal/embed/AGENTS.md
+++ b/internal/embed/AGENTS.md
@@ -24,7 +24,7 @@ Both providers implement `Embedder`. Ollama is local, no key required. VoyageAI 
 
 - Semaphore limits concurrent embed calls to `concurrency` (default 4).
 - Backpressure: enqueues rejected when pending backlog >= 50,000.
-- Embed timeout: 2 min per chunk. Content truncated to 4,000 chars (fits 2k-token model window).
+- Embed timeout: 2 min per chunk. Content truncated to 3,000 chars (fits 2k-token model window).
 - Retry limit: 3; then `MarkChunkEmbedFailed`. Backoff: 60 s base, 1.5x multiplier, 300 s cap.
 - FK violation on `InsertEmbedding` (chunk deleted mid-flight) is silently skipped.
 


### PR DESCRIPTION
## Summary

Single-line doc fix. `defaultMaxEmbedChars = 3000` (`queue.go:42`). The `4,000` figure was stale from before the chunker/embed contract was aligned.

Discovered during post-merge context mining of PR #323 / issue #322.

## Change type

- [x] docs (documentation only, no behavior change)

## Lane

- [x] tiny (0-1 risk flags, patch direct — but filed as PR per harness rules)

## Validation

- [x] No code changed — docs-only
