### PR TITLE
fix(harvest): resolve 'undefined: q' build error in integration test (#328)

### DIFF
--- a/docs/evidence/328-pre-merge-override.md
+++ b/docs/evidence/328-pre-merge-override.md
@@ -1,0 +1,35 @@
+# PRE-MERGE override — Issue #328 / PR #335
+
+**Date**: 2026-06-02
+
+## [HARNESS-OVERRIDE] Gate 3.3 — integration tests (partial)
+
+PR #335 actually **FIXES** part of gate 3.3 for the harvest package. Before this PR, `internal/harvest` failed with `[build failed]`. After this PR, `internal/harvest` runs and passes.
+
+The remaining gate 3.3 failures are from `internal/server/handlers` (tracked by issue #326). Those are NOT introduced by this PR — they're pre-existing on master.
+
+Confirmed by independent verification in worktree:
+```
+$ go test -race -tags=integration -short ./... 2>&1 | grep -E "FAIL|^ok|build failed"
+ok    github.com/nano-brain/nano-brain/internal/harvest 2.280s   ← FIXED
+ok    github.com/nano-brain/nano-brain/internal/search  1.041s
+FAIL  github.com/nano-brain/nano-brain/internal/server/handlers  ← issue #326
+```
+
+## [HARNESS-OVERRIDE] Gate 3.4 — golangci-lint
+
+Same pre-existing lint violations in `internal/server/handlers/*_test.go` (errcheck on json.Unmarshal, unused funcs). Not in scope for #328.
+
+## [HARNESS-OVERRIDE] Gate 3.12 — smoke:e2e
+
+Change-type=bug-fix triggers the smoke:e2e requirement. However, this PR fixes a **test-only file** (`_test.go`) — there is no runtime surface, no API change, no behavior change.
+
+The smoke:e2e equivalent for a test-only fix is:
+1. `go build -tags=integration ./internal/harvest/...` — clean (was failing before)
+2. `go test -tags=integration -short ./internal/harvest/...` — `ok` (was `[build failed]` before)
+
+Both verified in `docs/evidence/self-review-zfix-328-harvest-build-error.md`. Documenting `[HARNESS-OVERRIDE]` since the canonical smoke:e2e procedure (build binary + start server + curl endpoints) doesn't apply to a test-file fix.
+
+## All other gates PASS (8 PASS + 3 SKIP)
+
+Ready to merge.

--- a/docs/evidence/328-pre-work-gate.md
+++ b/docs/evidence/328-pre-work-gate.md
@@ -1,0 +1,40 @@
+# PRE-WORK gate — Issue #328
+
+**Date**: 2026-06-02
+**Issue**: #328 (internal/harvest integration test build error — `undefined: q`)
+**Lane**: tiny (1 file, 1-line fix)
+**Change-type**: bug-fix
+**Branch**: `fix/328-harvest-build-error`
+
+## Gate output
+
+```
+[FAIL] 1.1 Open PRs still pending (1)   ← unrelated PR #321
+[PASS] 1.2 No active OpenSpec changes
+[PASS] 1.3 Issue #328 exists (state: OPEN)
+[PASS] 1.4 master is up-to-date (at e03d8cb)
+[PASS] 1.5 Validation ladder passes
+[PASS] 1.6 Branch 'fix/328-harvest-build-error' is based on master
+```
+
+`[HARNESS-OVERRIDE]` 1.1: same as prior PRs — unrelated PR #321.
+
+## Lane justification (tiny)
+
+- 1 file changed: `internal/harvest/opencode_sqlite_integration_test.go`
+- 1 line edit: `q = sqlc.New(pgDB)` → `q := sqlc.New(pgDB)` (line 167)
+- 0 schema/API/auth changes
+- Test-only file (build-tag `//go:build integration`)
+- Risk flags: 0
+
+## Skip justifications
+
+- OpenSpec proposal: SKIP (tiny lane)
+- smoke:e2e: SKIP — test-only fix, no runtime behavior change
+- Review gate: ⚠️ self-verify only — test-only fix in integration suite
+
+## Root cause
+
+Variable shadowing. Inside an inner closure at line 137-150, `q := sqlc.New(pgDB)` was declared in a new scope. At line 167 (outer test scope), `q = sqlc.New(pgDB)` tried to reassign a variable that didn't exist in this scope.
+
+Fix: change `=` to `:=` to declare a fresh `q` in the outer scope.

--- a/docs/evidence/self-review-zfix-328-harvest-build-error.md
+++ b/docs/evidence/self-review-zfix-328-harvest-build-error.md
@@ -1,0 +1,81 @@
+# Self-review — Issue #328 / PR (TBD)
+
+**Date**: 2026-06-02
+**Story**: 328 (internal/harvest integration test build error)
+**Lane**: tiny | **Change-type**: bug-fix
+**Branch**: `fix/328-harvest-build-error`
+**Implementing agent**: Sisyphus orchestrator (direct edit — 1-line fix, no delegation needed)
+
+## Scope of changes
+
+| File | Change |
+|---|---|
+| `internal/harvest/opencode_sqlite_integration_test.go` | 1 line: `q = sqlc.New(pgDB)` → `q := sqlc.New(pgDB)` (line 167) |
+| `docs/evidence/328-pre-work-gate.md` | new evidence file |
+| `docs/evidence/self-review-zfix-328-harvest-build-error.md` | this file |
+
+**Production code**: zero changes (test-only fix).
+
+## Root cause
+
+The `q` variable was originally declared with `q := sqlc.New(pgDB)` (line 138) **inside a closure** (`successFn := func(...)` at line 137-150). Go's scoping rules confine `q` to that closure.
+
+Line 167 (outside the closure, in the outer test function scope) attempted `q = sqlc.New(pgDB)` — an assignment to an undeclared variable. This is the source of `undefined: q` at line 167 and the cascading error at line 168 where `q.GetDocumentBySourcePath(...)` references it.
+
+Fix: change `=` to `:=` so a new `q` is declared in the outer scope, identical naming to the closure's `q` (which is fine — they're in different scopes).
+
+## self-review:response-shape
+
+**N/A** — test fix, no API surface change.
+
+## self-review:staged-files
+
+```
+$ git status
+On branch fix/328-harvest-build-error
+Changes to be committed:
+	modified:   internal/harvest/opencode_sqlite_integration_test.go
+	new file:   docs/evidence/328-pre-work-gate.md
+	new file:   docs/evidence/self-review-zfix-328-harvest-build-error.md
+```
+
+- ✅ No `.opencode/` files
+- ✅ No `package-lock.json`
+- ✅ Only files semantically related to #328
+
+## Validation ladder
+
+| Layer | Required | Result |
+|---|---|---|
+| validate:quick (build + race -short) | yes | ✅ ALL PACKAGES PASS |
+| `go build -tags=integration ./internal/harvest/...` | yes (this fixes that build) | ✅ no output (build clean) |
+| `go test -tags=integration -short ./internal/harvest/...` | yes (this enables the test to RUN) | ✅ `ok internal/harvest 2.280s` |
+| self-review:staged-files | yes | ✅ PASS |
+
+## Evidence — before/after for `go test -tags=integration ./...`
+
+**Before this PR**:
+```
+FAIL  github.com/nano-brain/nano-brain/internal/harvest [build failed]
+FAIL  github.com/nano-brain/nano-brain/internal/search [build failed]
+FAIL  github.com/nano-brain/nano-brain/internal/server/handlers (TestEventsIntegration_ReindexPublishesSequence, TestListWorkspacesE2E)
+```
+
+**After this PR (verified in this worktree)**:
+```
+ok    github.com/nano-brain/nano-brain/internal/harvest 2.280s    ← FIXED by this PR
+ok    github.com/nano-brain/nano-brain/internal/search  1.041s    ← may have been fixed by another change; verify in #327
+FAIL  github.com/nano-brain/nano-brain/internal/server/handlers  ← tracked by issue #326
+```
+
+So this PR unblocks the harvest integration suite. The search suite is also passing now (possibly resolved by another recent change — will verify under issue #327's worktree). Only `internal/server/handlers` failures remain.
+
+## Backward compat
+
+Zero. The variable is local to a single test function. Changing `=` to `:=` has no observable effect outside the test.
+
+## Conclusion
+
+Minimal 1-character fix (well, `=` → `:=` is 1 character added). Test now compiles and passes. This was a typo / copy-paste accident that escaped CI because integration tests are gated behind `-tags=integration` (not run on master CI by default).
+
+Ready to merge.

--- a/internal/harvest/opencode_sqlite_integration_test.go
+++ b/internal/harvest/opencode_sqlite_integration_test.go
@@ -164,7 +164,7 @@ func TestOpenCodeSQLite_Integration_RealPostgres(t *testing.T) {
 		t.Errorf("errCount = %d, want 0", errCount)
 	}
 
-	q = sqlc.New(pgDB)
+	q := sqlc.New(pgDB)
 	doc, lookupErr := q.GetDocumentBySourcePath(context.Background(), sqlc.GetDocumentBySourcePathParams{
 		SourcePath:    "summary://opencode/int-sess-1",
 		WorkspaceHash: wsHash,


### PR DESCRIPTION
## Summary

Closes #328.

1-line fix to `internal/harvest/opencode_sqlite_integration_test.go` line 167: change `q = sqlc.New(pgDB)` to `q := sqlc.New(pgDB)`. The variable was declared inside a closure (line 138) and never propagated to outer scope; the assignment at line 167 referenced an undeclared name.

## Impact

`go test -race -tags=integration ./internal/harvest/...` now passes (`ok` instead of `[build failed]`). Unblocks harness gate 3.3 for the harvest package.

Before:
```
FAIL  github.com/nano-brain/nano-brain/internal/harvest [build failed]
```

After:
```
ok    github.com/nano-brain/nano-brain/internal/harvest 2.280s
```

## Lane

- **Lane**: tiny (1 line, 1 file, test-only)
- **Change-type**: bug-fix
- Risk flags: 0
- 0 production code changes (test file only)

## Validation

- `go build ./...`: ✅ PASS
- `go test -race -short ./...`: ✅ ALL PACKAGES PASS
- `go build -tags=integration ./internal/harvest/...`: ✅ PASS (previously: build failed)
- `go test -tags=integration -short ./internal/harvest/...`: ✅ PASS

## Evidence

- `docs/evidence/328-pre-work-gate.md` — PRE-WORK gate
- `docs/evidence/self-review-zfix-328-harvest-build-error.md` — self-review with full before/after

## Skip justifications

- OpenSpec proposal: SKIP (tiny lane)
- smoke:e2e: SKIP — test file only, no runtime change
- Review gate: ⚠️ self-verify only per HARNESS.md change-type table
- self-review:response-shape: N/A (no API surface)

`[skip-release]` — test-only change, no need to spin a new npm release.