### PR TITLE
fix(search): add tags arg to HybridSearch calls in isolation_test.go (#327)

### DIFF
--- a/docs/evidence/327-pre-merge-override.md
+++ b/docs/evidence/327-pre-merge-override.md
@@ -1,0 +1,25 @@
+# PRE-MERGE override — Issue #327 / PR #336
+
+**Date**: 2026-06-02
+
+## [HARNESS-OVERRIDE] Gate 3.3 — integration tests (partial)
+
+This PR **FIXES** part of gate 3.3 for the search package. Before: `FAIL internal/search [build failed]`. After: `ok internal/search 1.574s`.
+
+Remaining gate 3.3 failure is `internal/server/handlers` integration tests (issue #326), which is NOT touched by this PR. Pre-existing on master.
+
+## [HARNESS-OVERRIDE] Gate 3.4 — golangci-lint
+
+Pre-existing lint violations in `internal/server/handlers/*_test.go`. Not in scope for #327.
+
+## [HARNESS-OVERRIDE] Gate 3.12 — smoke:e2e
+
+Change-type=bug-fix triggers smoke:e2e requirement. This PR fixes a test-only file with zero runtime surface. The equivalent verification is:
+1. `go build -tags=integration ./internal/search/...` — clean (was failing before)
+2. `go test -tags=integration -short ./internal/search/...` — `ok` (was `[build failed]` before)
+
+Both documented in `docs/evidence/self-review-zfix-327-search-hybridsearch-sig.md`.
+
+## All other gates PASS
+
+Ready to merge.

--- a/docs/evidence/327-pre-work-gate.md
+++ b/docs/evidence/327-pre-work-gate.md
@@ -1,0 +1,60 @@
+# PRE-WORK gate — Issue #327
+
+**Date**: 2026-06-02
+**Issue**: #327 (internal/search isolation_test.go HybridSearch signature mismatch)
+**Lane**: tiny | **Change-type**: bug-fix
+**Branch**: `fix/327-search-hybridsearch-sig`
+
+## Lane (tiny)
+
+- 1 test file changed: `internal/search/isolation_test.go`
+- 5 line edits (add `, nil` to each HybridSearch call)
+- 0 production code changes
+- Risk flags: 0
+
+## Root cause
+
+`SearchService.HybridSearch` signature was extended at some point to accept a `tags []string` parameter:
+
+```go
+func (s *SearchService) HybridSearch(ctx context.Context, query string, workspace string, maxResults int, tags []string) ([]Result, error)
+```
+
+But `isolation_test.go` (build-tagged `//go:build integration`) was never updated — 5 call sites still pass only 4 args, causing build failure:
+
+```
+internal/search/isolation_test.go:483:72: not enough arguments in call to svc.HybridSearch
+    have (context.Context, string, string, number)
+    want (context.Context, string, string, int, []string)
+```
+
+## Fix
+
+Add `, nil` (= no tag filter, equivalent to passing `[]string{}`) to all 5 call sites in `isolation_test.go`:
+- Line 315: `svc.HybridSearch(ctx, wsAlpha.keyword, wsAlpha.hash, 20, nil)`
+- Line 331: `svc.HybridSearch(ctx, wsBeta.keyword, wsBeta.hash, 20, nil)`
+- Line 347: `svc.HybridSearch(ctx, wsBeta.keyword, wsAlpha.hash, 20, nil)`
+- Line 360: `svc.HybridSearch(ctx, wsAlpha.keyword, wsBeta.hash, 20, nil)`
+- Line 483: `svc.HybridSearch(ctx, other.keyword, queried.hash, 20, nil)`
+
+Used `ast-grep` for safe AST-aware replacement (matched pattern `svc.HybridSearch(ctx, $A, $B, 20)` → `svc.HybridSearch(ctx, $A, $B, 20, nil)`).
+
+`nil` is the appropriate value because:
+- Pre-existing test intent was to test isolation behavior WITHOUT tag filtering
+- Tests still cover the un-tagged code path
+- `[]string{}` vs `nil` is functionally identical in HybridSearch (both fall through to base queries)
+
+## Skip justifications
+
+- OpenSpec proposal: SKIP (tiny lane)
+- smoke:e2e: SKIP — test-only file change, no runtime surface
+- Review gate: ⚠️ self-verify only (per HARNESS.md change-type table for bug-fix in test files)
+
+## After-fix verification
+
+```
+$ go test -race -tags=integration -short ./internal/search/...
+ok  github.com/nano-brain/nano-brain/internal/search  1.574s
+```
+
+Before: `FAIL ... [build failed]`. After: `ok` with passing tests.

--- a/docs/evidence/self-review-zfix-327-search-hybridsearch-sig.md
+++ b/docs/evidence/self-review-zfix-327-search-hybridsearch-sig.md
@@ -1,0 +1,64 @@
+# Self-review — Issue #327 / PR (TBD)
+
+**Date**: 2026-06-02
+**Story**: 327 (HybridSearch signature mismatch in isolation_test.go)
+**Lane**: tiny | **Change-type**: bug-fix
+**Branch**: `fix/327-search-hybridsearch-sig`
+**Implementing agent**: Sisyphus orchestrator (ast-grep + direct edit — 5-line test fix)
+
+## Scope
+
+| File | Change |
+|---|---|
+| `internal/search/isolation_test.go` | 5 lines: add `, nil` as 5th arg to HybridSearch calls (lines 315, 331, 347, 360, 483) |
+| `docs/evidence/327-pre-work-gate.md` | new evidence |
+| `docs/evidence/self-review-zfix-327-search-hybridsearch-sig.md` | this file |
+
+Production code: zero changes. Test file only.
+
+## self-review:response-shape
+
+**N/A** — test fix, no API surface change.
+
+## self-review:staged-files
+
+```
+$ git status (post-stage)
+On branch fix/327-search-hybridsearch-sig
+Changes to be committed:
+	modified:   internal/search/isolation_test.go
+	new file:   docs/evidence/327-pre-work-gate.md
+	new file:   docs/evidence/self-review-zfix-327-search-hybridsearch-sig.md
+```
+
+✅ No `.opencode/`, no `package-lock.json`, no binary artifacts.
+
+## Validation evidence
+
+```
+$ go build ./...
+(no output — success)
+
+$ go test -race -short ./... | grep -E "FAIL|^ok" | tail -10
+ok  internal/search           1.022s
+ok  internal/server           1.062s
+ok  internal/server/handlers  1.778s
+... (all packages pass)
+
+$ go test -race -tags=integration -short ./internal/search/...
+ok  internal/search  1.574s
+```
+
+Before this PR: `FAIL [build failed]`. After: `ok` with passing isolation tests.
+
+## Backward compat
+
+Zero impact. Tests in this file are gated behind `//go:build integration` and were not running in CI's default `validate:quick` step. Their failure was discovered when documenting harness override for PR #322 gate 3.3.
+
+## Why `nil` is correct (not `[]string{}`)
+
+Both work identically — `HybridSearch` checks `len(tags) > 0` to decide whether to dispatch to tag-filtered queries. `nil` slice has length 0, same as `[]string{}`. Idiomatic Go preference is `nil` for the "no value" case.
+
+## Conclusion
+
+5-line test fix, ast-grep-validated for safety. Integration tests for `internal/search` now pass. Unblocks harness gate 3.3 for the search package.

--- a/internal/search/isolation_test.go
+++ b/internal/search/isolation_test.go
@@ -312,7 +312,7 @@ func TestHybridSearchIsolation(t *testing.T) {
 
 	t.Run("alpha_hybrid_returns_only_alpha", func(t *testing.T) {
 		svc := search.NewSearchService(q, &fakeEmbedder{vec: wsAlpha.vec}, cfg, zerolog.Nop())
-		results, err := svc.HybridSearch(ctx, wsAlpha.keyword, wsAlpha.hash, 20)
+		results, err := svc.HybridSearch(ctx, wsAlpha.keyword, wsAlpha.hash, 20, nil)
 		if err != nil {
 			t.Fatalf("HybridSearch: %v", err)
 		}
@@ -328,7 +328,7 @@ func TestHybridSearchIsolation(t *testing.T) {
 
 	t.Run("beta_hybrid_returns_only_beta", func(t *testing.T) {
 		svc := search.NewSearchService(q, &fakeEmbedder{vec: wsBeta.vec}, cfg, zerolog.Nop())
-		results, err := svc.HybridSearch(ctx, wsBeta.keyword, wsBeta.hash, 20)
+		results, err := svc.HybridSearch(ctx, wsBeta.keyword, wsBeta.hash, 20, nil)
 		if err != nil {
 			t.Fatalf("HybridSearch: %v", err)
 		}
@@ -344,7 +344,7 @@ func TestHybridSearchIsolation(t *testing.T) {
 
 	t.Run("beta_keyword_in_alpha_scope_hybrid_returns_zero", func(t *testing.T) {
 		svc := search.NewSearchService(q, &fakeEmbedder{vec: wsBeta.vec}, cfg, zerolog.Nop())
-		results, err := svc.HybridSearch(ctx, wsBeta.keyword, wsAlpha.hash, 20)
+		results, err := svc.HybridSearch(ctx, wsBeta.keyword, wsAlpha.hash, 20, nil)
 		if err != nil {
 			t.Fatalf("HybridSearch: %v", err)
 		}
@@ -357,7 +357,7 @@ func TestHybridSearchIsolation(t *testing.T) {
 
 	t.Run("alpha_keyword_in_beta_scope_hybrid_returns_zero", func(t *testing.T) {
 		svc := search.NewSearchService(q, &fakeEmbedder{vec: wsAlpha.vec}, cfg, zerolog.Nop())
-		results, err := svc.HybridSearch(ctx, wsAlpha.keyword, wsBeta.hash, 20)
+		results, err := svc.HybridSearch(ctx, wsAlpha.keyword, wsBeta.hash, 20, nil)
 		if err != nil {
 			t.Fatalf("HybridSearch: %v", err)
 		}
@@ -480,7 +480,7 @@ func TestCrossWorkspacePermutations(t *testing.T) {
 
 			t.Run(fmt.Sprintf("hybrid_%s_keyword_in_%s", other.name, queried.name), func(t *testing.T) {
 				svc := search.NewSearchService(q, &fakeEmbedder{vec: other.vec}, cfg, zerolog.Nop())
-				results, err := svc.HybridSearch(ctx, other.keyword, queried.hash, 20)
+				results, err := svc.HybridSearch(ctx, other.keyword, queried.hash, 20, nil)
 				if err != nil {
 					t.Fatalf("HybridSearch: %v", err)
 				}


### PR DESCRIPTION
## Summary

Closes #327.

Production `SearchService.HybridSearch` signature was extended at some point to accept a `tags []string` 5th parameter. The integration test file `internal/search/isolation_test.go` was never updated, causing 5 call sites to fail compilation with:

```
internal/search/isolation_test.go:483:72: not enough arguments in call to svc.HybridSearch
    have (context.Context, string, string, number)
    want (context.Context, string, string, int, []string)
```

Fix: add `, nil` to each of 5 call sites in `TestHybridSearchIsolation` and `TestCrossWorkspaceSearchIsolation`. `nil` preserves the original test intent (test workspace isolation behavior without tag filtering).

Applied via `ast-grep` for AST-aware safe replacement.

## Impact

| Before | After |
|---|---|
| `FAIL internal/search [build failed]` | `ok internal/search 1.574s` |

Unblocks harness gate 3.3 for the search package.

## Lane

- **Lane**: tiny (1 file, 5 line edits, test-only)
- **Change-type**: bug-fix
- Risk flags: 0
- Zero production code changes

## Validation

- `go build ./...`: ✅ PASS
- `go test -race -short ./...`: ✅ ALL PACKAGES PASS
- `go test -race -tags=integration -short ./internal/search/...`: ✅ PASS (was previously `[build failed]`)

## Evidence

- `docs/evidence/327-pre-work-gate.md` — PRE-WORK gate + lane rationale
- `docs/evidence/self-review-zfix-327-search-hybridsearch-sig.md` — self-review

## Skip justifications

- OpenSpec: SKIP (tiny lane)
- smoke:e2e: SKIP (test-file only, no runtime surface)
- Review gate: ⚠️ self-verify only per HARNESS.md change-type table
- self-review:response-shape: N/A (no API surface)

`[skip-release]` — test-only change.