### PR TITLE
fix(handlers): align integration test assertions with actual API contract (#326)

### DIFF
--- a/docs/evidence/326-pre-work-gate.md
+++ b/docs/evidence/326-pre-work-gate.md
@@ -1,0 +1,44 @@
+# PRE-WORK gate — Issue #326
+
+**Date**: 2026-06-02
+**Issue**: #326 (internal/server/handlers integration test failures)
+**Lane**: tiny (2 test files, ~15 line edits)
+**Change-type**: bug-fix
+**Branch**: `fix/326-handlers-integration`
+
+## Failures
+
+1. **`events_integration_test.go:96`** — `expected state=started, got map[payload:map[state:started] ts:... type:reindex workspace:...]`
+   - Root cause: `readEvent` returns the full SSE event object `{type, workspace, payload, ts}` where `payload` is the inner JSON.RawMessage. Test directly accessed `payload["state"]` but should access `payload["payload"].(map[string]any)["state"]`.
+
+2. **`workspace_integration_test.go:127`** — `workspace with hash X not found in list`
+   - Root cause: Two separate bugs in one test:
+     - Test decoded response as `[]map[...]` but handler returns wrapped `{"workspaces": [...]}` (per `openspec/specs/workspaces-api-contract`).
+     - Test looked up `item["workspace_hash"]` but handler returns `item["hash"]` (per `workspaceItem` struct JSON tag).
+
+## Lane (tiny)
+
+- 2 test files changed
+- ~15 line edits total (test assertions only)
+- 0 production code changes
+- Risk flags: 0
+
+## Skip justifications
+
+- OpenSpec proposal: SKIP (tiny lane)
+- smoke:e2e: SKIP — test-only file changes, no runtime surface
+- Review gate: ⚠️ self-verify only (per HARNESS.md for bug-fix in test files)
+
+## After-fix verification
+
+```
+$ go test -race -tags=integration -short ./...
+ok  internal/embed
+ok  internal/harvest
+ok  internal/search
+ok  internal/server/handlers   ← FIXED
+ok  internal/storage
+... (all packages PASS)
+```
+
+**Full integration suite is now GREEN.** This PR closes the last remaining gate 3.3 failure on master. Going forward, every PR can have a clean gate 3.3 PASS.

--- a/docs/evidence/self-review-zfix-326-handlers-integration.md
+++ b/docs/evidence/self-review-zfix-326-handlers-integration.md
@@ -1,0 +1,56 @@
+# Self-review — Issue #326 / PR (TBD)
+
+**Date**: 2026-06-02
+**Story**: 326 (handlers integration test failures)
+**Lane**: tiny | **Change-type**: bug-fix
+**Implementing agent**: Sisyphus orchestrator (direct edit, test-only)
+
+## Scope
+
+| File | Change |
+|---|---|
+| `internal/server/handlers/events_integration_test.go` | Replace 2 blocks of `payload["state"]` assertions with `ev["payload"].(map[string]any)["state"]` pattern (the real event wraps payload inside the SSE event object) |
+| `internal/server/handlers/workspace_integration_test.go` | Change decode to `{Workspaces []map[...]}` shape (matches handler contract) + change lookup key from `"workspace_hash"` to `"hash"` (matches struct JSON tag) |
+
+Production code: zero changes.
+
+## Why these fixes are correct
+
+### Fix 1 (events)
+
+Production handler `writeSSEEvent` (`internal/server/handlers/events.go:114`) marshals the entire `eventbus.Event` struct to the SSE `data:` line:
+
+```go
+data, _ := json.Marshal(ev)   // ev = {Type, Workspace, Payload (json.RawMessage), TS}
+fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, data)
+```
+
+When the test unmarshals `data:` into `map[string]any`, it gets `{"type":"reindex", "workspace":"...", "payload":{"state":"started"}, "ts":"..."}`. The `payload` value itself is the nested map. The test was reading `payload["state"]` (= the outer event's "state" field, which doesn't exist) instead of `payload["payload"]["state"]`.
+
+The reindex handler `publishReindex()` (`reindex.go:139-159`) marshals `{state, enqueued, embedded, ...}` into `eventbus.Event.Payload`, confirming the nested structure.
+
+### Fix 2 (workspaces)
+
+Production handler `ListWorkspaces` (`workspace.go:218`) returns `listWorkspacesResponse{Workspaces: items}` which serializes to `{"workspaces": [{"hash":"...", "root_path":"...", "name":"...", "doc_count":N, ...}]}`. 
+
+The handler comment explicitly documents this contract:
+> Field names match web/src/api/types.ts Workspace interface. Renaming these JSON tags is a breaking API change — see openspec/specs/workspaces-api-contract for the canonical contract.
+
+The test was making two wrong assumptions: (1) bare array shape, (2) field named `workspace_hash`. Both contradicted the canonical contract.
+
+## Validation
+
+| Check | Before | After |
+|---|---|---|
+| `go test -race -tags=integration ./internal/server/handlers/...` | FAIL (2 tests) | ✅ PASS |
+| Full integration suite `go test -tags=integration ./...` | FAIL (handlers) | ✅ ALL PASS |
+| `go test -race -short ./...` | PASS | ✅ PASS |
+| `go build ./...` | PASS | ✅ PASS |
+
+## Backward compat
+
+Zero. Test-file-only changes. Production behavior unchanged.
+
+## Conclusion
+
+This PR makes the integration test assertions match the actual production contract. After merge, harness gate 3.3 will be FULLY GREEN across all packages on master. No more `[HARNESS-OVERRIDE]` 3.3 needed for future PRs.

--- a/internal/server/handlers/events_integration_test.go
+++ b/internal/server/handlers/events_integration_test.go
@@ -88,20 +88,28 @@ func TestEventsIntegration_ReindexPublishesSequence(t *testing.T) {
 		Payload:   json.RawMessage(`{"state":"completed","enqueued":5}`),
 	})
 
-	evType, payload := readEvent(2 * time.Second)
+	evType, ev := readEvent(2 * time.Second)
 	if evType != "reindex" {
 		t.Fatalf("expected reindex event, got %q", evType)
 	}
-	if state, ok := payload["state"].(string); !ok || state != "started" {
-		t.Fatalf("expected state=started, got %v", payload)
+	innerPayload, ok := ev["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested payload object, got %v", ev)
+	}
+	if state, ok := innerPayload["state"].(string); !ok || state != "started" {
+		t.Fatalf("expected state=started, got %v", innerPayload)
 	}
 
-	evType, payload = readEvent(2 * time.Second)
+	evType, ev = readEvent(2 * time.Second)
 	if evType != "reindex" {
 		t.Fatalf("expected reindex event, got %q", evType)
 	}
-	if state, ok := payload["state"].(string); !ok || state != "completed" {
-		t.Fatalf("expected state=completed, got %v", payload)
+	innerPayload, ok = ev["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested payload object, got %v", ev)
+	}
+	if state, ok := innerPayload["state"].(string); !ok || state != "completed" {
+		t.Fatalf("expected state=completed, got %v", innerPayload)
 	}
 
 	cancel()

--- a/internal/server/handlers/workspace_integration_test.go
+++ b/internal/server/handlers/workspace_integration_test.go
@@ -122,12 +122,14 @@ func TestListWorkspacesE2E(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var items []map[string]interface{}
-	if err := json.NewDecoder(rec.Body).Decode(&items); err != nil {
+	var resp struct {
+		Workspaces []map[string]interface{} `json:"workspaces"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	if len(items) == 0 {
+	if len(resp.Workspaces) == 0 {
 		t.Error("expected at least one workspace in list")
 	}
 
@@ -136,8 +138,8 @@ func TestListWorkspacesE2E(t *testing.T) {
 		t.Fatalf("WorkspaceHash: %v", err)
 	}
 	found := false
-	for _, item := range items {
-		if item["workspace_hash"] == expectedHash {
+	for _, item := range resp.Workspaces {
+		if item["hash"] == expectedHash {
 			found = true
 			break
 		}


### PR DESCRIPTION
## Summary

Closes #326.

Fixes 2 failing integration tests in `internal/server/handlers` that had assertions against outdated/incorrect API contracts.

**After this PR, `go test -race -tags=integration ./...` is GREEN across ALL packages on master.** Combined with PRs #335 (#328) and #336 (#327), gate 3.3 will be fully clean — no more `[HARNESS-OVERRIDE]` 3.3 needed for future PRs.

## Fixes

### Fix 1: `TestEventsIntegration_ReindexPublishesSequence` (events_integration_test.go)

SSE event serialization wraps the inner payload:
```go
// Production code (events.go:114)
data, _ := json.Marshal(ev)  // ev = eventbus.Event{Type, Workspace, Payload, TS}
```

Result: `{"type":"reindex", "workspace":"...", "payload":{"state":"started"}, "ts":"..."}`

Test was reading top-level `payload["state"]` (always nil — there's no top-level state field). Fixed to navigate the nested `payload["payload"].(map[string]any)["state"]`.

### Fix 2: `TestListWorkspacesE2E` (workspace_integration_test.go)

Two related fixes:

**a) Response shape**: Handler returns wrapped `{"workspaces": [...]}` per canonical contract (see comment on `workspaceItem` struct: "openspec/specs/workspaces-api-contract"). Test was decoding bare `[]map`. Fixed to decode `struct{Workspaces []map}`.

**b) Field name**: `workspaceItem` struct uses JSON tag `\"hash\"` (not \"workspace_hash\"). Fixed lookup key.

Both shape and field-name mismatches were silently making the test always look for an empty/missing key, hence `workspace with hash X not found`.

## Lane

- **Lane**: tiny (2 test files, ~15 line edits)
- **Change-type**: bug-fix
- Risk flags: 0
- Zero production code changes

## Validation

| Check | Before | After |
|---|---|---|
| `go test -race -tags=integration ./internal/server/handlers/...` | FAIL (2 tests) | ✅ PASS |
| Full integration suite `go test -tags=integration ./...` | FAIL (handlers) | ✅ ALL PASS |
| `go test -race -short ./...` | PASS | ✅ PASS |
| `go build ./...` | PASS | ✅ PASS |

## Evidence

- `docs/evidence/326-pre-work-gate.md`
- `docs/evidence/self-review-zfix-326-handlers-integration.md` with full forensic explanation of both fixes

## Skip justifications

- OpenSpec: SKIP (tiny lane)
- smoke:e2e: SKIP (test files only, no runtime change)
- Review gate: ⚠️ self-verify only per HARNESS.md change-type table
- self-review:response-shape: N/A (no API surface change)

`[skip-release]` — test-only change.