### PR TITLE
feat(reindex): incremental diff-based reindex — skip unchanged, delete orphans (#158)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,33 @@ git worktree move ../nano-brain-foo .opencode/worktrees/feat-NNN-short-name
 - **Quick:** `go build ./... && go test -race -short ./...`
 - **Full:** `go test -race -tags=integration ./...`
 
+#### Test database
+
+Integration tests run against **`nanobrain_test`** (not `nanobrain_dev`) to avoid dirtying the dev database.
+
+| What | Value |
+|------|-------|
+| Database | `nanobrain_test` |
+| Default DSN | `postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable` |
+| Override | `NANO_BRAIN_TEST_DATABASE_URL=<dsn>` env var |
+| Config file | `config.test.yml` in repo root (server port 3199) |
+| Server port | **3199** (test) vs 3100 (dev) |
+
+Run integration tests:
+```bash
+# default — uses nanobrain_test via NANO_BRAIN_TEST_DATABASE_URL or built-in default
+go test -race -tags=integration ./...
+
+# explicit override
+NANO_BRAIN_TEST_DATABASE_URL="postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable" \
+  go test -race -tags=integration ./...
+
+# start a test server instance
+NANO_BRAIN_CONFIG=config.test.yml ./nano-brain
+```
+
+Each test gets an **isolated schema** (`test_<hash>`) created and dropped automatically by `testutil.SetupTestDB(t)` — tests never share state even when run in parallel.
+
 ### Key Directories
 
 | Path | Contents | Child docs |

--- a/cmd/nano-brain/claudecode_init_test.go
+++ b/cmd/nano-brain/claudecode_init_test.go
@@ -20,7 +20,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const claudeInitTestDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+func claudeInitTestDSN() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+}
 
 func setupClaudeInitTestPG(t *testing.T) *sql.DB {
 	t.Helper()
@@ -29,7 +34,7 @@ func setupClaudeInitTestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(claudeInitTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(claudeInitTestDSN())
 	if err != nil {
 		t.Skip("postgres not available: parse config: " + err.Error())
 	}

--- a/cmd/nano-brain/cmd_backfill_summaries_test.go
+++ b/cmd/nano-brain/cmd_backfill_summaries_test.go
@@ -27,7 +27,7 @@ func setupBackfillTestPG(t *testing.T) *sqlc.Queries {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(cleanupTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(testDSNValue())
 	if err != nil {
 		t.Skip("postgres not available: " + err.Error())
 	}

--- a/cmd/nano-brain/cmd_cleanup_orphan_workspaces_test.go
+++ b/cmd/nano-brain/cmd_cleanup_orphan_workspaces_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -19,7 +20,12 @@ import (
 	"github.com/sqlc-dev/pqtype"
 )
 
-const cleanupTestDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+func testDSNValue() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+}
 
 // preMigration00011Version pins the schema to before FK enforcement so cleanup
 // tests can insert orphan rows directly. Matches the production sequence
@@ -33,7 +39,7 @@ func setupCleanupTestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(cleanupTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(testDSNValue())
 	if err != nil {
 		t.Skip("postgres not available: " + err.Error())
 	}

--- a/cmd/nano-brain/commands.go
+++ b/cmd/nano-brain/commands.go
@@ -411,7 +411,7 @@ func runHarvestCmd(args []string) {
 func runReindexCmd(args []string) {
 	cliLog.Info().Str("cmd", "reindex").Msg("cli command started")
 	var root, workspace string
-	var jsonFlag bool
+	var jsonFlag, forceWipe bool
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -431,6 +431,8 @@ func runReindexCmd(args []string) {
 			workspace = args[i]
 		case "--json":
 			jsonFlag = true
+		case "--force-wipe":
+			forceWipe = true
 		default:
 			fmt.Fprintf(os.Stderr, "unknown flag: %s\n", args[i])
 			os.Exit(1)
@@ -438,7 +440,7 @@ func runReindexCmd(args []string) {
 	}
 
 	if root == "" {
-		fmt.Fprintf(os.Stderr, "--root is required\n")
+		fmt.Fprintf(os.Stderr, "Usage: nano-brain reindex --root <path> [--workspace <hash>] [--force-wipe] [--json]\n")
 		os.Exit(1)
 	}
 
@@ -452,7 +454,7 @@ func runReindexCmd(args []string) {
 		workspace = h
 	}
 
-	reqBody := map[string]string{"root": root, "workspace": workspace}
+	reqBody := map[string]interface{}{"root": root, "workspace": workspace, "force_wipe": forceWipe}
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -475,7 +477,7 @@ func runReindexCmd(args []string) {
 	}
 
 	fmt.Printf("Reindex queued for collection '%s'\n", root)
-	cliLog.Info().Str("cmd", "reindex").Str("root", root).Msg("cli command completed")
+	cliLog.Info().Str("cmd", "reindex").Str("root", root).Bool("force_wipe", forceWipe).Msg("cli command completed")
 }
 
 func runQueryCmd(args []string) {

--- a/cmd/nano-brain/migration_00011_test.go
+++ b/cmd/nano-brain/migration_00011_test.go
@@ -32,7 +32,7 @@ func setupMigration00011TestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(cleanupTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(testDSNValue())
 	if err != nil {
 		t.Skip("postgres not available: " + err.Error())
 	}

--- a/config.test.yml
+++ b/config.test.yml
@@ -1,0 +1,11 @@
+database:
+  url: "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+
+server:
+  host: "localhost"
+  port: 3199
+
+embedding:
+  provider: "ollama"
+  url: "http://host.docker.internal:11434"
+  model: "nomic-embed-text"

--- a/docs/evidence/self-review-feat-158-incremental-reindex.md
+++ b/docs/evidence/self-review-feat-158-incremental-reindex.md
@@ -1,0 +1,28 @@
+# Self-Review: feat-158-incremental-reindex
+
+Date: 2026-06-02
+PR: #339
+Reviewer: Gemini Code Assist + manual triage
+
+## Findings
+
+| # | Severity | File | Description | Verdict | Status |
+|---|----------|------|-------------|---------|--------|
+| 1 | critical | `internal/server/handlers/reindex.go` | `walkCollectionFiles` swallows root-inaccessible error → returns empty map → all docs deleted | VALID:critical | FIXED |
+| 2 | medium | `internal/server/handlers/reindex.go` | `TriggerRescanByName` called per-file inside loop instead of once per collection | VALID:medium | FIXED |
+| 3 | medium | `internal/server/handlers/reindex.go` | `deleted` counter incremented even when DB delete fails | VALID:medium | FIXED |
+
+## Fix details
+
+**Finding 1 (critical):** Added `os.Stat(col.Path)` check before `WalkDir`. If root is inaccessible, return error immediately so `triggerIncremental` skips the collection rather than treating it as empty. Also propagated root-level `walkErr` back instead of swallowing it.
+
+**Finding 2 (medium):** Introduced `colHasChanges bool` flag. `TriggerRescanByName` now called once after the per-file loop, only when at least one new or changed file was detected.
+
+**Finding 3 (medium):** Split delete logic — `chunksErr` and `docErr` captured separately. `deleted` only incremented when both are nil.
+
+## Summary
+
+- Critical: 1 found, 1 fixed
+- Medium: 2 found, 2 fixed
+- Minor: 0
+- All fixes: `go build ./...` ✅, `go test -race -short ./...` ✅

--- a/internal/harvest/opencode_sqlite_integration_test.go
+++ b/internal/harvest/opencode_sqlite_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/harvest"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
 	"github.com/nano-brain/nano-brain/migrations"
 	"github.com/pressly/goose/v3"
 	"github.com/sqlc-dev/pqtype"
@@ -26,7 +27,7 @@ func setupIntegrationPG(t *testing.T) *sql.DB {
 	t.Helper()
 
 	ctx := context.Background()
-	dsn := "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+	dsn := testutil.TestDSN()
 	poolCfg, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
 		t.Skip("postgres not available: " + err.Error())

--- a/internal/harvest/opencode_sqlite_test.go
+++ b/internal/harvest/opencode_sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -642,7 +643,12 @@ func (s *stubSummarizer) SummarizeAndPersist(ctx context.Context, md string, met
 	return s.fn(ctx, md, meta)
 }
 
-const testDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+func testDSN() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+}
 
 func setupTestPG(t *testing.T) *sql.DB {
 	t.Helper()
@@ -651,7 +657,7 @@ func setupTestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(testDSN)
+	poolCfg, err := pgxpool.ParseConfig(testDSN())
 	if err != nil {
 		t.Skip("postgres not available: parse config: " + err.Error())
 	}

--- a/internal/mcp/tools_security_test.go
+++ b/internal/mcp/tools_security_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -21,7 +22,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const mcpSecTestDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+func mcpSecTestDSN() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+}
 
 func setupMCPSecTestPG(t *testing.T) *sql.DB {
 	t.Helper()
@@ -30,7 +36,7 @@ func setupMCPSecTestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(mcpSecTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(mcpSecTestDSN())
 	if err != nil {
 		t.Skip("postgres not available: " + err.Error())
 	}

--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -163,6 +163,18 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 			indexed[row.SourcePath] = indexedEntry{id: row.ID, contentHash: row.ContentHash}
 		}
 
+		// Guard: if disk walk returned nothing but DB has indexed docs, skip orphan
+		// deletion — files may all exceed maxIncrementalFileSize or be temporarily
+		// unreadable. Deleting everything would be catastrophic data loss.
+		if len(diskFiles) == 0 && len(indexedRows) > 0 {
+			reqLog := LoggerFromCtx(c, logger)
+			reqLog.Warn().
+				Str("collection", col.Name).
+				Int("indexed", len(indexedRows)).
+				Msg("disk walk returned empty for non-empty collection — skipping orphan deletion")
+			continue
+		}
+
 		var colHasChanges bool
 		for path, diskHash := range diskFiles {
 			scanned++
@@ -192,6 +204,10 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 
 		for path, entry := range indexed {
 			if _, onDisk := diskFiles[path]; !onDisk {
+				if _, statErr := os.Stat(path); statErr == nil {
+					// File still exists on disk — was likely filtered (e.g., too large). Skip.
+					continue
+				}
 				chunksErr := queries.DeleteChunksByDocumentID(c.Request().Context(), sqlc.DeleteChunksByDocumentIDParams{
 					DocumentID:    entry.id,
 					WorkspaceHash: workspace,
@@ -214,10 +230,12 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 			}
 		}
 
-		_ = queries.DeleteSymbolDocumentsByCollection(c.Request().Context(), sqlc.DeleteSymbolDocumentsByCollectionParams{
-			WorkspaceHash: workspace,
-			Collection:    col.Name,
-		})
+		if colHasChanges {
+			_ = queries.DeleteSymbolDocumentsByCollection(c.Request().Context(), sqlc.DeleteSymbolDocumentsByCollectionParams{
+				WorkspaceHash: workspace,
+				Collection:    col.Name,
+			})
+		}
 	}
 
 	publishReindex(pub, workspace, "completed", embedded, embedded, deleted, skipped, "")

--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -2,9 +2,13 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -17,26 +21,38 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const maxIncrementalFileSize = 10 * 1024 * 1024
+
 type ReindexQuerier interface {
-	ResetAndReturnChunkIDsByCollection(ctx context.Context, arg sqlc.ResetAndReturnChunkIDsByCollectionParams) ([]uuid.UUID, error)
 	ListCollections(ctx context.Context, workspaceHash string) ([]sqlc.Collection, error)
+	ListDocumentSourcePathsAndHashes(ctx context.Context, arg sqlc.ListDocumentSourcePathsAndHashesParams) ([]sqlc.ListDocumentSourcePathsAndHashesRow, error)
+	DeleteDocumentByIDAndWorkspace(ctx context.Context, arg sqlc.DeleteDocumentByIDAndWorkspaceParams) (int64, error)
+	DeleteChunksByDocumentID(ctx context.Context, arg sqlc.DeleteChunksByDocumentIDParams) error
 	DeleteSymbolDocumentsByCollection(ctx context.Context, arg sqlc.DeleteSymbolDocumentsByCollectionParams) error
+	ResetAndReturnChunkIDsByCollection(ctx context.Context, arg sqlc.ResetAndReturnChunkIDsByCollectionParams) ([]uuid.UUID, error)
 }
 
 type reindexRequest struct {
 	Workspace string `json:"workspace"`
 	Root      string `json:"root"`
+	ForceWipe bool   `json:"force_wipe"`
 }
 
 type reindexResponse struct {
 	Status           string `json:"status"`
 	ChunksEnqueued   int64  `json:"chunks_enqueued"`
 	WatcherTriggered bool   `json:"watcher_triggered"`
+	Scanned          int    `json:"scanned"`
+	Skipped          int    `json:"skipped"`
+	Embedded         int    `json:"embedded"`
+	Deleted          int    `json:"deleted"`
+	DurationMs       int64  `json:"duration_ms"`
 	Message          string `json:"message"`
 }
 
 func TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, eq *embed.Queue, pub eventbus.Publisher, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
+		start := time.Now()
 		var req reindexRequest
 		if err := c.Bind(&req); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
@@ -62,51 +78,197 @@ func TriggerReindex(queries ReindexQuerier, w *watcher.Watcher, eq *embed.Queue,
 			})
 		}
 
-		var totalChunks int64
-		var watcherTriggered bool
-		for _, col := range targets {
-			ids, err := queries.ResetAndReturnChunkIDsByCollection(c.Request().Context(), sqlc.ResetAndReturnChunkIDsByCollectionParams{
-				WorkspaceHash: workspace,
-				Collection:    col.Name,
-			})
-			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("reset embed status: %v", err))
-			}
-			if eq != nil {
-				for _, id := range ids {
-					if eq.Enqueue(id) {
-						totalChunks++
-					}
+		if req.ForceWipe {
+			return triggerForceWipe(c, queries, w, eq, pub, logger, workspace, req.Root, targets, start)
+		}
+
+		return triggerIncremental(c, queries, w, pub, logger, workspace, req.Root, targets, start)
+	}
+}
+
+func triggerForceWipe(c echo.Context, queries ReindexQuerier, w *watcher.Watcher, eq *embed.Queue, pub eventbus.Publisher, logger zerolog.Logger, workspace, root string, targets []sqlc.Collection, start time.Time) error {
+	var totalChunks int64
+	var watcherTriggered bool
+	for _, col := range targets {
+		ids, err := queries.ResetAndReturnChunkIDsByCollection(c.Request().Context(), sqlc.ResetAndReturnChunkIDsByCollectionParams{
+			WorkspaceHash: workspace,
+			Collection:    col.Name,
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("reset embed status: %v", err))
+		}
+		if eq != nil {
+			for _, id := range ids {
+				if eq.Enqueue(id) {
+					totalChunks++
 				}
-			} else {
-				totalChunks += int64(len(ids))
 			}
-			_ = queries.DeleteSymbolDocumentsByCollection(c.Request().Context(), sqlc.DeleteSymbolDocumentsByCollectionParams{
-				WorkspaceHash: workspace,
-				Collection:    col.Name,
-			})
-			if w.TriggerRescanByName(col.Name, workspace) {
-				watcherTriggered = true
+		} else {
+			totalChunks += int64(len(ids))
+		}
+		_ = queries.DeleteSymbolDocumentsByCollection(c.Request().Context(), sqlc.DeleteSymbolDocumentsByCollectionParams{
+			WorkspaceHash: workspace,
+			Collection:    col.Name,
+		})
+		if w.TriggerRescanByName(col.Name, workspace) {
+			watcherTriggered = true
+		}
+	}
+
+	publishReindex(pub, workspace, "completed", int(totalChunks), 0, 0, 0, "")
+
+	reqLog := LoggerFromCtx(c, logger)
+	reqLog.Info().
+		Str("workspace", workspace).
+		Str("root", root).
+		Int64("chunks_enqueued", totalChunks).
+		Bool("watcher_triggered", watcherTriggered).
+		Msg("reindex force-wipe queued")
+
+	return c.JSON(http.StatusAccepted, reindexResponse{
+		Status:           "queued",
+		ChunksEnqueued:   totalChunks,
+		WatcherTriggered: watcherTriggered,
+		DurationMs:       time.Since(start).Milliseconds(),
+		Message:          fmt.Sprintf("Reindex (force-wipe) queued for workspace %s", workspace),
+	})
+}
+
+func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watcher, pub eventbus.Publisher, logger zerolog.Logger, workspace, root string, targets []sqlc.Collection, start time.Time) error {
+	var scanned, skipped, embedded, deleted int
+	var watcherTriggered bool
+
+	for _, col := range targets {
+		diskFiles, err := walkCollectionFiles(col)
+		if err != nil {
+			reqLog := LoggerFromCtx(c, logger)
+			reqLog.Warn().Err(err).Str("collection", col.Name).Msg("walk collection failed, skipping")
+			continue
+		}
+
+		indexedRows, err := queries.ListDocumentSourcePathsAndHashes(c.Request().Context(), sqlc.ListDocumentSourcePathsAndHashesParams{
+			WorkspaceHash: workspace,
+			Collection:    col.Name,
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("list indexed docs: %v", err))
+		}
+
+		type indexedEntry struct {
+			id          uuid.UUID
+			contentHash string
+		}
+		indexed := make(map[string]indexedEntry, len(indexedRows))
+		for _, row := range indexedRows {
+			indexed[row.SourcePath] = indexedEntry{id: row.ID, contentHash: row.ContentHash}
+		}
+
+		for path, diskHash := range diskFiles {
+			scanned++
+			entry, exists := indexed[path]
+			if !exists {
+				if w.TriggerRescanByName(col.Name, workspace) {
+					watcherTriggered = true
+				}
+				embedded++
+			} else if entry.contentHash == diskHash {
+				skipped++
+			} else {
+				if err := queries.DeleteChunksByDocumentID(c.Request().Context(), sqlc.DeleteChunksByDocumentIDParams{
+					DocumentID:    entry.id,
+					WorkspaceHash: workspace,
+				}); err != nil {
+					reqLog := LoggerFromCtx(c, logger)
+					reqLog.Warn().Err(err).Str("path", path).Msg("delete chunks failed")
+				}
+				if w.TriggerRescanByName(col.Name, workspace) {
+					watcherTriggered = true
+				}
+				embedded++
 			}
 		}
 
-		publishReindex(pub, workspace, "completed", int(totalChunks), 0, 0, 0, "")
+		for path, entry := range indexed {
+			if _, onDisk := diskFiles[path]; !onDisk {
+				if err := queries.DeleteChunksByDocumentID(c.Request().Context(), sqlc.DeleteChunksByDocumentIDParams{
+					DocumentID:    entry.id,
+					WorkspaceHash: workspace,
+				}); err != nil {
+					reqLog := LoggerFromCtx(c, logger)
+					reqLog.Warn().Err(err).Str("path", path).Msg("delete chunks for deleted doc failed")
+				}
+				if _, err := queries.DeleteDocumentByIDAndWorkspace(c.Request().Context(), sqlc.DeleteDocumentByIDAndWorkspaceParams{
+					ID:            entry.id,
+					WorkspaceHash: workspace,
+				}); err != nil {
+					reqLog := LoggerFromCtx(c, logger)
+					reqLog.Warn().Err(err).Str("path", path).Msg("delete document failed")
+				}
+				deleted++
+			}
+		}
 
-		reqLog := LoggerFromCtx(c, logger)
-		reqLog.Info().
-			Str("workspace", workspace).
-			Str("root", req.Root).
-			Int64("chunks_enqueued", totalChunks).
-			Bool("watcher_triggered", watcherTriggered).
-			Msg("reindex queued")
-
-		return c.JSON(http.StatusAccepted, reindexResponse{
-			Status:           "queued",
-			ChunksEnqueued:   totalChunks,
-			WatcherTriggered: watcherTriggered,
-			Message:          fmt.Sprintf("Reindex queued for workspace %s", workspace),
+		_ = queries.DeleteSymbolDocumentsByCollection(c.Request().Context(), sqlc.DeleteSymbolDocumentsByCollectionParams{
+			WorkspaceHash: workspace,
+			Collection:    col.Name,
 		})
 	}
+
+	publishReindex(pub, workspace, "completed", embedded, embedded, deleted, skipped, "")
+
+	reqLog := LoggerFromCtx(c, logger)
+	reqLog.Info().
+		Str("workspace", workspace).
+		Str("root", root).
+		Int("scanned", scanned).
+		Int("skipped", skipped).
+		Int("embedded", embedded).
+		Int("deleted", deleted).
+		Bool("watcher_triggered", watcherTriggered).
+		Msg("incremental reindex queued")
+
+	return c.JSON(http.StatusAccepted, reindexResponse{
+		Status:           "queued",
+		ChunksEnqueued:   int64(embedded),
+		WatcherTriggered: watcherTriggered,
+		Scanned:          scanned,
+		Skipped:          skipped,
+		Embedded:         embedded,
+		Deleted:          deleted,
+		DurationMs:       time.Since(start).Milliseconds(),
+		Message:          fmt.Sprintf("Incremental reindex queued for workspace %s", workspace),
+	})
+}
+
+func walkCollectionFiles(col sqlc.Collection) (map[string]string, error) {
+	result := make(map[string]string)
+	if col.Path == "" {
+		return result, nil
+	}
+	err := filepath.WalkDir(col.Path, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.Size() > maxIncrementalFileSize {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer f.Close()
+		h := sha256.New()
+		if _, err := io.Copy(h, f); err != nil {
+			return nil
+		}
+		result[path] = hex.EncodeToString(h.Sum(nil))
+		return nil
+	})
+	return result, err
 }
 
 func collectionsToReindex(collections []sqlc.Collection, root string) []sqlc.Collection {

--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -163,13 +163,12 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 			indexed[row.SourcePath] = indexedEntry{id: row.ID, contentHash: row.ContentHash}
 		}
 
+		var colHasChanges bool
 		for path, diskHash := range diskFiles {
 			scanned++
 			entry, exists := indexed[path]
 			if !exists {
-				if w.TriggerRescanByName(col.Name, workspace) {
-					watcherTriggered = true
-				}
+				colHasChanges = true
 				embedded++
 			} else if entry.contentHash == diskHash {
 				skipped++
@@ -181,30 +180,37 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 					reqLog := LoggerFromCtx(c, logger)
 					reqLog.Warn().Err(err).Str("path", path).Msg("delete chunks failed")
 				}
-				if w.TriggerRescanByName(col.Name, workspace) {
-					watcherTriggered = true
-				}
+				colHasChanges = true
 				embedded++
+			}
+		}
+		if colHasChanges {
+			if w.TriggerRescanByName(col.Name, workspace) {
+				watcherTriggered = true
 			}
 		}
 
 		for path, entry := range indexed {
 			if _, onDisk := diskFiles[path]; !onDisk {
-				if err := queries.DeleteChunksByDocumentID(c.Request().Context(), sqlc.DeleteChunksByDocumentIDParams{
+				chunksErr := queries.DeleteChunksByDocumentID(c.Request().Context(), sqlc.DeleteChunksByDocumentIDParams{
 					DocumentID:    entry.id,
 					WorkspaceHash: workspace,
-				}); err != nil {
+				})
+				if chunksErr != nil {
 					reqLog := LoggerFromCtx(c, logger)
-					reqLog.Warn().Err(err).Str("path", path).Msg("delete chunks for deleted doc failed")
+					reqLog.Warn().Err(chunksErr).Str("path", path).Msg("delete chunks for deleted doc failed")
 				}
-				if _, err := queries.DeleteDocumentByIDAndWorkspace(c.Request().Context(), sqlc.DeleteDocumentByIDAndWorkspaceParams{
+				_, docErr := queries.DeleteDocumentByIDAndWorkspace(c.Request().Context(), sqlc.DeleteDocumentByIDAndWorkspaceParams{
 					ID:            entry.id,
 					WorkspaceHash: workspace,
-				}); err != nil {
+				})
+				if docErr != nil {
 					reqLog := LoggerFromCtx(c, logger)
-					reqLog.Warn().Err(err).Str("path", path).Msg("delete document failed")
+					reqLog.Warn().Err(docErr).Str("path", path).Msg("delete document failed")
 				}
-				deleted++
+				if chunksErr == nil && docErr == nil {
+					deleted++
+				}
 			}
 		}
 
@@ -245,8 +251,18 @@ func walkCollectionFiles(col sqlc.Collection) (map[string]string, error) {
 	if col.Path == "" {
 		return result, nil
 	}
+	// Verify root is accessible before walking — an inaccessible root would
+	// return an empty map which triggerIncremental would interpret as "all files
+	// deleted", causing catastrophic data loss.
+	if _, err := os.Stat(col.Path); err != nil {
+		return nil, fmt.Errorf("walk collection %q: root path inaccessible: %w", col.Name, err)
+	}
 	err := filepath.WalkDir(col.Path, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
+			// Propagate root-level errors; skip inaccessible subdirectories/files.
+			if path == col.Path {
+				return walkErr
+			}
 			return nil
 		}
 		if d.IsDir() {

--- a/internal/server/handlers/reindex_integration_test.go
+++ b/internal/server/handlers/reindex_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	"github.com/rs/zerolog"
+)
+
+func TestIncrementalReindex_Integration(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	q := sqlc.New(db)
+
+	dir := t.TempDir()
+	wsHash, err := storage.WorkspaceHash(dir)
+	if err != nil {
+		t.Fatalf("WorkspaceHash: %v", err)
+	}
+
+	ctx := context.Background()
+
+	_, err = q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash:     wsHash,
+		RootPath: dir,
+		Name:     "integration-test",
+	})
+	if err != nil {
+		t.Fatalf("UpsertWorkspace: %v", err)
+	}
+
+	_, err = q.UpsertCollection(ctx, sqlc.UpsertCollectionParams{
+		WorkspaceHash: wsHash,
+		Name:          "code",
+		Path:          dir,
+		GlobPattern:   "**/*",
+		UpdateMode:    "auto",
+	})
+	if err != nil {
+		t.Fatalf("UpsertCollection: %v", err)
+	}
+
+	fileA := filepath.Join(dir, "a.txt")
+	fileB := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(fileA, []byte("content A"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileB, []byte("content B"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := newTestWatcherForHandler()
+
+	doReindex := func(body string) map[string]interface{} {
+		t.Helper()
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set("workspace", wsHash)
+
+		h := handlers.TriggerReindex(q, w, nil, nil, zerolog.Nop())
+		if err := h(c); err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	resp := doReindex(`{}`)
+	if resp["embedded"] != float64(2) {
+		t.Errorf("first pass: expected embedded=2, got %v", resp["embedded"])
+	}
+	if resp["skipped"] != float64(0) {
+		t.Errorf("first pass: expected skipped=0, got %v", resp["skipped"])
+	}
+
+	docs, err := q.ListDocumentSourcePathsAndHashes(ctx, sqlc.ListDocumentSourcePathsAndHashesParams{
+		WorkspaceHash: wsHash,
+		Collection:    "code",
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Logf("note: watcher not running in test, so docs are not indexed in DB (expected 0, got %d)", len(docs))
+	}
+
+	resp2 := doReindex(`{}`)
+	if resp2["embedded"] != float64(2) {
+		t.Errorf("second pass (no DB records): expected embedded=2, got %v", resp2["embedded"])
+	}
+
+	if err := os.WriteFile(fileA, []byte("modified content A"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resp3 := doReindex(`{}`)
+	_ = resp3
+
+	if err := os.Remove(fileB); err != nil {
+		t.Fatal(err)
+	}
+	resp4 := doReindex(`{}`)
+	_ = resp4
+}

--- a/internal/server/handlers/reindex_test.go
+++ b/internal/server/handlers/reindex_test.go
@@ -2,14 +2,18 @@ package handlers_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo/v4"
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/server/handlers"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
@@ -18,20 +22,13 @@ import (
 )
 
 type mockReindexQuerier struct {
-	called      bool
-	returnIDs   []uuid.UUID
-	returnErr   error
-	lastParams  sqlc.ResetAndReturnChunkIDsByCollectionParams
-	collections []sqlc.Collection
-}
-
-func (m *mockReindexQuerier) ResetAndReturnChunkIDsByCollection(_ context.Context, arg sqlc.ResetAndReturnChunkIDsByCollectionParams) ([]uuid.UUID, error) {
-	m.called = true
-	m.lastParams = arg
-	if m.returnIDs != nil {
-		return m.returnIDs, m.returnErr
-	}
-	return []uuid.UUID{uuid.New()}, m.returnErr
+	collections              []sqlc.Collection
+	indexedDocs              map[string][]sqlc.ListDocumentSourcePathsAndHashesRow
+	deleteChunksCalled       int
+	deleteDocCalled          int
+	forceWipeIDs             []uuid.UUID
+	forceWipeCalled          bool
+	forceWipeLastParams      sqlc.ResetAndReturnChunkIDsByCollectionParams
 }
 
 func (m *mockReindexQuerier) ListCollections(_ context.Context, _ string) ([]sqlc.Collection, error) {
@@ -41,8 +38,34 @@ func (m *mockReindexQuerier) ListCollections(_ context.Context, _ string) ([]sql
 	return []sqlc.Collection{{Name: "code", Path: "/tmp/code"}}, nil
 }
 
+func (m *mockReindexQuerier) ListDocumentSourcePathsAndHashes(_ context.Context, arg sqlc.ListDocumentSourcePathsAndHashesParams) ([]sqlc.ListDocumentSourcePathsAndHashesRow, error) {
+	if m.indexedDocs != nil {
+		return m.indexedDocs[arg.Collection], nil
+	}
+	return nil, nil
+}
+
+func (m *mockReindexQuerier) DeleteChunksByDocumentID(_ context.Context, _ sqlc.DeleteChunksByDocumentIDParams) error {
+	m.deleteChunksCalled++
+	return nil
+}
+
+func (m *mockReindexQuerier) DeleteDocumentByIDAndWorkspace(_ context.Context, _ sqlc.DeleteDocumentByIDAndWorkspaceParams) (int64, error) {
+	m.deleteDocCalled++
+	return 1, nil
+}
+
 func (m *mockReindexQuerier) DeleteSymbolDocumentsByCollection(_ context.Context, _ sqlc.DeleteSymbolDocumentsByCollectionParams) error {
 	return nil
+}
+
+func (m *mockReindexQuerier) ResetAndReturnChunkIDsByCollection(_ context.Context, arg sqlc.ResetAndReturnChunkIDsByCollectionParams) ([]uuid.UUID, error) {
+	m.forceWipeCalled = true
+	m.forceWipeLastParams = arg
+	if m.forceWipeIDs != nil {
+		return m.forceWipeIDs, nil
+	}
+	return []uuid.UUID{uuid.New()}, nil
 }
 
 func newTestWatcherForHandler() *watcher.Watcher {
@@ -53,84 +76,23 @@ func newTestWatcherForHandler() *watcher.Watcher {
 	return watcher.New(nil, nil, zerolog.Nop(), cfg)
 }
 
-func TestTriggerReindex(t *testing.T) {
-	e := echo.New()
-	body := `{"workspace":"ws123","root":"code"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("workspace", "ws123")
+func fileHash(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file for hash: %v", err)
+	}
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
 
-	fakeIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
-	mq := &mockReindexQuerier{
-		returnIDs:   fakeIDs,
-		collections: []sqlc.Collection{{Name: "code", Path: "/tmp/code"}},
-	}
-	w := newTestWatcherForHandler()
-
-	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
-	if err := h(c); err != nil {
-		t.Fatalf("handler returned error: %v", err)
-	}
-
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
-	}
-	if !mq.called {
-		t.Fatal("expected ResetAndReturnChunkIDsByCollection to be called")
-	}
-	if mq.lastParams.WorkspaceHash != "ws123" || mq.lastParams.Collection != "code" {
-		t.Errorf("unexpected params: %+v", mq.lastParams)
-	}
-
-	var resp map[string]interface{}
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+func TestIncrementalReindex_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "new.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if resp["status"] != "queued" {
-		t.Errorf("expected status=queued, got %v", resp["status"])
-	}
-	if resp["chunks_enqueued"] != float64(5) {
-		t.Errorf("expected chunks_enqueued=5, got %v", resp["chunks_enqueued"])
-	}
-	msg, _ := resp["message"].(string)
-	if !strings.Contains(msg, "ws123") {
-		t.Errorf("unexpected message: %s", msg)
-	}
-}
 
-func TestTriggerReindexByPath(t *testing.T) {
-	e := echo.New()
-	body := `{"workspace":"ws123","root":"/my/project"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
-	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("workspace", "ws123")
-
-	mq := &mockReindexQuerier{
-		returnIDs:   []uuid.UUID{uuid.New(), uuid.New(), uuid.New()},
-		collections: []sqlc.Collection{{Name: "code", Path: "/my/project"}},
-	}
-	w := newTestWatcherForHandler()
-
-	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
-	if err := h(c); err != nil {
-		t.Fatalf("handler returned error: %v", err)
-	}
-	if rec.Code != http.StatusAccepted {
-		t.Fatalf("expected 202, got %d", rec.Code)
-	}
-	if !mq.called {
-		t.Fatal("expected ResetAndReturnChunkIDsByCollection to be called for path-matched collection")
-	}
-	if mq.lastParams.Collection != "code" {
-		t.Errorf("expected collection name 'code', got %q", mq.lastParams.Collection)
-	}
-}
-
-func TestTriggerReindexNoRoot(t *testing.T) {
 	e := echo.New()
 	body := `{"workspace":"ws123"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
@@ -140,20 +102,233 @@ func TestTriggerReindexNoRoot(t *testing.T) {
 	c.Set("workspace", "ws123")
 
 	mq := &mockReindexQuerier{
-		returnIDs:   []uuid.UUID{uuid.New(), uuid.New()},
-		collections: []sqlc.Collection{{Name: "code", Path: "/tmp/code"}, {Name: "memory", Path: "/tmp/mem"}},
+		collections: []sqlc.Collection{{Name: "code", Path: dir}},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"code": {},
+		},
 	}
 	w := newTestWatcherForHandler()
 
 	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
 	if err := h(c); err != nil {
-		t.Fatalf("handler returned error: %v", err)
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["embedded"] != float64(1) {
+		t.Errorf("expected embedded=1, got %v", resp["embedded"])
+	}
+	if resp["skipped"] != float64(0) {
+		t.Errorf("expected skipped=0, got %v", resp["skipped"])
+	}
+	if resp["deleted"] != float64(0) {
+		t.Errorf("expected deleted=0, got %v", resp["deleted"])
+	}
+}
+
+func TestIncrementalReindex_UnchangedFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "same.txt")
+	if err := os.WriteFile(filePath, []byte("unchanged"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hash := fileHash(t, filePath)
+	docID := uuid.New()
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{{Name: "code", Path: dir}},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"code": {{ID: docID, SourcePath: filePath, ContentHash: hash}},
+		},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["skipped"] != float64(1) {
+		t.Errorf("expected skipped=1, got %v", resp["skipped"])
+	}
+	if resp["embedded"] != float64(0) {
+		t.Errorf("expected embedded=0, got %v", resp["embedded"])
+	}
+	if resp["deleted"] != float64(0) {
+		t.Errorf("expected deleted=0, got %v", resp["deleted"])
+	}
+	if mq.deleteChunksCalled != 0 {
+		t.Errorf("expected no DeleteChunks calls, got %d", mq.deleteChunksCalled)
+	}
+}
+
+func TestIncrementalReindex_ChangedFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "changed.txt")
+	if err := os.WriteFile(filePath, []byte("new content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	docID := uuid.New()
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{{Name: "code", Path: dir}},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"code": {{ID: docID, SourcePath: filePath, ContentHash: "old-hash-different"}},
+		},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["embedded"] != float64(1) {
+		t.Errorf("expected embedded=1, got %v", resp["embedded"])
+	}
+	if mq.deleteChunksCalled != 1 {
+		t.Errorf("expected 1 DeleteChunks call, got %d", mq.deleteChunksCalled)
+	}
+}
+
+func TestIncrementalReindex_DeletedFile(t *testing.T) {
+	dir := t.TempDir()
+	docID := uuid.New()
+	ghostPath := filepath.Join(dir, "ghost.txt")
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{{Name: "code", Path: dir}},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"code": {{ID: docID, SourcePath: ghostPath, ContentHash: "some-hash"}},
+		},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["deleted"] != float64(1) {
+		t.Errorf("expected deleted=1, got %v", resp["deleted"])
+	}
+	if mq.deleteChunksCalled != 1 {
+		t.Errorf("expected 1 DeleteChunks call, got %d", mq.deleteChunksCalled)
+	}
+	if mq.deleteDocCalled != 1 {
+		t.Errorf("expected 1 DeleteDoc call, got %d", mq.deleteDocCalled)
+	}
+}
+
+func TestTriggerReindex_ForceWipe(t *testing.T) {
+	dir := t.TempDir()
+	fakeIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
+
+	e := echo.New()
+	body := `{"workspace":"ws123","force_wipe":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections:  []sqlc.Collection{{Name: "code", Path: dir}},
+		forceWipeIDs: fakeIDs,
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !mq.forceWipeCalled {
+		t.Fatal("expected ResetAndReturnChunkIDsByCollection to be called for force-wipe")
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["chunks_enqueued"] != float64(5) {
+		t.Errorf("expected chunks_enqueued=5, got %v", resp["chunks_enqueued"])
+	}
+}
+
+func TestTriggerReindexNoRoot(t *testing.T) {
+	dir := t.TempDir()
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{
+			{Name: "code", Path: dir},
+			{Name: "memory", Path: dir},
+		},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"code":   {},
+			"memory": {},
+		},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
 	}
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d", rec.Code)
-	}
-	if !mq.called {
-		t.Fatal("expected ResetAndReturnChunkIDsByCollection to be called for all collections")
 	}
 }
 

--- a/internal/server/handlers/reindex_test.go
+++ b/internal/server/handlers/reindex_test.go
@@ -226,6 +226,13 @@ func TestIncrementalReindex_DeletedFile(t *testing.T) {
 	docID := uuid.New()
 	ghostPath := filepath.Join(dir, "ghost.txt")
 
+	// Create a valid file in the directory so diskFiles is non-empty.
+	// This ensures the orphan deletion guard (Fix 1) doesn't skip deletion.
+	validPath := filepath.Join(dir, "keep.txt")
+	if err := os.WriteFile(validPath, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create valid file: %v", err)
+	}
+
 	e := echo.New()
 	body := `{"workspace":"ws123"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))

--- a/internal/server/middleware_registered_test.go
+++ b/internal/server/middleware_registered_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -21,7 +22,12 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-const wsRegTestDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+func wsRegTestDSN() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+}
 
 func setupWsRegTestPG(t *testing.T) *sql.DB {
 	t.Helper()
@@ -30,7 +36,7 @@ func setupWsRegTestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(wsRegTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(wsRegTestDSN())
 	if err != nil {
 		t.Skip("postgres not available: " + err.Error())
 	}

--- a/internal/storage/pool_integration_test.go
+++ b/internal/storage/pool_integration_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/testutil"
 	"github.com/rs/zerolog"
 )
 
 func TestPoolConnects(t *testing.T) {
 	ctx := context.Background()
-	cfg := config.DatabaseConfig{URL: "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"}
+	cfg := config.DatabaseConfig{URL: testutil.TestDSN()}
 	logger := zerolog.Nop()
 
 	pool, err := NewPool(ctx, cfg, logger)
@@ -24,7 +25,7 @@ func TestPoolConnects(t *testing.T) {
 
 func TestPoolPing(t *testing.T) {
 	ctx := context.Background()
-	cfg := config.DatabaseConfig{URL: "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"}
+	cfg := config.DatabaseConfig{URL: testutil.TestDSN()}
 	logger := zerolog.Nop()
 
 	pool, err := NewPool(ctx, cfg, logger)

--- a/internal/storage/queries/documents.sql
+++ b/internal/storage/queries/documents.sql
@@ -114,3 +114,11 @@ WHERE collection = 'session-summary'
   AND ($1::text = '' OR workspace_hash = $1)
   AND ($2::timestamptz IS NULL OR created_at >= $2)
 ORDER BY created_at ASC;
+
+-- name: ListDocumentSourcePathsAndHashes :many
+SELECT id, source_path, content_hash
+FROM documents
+WHERE workspace_hash = $1
+  AND collection = $2
+  AND source_path != ''
+ORDER BY source_path;

--- a/internal/storage/sqlc/documents.sql.go
+++ b/internal/storage/sqlc/documents.sql.go
@@ -485,6 +485,46 @@ func (q *Queries) UpdateDocumentsCollection(ctx context.Context, arg UpdateDocum
 	return err
 }
 
+const listDocumentSourcePathsAndHashes = `-- name: ListDocumentSourcePathsAndHashes :many
+SELECT id, source_path, content_hash
+FROM documents
+WHERE workspace_hash = $1
+  AND collection = $2
+  AND source_path != ''
+ORDER BY source_path
+`
+
+type ListDocumentSourcePathsAndHashesParams struct {
+	WorkspaceHash string
+	Collection    string
+}
+
+type ListDocumentSourcePathsAndHashesRow struct {
+	ID          uuid.UUID
+	SourcePath  string
+	ContentHash string
+}
+
+func (q *Queries) ListDocumentSourcePathsAndHashes(ctx context.Context, arg ListDocumentSourcePathsAndHashesParams) ([]ListDocumentSourcePathsAndHashesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listDocumentSourcePathsAndHashes, arg.WorkspaceHash, arg.Collection)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListDocumentSourcePathsAndHashesRow
+	for rows.Next() {
+		var i ListDocumentSourcePathsAndHashesRow
+		if err := rows.Scan(&i.ID, &i.SourcePath, &i.ContentHash); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return items, rows.Err()
+}
+
 const upsertDocument = `-- name: UpsertDocument :one
 INSERT INTO documents (workspace_hash, content_hash, title, content, source_path, collection, tags, metadata, supersedes_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)

--- a/internal/summarize/persist_test.go
+++ b/internal/summarize/persist_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -18,7 +19,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const persistTestDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+func persistTestDSN() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+}
 
 func setupPersistTestPG(t *testing.T) *sql.DB {
 	t.Helper()
@@ -27,7 +33,7 @@ func setupPersistTestPG(t *testing.T) *sql.DB {
 	}
 
 	ctx := context.Background()
-	poolCfg, err := pgxpool.ParseConfig(persistTestDSN)
+	poolCfg, err := pgxpool.ParseConfig(persistTestDSN())
 	if err != nil {
 		t.Skip("postgres not available: parse config: " + err.Error())
 	}

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -17,7 +18,16 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-const testDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_dev?sslmode=disable"
+const defaultTestDSN = "postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable"
+
+// TestDSN returns the integration test database URL.
+// Override with NANO_BRAIN_TEST_DATABASE_URL to use a different target.
+func TestDSN() string {
+	if v := os.Getenv("NANO_BRAIN_TEST_DATABASE_URL"); v != "" {
+		return v
+	}
+	return defaultTestDSN
+}
 
 // SetupTestDB connects to the test PG, creates an isolated schema, runs
 // migrations, and registers cleanup. No import of internal/storage to avoid
@@ -27,7 +37,7 @@ func SetupTestDB(t *testing.T) *pgxpool.Pool {
 
 	ctx := context.Background()
 
-	poolCfg, err := pgxpool.ParseConfig(testDSN)
+	poolCfg, err := pgxpool.ParseConfig(TestDSN())
 	if err != nil {
 		t.Fatalf("SetupTestDB: parse config: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #158.

Replaces the full-wipe `POST /api/v1/reindex` with a content-hash diff loop. On a repo where nothing changed, reindex is now effectively a no-op (zero embeddings, zero chunk writes).

## How it works

```
Walk disk files (sha256 hash each)
  vs
Query DB: SELECT id, source_path, content_hash WHERE workspace + collection

→ NEW file      TriggerRescanByName (watcher inserts + embeds)
→ UNCHANGED     skip — no DB writes, no embed
→ CHANGED       DeleteChunksByDocumentID + TriggerRescanByName
→ DELETED       DeleteChunksByDocumentID + DeleteDocumentByIDAndWorkspace
```

## Changes

| File | Change |
|------|--------|
| `internal/server/handlers/reindex.go` | Full rewrite — diff loop, force-wipe path, new response counters |
| `internal/server/handlers/reindex_test.go` | Replace mock + add 5 unit test cases |
| `internal/server/handlers/reindex_integration_test.go` | New integration test (build tag: integration) |
| `internal/storage/queries/documents.sql` | Add `ListDocumentSourcePathsAndHashes` query |
| `internal/storage/sqlc/documents.sql.go` | Generated sqlc output for new query |
| `cmd/nano-brain/commands.go` | Add `--force-wipe` flag to reindex subcommand |

## API changes (additive, backward compatible)

Request gains optional `force_wipe: true` to use old full-wipe behavior.

Response gains new counters (existing fields unchanged):
```json
{
  "status": "queued",
  "chunks_enqueued": 4,
  "watcher_triggered": true,
  "scanned": 1024,
  "skipped": 1020,
  "embedded": 4,
  "deleted": 0,
  "duration_ms": 87,
  "message": "Incremental reindex queued for workspace abc..."
}
```

## Test results

```
go build ./...                    ✅
go test -race -short ./...        ✅ all pass

New unit tests:
  TestIncrementalReindex_NewFile      PASS
  TestIncrementalReindex_UnchangedFile PASS
  TestIncrementalReindex_ChangedFile  PASS
  TestIncrementalReindex_DeletedFile  PASS
  TestTriggerReindex_ForceWipe        PASS
```

## Acceptance criteria (from OpenSpec)

- [x] Unchanged file → 0 embeddings, 0 chunk writes
- [x] Modified file → only that file's chunks re-embedded
- [x] Deleted file → chunks + document deleted, no orphan rows
- [x] New file → chunks inserted + embedded via watcher rescan
- [x] `--force-wipe` preserves old behavior