### PR TITLE
fix(wakeup): filter recent_memories to memory/session-summary collections (#338)

### DIFF
--- a/internal/server/handlers/wakeup.go
+++ b/internal/server/handlers/wakeup.go
@@ -85,11 +85,12 @@ func WakeUpHandler(q WakeUpQuerier, logger zerolog.Logger) echo.HandlerFunc {
 
 		ctx := c.Request().Context()
 
-		docs, err := q.RecentDocuments(ctx, sqlc.RecentDocumentsParams{
-			WorkspaceHash: workspace,
-			Limit:         int32(limit),
-		})
-		if err != nil {
+	docs, err := q.RecentDocuments(ctx, sqlc.RecentDocumentsParams{
+		WorkspaceHash: workspace,
+		Limit:         int32(limit),
+		Collections:   []string{"memory", "session-summary"},
+	})
+	if err != nil {
 			logger.Error().Err(err).Str("workspace", workspace).Msg("wake-up: recent documents failed")
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch recent documents")
 		}

--- a/internal/storage/queries/wakeup.sql
+++ b/internal/storage/queries/wakeup.sql
@@ -3,6 +3,7 @@ SELECT id, title, tags, updated_at,
        LEFT(content, 200) AS snippet
 FROM documents
 WHERE workspace_hash = $1
+  AND collection = ANY($3::text[])
 ORDER BY updated_at DESC
 LIMIT $2;
 

--- a/internal/storage/sqlc/wakeup.sql.go
+++ b/internal/storage/sqlc/wakeup.sql.go
@@ -62,6 +62,7 @@ SELECT id, title, tags, updated_at,
        LEFT(content, 200) AS snippet
 FROM documents
 WHERE workspace_hash = $1
+  AND collection = ANY($3::text[])
 ORDER BY updated_at DESC
 LIMIT $2
 `
@@ -69,6 +70,7 @@ LIMIT $2
 type RecentDocumentsParams struct {
 	WorkspaceHash string
 	Limit         int32
+	Collections   []string
 }
 
 type RecentDocumentsRow struct {
@@ -80,7 +82,7 @@ type RecentDocumentsRow struct {
 }
 
 func (q *Queries) RecentDocuments(ctx context.Context, arg RecentDocumentsParams) ([]RecentDocumentsRow, error) {
-	rows, err := q.db.QueryContext(ctx, recentDocuments, arg.WorkspaceHash, arg.Limit)
+	rows, err := q.db.QueryContext(ctx, recentDocuments, arg.WorkspaceHash, arg.Limit, pq.Array(arg.Collections))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem
wake-up `recent_memories` returned code symbols and other irrelevant documents because `RecentDocuments` fetched from ALL collections.

## Fix
Added `AND collection = ANY($3::text[])` to the SQL query, scoped to `['memory', 'session-summary']` — the two collections that contain user-authored decisions and session summaries.

## Changes
- `internal/storage/queries/wakeup.sql` — add collection filter
- `internal/storage/sqlc/wakeup.sql.go` — add `Collections []string` param, pass `pq.Array`
- `internal/server/handlers/wakeup.go` — pass `[]string{"memory", "session-summary"}`

Closes #338