### PR TITLE
chore(openspec): propose nano-brain-cli-ux-overhaul

### DIFF
--- a/docs/HARNESS_BACKLOG.md
+++ b/docs/HARNESS_BACKLOG.md
@@ -249,3 +249,64 @@ real metrics, vocabulary closed-set defined. Token budget for tasks reduced
 
 Tracking: in-session harness update (no GitHub issue per R89 — this work
 was the harness rule update itself; the agent's task IS the rule fix).
+
+---
+
+## Missing Harness Capability
+
+### Title
+
+Pre-existing-failure exemption for docs-only PRs (gates 3.3 + 3.4)
+
+### Discovered While
+
+`chore/openspec-cli-ux-overhaul-proposal` PR #344 (issue #343). Diff is 8 spec
+markdown files, 0 `.go` files. Pre-merge gate FAILed on 3.3 (integration tests
+in `internal/harvest` + build-failed in `internal/server/handlers`) and 3.4
+(golangci-lint violations in `_test.go` files). Both failures reproduce on
+master HEAD `23b5afa` — the PR cannot have caused or fixed them.
+
+Same pattern previously hit by PR #332 (issue #331) — see
+`docs/evidence/331-pre-merge-override.md` for prior precedent of overriding
+pre-existing 3.3 + 3.4 failures on a docs-only PR.
+
+### Current Pain
+
+Currently, every docs-only PR has to:
+1. Manually verify the failures are pre-existing (run on master HEAD).
+2. Write a custom `<issue>-pre-merge-override.md` evidence file.
+3. Ask the user to post a `[HARNESS-OVERRIDE]` comment (R7 mechanism, which is
+   technically scoped to Gemini comments only).
+
+This is friction every docs PR pays. R7 was not designed for this case.
+
+### Suggested Improvement
+
+Add a new check before gates 3.3 and 3.4 that auto-SKIP'd them when the diff
+contains zero `.go` files:
+
+```bash
+# Pseudocode for harness-check.sh
+diff_files=$(git diff --name-only "$(git merge-base master HEAD)" HEAD)
+has_go=$(echo "$diff_files" | grep -cE '\.go$|go\.(mod|sum)$' || echo 0)
+if [[ "$has_go" -eq 0 ]]; then
+    add_check "SKIP" "3.3 PR has no Go files; integration tests not relevant to diff"
+    add_check "SKIP" "3.4 PR has no Go files; lint not relevant to diff"
+else
+    # existing 3.3 + 3.4 logic
+fi
+```
+
+Alternative: rename R7 to be more general ("pre-existing failure override"),
+not Gemini-specific.
+
+### Risk
+
+Tiny — change is local to `scripts/harness-check.sh`, additive guard before
+existing logic.
+
+### Status
+
+proposed — awaiting user approval per Forbidden Practice #13 ("No modifying
+harness rules without user approval"). Tracking: in this PR's
+`docs/evidence/343-pre-merge-override.md`.

--- a/docs/evidence/343-pre-merge-override.md
+++ b/docs/evidence/343-pre-merge-override.md
@@ -1,0 +1,82 @@
+# PRE-MERGE gate — Issue #343 / PR #344
+
+**Date**: 2026-06-03
+**Issue**: #343 (chore(openspec): propose nano-brain-cli-ux-overhaul)
+**PR**: #344
+**Branch**: `chore/openspec-cli-ux-overhaul-proposal`
+**Lane**: tiny | **Change-type**: docs (spec-only)
+
+## Gate Run Output
+
+```
+─ PRE-MERGE checks
+[PASS] 3.1 go build ./...
+[PASS] 3.2 go test -race -short ./...
+[FAIL] 3.3 go test -race -tags=integration ./... failed
+[FAIL] 3.4 golangci-lint found issues
+[PASS] 3.5 Review Verdict: PASS in docs/evidence/review-gate-188.md (R27)
+[PASS] 3.6 No Gemini comments on PR
+[SKIP] 3.7 No open PR or CI not yet complete
+[PASS] 3.8 PR closes exactly 1 issue (R1)
+[PASS] 3.9 PR targets master
+[FAIL] 3.10 No self-review evidence for story openspec
+[PASS] 3.11 PR commit count: 1 (R29: ≤ 3)
+[SKIP] 3.12 No smoke-e2e-openspec*.{md,txt} (R19)
+[SKIP] 3.13 no web change in PR diff (smoke:ui not required)
+Summary: 7 PASS, 3 FAIL, 3 SKIP (13 total)
+```
+
+## [HARNESS-OVERRIDE] Gate 3.3 — integration tests
+
+**Reason**: Pre-existing failures on master, NOT introduced by PR #344. The PR diff is 8 spec markdown files (729 insertions, 0 deletions). Zero `.go` files touched. Cannot have introduced these failures.
+
+**Evidence (run from worktree, branched off latest master `23b5afa`)**:
+
+```
+$ git diff --name-only master HEAD
+openspec/changes/nano-brain-cli-ux-overhaul/design.md
+openspec/changes/nano-brain-cli-ux-overhaul/proposal.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-binary-resolution/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-doctor-runtime/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-install-path-optimization/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-mcp-url-resolution/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/skill-distribution-docs/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/tasks.md
+```
+
+```
+$ go test -race -tags=integration -count=1 -timeout=60s ./internal/harvest/ ./internal/server/handlers/
+FAIL  github.com/nano-brain/nano-brain/internal/server/handlers [build failed]
+--- FAIL: TestOpenCodeSQLite_OrphanSession_NoWorktree_Skipped (0.15s)
+--- FAIL: TestOpenCodeSQLite_UnregisteredWorktree_Skipped (0.18s)
+FAIL  github.com/nano-brain/nano-brain/internal/harvest 2.238s
+```
+
+Reproduced identically on master HEAD (`git checkout master -- internal/`). All other packages PASS.
+
+These pre-existing failures should be tracked by a separate issue — recommended follow-up: file an issue covering both the `handlers` build failure and the `harvest` test failures, then reference it in `docs/HARNESS_BACKLOG.md`.
+
+## [HARNESS-OVERRIDE] Gate 3.4 — golangci-lint
+
+**Reason**: Pre-existing lint violations on master, NOT introduced by PR #344. Same zero-Go-files-in-diff argument as 3.3.
+
+## Gate 3.10 — self-review evidence
+
+Created at `docs/evidence/self-review-openspec-cli-ux-overhaul-proposal.md`. This file references it for completeness.
+
+## R19 — smoke:e2e not required
+
+Change-type is `docs` (spec-only). Per `docs/HARNESS.md` change-type table, smoke:e2e is `❌` for docs. Gate 3.12 correctly SKIP'd.
+
+## R56 — Review Gate not required
+
+Tiny lane + docs change-type: Review Gate is `❌` per harness change-type table.
+
+## Validation summary
+
+- validate:quick: ✅ PASS — full output in self-review file
+- self-review:staged-files: ✅ PASS — only intended files
+- self-review:response-shape: N/A — no API surface change
+- 1 commit, atomic, conventional message, Closes #343
+- openspec validate --strict --no-interactive: ✅ PASS
+- Pre-existing failures (3.3 + 3.4) overridden with evidence; awaiting user `[HARNESS-OVERRIDE]: <reason>` comment on PR #344 per R7

--- a/docs/evidence/self-review-openspec-cli-ux-overhaul-proposal.md
+++ b/docs/evidence/self-review-openspec-cli-ux-overhaul-proposal.md
@@ -1,0 +1,82 @@
+# Self-Review — chore(openspec): nano-brain-cli-ux-overhaul proposal
+
+**Date**: 2026-06-03
+**Issue**: #343
+**PR**: #344
+**Branch**: `chore/openspec-cli-ux-overhaul-proposal`
+**Lane**: tiny
+**Change type**: docs (spec-only)
+
+## Diff scope
+
+```
+$ git diff --name-only master HEAD
+openspec/changes/nano-brain-cli-ux-overhaul/design.md
+openspec/changes/nano-brain-cli-ux-overhaul/proposal.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-binary-resolution/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-doctor-runtime/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-install-path-optimization/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-mcp-url-resolution/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/specs/skill-distribution-docs/spec.md
+openspec/changes/nano-brain-cli-ux-overhaul/tasks.md
+```
+
+8 files added (729 insertions, 0 deletions). Zero `.go` files. Zero existing files modified.
+
+## self-review:staged-files — PASS
+
+`git status` before commit showed only intended files. No `.opencode/` content staged (worktree dir is in `.gitignore`). No `package-lock.json`. Clean.
+
+## self-review:response-shape — N/A
+
+No API surface change. Spec-only PR.
+
+## Validation ladder run from worktree
+
+### validate:quick — PASS
+
+```
+$ go build ./...
+(exit 0, no output)
+
+$ go test -race -short ./...
+ok  	github.com/nano-brain/nano-brain/cmd/nano-brain	8.336s
+ok  	github.com/nano-brain/nano-brain/internal/bench	1.042s
+ok  	github.com/nano-brain/nano-brain/internal/chunk	1.032s
+ok  	github.com/nano-brain/nano-brain/internal/config	1.170s
+ok  	github.com/nano-brain/nano-brain/internal/embed	1.604s
+ok  	github.com/nano-brain/nano-brain/internal/eventbus	1.281s
+ok  	github.com/nano-brain/nano-brain/internal/graph	2.480s
+ok  	github.com/nano-brain/nano-brain/internal/health	1.017s
+ok  	github.com/nano-brain/nano-brain/internal/links	1.338s
+ok  	github.com/nano-brain/nano-brain/internal/mcp	2.064s
+ok  	github.com/nano-brain/nano-brain/internal/migrate	1.078s
+ok  	github.com/nano-brain/nano-brain/internal/search	3.800s
+ok  	github.com/nano-brain/nano-brain/internal/server	2.695s
+ok  	github.com/nano-brain/nano-brain/internal/server/middleware	9.486s
+ok  	github.com/nano-brain/nano-brain/internal/server/webui	1.032s
+```
+(packages without `_test.go` files omitted; all packages with tests pass)
+
+### openspec validate --strict --no-interactive — PASS
+
+```
+$ openspec validate nano-brain-cli-ux-overhaul --strict --no-interactive
+Change 'nano-brain-cli-ux-overhaul' is valid
+```
+
+### Pre-work gate — 6/6 PASS
+
+See `harness-check.sh pre-work --issue 343` output recorded during gate run.
+
+## R19 — smoke:e2e not required
+
+Change-type is `docs`, not `user-feature` or `bug-fix`. Per harness change-type table, smoke:e2e is `❌` for docs. Gate 3.12 correctly SKIP'd.
+
+## R56 — Review Gate not required
+
+Tiny lane + docs change-type: Review Gate is `❌` per harness change-type table. Gate 3.5 reports the existing `docs/evidence/review-gate-188.md` precedent satisfies the literal grep — not a true review of this PR (none required).
+
+## Pre-existing master failures (gates 3.3 + 3.4)
+
+Documented in companion file: `docs/evidence/343-pre-merge-override.md`. PR diff has zero `.go` files; cannot have caused or fixed these failures.

--- a/openspec/changes/nano-brain-cli-ux-overhaul/design.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/design.md
@@ -1,0 +1,261 @@
+# Design — nano-brain CLI UX Overhaul
+
+## Context
+
+### Current state
+
+nano-brain ships three coexisting invocation paths that all funnel into the same Go binary:
+
+1. `npx @nano-step/nano-brain[@tag]` — primary documented path in `README.md` and `SKILL.md`. Downloads (or resolves from npm cache) a Go binary via `npm/postinstall.js`, then `npm/run.js` re-execs it.
+2. `npm install -g @nano-step/nano-brain` then `nano-brain ...` — fast path. Mentioned only in passing.
+3. `CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain` — dev / source build. Documented in `README.md` Option B.
+
+The `npx` path carries 600 ms–1.5 s of cold-start overhead per invocation (npm registry HEAD check + Node.js VM init + Go binary process spawn). An AI agent session that issues 20–50 `nano-brain query` / `nano-brain context` calls pays 15–75 s of cumulative overhead. The fast paths (#2 and #3) eliminate the Node.js layer entirely.
+
+### Existing diagnostics
+
+- `nano-brain doctor` (`cmd/nano-brain/doctor.go`, `internal/health/doctor/doctor.go`) runs five offline-ish prerequisite checks: config, PostgreSQL reachability, pgvector extension, embedding provider (Ollama HTTP probe or Voyage key presence), embedding model. **All checks are local-config-driven.** None of them ask the running server how it's doing.
+- `/api/status` (`internal/server/handlers/health.go:115-194`) already exposes `pg_status`, `migration_version`, `embedding_queue_depth`, `active_provider`, `workspace_count`, `queue_depth`, `queue_capacity`, `queue_status`, `queue_pending`, and harvester status. It does **not** expose `version` (the version string is on `/health` but not `/api/status`).
+- The npm postinstall (`npm/postinstall.js`) downloads the platform binary, verifies SHA-256, places it under `npm/bin/<platform>/nano-brain`. On failure it WARNs and exits 0 (silent failure footgun) — see issue #320 history.
+
+### Existing hardcoded MCP URL
+
+`.opencode/skills/nano-brain/skill.json:11` hardcodes `"url": "http://host.docker.internal:3100/mcp"`. This is correct for OpenCode running inside a container (which is the dominant deployment), wrong for bare-metal users (where the agent IS the host and needs `localhost:3100/mcp`).
+
+### `@beta` references still live
+
+`cmd/nano-brain/client_helpers.go:69` returns `"npx @nano-step/nano-brain@beta serve -d"` as the suggested start command. `README.md:47-53` shows three `@beta` examples. `SKILL.md` already uses `@latest` (line 204). This is an inconsistency to clean up.
+
+### Constraints
+
+- **Single static Go binary** (`CGO_ENABLED=0`). No new Go dependencies. All new logic must use stdlib + existing koanf, zerolog, net/http, pgx/v5.
+- **Custom CLI dispatcher** (`cmd/nano-brain/main.go` switch on `os.Args[1]`). No cobra. New subcommands are added by appending a `case "name":` arm.
+- **Cross-platform shipping**: Linux amd64/arm64, macOS amd64/arm64, plus a "not supported" branch for Windows in postinstall.
+- **Cross-repo coordination**: `SKILL.md` ships via the `@nano-step/skill-manager` npm package as well as via this repo's `.opencode/skills/nano-brain/SKILL.md`. The two MUST stay in sync; the skill-manager publish cycle is user-owned (per Q5 confirmation in proposal).
+- **No breaking change to existing Docker users.** `host.docker.internal:3100` must remain a working URL out of the box.
+
+### Stakeholders
+
+- AI agents running inside OpenCode containers (today's primary user) — Docker MCP URL must keep working.
+- Bare-metal users (today's silently-broken case) — `localhost` MCP URL must become available without manual config.
+- Skill-manager publisher (the user) — controls the SKILL.md publish cycle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+1. Make the fast invocation path (`npm install -g` or pre-built binary) obvious in docs — `npx` documented as fallback only.
+2. Give users a one-command runtime health diagnostic (`nano-brain doctor --online`) covering: server reachable, embed queue not backpressured, CLI ↔ server version match, MCP endpoint reachable.
+3. Make MCP URL portable across Docker and bare-metal without manual config: env var override + container auto-detection.
+4. Surface which binary is actually running (`nano-brain version --which`) so users can diagnose "wrong version" footguns.
+5. Give power users an opt-in fast PATH placement after `npm install` (no PATH auto-modification, never overwrite existing files).
+6. Eliminate `@beta` references from user-facing surfaces. Default to `@latest`.
+
+**Non-Goals:**
+
+- `nano-brain doctor --fix` auto-remediation (out of scope per proposal).
+- `curl | sh` install script or rustup-style installer (out of scope).
+- Per-platform optional npm dependencies (out of scope — postinstall continues to dynamically download).
+- Modifying the user's shell rc files (`.zshrc`, `.bashrc`). PATH guidance is printed, never injected.
+- Embedding queue backpressure investigation / fix (parallel workstream, separate GitHub issue).
+- Forcing existing Docker users onto `localhost` URL. Container detection must remain backward-compatible.
+
+## Decisions
+
+### D1 — Phased rollout: docs first, code second, packaging third
+
+**Decision:** Phase 0 (docs + investigation) and Phase 1 (CLI additions) ship independently. Phase 3 (skill.json change) and Phase 4 (opt-in postinstall copy) are deferred and gated on the Phase 0 investigation outcome.
+
+**Why:** Phase 0 is reversible (`git revert`), zero-risk, immediately useful (clears `@beta` confusion). Phase 1 adds new flags / subcommands — additive only, no behaviour change to existing commands. Phase 3 changes a file that ships cross-repo (skill-manager), so we want full design review with the templating-feasibility answer in hand. Phase 4 touches install-time behaviour on three platforms — needs explicit testing.
+
+**Alternative considered:** Ship everything in one PR. Rejected — too large, hard to revert, mixes pure-docs (low risk) with cross-platform postinstall (high risk).
+
+### D2 — `nano-brain doctor --online` is opt-in, not default
+
+**Decision:** Existing `nano-brain doctor` keeps current behaviour (offline prerequisite checks). New `--online` flag adds runtime checks against a running server.
+
+**Why:**
+- Today's `doctor` is run BEFORE the server is started (its job is to validate prerequisites). Adding online checks by default would make `doctor` fail in the most common "I'm running this because nothing works yet" case.
+- `--online` gives ops a single command to ask "is my running server healthy", which is a different question.
+- JSON output (`--json`) enables CI consumption.
+
+**Alternative considered:** Split into `nano-brain doctor` (prereq) and `nano-brain healthcheck` (runtime). Rejected — adds a new top-level subcommand for a small surface area. The flag pattern matches `--json` precedent on the same command.
+
+### D3 — Embed queue health thresholds: WARN ≥ 80 %, FAIL ≥ 95 % of `queue_capacity`
+
+**Decision:** `--online` interprets `queue_pending / queue_capacity` as a saturation ratio. ≥ 0.80 → WARN, ≥ 0.95 → FAIL.
+
+**Why:**
+- `channelCapacity = 10000` is hardcoded in `internal/embed/queue.go:26`. Worst-case "queue full, chunk dropped" warning fires at `len(q.ch) >= channelCapacity`. We want users to see WARN well before that hard limit.
+- Backpressure rejection kicks in at `pending >= 50000` (`rejectionThreshold`, queue.go:34). FAIL at 0.95 of channel capacity is upstream of that — early signal.
+- These match precedent in `internal/embed/queue.go:checkCapacity()` which already uses 60 %/90 % WARN/ERROR thresholds for the channel itself. Doctor's thresholds are stricter because doctor is read by humans, not log scrapers.
+
+**Alternative considered:** Use `queue_pending / rejectionThreshold (50000)`. Rejected — that's a workspace-aggregate count, not per-channel; mismatched with the natural "is the buffer about to drop messages" question doctor is answering.
+
+### D4 — Version skew detection compares CLI build version to `/api/status` server version
+
+**Decision:** Require `/api/status` to return a `version` field. Doctor compares it to the CLI's compile-time `Version` constant (currently `cmd/nano-brain/main.go:33` `var Version = "dev"`). Mismatch → WARN with both versions reported.
+
+**Why:** A common failure mode is "CLI in npm cache is stale, server is up-to-date" — query result format may have drifted. WARN (not FAIL) because most version skew is benign.
+
+**Cost:** Adds a `version` field to `statusResponse` in `internal/server/handlers/health.go`. Additive JSON change, no breaking compat.
+
+**Alternative considered:** Add a dedicated `/api/version` endpoint. Rejected — `/api/status` already returns 7+ fields; one more is cheaper than a new route.
+
+### D5 — `NANO_BRAIN_BIN` env var validates file exists AND is executable
+
+**Decision:** When set, `NANO_BRAIN_BIN` overrides binary resolution. Validation: `os.Stat()` succeeds, mode has any `0111` bit set. On failure: print error, exit non-zero, do NOT fall back to PATH.
+
+**Why:** Silent fallback when the user explicitly pointed at a binary is hostile — they want to know if their override is broken. Fail loudly.
+
+**Alternative considered:** Fall back to PATH on validation failure with a WARN. Rejected — masks the user's intent.
+
+### D6 — MCP URL resolution precedence
+
+**Decision:** Resolve in this fixed order:
+1. `NANO_BRAIN_MCP_URL` env var (if set and non-empty after trim) → use as-is, no validation
+2. If `/.dockerenv` exists → `http://host.docker.internal:3100/mcp`
+3. Default → `http://localhost:3100/mcp`
+
+**Why:**
+- Env var wins because operators need an explicit override (custom port, remote VPS deployment, etc.).
+- `/.dockerenv` detection matches existing precedent in `cmd/nano-brain/guard.go` and `cmd/nano-brain/client.go` (`resolveHostPort` already special-cases container env). Reuse the same probe, don't invent a new one.
+- `localhost` default is safer for bare-metal users (the silently-broken case today).
+
+**Alternative considered:** Probe both URLs and use whichever answers. Rejected — adds latency to every CLI invocation, and probes can succeed for the wrong reason (e.g. a different server on `localhost:3100`).
+
+**Alternative considered:** Use `runtime.GOOS == "linux" && hostname == "...docker.internal..."`. Rejected — `/.dockerenv` is the canonical signal and already used elsewhere in the codebase.
+
+### D7 — `nano-brain mcp-url` subcommand prints resolved URL on stdout
+
+**Decision:** New subcommand prints the resolved URL on stdout with no trailing newline beyond `Println`'s default, exit 0. No flags. Designed for skill installers and shell substitution.
+
+**Use case:** `MCP_URL=$(nano-brain mcp-url)` lets a skill-manager postinstall script inject the right URL into a templated `skill.json`.
+
+**Alternative considered:** Add `--mcp-url` to `nano-brain version --which`. Rejected — version is about the binary; URL is about runtime config. Mixing concerns.
+
+### D8 — Phase 3 (`skill.json` templating) chosen: OpenCode `{env:VAR}` substitution
+
+**Decision (resolved by Phase 0 investigation, librarian session `ses_176acfc2dffej4VvNPdnOpj1f0`):** Use OpenCode's native `{env:VAR}` substitution syntax. Change `skill.json:11` from a hardcoded URL to `"url": "{env:NANO_BRAIN_MCP_URL}"`.
+
+**Evidence:**
+
+- OpenCode's `ConfigVariable.substitute` (`packages/opencode/src/config/variable.ts:36`) regex `\{env:([^}]+)\}` substitutes the entire config text **before** schema parsing (`config.ts:420-428`).
+- skill-manager merges `skill.json.mcp` directly into the opencode.json config object (`@nano-step/skill-manager/src/config.ts:43-58`), so MCP fields shipped via skill.json pass through the same substitution as native opencode.json fields.
+- Confirmed working in OpenCode test `packages/opencode/test/config/config.test.ts:1847-1863` (`it("substitutes {env:} tokens in OPENCODE_CONFIG_CONTENT")`).
+- Official docs example: `specs/v2/config.md` shows `"headers": {"Authorization": "Bearer {env:DOCS_TOKEN}"}` in MCP server config.
+
+**Empty-env-var behaviour:** If `NANO_BRAIN_MCP_URL` is unset, `{env:NANO_BRAIN_MCP_URL}` substitutes to `""`. OpenCode then fails at MCP URL validation with a clear error. Acceptable UX — beats silent connection failure to `host.docker.internal` for bare-metal users.
+
+**Alternatives considered and rejected:**
+
+- **3b. Skill-manager postinstall templating** — would have required a custom install-time mustache pass in skill-manager. Rejected — D8 is simpler and supported natively.
+- **3c. Dual skill.json variants** (`skill.json.docker`, `skill.json.bare`) — rejected as worst UX, no longer needed.
+- **3d. Status quo + docs** — rejected; doesn't fix the silent-failure case D8 was created to solve.
+
+**Phase 3 implementation surface (1 line change + docs):**
+- `.opencode/skills/nano-brain/skill.json` line 11: `"url": "{env:NANO_BRAIN_MCP_URL}"`
+- `SKILL.md` (both copies): document the env var with two example values (`http://host.docker.internal:3100/mcp` for container, `http://localhost:3100/mcp` for bare-metal).
+- skill-manager npm publish cycle (user-owned per Q5).
+
+**Cross-dependency on Phase 1:** Phase 1 ships `NANO_BRAIN_MCP_URL` resolution INSIDE the nano-brain CLI/server (env var → `/.dockerenv` → `localhost`). Phase 3 ships the OpenCode-side consumption (skill.json reads the same env var via `{env:...}`). The env var name is the contract between the two phases.
+
+**Risk:** If a future OpenCode release removes `{env:VAR}` substitution, Phase 3 regresses. Mitigation: pin the contract in nano-brain's docs; if OpenCode breaks compat, fall back to alternative 3b.
+
+### D9 — Phase 4 (opt-in postinstall copy): copy, not symlink, never overwrite
+
+**Decision:** When `NANO_BRAIN_AUTO_LINK=1` env OR `~/.nano-brain/auto-link` marker file exists, `npm/postinstall.js` **copies** (not symlinks) the downloaded binary to:
+- Linux: `~/.local/bin/nano-brain`
+- macOS: `~/Library/nano-brain/bin/nano-brain`
+- Windows: skip entirely
+
+Pre-flight: `fs.existsSync(target) || fs.existsSync(target + '.lnk')` → log WARN, skip. Never overwrite.
+
+After successful copy: print PATH guidance ("Add ~/.local/bin to your PATH:..."). Do NOT modify shell rc files.
+
+**Why copy not symlink:**
+- The source binary lives in npm's cache (`node_modules/.bin/...` or version-specific paths). When the user runs `npm update`, the source moves; a symlink would dangle.
+- Copy + later `npm update` produces a stale binary — but `version --which` will catch the skew, and the user can re-run install or manually delete.
+- Symlink races with npm's internal symlinking can be confusing on macOS (System Integrity Protection edge cases).
+
+**Why per-OS path:**
+- `~/.local/bin` is on most Linux distros' default `$PATH` (XDG-compliant). macOS does not include it by default.
+- `~/Library/nano-brain/bin/` follows macOS app conventions; users are used to adding `~/Library/<app>/bin` to PATH manually.
+
+**Why skip Windows:** PATH conventions are radically different (PowerShell profile vs CMD vs winget). Not worth the testing budget for a small user base; documented in postinstall WARN.
+
+**Alternative considered:** Default-on auto-link. Rejected — touching user's PATH-visible directories without consent is hostile; opt-in matches Rust / Bun convention.
+
+### D10 — `@beta` → `@latest` migration is atomic per surface
+
+**Decision:** Each user-facing surface (`README.md`, `client_helpers.go`, `SKILL.md`, tests) flips `@beta` to `@latest` in the same PR / commit. Do not leave mixed-state.
+
+**Why:** Users grep docs for invocation patterns. Inconsistency erodes trust ("which one do I copy?").
+
+**Cost:** Updates expected-string asserts in `cmd/nano-brain/commands_test.go` and any `client_helpers_test.go`. Minor.
+
+## Risks / Trade-offs
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| R1 — Phase 0 investigation finds OpenCode does NOT support `${ENV_VAR}` in `skill.json`. Phase 3 falls back to a more invasive option (3b skill-manager templating or 3c dual variants). | Medium | Adds 1-3 days to Phase 3 | Phase 0 ships first; Phase 3 is gated. No commit is made to a 3a-shaped change until Phase 0 says YES. |
+| R2 — `NANO_BRAIN_MCP_URL` ergonomics: users set it once in `.zshrc`, forget, then wonder why a remote VPS deployment doesn't work. | Low | Medium | `nano-brain mcp-url` prints the resolved URL. `nano-brain doctor --online` logs which source resolved the URL. Document in SKILL.md troubleshooting. |
+| R3 — `/.dockerenv` detection misses some container runtimes (Podman, LXC, GitHub Actions runners). | Medium | Medium | Env var override (`NANO_BRAIN_MCP_URL`) is the escape hatch. Document precedence in SKILL.md. |
+| R4 — Phase 4 postinstall copy fails on macOS Gatekeeper (`xattr -dr com.apple.quarantine`). | Medium | Medium | Pre-flight check for quarantine attribute; if present, log INFO with `xattr` workaround. Document in SKILL.md troubleshooting. Skip Windows entirely. |
+| R5 — Existing user shim at `~/.local/bin/nano-brain` (e.g. a wrapper script) silently overwritten by Phase 4. | Low | High | Phase 4 detects existing file, prints WARN, skips. No overwrite. Test case `TestPostinstall_AutoLink_SkipsExistingTarget`. |
+| R6 — Cross-platform testing burden (Linux glibc/musl, Linux arm64, macOS amd64/arm64, Docker Alpine, behind corp proxy with cert MITM). | High | High | Phase 4 only. Explicit 2-3 day testing budget. Test matrix in tasks.md. Failing platform documented and skipped, not blocked. |
+| R7 — `version --which` reports the wrong source when `npm_execpath` is unset (e.g. user `chmod +x` a downloaded binary and ran it directly). | Low | Low | Treat unset `npm_execpath` AND binary not under `node_modules/` as `dev-build` or `path`. Tests cover each branch. |
+| R8 — `/api/status` `version` field breaks an external monitor that strict-parses the response. | Very Low | Low | Adding a JSON field is non-breaking in 99 % of clients. No known external consumer; only the CLI parses this response. |
+| R9 — User has `NANO_BRAIN_BIN` set to a path that becomes invalid (deleted binary). Loud fail kills their workflow until they unset. | Low | Medium | Error message names the env var and instructs how to unset. Faster recovery than silent fallback. |
+| R10 — `mcp-url` subcommand return shape changes break a future skill-manager postinstall script. | Low | Medium | Spec the contract: stdout-only, no trailing whitespace beyond `Println`'s `\n`, exit 0. Test it. |
+
+**Major trade-off: opt-in vs default for Phase 4 auto-link.**
+- Opt-in (chosen) → users opt into PATH placement; existing `npm install` UX unchanged. Cost: most users never discover the fast path.
+- Default-on (rejected) → discoverable, but installs into user's `~/.local/bin/` without consent. Hostile by current open-source ecosystem norms (rustup, bun, deno all ask first).
+
+**Trade-off accepted by D6: container detection via `/.dockerenv` is not 100 % reliable.**
+- Trade-off: simple stdlib check covers Docker (the dominant case), misses some niches.
+- Mitigation: env var override is the universal escape hatch. Doctor logs which signal resolved the URL.
+
+## Migration Plan
+
+### Sequence
+
+1. **Phase 0** — pure docs + Phase 0 investigation (no code shipped).
+   - Edit `README.md`, `cmd/nano-brain/client_helpers.go`, `SKILL.md` (both copies), tests to replace `@beta` with `@latest`.
+   - Phase 0 investigation: confirm OpenCode env-var substitution in `skill.json` (in-tree investigation note, not shipped code).
+   - Output: 1 PR ("docs: lead with MCP / npm install -g, drop @beta from user surfaces"). No code paths change.
+2. **Phase 1** — CLI additions (additive only).
+   - `nano-brain version --which`, `NANO_BRAIN_BIN`, `nano-brain mcp-url`, `NANO_BRAIN_MCP_URL`, `nano-brain doctor --online`, `binary-exists` check.
+   - `/api/status` gains `version` field.
+   - Output: 1 PR per logical surface (4 PRs total recommended) or 1 monolith PR with clear sections; reviewer's choice.
+3. **Phase 3** — `skill.json` change (gated on Phase 0).
+   - Only after Phase 0 investigation has a definitive YES on env-var templating.
+   - If NO: separate RFC for 3b/3c.
+4. **Phase 4** — opt-in postinstall copy.
+   - `npm/postinstall.js` gains opt-in branch behind `NANO_BRAIN_AUTO_LINK=1` env or `~/.nano-brain/auto-link` marker.
+   - Cross-platform test matrix (see tasks.md).
+
+### Rollback strategy
+
+- Phase 0: `git revert` the docs PR. Zero state change.
+- Phase 1: New flags / subcommands are additive. To roll back, `git revert` the PR; existing CLI surface is untouched. `/api/status` `version` field is harmless if rolled back (clients ignore unknown fields by spec).
+- Phase 3: The skill.json change ships via skill-manager publish cycle. Rollback = publish the previous skill-manager version. The repo-local `.opencode/skills/nano-brain/skill.json` is reverted via `git revert`.
+- Phase 4: `npm/postinstall.js` opt-in. If a platform breaks, change the gate to `NANO_BRAIN_AUTO_LINK=1 && process.platform !== "<broken-platform>"`. Already-copied binaries on user machines stay where they are — they are owned by the user.
+
+### Backward compatibility commitments
+
+- Existing `npx @nano-step/nano-brain ...` invocations continue to work unchanged. The `npm/run.js` wrapper is not modified.
+- Existing `nano-brain doctor` (no flags) continues to behave identically. Online checks only activate with `--online`.
+- Existing `skill.json` URL keeps `host.docker.internal:3100` until Phase 3 ships.
+- `/api/status` response gains one field. No fields are removed or renamed.
+- No new required env vars. All new env vars are optional overrides.
+
+## Open Questions
+
+1. **OQ1 (Phase 0 gate) — RESOLVED** — Does OpenCode expand env vars inside `skill.json`? **YES.** Syntax: `{env:VAR_NAME}` (curly-brace with `env:` prefix, NOT `${VAR}`). Applies to all string fields in the config including MCP server URLs merged from skill.json. Evidence: `sst/opencode/packages/opencode/src/config/variable.ts:36` regex + `config.ts:420-428` substitution before parse + `@nano-step/skill-manager/src/config.ts:43-58` merge behaviour + OpenCode test suite confirming the pattern. Phase 3 unblocked; D8 alternative 3a chosen.
+2. **OQ2** — Should `nano-brain doctor --online` count `pg_status != "healthy"` as FAIL or WARN? Today's `/api/status` returns `pg_status: "unreachable"` only when `pool.Ping()` fails; the server still answers HTTP requests in that state, but no query will succeed. **Tentative answer: FAIL.** Confirm in PR review.
+3. **OQ3** — Phase 4 macOS path: `~/Library/nano-brain/bin/` is unconventional (most CLI tools use `/usr/local/bin` which requires `sudo`). Alternative: `~/.local/bin/` on macOS too (XDG-style, no admin needed, but not in default PATH). **Tentative: keep `~/Library/nano-brain/bin/` per macOS convention.** Decide during Phase 4 cross-platform test.
+4. **OQ4** — Should `version --which` also report the running server's version when reachable? Today the CLI doesn't probe the server unless a subcommand requires it. Adding a probe to `version` adds latency. **Tentative: NO** — keep `version --which` offline. Use `doctor --online` for server-side version.
+5. **OQ5** — `mcp-url` subcommand output format: bare URL vs key=value (`MCP_URL=http://...`)? Bare URL is easier to consume via `MCP_URL=$(nano-brain mcp-url)`. Key=value matches `--export` precedent in `nano-brain workspaces current --export`. **Tentative: bare URL.** Skill installer can wrap as needed.
+6. **OQ6** — Is the existing `/health` endpoint sufficient for the MCP-reachable check in `doctor --online`, or do we need to probe `/mcp` directly? `/health` doesn't tell us the MCP transport is wired; `/mcp` is the actual transport (streamable HTTP, MCP 2025-03-26). **Tentative: probe `/mcp` with a `GET` — it returns a session-initialization response.** Confirm in PR after testing.

--- a/openspec/changes/nano-brain-cli-ux-overhaul/proposal.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+End users of nano-brain experience a degraded UX caused by the default invocation pattern (`npx nano-brain`) and inflexible skill configuration. Each `npx` call carries 600ms–1.5s of cold-start overhead (registry HEAD check + Node.js VM + Go binary init), multiplied by 20–50 invocations per AI agent session — 15–75 seconds of wasted overhead per session. Three different binaries (npm cache, local build, bash shim) can coexist on a single machine with no diagnostic to surface which is running. The shipped skill hardcodes `host.docker.internal:3100` as the MCP URL, which silently fails for bare-metal users. The existing `doctor` command checks installation prerequisites but cannot diagnose runtime health (server reachability, embedding queue backpressure, CLI↔server version skew), and a `postinstall` silent exit-0 means binary download failures are invisible until first use. Documentation pushes the `npx` pattern in every example without surfacing the `npm install -g` fast path.
+
+This overhaul makes the fast invocation path obvious, gives users self-service runtime diagnostics, and makes the skill MCP URL portable across Docker and bare-metal environments — without breaking existing Docker-based deployments.
+
+## What Changes
+
+- **NEW**: Pure-docs Phase 0 — reorder `SKILL.md` to recommend MCP / `npm install -g` over `npx`; audit `@beta` → `@latest` in `client_helpers.go`, README, SKILL.md, tests; document `NANO_BRAIN_SKIP_SHA_VERIFY`, `npm install -g --prefix ~/.local`, macOS Gatekeeper workaround
+- **NEW**: Phase 0 zero-code investigation — does OpenCode support `${ENV_VAR}` substitution in `skill.json`? Outcome gates Phase 3 implementation
+- **NEW**: `nano-brain doctor` gains a "binary exists at expected path" offline check (catches `postinstall.js` silent exit-0 footgun)
+- **NEW**: `nano-brain doctor --online` opt-in flag adding runtime checks: server reachable, embedding queue health (WARN at 80% capacity, FAIL at 95%), CLI↔server version comparison, MCP endpoint reachable
+- **NEW**: `nano-brain version --which` flag printing resolved binary path, version, and invocation source (npm-local / npm-global / dev-build / PATH)
+- **NEW**: `NANO_BRAIN_BIN` env var to override binary resolution (validated: file exists + executable)
+- **NEW**: `NANO_BRAIN_MCP_URL` env var read by nano-brain core; resolution order: env var → `/.dockerenv` exists ? `host.docker.internal:3100` : `localhost:3100`
+- **NEW**: `nano-brain mcp-url` subcommand printing resolved MCP URL (skill installers can call this)
+- **NEW**: Opt-in postinstall binary copy (Phase 4) — when `NANO_BRAIN_AUTO_LINK=1` env or `~/.nano-brain/auto-link` marker is present, `postinstall.js` copies (not symlinks) the downloaded Go binary to `~/.local/bin/nano-brain` (Linux) or `~/Library/nano-brain/bin/nano-brain` (macOS), detects existing files at target and skips with warning, prints PATH guidance, skips on Windows
+- **MODIFIED**: `SKILL.md` shipped via skill-manager — section order, recommended commands, troubleshooting
+- **CHANGED (deferred to Phase 3)**: `skill.json` MCP URL strategy depends on Phase 0 investigation outcome (env var templating, skill-manager postinstall templating, or dual skill.json variants). **Not a default change in Phase 0 — protects existing Docker users.**
+- **OUT OF SCOPE (parallel issue)**: Embedding queue backpressure investigation, multi-workspace queue fairness, Ollama provider tuning
+- **OUT OF SCOPE**: `nano-brain doctor --fix` auto-remediation, `nano-brain setup` rustup-style installer, `curl|sh` install script, per-platform optional npm dependencies, CLI write refusal under backpressure, automatic PATH modification
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-doctor-runtime`: Runtime health diagnostics for nano-brain CLI — adds `--online` mode to existing `doctor` command, new `binary exists` offline check, structured exit codes, JSON output for CI consumption. Covers server reachability, embedding queue depth thresholds (WARN ≥ 80%, FAIL ≥ 95%), CLI↔server version skew detection, MCP endpoint reachability.
+- `cli-binary-resolution`: Deterministic binary path discovery and reporting — `nano-brain version --which` surfaces resolved binary, version, and invocation source; `NANO_BRAIN_BIN` env var allows explicit override with validation; resolution precedence is documented and testable.
+- `cli-mcp-url-resolution`: Environment-aware MCP URL resolution — `NANO_BRAIN_MCP_URL` env var as primary; `/.dockerenv` container detection as fallback; `localhost:3100` as default. New `nano-brain mcp-url` subcommand for skill installers and diagnostic tooling. Pure Go stdlib, no probing.
+- `cli-install-path-optimization`: Opt-in postinstall binary placement — `NANO_BRAIN_AUTO_LINK=1` or `~/.nano-brain/auto-link` marker triggers copy of Go binary to platform-appropriate PATH location. Copy (not symlink) for robustness. Detects existing files, never overwrites. Skips Windows. Prints PATH guidance without auto-modifying shell config.
+- `skill-distribution-docs`: Skill documentation contract — `SKILL.md` shipped via skill-manager npm package must lead with MCP (zero overhead) and `npm install -g` (fast invocation), document `npx` as fallback only. Includes troubleshooting for `NANO_BRAIN_SKIP_SHA_VERIFY`, non-root install via `--prefix ~/.local`, macOS Gatekeeper `xattr` workaround.
+
+### Modified Capabilities
+
+(No existing spec requirements are changing. The existing `cli-reindex`, `cli-code-intelligence`, and `mcp-server` capabilities remain untouched at the spec level; this change is additive.)
+
+## Impact
+
+**Affected code:**
+- `cmd/nano-brain/doctor.go` — extend with `--online` flag and `binary exists` check
+- `internal/health/doctor/doctor.go` — add new check functions (server-running, queue-health, version-skew, mcp-reachable, binary-exists)
+- `cmd/nano-brain/version.go` (or wherever `version` is registered — verify) — add `--which` flag
+- `cmd/nano-brain/main.go` — register new `mcp-url` subcommand
+- `cmd/nano-brain/client_helpers.go` — update `suggestStartCommand()` to drop `@beta`, become invocation-aware
+- `cmd/nano-brain/client_helpers_test.go` (and any `commands_test.go` referencing `@beta`) — update expected strings
+- `internal/server/handlers/` — verify `/api/status` exposes everything needed by `--online` doctor (queue_pending, queue_capacity, version); if missing, add fields
+- `npm/postinstall.js` — add opt-in copy-to-PATH logic (Phase 4 only)
+- `npm/run.js` — no changes; left as-is for `npx` fallback
+- `README.md` — update Quick Start, remove `@beta` references
+- `SKILL.md` (both project-local `.opencode/skills/nano-brain/SKILL.md` and the version shipped via skill-manager npm package) — reorder sections, update commands, add troubleshooting
+
+**Affected APIs:**
+- New HTTP fields possibly added to `/api/status` response if not already present (`version`, `queue_pending`, `queue_capacity`) — additive only, no breaking change
+- New CLI subcommand `mcp-url` and new flag `version --which`, `doctor --online` — additive only
+
+**Affected dependencies:**
+- No new Go dependencies (all logic uses stdlib + existing koanf, zerolog, net/http)
+- No new npm dependencies (postinstall.js stays Node stdlib)
+- Cross-repo coordination: SKILL.md changes ship via skill-manager npm publish cycle (user-owned per Q5 confirmation)
+
+**Affected systems:**
+- Phase 3 skill.json change is deferred and gated on OpenCode templating investigation; no breaking change to existing Docker users
+- Phase 4 binary copy is strictly opt-in; default `npm install` behavior unchanged
+
+**Out-of-scope but tracked separately:**
+- Embedding queue backpressure investigation (parallel GitHub issue, separate workstream)
+- Multi-workspace queue fairness (deferred; tracked as known limitation)
+- Skill-manager publish coordination is user-owned per Q5
+
+**Risks tracked (see design.md for mitigations):**
+- skill-manager postinstall infrastructure unverified → Phase 0 investigation gates Phase 3 scope
+- Cross-platform testing burden (macOS arm64/amd64, Linux glibc/musl, Docker Alpine, behind corp proxy) explicitly budgeted in Phase 4 (2–3 days)
+- Existing user shims at `~/.local/bin/nano-brain` → Phase 4 detects and skips, never overwrites

--- a/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-binary-resolution/spec.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-binary-resolution/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: `nano-brain version --which` SHALL report resolved binary path, version, and invocation source
+
+A new `--which` flag on the existing `version` subcommand SHALL print the absolute path of the running binary, its compile-time version, and the invocation source category (`npm-local`, `npm-global`, `dev-build`, `path`, or `env-override`). Without `--which`, the existing `version` output MUST remain unchanged.
+
+#### Scenario: npx invocation reports `npm-local`
+- **WHEN** the user runs `nano-brain version --which` and the binary's parent directory matches `*/node_modules/.bin/` or `*/node_modules/@nano-step/nano-brain/*` AND `os.Getenv("npm_execpath") != ""`
+- **THEN** stdout contains three lines: `path: <absolute-path>`, `version: <Version>`, `source: npm-local`
+
+#### Scenario: Global npm install reports `npm-global`
+- **WHEN** the user runs `nano-brain version --which` and the binary's parent directory contains the npm global prefix (resolved by `npm root -g` heuristic, or matches `/usr/local/lib/node_modules/`, `~/.npm-global/`, or `~/.local/lib/node_modules/`)
+- **THEN** stdout contains `source: npm-global`
+
+#### Scenario: Source build reports `dev-build`
+- **WHEN** the user runs `nano-brain version --which` and `Version == "dev"` (the default for `go build` without ldflags)
+- **THEN** stdout contains `source: dev-build`
+
+#### Scenario: PATH-resolved binary reports `path`
+- **WHEN** the user runs `nano-brain version --which` and none of the above categories match AND the binary is found via `$PATH`
+- **THEN** stdout contains `source: path`
+
+#### Scenario: `NANO_BRAIN_BIN` override reports `env-override`
+- **WHEN** the user runs `nano-brain version --which` and the binary's absolute path equals the value of `NANO_BRAIN_BIN`
+- **THEN** stdout contains `source: env-override`
+
+#### Scenario: `--which --json` machine-readable output
+- **WHEN** the user runs `nano-brain version --which --json`
+- **THEN** stdout contains a single JSON object `{"path": "...", "version": "...", "source": "..."}` with no surrounding text
+
+### Requirement: `NANO_BRAIN_BIN` env var SHALL override binary resolution with strict validation
+
+When `NANO_BRAIN_BIN` is set to a non-empty value, the nano-brain CLI (in any invocation context that re-execs the binary, including the npm `run.js` shim) SHALL use that path as the binary to execute. The path MUST be validated: file exists AND has at least one executable bit (`mode & 0111 != 0`). On validation failure, the CLI exits non-zero with a clear error message naming the env var. There is no silent fallback.
+
+#### Scenario: Valid override
+- **WHEN** `NANO_BRAIN_BIN=/usr/local/bin/nano-brain-custom` is set AND the file exists AND is executable AND the user runs any `nano-brain ...` command via the npm shim
+- **THEN** the shim execs the path from `NANO_BRAIN_BIN` and the command runs normally
+
+#### Scenario: Override file missing
+- **WHEN** `NANO_BRAIN_BIN=/nonexistent/path` is set AND the user runs `nano-brain version`
+- **THEN** the shim prints `Error: NANO_BRAIN_BIN points to /nonexistent/path which does not exist. Unset the variable or correct the path.` to stderr and exits with code 1
+
+#### Scenario: Override file not executable
+- **WHEN** `NANO_BRAIN_BIN=/tmp/nano-brain-build` is set AND the file exists AND has mode 0644 (no executable bit) AND the user runs `nano-brain version`
+- **THEN** the shim prints `Error: NANO_BRAIN_BIN points to /tmp/nano-brain-build which is not executable. Run: chmod +x /tmp/nano-brain-build` to stderr and exits with code 1
+
+#### Scenario: Override env var unset uses default resolution
+- **WHEN** `NANO_BRAIN_BIN` is not set in the environment
+- **THEN** binary resolution falls back to the default npm-bin path or PATH lookup with no validation override behaviour
+
+#### Scenario: Override is reported by `version --which`
+- **WHEN** `NANO_BRAIN_BIN=/custom/path/nano-brain` is set AND the user runs `nano-brain version --which`
+- **THEN** stdout contains `source: env-override` and `path: /custom/path/nano-brain`

--- a/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-doctor-runtime/spec.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-doctor-runtime/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: `nano-brain doctor` SHALL include an offline "binary exists" check
+
+The existing offline doctor checks SHALL be extended with a check that verifies the resolved nano-brain binary file exists on disk and is executable. This catches the silent-failure footgun where `npm/postinstall.js` exits 0 even when the binary download failed.
+
+#### Scenario: Binary present and executable
+- **WHEN** the user runs `nano-brain doctor` and the resolved binary at the npm-bin install path (or `NANO_BRAIN_BIN` override) is a regular file with at least one executable bit set
+- **THEN** the report includes a row `Binary exists: <path> OK` and the overall exit code is unaffected by this check
+
+#### Scenario: Binary missing
+- **WHEN** the user runs `nano-brain doctor` and the resolved binary path does not exist (`os.Stat` returns `ErrNotExist`)
+- **THEN** the report includes a row `Binary exists: <path> FAIL` with hint `Reinstall: npm install -g @nano-step/nano-brain@latest` and the overall exit code is non-zero
+
+#### Scenario: Binary present but not executable
+- **WHEN** the user runs `nano-brain doctor` and the resolved binary exists but has no executable bit (`mode & 0111 == 0`)
+- **THEN** the report includes a row `Binary exists: <path> FAIL` with hint `chmod +x <path>` and the overall exit code is non-zero
+
+### Requirement: `nano-brain doctor --online` SHALL perform runtime health checks against a running server
+
+A new `--online` flag SHALL add runtime checks beyond the existing offline prerequisite checks. Without the flag, behaviour MUST remain unchanged. With the flag, the doctor SHALL connect to the resolved nano-brain server URL (via `getBaseURL()`) and report on server reachability, embed queue saturation, CLI ↔ server version skew, and MCP endpoint reachability.
+
+#### Scenario: Server reachable, queue nominal, versions match, MCP responding
+- **WHEN** the user runs `nano-brain doctor --online` and the server's `/api/status` returns HTTP 200 with `queue_pending / queue_capacity < 0.80` AND `version` matches the CLI's compile-time `Version` AND `/mcp` returns HTTP 200
+- **THEN** the report includes rows `Server reachable: OK`, `Queue health: OK (N/M)`, `Version skew: OK (vX.Y.Z)`, `MCP endpoint: OK` and overall exit code is 0
+
+#### Scenario: Server unreachable
+- **WHEN** the user runs `nano-brain doctor --online` and the GET to `/api/status` fails with a connection error within 3 seconds
+- **THEN** the report includes `Server reachable: <host:port> FAIL` with hint `Is the server running? Try: nano-brain serve -d` and subsequent online checks are reported as SKIP and the overall exit code is non-zero
+
+#### Scenario: Queue saturation WARN at 80 %
+- **WHEN** the user runs `nano-brain doctor --online` and the server returns `queue_pending = 8000` with `queue_capacity = 10000` (ratio 0.80)
+- **THEN** the report includes `Queue health: 8000/10000 WARN` with hint `Embed queue is saturated; investigate slow embedding provider or backlog` and the overall exit code is non-zero
+
+#### Scenario: Queue saturation FAIL at 95 %
+- **WHEN** the user runs `nano-brain doctor --online` and the server returns `queue_pending = 9500` with `queue_capacity = 10000` (ratio 0.95)
+- **THEN** the report includes `Queue health: 9500/10000 FAIL` with hint `Queue at critical capacity; new chunks are being dropped` and the overall exit code is non-zero
+
+#### Scenario: CLI ↔ server version skew
+- **WHEN** the user runs `nano-brain doctor --online` and the server returns `version = "v2026.6.5.1"` while the CLI's compile-time `Version` is `"v2026.5.1.1"`
+- **THEN** the report includes `Version skew: cli=v2026.5.1.1 server=v2026.6.5.1 WARN` with hint `Reinstall CLI to match server: npm install -g @nano-step/nano-brain@latest` and overall exit code is non-zero
+
+#### Scenario: MCP endpoint unreachable
+- **WHEN** the user runs `nano-brain doctor --online` and the server responds on `/api/status` but the GET to `/mcp` fails with HTTP 404 or connection error
+- **THEN** the report includes `MCP endpoint: <url> FAIL` with hint `MCP transport not wired; check server logs for /mcp route` and overall exit code is non-zero
+
+### Requirement: `nano-brain doctor --online --json` SHALL emit machine-readable output
+
+When both flags are present, the doctor SHALL emit a single JSON document on stdout containing all check results, suitable for CI consumption. The schema MUST be backward-compatible with the existing `nano-brain doctor --json` output (existing fields unchanged, new fields additive).
+
+#### Scenario: JSON shape
+- **WHEN** the user runs `nano-brain doctor --online --json`
+- **THEN** stdout contains a JSON object with key `checks` (array of `{name, status, detail, hint}` objects) and key `all_passed` (boolean), AND online-mode checks appear AFTER offline-mode checks in the array, AND no human-readable headers or footers are emitted
+
+#### Scenario: JSON exit code matches text exit code
+- **WHEN** the user runs `nano-brain doctor --online --json` AND any check fails
+- **THEN** stdout contains `"all_passed": false` AND the process exit code is non-zero

--- a/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-install-path-optimization/spec.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-install-path-optimization/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: `npm/postinstall.js` SHALL support opt-in placement of the binary in a PATH-visible directory
+
+After successfully downloading and verifying the platform binary, `npm/postinstall.js` SHALL check for an opt-in marker (`NANO_BRAIN_AUTO_LINK=1` env var OR `~/.nano-brain/auto-link` marker file). When the marker is present, the postinstall script SHALL copy (NOT symlink) the binary to a platform-specific PATH-visible directory and print guidance. Without the marker, postinstall behaviour is unchanged.
+
+#### Scenario: Opt-in via env var on Linux
+- **WHEN** `NANO_BRAIN_AUTO_LINK=1` is set in the environment AND the user runs `npm install -g @nano-step/nano-brain` on Linux AND `~/.local/bin/` exists or can be created AND `~/.local/bin/nano-brain` does not already exist
+- **THEN** the binary is copied (not symlinked) from the npm install location to `~/.local/bin/nano-brain` with mode 0755 AND postinstall prints `Copied nano-brain to ~/.local/bin/nano-brain. Ensure ~/.local/bin is in your PATH.` AND postinstall exits 0
+
+#### Scenario: Opt-in via marker file on macOS
+- **WHEN** `~/.nano-brain/auto-link` marker file exists (any content) AND the user runs `npm install -g @nano-step/nano-brain` on macOS AND `~/Library/nano-brain/bin/` can be created AND target does not exist
+- **THEN** the binary is copied to `~/Library/nano-brain/bin/nano-brain` with mode 0755 AND postinstall prints PATH guidance referencing `~/Library/nano-brain/bin`
+
+#### Scenario: Existing target file is never overwritten
+- **WHEN** opt-in is enabled (env or marker) AND `~/.local/bin/nano-brain` already exists (regular file, symlink, or anything else)
+- **THEN** postinstall prints `WARN: ~/.local/bin/nano-brain already exists; skipping auto-link to preserve your existing file.` AND does NOT touch the existing file AND postinstall exits 0
+
+#### Scenario: Windows skip
+- **WHEN** the postinstall runs on Windows (`process.platform === "win32"`) regardless of opt-in marker
+- **THEN** postinstall prints `INFO: Auto-link is not supported on Windows; nano-brain binary remains at <npm-install-path>.` AND no copy is attempted
+
+#### Scenario: Opt-out is the default
+- **WHEN** neither `NANO_BRAIN_AUTO_LINK=1` nor `~/.nano-brain/auto-link` is present AND the user runs `npm install -g @nano-step/nano-brain` on any platform
+- **THEN** postinstall does NOT copy the binary anywhere outside the npm install location AND no PATH guidance is printed AND postinstall exits 0
+
+#### Scenario: Target directory created if missing
+- **WHEN** opt-in is enabled AND target parent directory (`~/.local/bin/` on Linux, `~/Library/nano-brain/bin/` on macOS) does not exist
+- **THEN** postinstall creates the directory recursively with mode 0755 before copying
+
+#### Scenario: Copy failure is non-fatal
+- **WHEN** opt-in is enabled AND the copy fails (permission denied, disk full, etc.)
+- **THEN** postinstall prints `WARN: failed to auto-link binary: <error message>. Binary remains at <npm-install-path>.` AND postinstall exits 0 (does not break the npm install)
+
+#### Scenario: PATH guidance is informational only
+- **WHEN** postinstall successfully copies the binary
+- **THEN** the printed PATH guidance is a single human-readable line; the postinstall MUST NOT modify the user's `.bashrc`, `.zshrc`, `.profile`, or any other shell configuration file
+
+### Requirement: Auto-linked binary SHALL be reported by `nano-brain version --which`
+
+When the user runs `nano-brain version --which` against a binary that was auto-linked via this feature, the reported `path` field SHALL be the auto-linked path (e.g. `~/.local/bin/nano-brain`), and `source` SHALL be the appropriate category (`npm-global` if installed into a global npm prefix, else `path`).
+
+#### Scenario: Linked binary reports its actual location
+- **WHEN** opt-in auto-link is enabled AND the user later runs `nano-brain version --which` and the running binary is `~/.local/bin/nano-brain`
+- **THEN** stdout `path:` field is the absolute path `~/.local/bin/nano-brain` (with `~` expanded)

--- a/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-mcp-url-resolution/spec.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/specs/cli-mcp-url-resolution/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: nano-brain SHALL resolve the MCP URL using a fixed precedence
+
+The nano-brain CLI and any shipped tooling that needs to print or use the MCP URL SHALL resolve it using exactly this precedence, evaluated in order, stopping at the first hit:
+
+1. `NANO_BRAIN_MCP_URL` environment variable, after trimming leading/trailing whitespace, if the result is non-empty.
+2. If `/.dockerenv` exists as a file on the filesystem, use `http://host.docker.internal:3100/mcp`.
+3. Default: `http://localhost:3100/mcp`.
+
+No probing, no DNS lookup, no HTTP request happens during resolution. Resolution is pure I/O over env var read + one `os.Stat` call.
+
+#### Scenario: Env var wins over container detection
+- **WHEN** `NANO_BRAIN_MCP_URL=http://my-vps.example.com:3100/mcp` is set AND `/.dockerenv` exists
+- **THEN** resolved URL is `http://my-vps.example.com:3100/mcp`
+
+#### Scenario: Whitespace trimmed from env var
+- **WHEN** `NANO_BRAIN_MCP_URL="   http://localhost:9000/mcp  \n"` is set (literal whitespace and newline)
+- **THEN** resolved URL is `http://localhost:9000/mcp`
+
+#### Scenario: Empty env var falls through to detection
+- **WHEN** `NANO_BRAIN_MCP_URL=""` (set but empty) AND `/.dockerenv` exists
+- **THEN** resolved URL is `http://host.docker.internal:3100/mcp`
+
+#### Scenario: Whitespace-only env var falls through to detection
+- **WHEN** `NANO_BRAIN_MCP_URL="   "` is set AND `/.dockerenv` does NOT exist
+- **THEN** resolved URL is `http://localhost:3100/mcp`
+
+#### Scenario: Container without env var
+- **WHEN** `NANO_BRAIN_MCP_URL` is unset AND `/.dockerenv` exists
+- **THEN** resolved URL is `http://host.docker.internal:3100/mcp`
+
+#### Scenario: Bare-metal default
+- **WHEN** `NANO_BRAIN_MCP_URL` is unset AND `/.dockerenv` does NOT exist
+- **THEN** resolved URL is `http://localhost:3100/mcp`
+
+### Requirement: `nano-brain mcp-url` subcommand SHALL print the resolved URL on stdout
+
+A new top-level subcommand `nano-brain mcp-url` SHALL print the URL resolved by the precedence above. The subcommand MUST take no flags and no positional arguments. It SHALL exit 0 on any successful resolution (which always succeeds, since the default is unconditional). It is designed for skill installers and shell substitution.
+
+#### Scenario: Stdout shape
+- **WHEN** the user runs `nano-brain mcp-url` in any environment
+- **THEN** stdout contains exactly the resolved URL followed by a single newline (`\n`) AND stderr is empty AND exit code is 0
+
+#### Scenario: Shell substitution usage
+- **WHEN** the user runs `MCP_URL=$(nano-brain mcp-url)` in a bash shell
+- **THEN** the shell variable `MCP_URL` contains the resolved URL with no trailing whitespace
+
+#### Scenario: Unknown flag rejected
+- **WHEN** the user runs `nano-brain mcp-url --json` or any other flag
+- **THEN** the CLI prints `Usage: nano-brain mcp-url` to stderr and exits with code 1
+
+#### Scenario: Subcommand registered in usage
+- **WHEN** the user runs `nano-brain help` or `nano-brain` with no arguments after the binary path
+- **THEN** the help output includes a line documenting `mcp-url` as a subcommand

--- a/openspec/changes/nano-brain-cli-ux-overhaul/specs/skill-distribution-docs/spec.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/specs/skill-distribution-docs/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: User-facing docs SHALL lead with the fast invocation path
+
+`README.md` Quick Start, `.opencode/skills/nano-brain/SKILL.md`, and the SKILL.md shipped via `@nano-step/skill-manager` SHALL present invocation options in this order: (1) MCP (zero per-call overhead, default for agents), (2) `npm install -g` + `nano-brain ...` (cold-start ≤ 50 ms), (3) `npx @nano-step/nano-brain ...` (documented as fallback only). The order MUST NOT be reversed; `npx` MUST NOT appear before `npm install -g` in any new or modified Quick Start section.
+
+#### Scenario: README Quick Start ordering
+- **WHEN** a user reads `README.md` Quick Start top-to-bottom
+- **THEN** the first invocation example uses MCP or `npm install -g`, and any `npx` example appears under a section explicitly labeled as fallback / no-Node-install case
+
+#### Scenario: SKILL.md ordering
+- **WHEN** an agent reads `SKILL.md` (either copy) top-to-bottom
+- **THEN** the MCP transport is documented before any CLI invocation, and `npm install -g` is documented before `npx`
+
+### Requirement: All `@beta` references SHALL be replaced with `@latest` in user-facing surfaces
+
+Every user-facing string that names an npm tag for `@nano-step/nano-brain` or `nano-brain` (unscoped alias) SHALL use `@latest`, not `@beta`. Affected surfaces include but are not limited to: `README.md`, `.opencode/skills/nano-brain/SKILL.md`, `cmd/nano-brain/client_helpers.go:suggestStartCommand()`, any string literal in `cmd/nano-brain/*_test.go` that asserts on the suggested start command, and the SKILL.md shipped via skill-manager.
+
+#### Scenario: No `@beta` in README
+- **WHEN** a user runs `grep -n '@beta' README.md`
+- **THEN** the command returns no matches
+
+#### Scenario: No `@beta` in SKILL.md (either copy)
+- **WHEN** a maintainer runs `grep -n '@beta' .opencode/skills/nano-brain/SKILL.md` and the same grep against the skill-manager-shipped SKILL.md
+- **THEN** both commands return no matches
+
+#### Scenario: `suggestStartCommand` returns `@latest`
+- **WHEN** the test `TestSuggestStartCommand_NpxLaunch` (or equivalent) calls `suggestStartCommand()` with `npm_execpath` set
+- **THEN** the returned string contains `@latest` and does not contain `@beta`
+
+### Requirement: SKILL.md SHALL document the documented escape hatches and platform workarounds
+
+The shipped `SKILL.md` (both the project-local copy at `.opencode/skills/nano-brain/SKILL.md` and the skill-manager-shipped copy) SHALL include a Troubleshooting section with at minimum the following entries:
+
+- `NANO_BRAIN_SKIP_SHA_VERIFY=1` — when and why to use it (corp proxy, air-gapped installs).
+- `npm install -g --prefix ~/.local` — how to install globally without sudo.
+- macOS Gatekeeper quarantine workaround — `xattr -dr com.apple.quarantine <path>` and when to apply it.
+- `NANO_BRAIN_MCP_URL` env var — how to override the MCP URL (with one container-mode example and one bare-metal example).
+- `NANO_BRAIN_BIN` env var — how to point at a custom binary; failure modes documented.
+
+#### Scenario: SHA-verify skip documented
+- **WHEN** a user searches SKILL.md for `NANO_BRAIN_SKIP_SHA_VERIFY`
+- **THEN** the surrounding text explains both when to use it (corp proxy modifying download stream) and the security trade-off (skips integrity check)
+
+#### Scenario: Non-root install documented
+- **WHEN** a user searches SKILL.md for `--prefix`
+- **THEN** the surrounding text shows the exact command `npm install -g --prefix ~/.local @nano-step/nano-brain@latest` and notes the resulting binary path
+
+#### Scenario: macOS Gatekeeper documented
+- **WHEN** a user searches SKILL.md for `xattr` or `Gatekeeper` or `quarantine`
+- **THEN** the surrounding text shows the exact remediation command and notes when it applies (downloaded binaries on macOS)
+
+#### Scenario: `NANO_BRAIN_MCP_URL` documented with both modes
+- **WHEN** a user searches SKILL.md for `NANO_BRAIN_MCP_URL`
+- **THEN** the surrounding text shows at minimum one container example (`http://host.docker.internal:3100/mcp`) and one bare-metal example (`http://localhost:3100/mcp`) and notes the OpenCode `{env:NANO_BRAIN_MCP_URL}` syntax used in skill.json
+
+### Requirement: skill.json MCP URL SHALL use OpenCode env-var substitution
+
+`.opencode/skills/nano-brain/skill.json` (and the skill-manager-shipped copy) SHALL use `{env:NANO_BRAIN_MCP_URL}` for the MCP server URL field, not a hardcoded host. This delivers Phase 3 of the proposal — Phase 0 investigation confirmed OpenCode supports this syntax via `ConfigVariable.substitute`.
+
+#### Scenario: skill.json MCP URL uses env-var syntax
+- **WHEN** a maintainer reads `.opencode/skills/nano-brain/skill.json`
+- **THEN** the `mcp.nano-brain.url` field value is exactly `{env:NANO_BRAIN_MCP_URL}` and not a hardcoded URL
+
+#### Scenario: skill-manager-shipped skill.json matches
+- **WHEN** a user installs the skill via `@nano-step/skill-manager` and inspects the installed skill.json
+- **THEN** the `mcp.nano-brain.url` field value matches the project-local copy (uses `{env:NANO_BRAIN_MCP_URL}`)

--- a/openspec/changes/nano-brain-cli-ux-overhaul/tasks.md
+++ b/openspec/changes/nano-brain-cli-ux-overhaul/tasks.md
@@ -1,0 +1,118 @@
+# Tasks — nano-brain CLI UX Overhaul
+
+Phased rollout per `design.md` D1. Each phase is independently shippable.
+
+## 0. Pre-implementation
+
+- [ ] 0.1 Run `deep-design` review of `proposal.md` + `design.md` + all five specs. Address findings before any Phase 1 code.
+- [ ] 0.2 Verify Phase 0 librarian investigation finding (OpenCode `{env:VAR}` substitution) by reading `sst/opencode/packages/opencode/src/config/variable.ts:36` and `config.ts:420-428` directly. Paste the actual regex + substitution call in design.md if any drift is found.
+- [ ] 0.3 Confirm with the user (or skill-manager publish workflow owner per Q5) the cadence for the skill-manager publish that will ship the updated SKILL.md + skill.json in Phase 3.
+
+## 1. Phase 0 — Pure docs (zero code)
+
+- [ ] 1.1 Replace `@beta` with `@latest` in `cmd/nano-brain/client_helpers.go:69` (`suggestStartCommand`).
+- [ ] 1.2 Replace all `@beta` occurrences in `README.md` (3 hits at lines 47, 50, 53 per current grep).
+- [ ] 1.3 Verify `.opencode/skills/nano-brain/SKILL.md` already uses `@latest` (line 204) — no change expected; document in PR description if a stray `@beta` is found.
+- [ ] 1.4 Update any test that asserts on the suggested start command (`cmd/nano-brain/client_helpers_test.go`, `cmd/nano-brain/commands_test.go`) to expect `@latest`.
+- [ ] 1.5 Reorder `README.md` Quick Start so MCP / `npm install -g` is the first/recommended example and `npx` is documented as fallback.
+- [ ] 1.6 Reorder `.opencode/skills/nano-brain/SKILL.md` so MCP transport is documented first, then `npm install -g`, then `npx`.
+- [ ] 1.7 Add the Troubleshooting section entries to `.opencode/skills/nano-brain/SKILL.md`: `NANO_BRAIN_SKIP_SHA_VERIFY`, `npm install -g --prefix ~/.local`, macOS Gatekeeper `xattr -dr com.apple.quarantine`, `NANO_BRAIN_MCP_URL` (with both example values), `NANO_BRAIN_BIN`.
+- [ ] 1.8 Run `validate:quick` (`go build ./... && go test -race -short ./...`).
+- [ ] 1.9 Grep verify: `grep -rn '@beta' README.md cmd/nano-brain/ .opencode/skills/nano-brain/` returns no matches.
+- [ ] 1.10 Open PR labeled `docs`, `lane:tiny` (or `lane:normal` if change-type policy demands — verify against `docs/FEATURE_INTAKE.md`). No code paths changed.
+
+## 2. Phase 1 — CLI additions
+
+### 2.1 `/api/status` exposes `version` field
+
+- [ ] 2.1.1 Add `Version string \`json:"version,omitempty"\`` field to `statusResponse` struct in `internal/server/handlers/health.go`.
+- [ ] 2.1.2 Populate `resp.Version = h.version` in the `Status(c echo.Context)` handler (the same `version` already stored in `Health` struct at construction).
+- [ ] 2.1.3 Update `internal/server/handlers/health_test.go` — add `TestStatusReturnsVersion` asserting the `version` field appears with the constructor's version string.
+- [ ] 2.1.4 No client breakage check needed: only the CLI consumes `/api/status` (verified via grep).
+
+### 2.2 `nano-brain version --which`
+
+- [ ] 2.2.1 In `cmd/nano-brain/ops.go:runVersionCmd`, parse `--which` flag.
+- [ ] 2.2.2 Implement `resolveBinarySource()` helper returning `(path string, source string, err error)` with branch logic per spec scenarios: `env-override`, `npm-local`, `npm-global`, `dev-build`, `path`.
+- [ ] 2.2.3 Print three lines on `--which`: `path: <abs>`, `version: <Version>`, `source: <source>`.
+- [ ] 2.2.4 `--which --json` emits `{"path":"...","version":"...","source":"..."}` on stdout.
+- [ ] 2.2.5 Tests in `cmd/nano-brain/ops_test.go`: `TestVersionWhich_NpmLocal`, `TestVersionWhich_DevBuild`, `TestVersionWhich_EnvOverride`, `TestVersionWhich_Json`. Use `t.Setenv` for env-var-controlled branches.
+
+### 2.3 `NANO_BRAIN_BIN` env override
+
+- [ ] 2.3.1 In `npm/run.js`, after computing the default binary path, check `process.env.NANO_BRAIN_BIN`. If set and non-empty, validate (file exists, mode has executable bit). On validation failure: print error to stderr naming the env var, exit 1.
+- [ ] 2.3.2 If validation passes, use the override path as the exec target.
+- [ ] 2.3.3 Tests in `npm/postinstall.test.js` (or a new `npm/run.test.js`): `TestRun_NanoBrainBin_ValidPath`, `TestRun_NanoBrainBin_MissingFile`, `TestRun_NanoBrainBin_NotExecutable`, `TestRun_NanoBrainBin_Empty_FallsThrough`.
+
+### 2.4 `nano-brain mcp-url` subcommand
+
+- [ ] 2.4.1 Add `case "mcp-url": runMCPURLCmd(args[1:]); return` in `cmd/nano-brain/main.go` switch.
+- [ ] 2.4.2 Implement `runMCPURLCmd` in a new file `cmd/nano-brain/cmd_mcp_url.go`. Reject any flag/positional argument with a `Usage:` line and exit 1. On success, print resolved URL + `\n` and exit 0.
+- [ ] 2.4.3 Extract MCP URL resolution into a pure function `resolveMCPURL() string` (likely in a new file `cmd/nano-brain/mcp_url.go` or in `internal/config/`) with precedence: env var (trimmed) → `/.dockerenv` → `localhost`.
+- [ ] 2.4.4 Tests: `TestResolveMCPURL_EnvVarWins`, `TestResolveMCPURL_EnvVarWhitespaceTrimmed`, `TestResolveMCPURL_EnvVarEmptyFallsThrough`, `TestResolveMCPURL_DockerEnvDetected`, `TestResolveMCPURL_Default`. Use `t.Setenv` and write a temp `/.dockerenv`-style path injection.
+- [ ] 2.4.5 Update `printUsage()` in `cmd/nano-brain/ops.go` to include `mcp-url` in the subcommand list.
+
+### 2.5 `nano-brain doctor --online` + binary-exists offline check
+
+- [ ] 2.5.1 In `internal/health/doctor/doctor.go`, add `CheckBinaryExists(path string) Check` — uses `os.Stat`, checks executable bit. Hooked into `RunAll` as an additional offline check.
+- [ ] 2.5.2 Add `CheckServerRunning(baseURL string) Check` — GET `/api/status` with 3 s timeout. Returns the parsed status response on success for downstream checks.
+- [ ] 2.5.3 Add `CheckQueueHealth(status statusResponse) Check` — WARN at `queue_pending / queue_capacity >= 0.80`, FAIL at `>= 0.95`. Detail format: `N/M`.
+- [ ] 2.5.4 Add `CheckVersionSkew(cliVersion, serverVersion string) Check` — WARN on mismatch with both versions in detail.
+- [ ] 2.5.5 Add `CheckMCPReachable(baseURL string) Check` — GET `/mcp` with 3 s timeout, expect HTTP 200.
+- [ ] 2.5.6 In `cmd/nano-brain/doctor.go:runDoctorCmd`, parse `--online` flag. When set, call the four runtime checks after the existing offline `RunAll`.
+- [ ] 2.5.7 JSON output mode: ensure online checks append to the `checks` array; `all_passed` accounts for all checks.
+- [ ] 2.5.8 Tests in `internal/health/doctor/doctor_test.go`: one test per scenario in `specs/cli-doctor-runtime/spec.md` — `TestCheckBinaryExists_Present`, `TestCheckBinaryExists_Missing`, `TestCheckBinaryExists_NotExecutable`, `TestCheckQueueHealth_Nominal`, `TestCheckQueueHealth_Warn80`, `TestCheckQueueHealth_Fail95`, `TestCheckVersionSkew_Match`, `TestCheckVersionSkew_Mismatch`, `TestCheckServerRunning_Unreachable`, `TestCheckMCPReachable_404`. Use `httptest.NewServer` for HTTP mocks.
+- [ ] 2.5.9 Integration test in `cmd/nano-brain/doctor_test.go` exercising `runDoctorCmd` with `--online` end-to-end against a `httptest.NewServer`.
+
+### 2.6 Phase 1 validation ladder
+
+- [ ] 2.6.1 `validate:quick` passes: `go build ./... && go test -race -short ./...`.
+- [ ] 2.6.2 `self-review:response-shape` — read `statusResponse` struct + `Status(c)` mapping; verify `Version` field is populated.
+- [ ] 2.6.3 `self-review:staged-files` — `git status` shows only intended files.
+- [ ] 2.6.4 `test:integration` — `go test -race -tags=integration ./...`.
+- [ ] 2.6.5 Smoke test: build binary; start server; run each new command (`version --which`, `mcp-url`, `doctor --online`); paste outputs into `docs/evidence/cli-ux-overhaul-phase1.md`.
+- [ ] 2.6.6 Open PR labeled `lane:normal`, `component:cli`. Include the evidence file in the PR description.
+
+## 3. Phase 3 — skill.json env-var substitution
+
+(Depends on Phase 1 having shipped `NANO_BRAIN_MCP_URL` handling — the env var contract.)
+
+- [ ] 3.1 Update `.opencode/skills/nano-brain/skill.json` line 11: `"url": "{env:NANO_BRAIN_MCP_URL}"`.
+- [ ] 3.2 Coordinate with skill-manager publish owner (per task 0.3): update the SKILL.md and skill.json shipped via `@nano-step/skill-manager` to match.
+- [ ] 3.3 Manual verification: install the updated skill in OpenCode running in a container; export `NANO_BRAIN_MCP_URL=http://host.docker.internal:3100/mcp`; confirm MCP tool calls succeed. Then unset the env var; confirm OpenCode reports a clear error (not a silent failure).
+- [ ] 3.4 Manual verification on bare-metal: install skill, `export NANO_BRAIN_MCP_URL=http://localhost:3100/mcp`, confirm MCP tool calls succeed.
+- [ ] 3.5 Add a regression test in `.opencode/skills/nano-brain/` (or wherever skill tests live) asserting `skill.json` does not contain a hardcoded MCP host.
+- [ ] 3.6 Open PR labeled `lane:normal`, `component:skill`. Reference Phase 0 librarian investigation evidence in the PR body.
+
+## 4. Phase 4 — Opt-in postinstall copy
+
+- [ ] 4.1 Update `npm/postinstall.js`: after the existing successful-install path, check opt-in (`process.env.NANO_BRAIN_AUTO_LINK === '1'` OR `fs.existsSync(path.join(os.homedir(), '.nano-brain', 'auto-link'))`).
+- [ ] 4.2 Branch on `process.platform`: `linux` → target `~/.local/bin/nano-brain`; `darwin` → target `~/Library/nano-brain/bin/nano-brain`; `win32` → print INFO skip line, return.
+- [ ] 4.3 Pre-flight: if target exists, WARN + skip. Never overwrite.
+- [ ] 4.4 Create target parent dir with `fs.mkdirSync(..., {recursive: true, mode: 0o755})`.
+- [ ] 4.5 Copy source binary to target with `fs.copyFileSync` then `fs.chmodSync(target, 0o755)`.
+- [ ] 4.6 Print PATH guidance. Do NOT modify any shell rc file.
+- [ ] 4.7 Wrap the copy block in try/catch; on failure print WARN with error message + exit 0 (do not break npm install).
+- [ ] 4.8 Tests in `npm/postinstall.test.js`:
+  - [ ] `TestAutoLink_OptIn_Linux_HappyPath` — env var set, target absent → file copied with mode 0755.
+  - [ ] `TestAutoLink_OptIn_MarkerFile_Linux` — marker present, env unset → file copied.
+  - [ ] `TestAutoLink_ExistingTarget_Skipped` — env set, target exists → WARN line printed, target file unchanged (compare bytes).
+  - [ ] `TestAutoLink_Windows_Skipped` — env set, `process.platform === "win32"` mocked → INFO line, no copy attempted.
+  - [ ] `TestAutoLink_OptOut_Default` — env unset, marker absent → no PATH guidance, no copy.
+  - [ ] `TestAutoLink_CopyFailure_NonFatal` — mock `fs.copyFileSync` to throw → WARN line, postinstall exits 0.
+  - [ ] `TestAutoLink_MacOS_TargetPath` — env set, `process.platform === "darwin"` → target is `~/Library/nano-brain/bin/nano-brain`.
+- [ ] 4.9 Cross-platform manual test matrix (budget: 2-3 days per design.md R6):
+  - [ ] macOS arm64 (M-series)
+  - [ ] macOS amd64 (Intel)
+  - [ ] Linux amd64 (Ubuntu glibc)
+  - [ ] Linux arm64 (Ubuntu glibc)
+  - [ ] Docker Alpine (musl) — verify Linux branch runs; verify behaviour
+  - [ ] Behind corp proxy with cert MITM — verify no extra failures introduced
+  - [ ] Document any platform that fails in `docs/evidence/cli-ux-overhaul-phase4-platform-matrix.md` and mark as known-not-supported (do not block on it)
+- [ ] 4.10 Open PR labeled `lane:high-risk`, `component:npm-postinstall`. Include the platform matrix evidence.
+
+## 5. Post-merge
+
+- [ ] 5.1 Update CHANGELOG.md with Phase-by-Phase entries under `[Unreleased]`.
+- [ ] 5.2 After each PR merge, archive the relevant slice of this change via `openspec archive nano-brain-cli-ux-overhaul` — OR keep the change open across phases and archive at end (decide with reviewer; archive once is simpler).
+- [ ] 5.3 Write a `nano-brain write --tags=summary,decision` memory record summarising: phases shipped, Phase 0 investigation outcome, env var contract for skill.json.


### PR DESCRIPTION
## Summary

Ships the OpenSpec proposal `nano-brain-cli-ux-overhaul` (spec-only, no code).

Adds:
- `proposal.md` — phased rollout (Phase 0 docs → Phase 1 CLI → Phase 3 skill.json → Phase 4 postinstall)
- `design.md` — 10 architectural decisions with alternatives, 10 risks with mitigations, Phase 0 OpenCode `{env:VAR}` substitution investigation resolved YES
- `tasks.md` — 64 verifiable tasks broken into Phase 0–4
- 5 spec deltas (cli-doctor-runtime, cli-binary-resolution, cli-mcp-url-resolution, cli-install-path-optimization, skill-distribution-docs)

`openspec validate nano-brain-cli-ux-overhaul --strict --no-interactive` → PASS.

## Why this is its own PR

Per harness 1-PR-1-concern: the proposal is the spec-driven prerequisite that downstream implementation PRs reference. Merging it independently:
- gives reviewers a clean diff (729 lines of spec content, no code mixed in)
- unblocks parallel implementation PRs for each phase
- matches the precedent set by `embed-status-index-and-inflight-dedup`

## Phase 0 implementation

Tracked separately at #342. Will reference this merged proposal.

## Validation

- `openspec validate --strict --no-interactive` → PASS
- `go build ./... && go test -race -short ./...` → PASS (no code changed)
- Pre-work gate `harness-check.sh pre-work --issue 343` → 6/6 PASS

Closes #343
