### PR TITLE
feat: Phase 3 — skill.json MCP URL env-var substitution

### DIFF
--- a/.opencode/skills/nano-brain/skill.json
+++ b/.opencode/skills/nano-brain/skill.json
@@ -1,0 +1,28 @@
+{
+    "name": "nano-brain",
+    "version": "3.1.0",
+    "description": "Persistent memory + code intelligence for AI coding agents. Hybrid search (BM25 + vector + LLM rerank), cross-session recall, symbol analysis, impact checks, OpenCode/Claude Code session harvesting. Use this skill when you need to recall prior decisions, search across sessions/codebase, trace symbol callers/callees, or persist long-term context.",
+    "compatibility": "OpenCode, Claude Code, any MCP-aware agent",
+    "agent": null,
+    "commands": [],
+    "mcp": {
+        "nano-brain": {
+            "type": "remote",
+            "url": "{env:NANO_BRAIN_MCP_URL}",
+            "enabled": true
+        }
+    },
+    "tags": [
+        "memory",
+        "persistence",
+        "search",
+        "context",
+        "sessions",
+        "code-intelligence",
+        "symbol-analysis",
+        "impact-analysis",
+        "mcp",
+        "http-api",
+        "harvest"
+    ]
+}


### PR DESCRIPTION
Closes #352.

Updates `.opencode/skills/nano-brain/skill.json` to use `{env:NANO_BRAIN_MCP_URL}` instead of hardcoded `host.docker.internal:3100/mcp` URL.

## Environment Variable Setup

Users must set `NANO_BRAIN_MCP_URL` in their OpenCode config:

- **Container (Docker):** `http://host.docker.internal:3100/mcp`
- **Bare metal (local):** `http://localhost:3100/mcp`

This allows the skill to work across different deployment environments without code changes.