### PR TITLE
feat(mcp): snippet-only search responses + cursor pagination (#358)

### DIFF
--- a/.opencode/skills/nano-brain/SKILL.md
+++ b/.opencode/skills/nano-brain/SKILL.md
@@ -48,25 +48,42 @@ Every tool takes a `workspace` string (the SHA-256 hash returned by `POST /api/v
 ```
 required: workspace, query
 optional: max_results (int, default 10, capped at 100)
-returns:  {results: [{id, title, snippet, score, tags, collection, source_path, workspace_hash, document_id, created_at, updated_at}], total, query_ms}
+          include_content (bool, default false) — opt-in full chunk text
+          cursor (string) — pagination token from previous response.next_cursor
+returns:  {results: [{id, title, snippet, score, tags, collection, source_path, workspace_hash, document_id, created_at, updated_at}], total, query_ms, next_cursor?}
 ```
-Source: `internal/mcp/tools.go:161-195`, `internal/search/search.go:35-67`.
+Each result includes a `snippet` (≤500 chars, UTF-8 safe). The full `content` field is OMITTED by default — pass `include_content: true` to include it, or call `memory_get` for one full document. `next_cursor` is present only when more results exist beyond the current page.
 
 ### memory_search — BM25 keyword
 ```
 required: workspace, query
 optional: max_results (capped 100), tags (array of strings — AND filter)
-returns:  same shape as memory_query
+          include_content (bool, default false), cursor (string)
+returns:  same shape as memory_query (snippet-only by default)
 ```
-Source: `internal/mcp/tools.go:198-321`. Note: tags filter is conjunctive (chunk must have ALL listed tags).
+Note: tags filter is conjunctive (chunk must have ALL listed tags).
 
 ### memory_vsearch — vector semantic
 ```
 required: workspace, query
-optional: max_results (capped 100)
-returns:  same shape as memory_query
+optional: max_results (capped 100), include_content (bool), cursor (string)
+returns:  same shape as memory_query (snippet-only by default)
 ```
-Source: `internal/mcp/tools.go:323-415`. Slower than BM25 (embedding round-trip); best for "concept similar to…" queries where exact words don't match.
+Slower than BM25 (embedding round-trip); best for "concept similar to…" queries where exact words don't match.
+
+### Pagination & include_content (since #358 / v2026.6.x)
+
+All three search tools share one response envelope. Paginate with the opaque `cursor` returned in `next_cursor` — pass the SAME `query` text on every page (server validates a hash to prevent cross-query cursor reuse → error `"cursor query mismatch"`).
+
+```
+# Browse 30 days of bug fixes incrementally — no payload bombs
+memory_search(workspace=ws, query="fix bug", max_results=5)
+  → {results: [...5...], total: 47, query_ms: 12, next_cursor: "eyJv..."}
+memory_search(workspace=ws, query="fix bug", max_results=5, cursor="eyJv...")
+  → next 5 results...
+```
+
+Need the FULL text of one specific hit? Call `memory_get(workspace, path="#<id-from-result>")` — that tool is the canonical full-content fetch and supports `start_line`/`end_line` slicing. Pass `include_content: true` to a search tool only when you genuinely need full text for ALL results in one shot (rare; inflates response 5–50×).
 
 ### memory_get — fetch one doc
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to nano-brain are documented here.
 
 
+## [Unreleased]
+
+### Changed (MCP only — breaking for agents parsing `content` from search results)
+
+- **`memory_query` / `memory_search` / `memory_vsearch`** now return a 500-char `snippet` by default and OMIT the full `content` field. Agents needing full text must either pass `include_content: true` or call `memory_get` for one full document. HTTP API (`/api/v1/search`, `/api/v1/query`, `/api/v1/vsearch`) is unchanged. (#358)
+
+### Added
+
+- Stateless cursor-based pagination for all three MCP search tools. Each response includes a `next_cursor` field when more results exist; pass it back in the next call's `cursor` parameter. Cursors are opaque base64url(JSON) and bound to the query text (server returns `"cursor query mismatch"` if the query changes mid-pagination). (#358)
+- New `include_content` boolean parameter on all three search tools (default `false`). Set to `true` to include full chunk content alongside the snippet. (#358)
+- New top-level response fields `total` (count of fused results) and `query_ms` (server-measured latency) on all three search tools. (#358)
+- Stable result-ordering tiebreaker (`id ASC`) in RRF fusion and recency boost. Equal-score results now have deterministic order across paginated calls. (#358)
+
+### Internal
+
+- Extracted `TruncateSnippet` helper from `internal/server/handlers/search.go` to `internal/search/snippet.go` so HTTP and MCP layers share the same rune-aware truncation.
+
 ## [2026.6.0] — 2026-05-30
 
 ### Added

--- a/docs/evidence/mcp-search-snippet-pagination/smoke.md
+++ b/docs/evidence/mcp-search-snippet-pagination/smoke.md
@@ -1,0 +1,98 @@
+# Smoke Test Evidence — #358 MCP search snippet+pagination
+
+Date: 2026-06-03
+Branch: `feat/358-mcp-search-response-pagination`
+Server: `nano-brain serve` binary built from this branch, port 4199, `nanobrain_test` DB
+
+## Setup
+
+1. Built binary: `CGO_ENABLED=0 go build -o /tmp/nano-brain-smoke-bin ./cmd/nano-brain`
+2. Started with config `/tmp/smoke-config.yml` (port 4199, host PG via `host.docker.internal:5432/nanobrain_test`)
+3. Registered workspace `c0b88b17f6eee2272b6e015c9150c7c322aee393cd8809c32fcd34d3f581e210`
+4. Wrote 8 documents containing "alpha" keyword via `POST /api/v1/write`
+5. Verified ingest: `doc_count: 8, chunk_count: 29` via `GET /api/v1/workspaces`
+6. Opened MCP streamable session via `POST /mcp` + `notifications/initialized`
+
+## Scenario 1 — Default response (snippet-only)
+
+Call:
+```json
+{"name":"memory_search","arguments":{"workspace":"<hash>","query":"alpha","max_results":3}}
+```
+
+Result (parsed from MCP envelope inner JSON):
+```
+total = 4
+count = 3
+has next_cursor = True
+result[0].snippet length = 500 chars
+result[0] has 'content' key = False  ← spec scenario "Default response excludes content" PASS
+```
+
+## Scenario 3 — Pagination with valid cursor
+
+Call (with `cursor` from S1):
+```json
+{"name":"memory_search","arguments":{"workspace":"<hash>","query":"alpha","max_results":3,"cursor":"eyJvIjozLCJxIjoiOGVkM2Y2YWQ2ODViOTU5ZSJ9"}}
+```
+
+Result:
+```
+count = 3
+snippet_len = 500
+has_content = False
+has next_cursor = True (more pages exist)
+```
+Different result set than S1 → pagination working.
+
+## Scenario 4 — Cursor query mismatch
+
+Call (valid cursor for query "alpha", but new query "BRAVO"):
+```json
+{"name":"memory_search","arguments":{"workspace":"<hash>","query":"BRAVO","max_results":3,"cursor":"eyJvIjozLCJxIjoiOGVkM2Y2YWQ2ODViOTU5ZSJ9"}}
+```
+
+Result:
+```
+isError = true
+text = "cursor query mismatch: pass the same query when paginating"
+```
+Matches spec scenario "Cursor from different query is rejected" PASS.
+
+## Scenario 5 — include_content=true
+
+Call:
+```json
+{"name":"memory_search","arguments":{"workspace":"<hash>","query":"alpha","max_results":1,"include_content":true}}
+```
+
+Result:
+```
+count = 1
+snippet_len = 500 chars
+result[0] has 'content' key = True  ← spec scenario "include_content=true preserves full chunk content" PASS
+```
+
+## Spec scenarios satisfied by smoke
+
+| Spec scenario | Smoke evidence |
+|---|---|
+| Default response excludes `content` | S1 — `has 'content' key = False` |
+| Snippet ≤ 500 chars | S1 — `snippet length = 500 chars` |
+| `include_content=true` includes full content | S5 — `has 'content' key = True` |
+| Pagination round-trip | S3 — different result set, `next_cursor` present |
+| Cursor query mismatch error | S4 — `"cursor query mismatch"` returned |
+| `total` and `query_ms` metadata | S1 — `total=4, query_ms=32` |
+| `next_cursor` only when more results | S1, S3 — present when more pages exist |
+
+All 11 spec scenarios are covered by integration tests in `internal/mcp/tools_pagination_integration_test.go` (build tag `integration`). Smoke test confirms the same behavior end-to-end against a running server binary.
+
+## Performance
+
+| Scenario | Response size | Approx vs pre-fix (full content) |
+|---|---|---|
+| S1 default (3 results) | 3,023 bytes | ~85% smaller than pre-fix (~20 KB with full content per chunk) |
+| S5 with `include_content` (1 result) | 3,781 bytes | Roughly matches pre-fix per-result size (intentional opt-in) |
+| S4 error | 202 bytes | error responses are tiny |
+
+Default-case payload now fits comfortably under OpenCode's 50 KB tool-output threshold — no truncation, no extra subagent spawn needed.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1004,7 +1004,7 @@ func registerMemoryWakeUp(server *mcpsdk.Server, a *Adapter) {
 			// Required since #338/PR #340 — nil makes ANY('{}'::text[]) always false. See #356.
 			docs, err := a.queries.RecentDocuments(ctx, sqlc.RecentDocumentsParams{
 				WorkspaceHash: ws,
-				Limit:         int32(limit),
+				MaxResults:    int32(limit),
 				Collections:   []string{"memory", "session-summary"},
 			})
 			if err != nil {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -557,6 +558,16 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 					})
 				}
 			}
+
+			// Stable secondary sort by id ASC on tied scores. Keeps cursor
+			// pagination deterministic without forcing PostgreSQL to satisfy
+			// a multi-column ORDER BY through the HNSW index (#358).
+			sort.SliceStable(allRows, func(i, j int) bool {
+				if allRows[i].Score != allRows[j].Score {
+					return allRows[i].Score > allRows[j].Score
+				}
+				return allRows[i].ID < allRows[j].ID
+			})
 
 			total := len(allRows)
 			hasMore := total > offset+maxResults

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/nano-brain/nano-brain/internal/chunk"
+	"github.com/nano-brain/nano-brain/internal/search"
 	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	pgvector_go "github.com/pgvector/pgvector-go"
@@ -120,6 +121,13 @@ func argStringSlice(args map[string]any, key string) []string {
 	return out
 }
 
+func argBool(args map[string]any, key string) bool {
+	if v, ok := args[key].(bool); ok {
+		return v
+	}
+	return false
+}
+
 func parseArgs(raw json.RawMessage) (map[string]any, error) {
 	var args map[string]any
 	if len(raw) == 0 {
@@ -161,18 +169,49 @@ func requireRegisteredWorkspace(ctx context.Context, a *Adapter, args map[string
 	return ws, nil
 }
 
+const mcpSnippetLen = 500
+
+// mcpSearchResultItem is the per-result payload returned by memory_query,
+// memory_search, and memory_vsearch over MCP. By default content is omitted;
+// agents set include_content=true (or call memory_get) to obtain full text.
+type mcpSearchResultItem struct {
+	ID            string    `json:"id"`
+	DocumentID    string    `json:"document_id"`
+	WorkspaceHash string    `json:"workspace_hash"`
+	Title         string    `json:"title"`
+	Snippet       string    `json:"snippet"`
+	Content       string    `json:"content,omitempty"`
+	Score         float64   `json:"score"`
+	Tags          []string  `json:"tags"`
+	Collection    string    `json:"collection"`
+	SourcePath    string    `json:"source_path"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// mcpSearchResponse is the response envelope for all three search tools.
+type mcpSearchResponse struct {
+	Results    []mcpSearchResultItem `json:"results"`
+	Total      int                   `json:"total"`
+	QueryMs    int64                 `json:"query_ms"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
 func registerMemoryQuery(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_query",
-			Description: "Hybrid search combining BM25 text and vector similarity",
+			Description: "Hybrid search (BM25 + vector + RRF + recency). Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Paginate via cursor.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"query":       {"type": "string", "description": "Search query"},
-				"workspace":   {"type": "string", "description": "Workspace hash"},
-				"max_results": {"type": "number", "description": "Max results (default 10, max 100)"},
+				"query":           {"type": "string", "description": "Search query"},
+				"workspace":       {"type": "string", "description": "Workspace hash"},
+				"max_results":     {"type": "number", "description": "Max results (default 10, max 100)"},
+				"cursor":          {"type": "string", "description": "Opaque pagination cursor from a previous response's next_cursor field. Pass the same query when paginating."},
+				"include_content": {"type": "boolean", "description": "Set to true to include full chunk content alongside the snippet. Defaults to false. Increases response size; prefer memory_get for fetching one full document."},
 			}, []string{"query", "workspace"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			start := time.Now()
 			args, err := parseArgs(req.Params.Arguments)
 			if err != nil {
 				return errResult("invalid arguments"), nil
@@ -189,11 +228,64 @@ func registerMemoryQuery(server *mcpsdk.Server, a *Adapter) {
 				return errResult("hybrid search not available (no embedding provider)"), nil
 			}
 			maxResults := argInt(args, "max_results", 10, 100)
-			results, err := a.searchService.HybridSearch(ctx, query, ws, maxResults, nil)
+			includeContent := argBool(args, "include_content")
+
+			cursorToken := argString(args, "cursor")
+			offset, cursorErr := search.VerifyCursor(cursorToken, query)
+			if cursorErr != nil {
+				if errors.Is(cursorErr, search.ErrCursorQueryMismatch) {
+					return errResult("cursor query mismatch: pass the same query when paginating"), nil
+				}
+				return errResult(fmt.Sprintf("invalid cursor: %v", cursorErr)), nil
+			}
+
+			fetchLimit := offset + maxResults + 1
+			results, err := a.searchService.HybridSearch(ctx, query, ws, fetchLimit, nil)
 			if err != nil {
 				return errResult(fmt.Sprintf("hybrid search failed: %v", err)), nil
 			}
-			return textResult(results)
+
+			total := len(results)
+			hasMore := total > offset+maxResults
+			pageEnd := offset + maxResults
+			if pageEnd > total {
+				pageEnd = total
+			}
+			pageStart := offset
+			if pageStart > total {
+				pageStart = total
+			}
+			page := results[pageStart:pageEnd]
+
+			items := make([]mcpSearchResultItem, len(page))
+			for i, r := range page {
+				item := mcpSearchResultItem{
+					ID: r.ID, DocumentID: r.DocumentID,
+					WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+					Snippet:    search.TruncateSnippet(r.Content, mcpSnippetLen),
+					Score:      r.Score,
+					Tags:       r.Tags,
+					Collection: r.Collection, SourcePath: r.SourcePath,
+					CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+				}
+				if item.Tags == nil {
+					item.Tags = []string{}
+				}
+				if includeContent {
+					item.Content = r.Content
+				}
+				items[i] = item
+			}
+
+			resp := mcpSearchResponse{
+				Results: items,
+				Total:   total,
+				QueryMs: time.Since(start).Milliseconds(),
+			}
+			if hasMore {
+				resp.NextCursor = search.EncodeCursor(pageEnd, search.QueryHash(query))
+			}
+			return textResult(resp)
 		},
 	)
 }
@@ -202,15 +294,18 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_search",
-			Description: "BM25 text search across memory documents",
+			Description: "BM25 text search. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Paginate via cursor.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"query":       {"type": "string", "description": "Search query"},
-				"workspace":   {"type": "string", "description": "Workspace hash"},
-				"max_results": {"type": "number", "description": "Max results (default 10, max 100)"},
-				"tags":        {"type": "array", "description": "Filter by tags", "items": map[string]any{"type": "string"}},
+				"query":           {"type": "string", "description": "Search query"},
+				"workspace":       {"type": "string", "description": "Workspace hash"},
+				"max_results":     {"type": "number", "description": "Max results (default 10, max 100)"},
+				"tags":            {"type": "array", "description": "Filter by tags", "items": map[string]any{"type": "string"}},
+				"cursor":          {"type": "string", "description": "Opaque pagination cursor from a previous response's next_cursor field. Pass the same query when paginating."},
+				"include_content": {"type": "boolean", "description": "Set to true to include full chunk content alongside the snippet. Defaults to false. Increases response size; prefer memory_get for fetching one full document."},
 			}, []string{"query", "workspace"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			start := time.Now()
 			args, err := parseArgs(req.Params.Arguments)
 			if err != nil {
 				return errResult("invalid arguments"), nil
@@ -225,36 +320,40 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 			}
 			maxResults := argInt(args, "max_results", 10, 100)
 			tags := argStringSlice(args, "tags")
+			includeContent := argBool(args, "include_content")
 
-			type resultRow struct {
-				ID            string    `json:"id"`
-				DocumentID    string    `json:"document_id"`
-				WorkspaceHash string    `json:"workspace_hash"`
-				Title         string    `json:"title"`
-				Content       string    `json:"content"`
-				SourcePath    string    `json:"source_path"`
-				Collection    string    `json:"collection"`
-				Tags          []string  `json:"tags"`
-				Score         float64   `json:"score"`
-				CreatedAt     time.Time `json:"created_at"`
-				UpdatedAt     time.Time `json:"updated_at"`
+			cursorToken := argString(args, "cursor")
+			offset, cursorErr := search.VerifyCursor(cursorToken, query)
+			if cursorErr != nil {
+				if errors.Is(cursorErr, search.ErrCursorQueryMismatch) {
+					return errResult("cursor query mismatch: pass the same query when paginating"), nil
+				}
+				return errResult(fmt.Sprintf("invalid cursor: %v", cursorErr)), nil
 			}
 
-			var results []resultRow
-			limit := int32(maxResults)
+			fetchLimit := int32(offset + maxResults + 1)
+
+			type bm25Row struct {
+				ID, DocumentID             string
+				WorkspaceHash, Title       string
+				Content, SourcePath        string
+				Collection                 string
+				Tags                       []string
+				Score                      float64
+				CreatedAt, UpdatedAt       time.Time
+			}
+			var allRows []bm25Row
 
 			if ws == "all" {
 				if len(tags) > 0 {
 					rows, err := a.queries.BM25SearchAllWithTags(ctx, sqlc.BM25SearchAllWithTagsParams{
-						Query:      query,
-						Tags:       tags,
-						MaxResults: limit,
+						Query: query, Tags: tags, MaxResults: fetchLimit,
 					})
 					if err != nil {
 						return errResult(fmt.Sprintf("bm25 search failed: %v", err)), nil
 					}
 					for _, r := range rows {
-						results = append(results, resultRow{
+						allRows = append(allRows, bm25Row{
 							ID: r.ID.String(), DocumentID: r.DocumentID.String(),
 							WorkspaceHash: r.WorkspaceHash, Title: r.Title,
 							Content: r.Content, SourcePath: r.SourcePath,
@@ -264,14 +363,13 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 					}
 				} else {
 					rows, err := a.queries.BM25SearchAll(ctx, sqlc.BM25SearchAllParams{
-						Query:      query,
-						MaxResults: limit,
+						Query: query, MaxResults: fetchLimit,
 					})
 					if err != nil {
 						return errResult(fmt.Sprintf("bm25 search failed: %v", err)), nil
 					}
 					for _, r := range rows {
-						results = append(results, resultRow{
+						allRows = append(allRows, bm25Row{
 							ID: r.ID.String(), DocumentID: r.DocumentID.String(),
 							WorkspaceHash: r.WorkspaceHash, Title: r.Title,
 							Content: r.Content, SourcePath: r.SourcePath,
@@ -282,16 +380,13 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 				}
 			} else if len(tags) > 0 {
 				rows, err := a.queries.BM25SearchWithTags(ctx, sqlc.BM25SearchWithTagsParams{
-					Query:         query,
-					WorkspaceHash: ws,
-					Tags:          tags,
-					MaxResults:    limit,
+					Query: query, WorkspaceHash: ws, Tags: tags, MaxResults: fetchLimit,
 				})
 				if err != nil {
 					return errResult(fmt.Sprintf("bm25 search failed: %v", err)), nil
 				}
 				for _, r := range rows {
-					results = append(results, resultRow{
+					allRows = append(allRows, bm25Row{
 						ID: r.ID.String(), DocumentID: r.DocumentID.String(),
 						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
 						Content: r.Content, SourcePath: r.SourcePath,
@@ -301,15 +396,13 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 				}
 			} else {
 				rows, err := a.queries.BM25Search(ctx, sqlc.BM25SearchParams{
-					Query:         query,
-					WorkspaceHash: ws,
-					MaxResults:    limit,
+					Query: query, WorkspaceHash: ws, MaxResults: fetchLimit,
 				})
 				if err != nil {
 					return errResult(fmt.Sprintf("bm25 search failed: %v", err)), nil
 				}
 				for _, r := range rows {
-					results = append(results, resultRow{
+					allRows = append(allRows, bm25Row{
 						ID: r.ID.String(), DocumentID: r.DocumentID.String(),
 						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
 						Content: r.Content, SourcePath: r.SourcePath,
@@ -318,7 +411,48 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 					})
 				}
 			}
-			return textResult(results)
+
+			total := len(allRows)
+			hasMore := total > offset+maxResults
+			pageEnd := offset + maxResults
+			if pageEnd > total {
+				pageEnd = total
+			}
+			pageStart := offset
+			if pageStart > total {
+				pageStart = total
+			}
+			page := allRows[pageStart:pageEnd]
+
+			items := make([]mcpSearchResultItem, len(page))
+			for i, r := range page {
+				item := mcpSearchResultItem{
+					ID: r.ID, DocumentID: r.DocumentID,
+					WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+					Snippet:    search.TruncateSnippet(r.Content, mcpSnippetLen),
+					Score:      r.Score,
+					Tags:       r.Tags,
+					Collection: r.Collection, SourcePath: r.SourcePath,
+					CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+				}
+				if item.Tags == nil {
+					item.Tags = []string{}
+				}
+				if includeContent {
+					item.Content = r.Content
+				}
+				items[i] = item
+			}
+
+			resp := mcpSearchResponse{
+				Results: items,
+				Total:   total,
+				QueryMs: time.Since(start).Milliseconds(),
+			}
+			if hasMore {
+				resp.NextCursor = search.EncodeCursor(pageEnd, search.QueryHash(query))
+			}
+			return textResult(resp)
 		},
 	)
 }
@@ -327,14 +461,17 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_vsearch",
-			Description: "Vector similarity search using embeddings",
+			Description: "Vector similarity search using embeddings. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Paginate via cursor.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"query":       {"type": "string", "description": "Search query"},
-				"workspace":   {"type": "string", "description": "Workspace hash"},
-				"max_results": {"type": "number", "description": "Max results (default 10, max 100)"},
+				"query":           {"type": "string", "description": "Search query"},
+				"workspace":       {"type": "string", "description": "Workspace hash"},
+				"max_results":     {"type": "number", "description": "Max results (default 10, max 100)"},
+				"cursor":          {"type": "string", "description": "Opaque pagination cursor from a previous response's next_cursor field. Pass the same query when paginating."},
+				"include_content": {"type": "boolean", "description": "Set to true to include full chunk content alongside the snippet. Defaults to false. Increases response size; prefer memory_get for fetching one full document."},
 			}, []string{"query", "workspace"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			start := time.Now()
 			args, err := parseArgs(req.Params.Arguments)
 			if err != nil {
 				return errResult("invalid arguments"), nil
@@ -351,6 +488,16 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				return errResult("vector search requires embedding provider"), nil
 			}
 			maxResults := argInt(args, "max_results", 10, 100)
+			includeContent := argBool(args, "include_content")
+
+			cursorToken := argString(args, "cursor")
+			offset, cursorErr := search.VerifyCursor(cursorToken, query)
+			if cursorErr != nil {
+				if errors.Is(cursorErr, search.ErrCursorQueryMismatch) {
+					return errResult("cursor query mismatch: pass the same query when paginating"), nil
+				}
+				return errResult(fmt.Sprintf("invalid cursor: %v", cursorErr)), nil
+			}
 
 			embedCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
@@ -359,32 +506,30 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				return errResult(fmt.Sprintf("embedding query failed: %v", err)), nil
 			}
 
-			type vsearchRow struct {
-				ID            string    `json:"id"`
-				DocumentID    string    `json:"document_id"`
-				WorkspaceHash string    `json:"workspace_hash"`
-				Title         string    `json:"title"`
-				Content       string    `json:"content"`
-				SourcePath    string    `json:"source_path"`
-				Collection    string    `json:"collection"`
-				Tags          []string  `json:"tags"`
-				Score         float64   `json:"score"`
-				CreatedAt     time.Time `json:"created_at"`
-				UpdatedAt     time.Time `json:"updated_at"`
-			}
+			fetchLimit := int32(offset + maxResults + 1)
 
-			var results []vsearchRow
+			type vsRow struct {
+				ID, DocumentID             string
+				WorkspaceHash, Title       string
+				Content, SourcePath        string
+				Collection                 string
+				Tags                       []string
+				Score                      float64
+				CreatedAt, UpdatedAt       time.Time
+			}
+			var allRows []vsRow
+
 			if ws == "all" {
 				rows, err := a.queries.VectorSearchAll(ctx, sqlc.VectorSearchAllParams{
 					QueryEmbedding: pgvector_go.NewVector(vec),
-					MaxResults:     int32(maxResults),
+					MaxResults:     fetchLimit,
 				})
 				if err != nil {
 					return errResult(fmt.Sprintf("vector search failed: %v", err)), nil
 				}
-				results = make([]vsearchRow, 0, len(rows))
+				allRows = make([]vsRow, 0, len(rows))
 				for _, r := range rows {
-					results = append(results, vsearchRow{
+					allRows = append(allRows, vsRow{
 						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
 						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
 						Content: r.Content, SourcePath: r.SourcePath,
@@ -396,14 +541,14 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				rows, err := a.queries.VectorSearch(ctx, sqlc.VectorSearchParams{
 					QueryEmbedding: pgvector_go.NewVector(vec),
 					WorkspaceHash:  ws,
-					MaxResults:     int32(maxResults),
+					MaxResults:     fetchLimit,
 				})
 				if err != nil {
 					return errResult(fmt.Sprintf("vector search failed: %v", err)), nil
 				}
-				results = make([]vsearchRow, 0, len(rows))
+				allRows = make([]vsRow, 0, len(rows))
 				for _, r := range rows {
-					results = append(results, vsearchRow{
+					allRows = append(allRows, vsRow{
 						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
 						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
 						Content: r.Content, SourcePath: r.SourcePath,
@@ -412,7 +557,48 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 					})
 				}
 			}
-			return textResult(results)
+
+			total := len(allRows)
+			hasMore := total > offset+maxResults
+			pageEnd := offset + maxResults
+			if pageEnd > total {
+				pageEnd = total
+			}
+			pageStart := offset
+			if pageStart > total {
+				pageStart = total
+			}
+			page := allRows[pageStart:pageEnd]
+
+			items := make([]mcpSearchResultItem, len(page))
+			for i, r := range page {
+				item := mcpSearchResultItem{
+					ID: r.ID, DocumentID: r.DocumentID,
+					WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+					Snippet:    search.TruncateSnippet(r.Content, mcpSnippetLen),
+					Score:      r.Score,
+					Tags:       r.Tags,
+					Collection: r.Collection, SourcePath: r.SourcePath,
+					CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+				}
+				if item.Tags == nil {
+					item.Tags = []string{}
+				}
+				if includeContent {
+					item.Content = r.Content
+				}
+				items[i] = item
+			}
+
+			resp := mcpSearchResponse{
+				Results: items,
+				Total:   total,
+				QueryMs: time.Since(start).Milliseconds(),
+			}
+			if hasMore {
+				resp.NextCursor = search.EncodeCursor(pageEnd, search.QueryHash(query))
+			}
+			return textResult(resp)
 		},
 	)
 }

--- a/internal/mcp/tools_pagination_integration_test.go
+++ b/internal/mcp/tools_pagination_integration_test.go
@@ -1,0 +1,474 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/stdlib"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
+	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	"github.com/rs/zerolog"
+)
+
+func setupSearchMCP(t *testing.T) (context.Context, *sql.DB, *sqlc.Queries, string, func(string, map[string]any) *mcpsdk.CallToolResult) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { db.Close() })
+
+	queries := sqlc.New(db)
+	wsHash := "test_ws_" + uuid.New().String()[:8]
+	if _, err := queries.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: wsHash, Name: "test-ws", Path: "/tmp/" + wsHash,
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+
+	server := internalmcp.NewMCPServer("test")
+	adapter := internalmcp.NewAdapter(queries, db, nil, nil, nil, config.EmbeddingConfig{}, config.SearchConfig{}, nil, zerolog.Nop())
+	internalmcp.RegisterTools(server, adapter)
+
+	ct, st := mcpsdk.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+
+	callTool := func(name string, args map[string]any) *mcpsdk.CallToolResult {
+		t.Helper()
+		result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("CallTool(%s): %v", name, err)
+		}
+		return result
+	}
+	return ctx, db, queries, wsHash, callTool
+}
+
+func contentHash(s string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s)))
+}
+
+func insertDocWithChunk(t *testing.T, ctx context.Context, db *sql.DB, wsHash, title, content string) uuid.UUID {
+	t.Helper()
+	docID := uuid.New()
+	chunkID := uuid.New()
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO documents (id, workspace_hash, content_hash, title, source_path, collection)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		docID, wsHash, contentHash(title+content), title, "/tmp/"+title+".md", "memory")
+	if err != nil {
+		t.Fatalf("insert doc %q: %v", title, err)
+	}
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO chunks (id, document_id, workspace_hash, content_hash, content, chunk_index)
+		 VALUES ($1, $2, $3, $4, $5, 0)`,
+		chunkID, docID, wsHash, contentHash(content+chunkID.String()), content)
+	if err != nil {
+		t.Fatalf("insert chunk for %q: %v", title, err)
+	}
+	return chunkID
+}
+
+type searchResponse struct {
+	Results    []json.RawMessage `json:"results"`
+	Total      int               `json:"total"`
+	QueryMs    int64             `json:"query_ms"`
+	NextCursor string            `json:"next_cursor,omitempty"`
+}
+
+type searchResultItem struct {
+	ID            string  `json:"id"`
+	DocumentID    string  `json:"document_id"`
+	WorkspaceHash string  `json:"workspace_hash"`
+	Title         string  `json:"title"`
+	Snippet       string  `json:"snippet"`
+	Content       string  `json:"content,omitempty"`
+	Score         float64 `json:"score"`
+	Tags          []string `json:"tags"`
+	Collection    string  `json:"collection"`
+	SourcePath    string  `json:"source_path"`
+}
+
+func parseSearchResponse(t *testing.T, result *mcpsdk.CallToolResult) (searchResponse, string) {
+	t.Helper()
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	var resp searchResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nraw: %s", err, text)
+	}
+	return resp, text
+}
+
+func parseResultItems(t *testing.T, resp searchResponse) []searchResultItem {
+	t.Helper()
+	items := make([]searchResultItem, len(resp.Results))
+	for i, raw := range resp.Results {
+		if err := json.Unmarshal(raw, &items[i]); err != nil {
+			t.Fatalf("unmarshal result[%d]: %v", i, err)
+		}
+	}
+	return items
+}
+
+func TestMemorySearch_DefaultExcludesContent(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	for i := 0; i < 3; i++ {
+		insertDocWithChunk(t, ctx, db, wsHash,
+			fmt.Sprintf("snippet-test-%d", i),
+			fmt.Sprintf("searchable keyword bravo document number %d with some extra text", i))
+	}
+
+	result := callTool("memory_search", map[string]any{"workspace": wsHash, "query": "bravo"})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, rawText := parseSearchResponse(t, result)
+	if len(resp.Results) == 0 {
+		t.Fatal("expected results, got 0")
+	}
+
+	items := parseResultItems(t, resp)
+	for i, item := range items {
+		if item.Snippet == "" {
+			t.Errorf("result[%d]: snippet is empty", i)
+		}
+		if utf8.RuneCountInString(item.Snippet) > 500 {
+			t.Errorf("result[%d]: snippet length %d > 500 runes", i, utf8.RuneCountInString(item.Snippet))
+		}
+	}
+
+	for i, raw := range resp.Results {
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("result[%d] unmarshal to map: %v", i, err)
+		}
+		if _, ok := m["content"]; ok {
+			t.Errorf("result[%d]: content field should be absent in default response, raw: %s", i, rawText)
+		}
+	}
+}
+
+func TestMemorySearch_IncludeContentTrue(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	originalContent := "searchable keyword charlie full content to verify inclusion in response payload"
+	insertDocWithChunk(t, ctx, db, wsHash, "include-content-doc", originalContent)
+
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "charlie", "include_content": true,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	if len(resp.Results) == 0 {
+		t.Fatal("expected results, got 0")
+	}
+
+	items := parseResultItems(t, resp)
+	for i, item := range items {
+		if item.Snippet == "" {
+			t.Errorf("result[%d]: snippet is empty", i)
+		}
+		if item.Content == "" {
+			t.Errorf("result[%d]: content should be present with include_content=true", i)
+		}
+		if item.Content != originalContent {
+			t.Errorf("result[%d]: content mismatch\ngot:  %q\nwant: %q", i, item.Content, originalContent)
+		}
+	}
+}
+
+func TestMemorySearch_IncludeContentFalseMatchesDefault(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	insertDocWithChunk(t, ctx, db, wsHash, "false-default-doc",
+		"searchable keyword delta comparing explicit false vs omitted parameter")
+
+	resultDefault := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "delta",
+	})
+	resultFalse := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "delta", "include_content": false,
+	})
+
+	respDefault, _ := parseSearchResponse(t, resultDefault)
+	respFalse, _ := parseSearchResponse(t, resultFalse)
+
+	if len(respDefault.Results) != len(respFalse.Results) {
+		t.Fatalf("result count mismatch: default=%d, false=%d", len(respDefault.Results), len(respFalse.Results))
+	}
+
+	itemsDefault := parseResultItems(t, respDefault)
+	itemsFalse := parseResultItems(t, respFalse)
+	for i := range itemsDefault {
+		if itemsDefault[i].Snippet != itemsFalse[i].Snippet {
+			t.Errorf("result[%d] snippet mismatch: default=%q false=%q", i, itemsDefault[i].Snippet, itemsFalse[i].Snippet)
+		}
+		if itemsDefault[i].Content != "" || itemsFalse[i].Content != "" {
+			t.Errorf("result[%d]: content should be absent in both; default=%q false=%q", i, itemsDefault[i].Content, itemsFalse[i].Content)
+		}
+	}
+}
+
+func TestMemorySearch_SnippetUTF8Boundary(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+
+	prefix := "echo " + strings.Repeat("x", 485) // 490 ASCII runes before multi-byte zone
+	suffix := strings.Repeat("世", 20)            // 3-byte runes spanning positions 490..509
+	content := prefix + suffix
+	insertDocWithChunk(t, ctx, db, wsHash, "utf8-boundary-doc", content)
+
+	result := callTool("memory_search", map[string]any{"workspace": wsHash, "query": "echo"})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	if len(resp.Results) == 0 {
+		t.Fatal("expected results, got 0")
+	}
+
+	items := parseResultItems(t, resp)
+	snippet := items[0].Snippet
+
+	if !utf8.ValidString(snippet) {
+		t.Error("snippet contains invalid UTF-8")
+	}
+	runeCount := utf8.RuneCountInString(snippet)
+	if runeCount > 500 {
+		t.Errorf("snippet rune count %d > 500", runeCount)
+	}
+}
+
+func TestMemorySearch_PayloadSizeBudget(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	for i := 0; i < 10; i++ {
+		insertDocWithChunk(t, ctx, db, wsHash,
+			fmt.Sprintf("budget-doc-%d", i),
+			fmt.Sprintf("foxtrot keyword %s", strings.Repeat("a", 1500+i)))
+	}
+
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "foxtrot", "max_results": 10,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	responseText := result.Content[0].(*mcpsdk.TextContent).Text
+	if len(responseText) > 20000 {
+		t.Errorf("response payload %d bytes > 20000 byte budget", len(responseText))
+	}
+}
+
+func TestMemorySearch_PaginationRoundTrip(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	for i := 0; i < 12; i++ {
+		insertDocWithChunk(t, ctx, db, wsHash,
+			fmt.Sprintf("page-doc-%02d", i),
+			fmt.Sprintf("golf keyword item number %d searchable", i))
+	}
+
+	page1 := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "golf", "max_results": 5,
+	})
+	if page1.IsError {
+		t.Fatalf("page1 error: %s", page1.Content[0].(*mcpsdk.TextContent).Text)
+	}
+	resp1, _ := parseSearchResponse(t, page1)
+	if len(resp1.Results) != 5 {
+		t.Fatalf("page1: got %d results, want 5", len(resp1.Results))
+	}
+	if resp1.NextCursor == "" {
+		t.Fatal("page1: expected next_cursor, got empty")
+	}
+
+	page2 := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "golf", "max_results": 5, "cursor": resp1.NextCursor,
+	})
+	if page2.IsError {
+		t.Fatalf("page2 error: %s", page2.Content[0].(*mcpsdk.TextContent).Text)
+	}
+	resp2, _ := parseSearchResponse(t, page2)
+	if len(resp2.Results) != 5 {
+		t.Fatalf("page2: got %d results, want 5", len(resp2.Results))
+	}
+	if resp2.NextCursor == "" {
+		t.Fatal("page2: expected next_cursor, got empty")
+	}
+
+	page3 := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "golf", "max_results": 5, "cursor": resp2.NextCursor,
+	})
+	if page3.IsError {
+		t.Fatalf("page3 error: %s", page3.Content[0].(*mcpsdk.TextContent).Text)
+	}
+	resp3, _ := parseSearchResponse(t, page3)
+	if len(resp3.Results) != 2 {
+		t.Fatalf("page3: got %d results, want 2", len(resp3.Results))
+	}
+	if resp3.NextCursor != "" {
+		t.Errorf("page3: next_cursor should be absent, got %q", resp3.NextCursor)
+	}
+
+	seen := make(map[string]bool)
+	allItems := append(parseResultItems(t, resp1), parseResultItems(t, resp2)...)
+	allItems = append(allItems, parseResultItems(t, resp3)...)
+	for _, item := range allItems {
+		if seen[item.ID] {
+			t.Errorf("duplicate result ID across pages: %s", item.ID)
+		}
+		seen[item.ID] = true
+	}
+	if len(seen) != 12 {
+		t.Errorf("total unique results = %d, want 12", len(seen))
+	}
+}
+
+func TestMemorySearch_FirstPageWithoutCursorReturnsResults(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	for i := 0; i < 5; i++ {
+		insertDocWithChunk(t, ctx, db, wsHash,
+			fmt.Sprintf("exact-doc-%d", i),
+			fmt.Sprintf("hotel keyword result %d", i))
+	}
+
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "hotel", "max_results": 5,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	if len(resp.Results) != 5 {
+		t.Fatalf("got %d results, want 5", len(resp.Results))
+	}
+	if resp.NextCursor != "" {
+		t.Errorf("next_cursor should be absent when exact match count, got %q", resp.NextCursor)
+	}
+}
+
+func TestMemorySearch_CursorQueryMismatch(t *testing.T) {
+	_, _, _, wsHash, callTool := setupSearchMCP(t)
+
+	cursor := search.EncodeCursor(5, search.QueryHash("alpha"))
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "beta", "cursor": cursor,
+	})
+
+	if !result.IsError {
+		t.Fatal("expected error for cursor query mismatch, got success")
+	}
+	errText := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(errText, "cursor query mismatch") {
+		t.Errorf("error should contain 'cursor query mismatch', got: %s", errText)
+	}
+}
+
+func TestMemorySearch_InvalidCursor(t *testing.T) {
+	_, _, _, wsHash, callTool := setupSearchMCP(t)
+
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "anything", "cursor": "not-valid-base64!@#",
+	})
+
+	if !result.IsError {
+		t.Fatal("expected error for invalid cursor, got success")
+	}
+	errText := result.Content[0].(*mcpsdk.TextContent).Text
+	if !strings.Contains(errText, "invalid cursor") {
+		t.Errorf("error should contain 'invalid cursor', got: %s", errText)
+	}
+}
+
+func TestMemorySearch_ResponseIncludesTotalAndQueryMs(t *testing.T) {
+	ctx, db, _, wsHash, callTool := setupSearchMCP(t)
+	insertDocWithChunk(t, ctx, db, wsHash, "meta-doc", "india keyword metadata verification test")
+
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "india",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, rawText := parseSearchResponse(t, result)
+	if resp.Total < len(resp.Results) {
+		t.Errorf("total (%d) < len(results) (%d)", resp.Total, len(resp.Results))
+	}
+	if resp.QueryMs < 0 {
+		t.Errorf("query_ms should be >= 0, got %d", resp.QueryMs)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(rawText), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, ok := raw["total"]; !ok {
+		t.Error("response missing 'total' field at top level")
+	}
+	if _, ok := raw["query_ms"]; !ok {
+		t.Error("response missing 'query_ms' field at top level")
+	}
+}
+
+func TestMemorySearch_EmptyResultSet(t *testing.T) {
+	_, _, _, wsHash, callTool := setupSearchMCP(t)
+
+	result := callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "nonexistentterm_xyz_qpr",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, rawText := parseSearchResponse(t, result)
+	if len(resp.Results) != 0 {
+		t.Errorf("expected empty results, got %d", len(resp.Results))
+	}
+	if resp.Total != 0 {
+		t.Errorf("total should be 0, got %d", resp.Total)
+	}
+	if resp.QueryMs < 0 {
+		t.Errorf("query_ms should be >= 0, got %d", resp.QueryMs)
+	}
+	if resp.NextCursor != "" {
+		t.Errorf("next_cursor should be absent for empty results, got %q", resp.NextCursor)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(rawText), &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	results, ok := raw["results"]
+	if !ok {
+		t.Fatal("response missing 'results' field")
+	}
+	arr, ok := results.([]any)
+	if !ok || arr == nil {
+		t.Errorf("results should be empty array (not null); got %T: %v", results, results)
+	}
+}

--- a/internal/search/cursor.go
+++ b/internal/search/cursor.go
@@ -16,6 +16,12 @@ var ErrInvalidCursor = errors.New("invalid cursor")
 // embedded query hash does not match the current request's query.
 var ErrCursorQueryMismatch = errors.New("cursor query mismatch")
 
+// MaxCursorOffset caps how deep a cursor may page. Bounds the SQL LIMIT
+// derived from `offset + max_results + 1` so it cannot trigger int32
+// overflow (#358 review) or unbounded server work. 10k offset × 100 per
+// page = 1M results — well past any realistic agent workflow.
+const MaxCursorOffset = 10_000
+
 // cursorPayload is the internal JSON structure encoded in a cursor token.
 type cursorPayload struct {
 	Offset int    `json:"o"`
@@ -67,6 +73,9 @@ func DecodeCursor(token string) (offset int, queryHash string, err error) {
 
 	if p.Offset < 0 {
 		return 0, "", fmt.Errorf("%w: negative offset %d", ErrInvalidCursor, p.Offset)
+	}
+	if p.Offset > MaxCursorOffset {
+		return 0, "", fmt.Errorf("%w: offset %d exceeds maximum %d", ErrInvalidCursor, p.Offset, MaxCursorOffset)
 	}
 
 	return p.Offset, p.QueryHash, nil

--- a/internal/search/cursor.go
+++ b/internal/search/cursor.go
@@ -1,0 +1,95 @@
+package search
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidCursor is returned when a cursor token is malformed
+// (not valid base64url, not valid JSON, or contains a negative offset).
+var ErrInvalidCursor = errors.New("invalid cursor")
+
+// ErrCursorQueryMismatch is returned by VerifyCursor when the cursor's
+// embedded query hash does not match the current request's query.
+var ErrCursorQueryMismatch = errors.New("cursor query mismatch")
+
+// cursorPayload is the internal JSON structure encoded in a cursor token.
+type cursorPayload struct {
+	Offset int    `json:"o"`
+	QueryHash string `json:"q"`
+}
+
+// QueryHash returns the first 16 hex chars of sha256(query),
+// used to guard against cross-query cursor reuse.
+func QueryHash(query string) string {
+	sum := sha256.Sum256([]byte(query))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// EncodeCursor encodes a pagination offset + query hash into an
+// opaque base64url JSON token suitable for round-tripping through
+// an MCP client. Format: base64url(JSON{"o":<offset>,"q":<hash>}).
+// MUST NOT be parsed by clients.
+func EncodeCursor(offset int, queryHash string) string {
+	payload := cursorPayload{
+		Offset:    offset,
+		QueryHash: queryHash,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		// JSON marshaling of simple struct should never fail; panic if it does
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+// DecodeCursor decodes a cursor token previously produced by EncodeCursor.
+// Returns the embedded offset and queryHash, or an error wrapping one of:
+//   - ErrInvalidCursor (base64 or JSON malformed, or negative offset)
+func DecodeCursor(token string) (offset int, queryHash string, err error) {
+	if token == "" {
+		return 0, "", fmt.Errorf("%w: empty token", ErrInvalidCursor)
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, "", fmt.Errorf("%w: %w", ErrInvalidCursor, err)
+	}
+
+	var p cursorPayload
+	err = json.Unmarshal(data, &p)
+	if err != nil {
+		return 0, "", fmt.Errorf("%w: %w", ErrInvalidCursor, err)
+	}
+
+	if p.Offset < 0 {
+		return 0, "", fmt.Errorf("%w: negative offset %d", ErrInvalidCursor, p.Offset)
+	}
+
+	return p.Offset, p.QueryHash, nil
+}
+
+// VerifyCursor decodes the token and confirms the embedded queryHash
+// matches QueryHash(currentQuery). Returns the decoded offset on success.
+// Returns ErrInvalidCursor for malformed cursors, ErrCursorQueryMismatch
+// when the query has changed. Empty token is treated as first page (offset 0).
+func VerifyCursor(token string, currentQuery string) (offset int, err error) {
+	if token == "" {
+		return 0, nil
+	}
+
+	decodedOffset, decodedHash, err := DecodeCursor(token)
+	if err != nil {
+		return 0, err
+	}
+
+	expectedHash := QueryHash(currentQuery)
+	if decodedHash != expectedHash {
+		return 0, fmt.Errorf("%w", ErrCursorQueryMismatch)
+	}
+
+	return decodedOffset, nil
+}

--- a/internal/search/cursor_test.go
+++ b/internal/search/cursor_test.go
@@ -1,0 +1,261 @@
+package search_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/search"
+)
+
+func TestQueryHash(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "same query produces same hash",
+			query: "hello world",
+		},
+		{
+			name:  "empty query",
+			query: "",
+		},
+		{
+			name:  "long query",
+			query: "this is a much longer query with many words in it",
+		},
+		{
+			name:  "unicode query",
+			query: "你好世界",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1 := search.QueryHash(tt.query)
+			hash2 := search.QueryHash(tt.query)
+
+			// Same query must produce same hash (deterministic)
+			if hash1 != hash2 {
+				t.Errorf("QueryHash(%q) not deterministic: %s vs %s", tt.query, hash1, hash2)
+			}
+
+			// Hash must be exactly 16 hex characters
+			if len(hash1) != 16 {
+				t.Errorf("QueryHash(%q) length = %d, want 16, got %s", tt.query, len(hash1), hash1)
+			}
+
+			// Hash must only contain hex digits
+			for _, c := range hash1 {
+				if !strings.ContainsRune("0123456789abcdef", c) {
+					t.Errorf("QueryHash(%q) contains non-hex character: %c in %s", tt.query, c, hash1)
+				}
+			}
+		})
+	}
+}
+
+func TestQueryHashDifferent(t *testing.T) {
+	hash1 := search.QueryHash("query1")
+	hash2 := search.QueryHash("query2")
+	if hash1 == hash2 {
+		t.Errorf("Different queries should produce different hashes: %s vs %s", hash1, hash2)
+	}
+}
+
+func TestEncodeDecodeRoundtrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		offset    int
+		queryHash string
+	}{
+		{
+			name:      "offset 0 with simple hash",
+			offset:    0,
+			queryHash: "abc123def456",
+		},
+		{
+			name:      "offset 100 with QueryHash result",
+			offset:    100,
+			queryHash: search.QueryHash("hello world"),
+		},
+		{
+			name:      "large offset",
+			offset:    99999,
+			queryHash: search.QueryHash("test query"),
+		},
+		{
+			name:      "offset 1",
+			offset:    1,
+			queryHash: "fedcba9876543210",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Encode
+			cursor := search.EncodeCursor(tt.offset, tt.queryHash)
+
+			// Cursor must be non-empty
+			if cursor == "" {
+				t.Errorf("EncodeCursor(%d, %q) returned empty string", tt.offset, tt.queryHash)
+			}
+
+			// Cursor must be URL-safe (no +, /, or =)
+			if strings.ContainsAny(cursor, "+/=") {
+				t.Errorf("EncodeCursor(%d, %q) contains non-URL-safe characters: %s", tt.offset, tt.queryHash, cursor)
+			}
+
+			// Decode
+			decodedOffset, decodedHash, err := search.DecodeCursor(cursor)
+			if err != nil {
+				t.Fatalf("DecodeCursor(%q) returned error: %v", cursor, err)
+			}
+
+			// Verify roundtrip
+			if decodedOffset != tt.offset {
+				t.Errorf("DecodeCursor offset: got %d, want %d", decodedOffset, tt.offset)
+			}
+			if decodedHash != tt.queryHash {
+				t.Errorf("DecodeCursor hash: got %s, want %s", decodedHash, tt.queryHash)
+			}
+		})
+	}
+}
+
+func TestEncodeCursorDeterministic(t *testing.T) {
+	// Same input must always produce same output
+	offset := 42
+	hash := search.QueryHash("test")
+
+	cursor1 := search.EncodeCursor(offset, hash)
+	cursor2 := search.EncodeCursor(offset, hash)
+
+	if cursor1 != cursor2 {
+		t.Errorf("EncodeCursor not deterministic: %s vs %s", cursor1, cursor2)
+	}
+}
+
+func TestDecodeCursorInvalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		shouldError bool
+	}{
+		{
+			name:        "empty string",
+			token:       "",
+			shouldError: true,
+		},
+		{
+			name:        "garbage",
+			token:       "not-base64!@#",
+			shouldError: true,
+		},
+		{
+			name:        "valid base64 but invalid JSON",
+			token:       base64.RawURLEncoding.EncodeToString([]byte("not json")),
+			shouldError: true,
+		},
+		{
+			name:        "negative offset",
+			token:       encodeTestCursor(t, -1, "abc123"),
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := search.DecodeCursor(tt.token)
+			if !tt.shouldError && err != nil {
+				t.Errorf("DecodeCursor(%q) returned unexpected error: %v", tt.token, err)
+			}
+			if tt.shouldError && err == nil {
+				t.Errorf("DecodeCursor(%q) should have returned error", tt.token)
+			}
+			if tt.shouldError && err != nil && !errors.Is(err, search.ErrInvalidCursor) {
+				t.Errorf("DecodeCursor(%q) error should wrap ErrInvalidCursor, got: %v", tt.token, err)
+			}
+		})
+	}
+}
+
+func TestVerifyCursor(t *testing.T) {
+	tests := []struct {
+		name          string
+		token         string
+		currentQuery  string
+		wantOffset    int
+		wantError     error
+		shouldBeEmpty bool
+	}{
+		{
+			name:         "empty token is first page",
+			token:        "",
+			currentQuery: "any query",
+			wantOffset:   0,
+			wantError:    nil,
+		},
+		{
+			name:         "valid cursor matching query",
+			token:        encodeCursorWithQuery(t, 50, "alpha"),
+			currentQuery: "alpha",
+			wantOffset:   50,
+			wantError:    nil,
+		},
+		{
+			name:         "valid cursor but different query",
+			token:        encodeCursorWithQuery(t, 50, "alpha"),
+			currentQuery: "beta",
+			wantOffset:   0, // offset not used on mismatch
+			wantError:    search.ErrCursorQueryMismatch,
+		},
+		{
+			name:         "invalid cursor with garbage",
+			token:        "not-valid-cursor",
+			currentQuery: "any query",
+			wantOffset:   0,
+			wantError:    search.ErrInvalidCursor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offset, err := search.VerifyCursor(tt.token, tt.currentQuery)
+
+			if tt.wantError != nil {
+				if !errors.Is(err, tt.wantError) {
+					t.Errorf("VerifyCursor(%q, %q) error: got %v, want %v", tt.token, tt.currentQuery, err, tt.wantError)
+				}
+			} else if err != nil {
+				t.Errorf("VerifyCursor(%q, %q) returned unexpected error: %v", tt.token, tt.currentQuery, err)
+			}
+
+			if tt.wantError == nil && offset != tt.wantOffset {
+				t.Errorf("VerifyCursor(%q, %q) offset: got %d, want %d", tt.token, tt.currentQuery, offset, tt.wantOffset)
+			}
+		})
+	}
+}
+
+// Helper: encode a cursor with a specific query for testing
+func encodeCursorWithQuery(t *testing.T, offset int, query string) string {
+	hash := search.QueryHash(query)
+	return search.EncodeCursor(offset, hash)
+}
+
+// Helper: encode a raw cursor payload with specific offset (for negative offset test)
+func encodeTestCursor(t *testing.T, offset int, hash string) string {
+	payload := map[string]interface{}{
+		"o": offset,
+		"q": hash,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Failed to marshal test cursor: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}

--- a/internal/search/cursor_test.go
+++ b/internal/search/cursor_test.go
@@ -83,8 +83,8 @@ func TestEncodeDecodeRoundtrip(t *testing.T) {
 			queryHash: search.QueryHash("hello world"),
 		},
 		{
-			name:      "large offset",
-			offset:    99999,
+			name:      "large offset (at MaxCursorOffset boundary)",
+			offset:    9999,
 			queryHash: search.QueryHash("test query"),
 		},
 		{
@@ -164,6 +164,16 @@ func TestDecodeCursorInvalid(t *testing.T) {
 			name:        "negative offset",
 			token:       encodeTestCursor(t, -1, "abc123"),
 			shouldError: true,
+		},
+		{
+			name:        "offset above MaxCursorOffset",
+			token:       encodeTestCursor(t, search.MaxCursorOffset+1, "abc123"),
+			shouldError: true,
+		},
+		{
+			name:        "offset exactly at MaxCursorOffset is accepted",
+			token:       encodeTestCursor(t, search.MaxCursorOffset, "abc123"),
+			shouldError: false,
 		},
 	}
 

--- a/internal/search/recency.go
+++ b/internal/search/recency.go
@@ -42,7 +42,11 @@ func ApplyRecencyBoost(results []Result, weight float64, halfLifeDays int, now t
 	}
 
 	sort.Slice(boosted, func(i, j int) bool {
-		return boosted[i].Score > boosted[j].Score
+		if boosted[i].Score != boosted[j].Score {
+			return boosted[i].Score > boosted[j].Score
+		}
+		// Stable tiebreaker for deterministic cursor pagination (#358).
+		return boosted[i].ID < boosted[j].ID
 	})
 
 	return boosted

--- a/internal/search/recency_test.go
+++ b/internal/search/recency_test.go
@@ -89,3 +89,41 @@ func TestRecencyBoost_VeryOldDoc(t *testing.T) {
 		t.Errorf("1000-day multiplier should be near zero, got %f", multiplier)
 	}
 }
+
+func TestApplyRecencyBoost_StableTiebreaker(t *testing.T) {
+	// Two results with identical Score and identical UpdatedAt timestamp.
+	// After recency boost, both must have identical boosted scores (same pre-score, same age → same boost).
+	// Tiebreaker: smaller ID wins.
+	baseTime := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+	results := []Result{
+		{ID: "uuid-x-bbb", Score: 0.5, UpdatedAt: baseTime},
+		{ID: "uuid-a-aaa", Score: 0.5, UpdatedAt: baseTime},
+	}
+
+	boosted := ApplyRecencyBoost(results, 0.3, 180, now)
+	if len(boosted) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(boosted))
+	}
+
+	// Both must have identical scores (since pre-score and age are identical)
+	if !approxEqual(boosted[0].Score, boosted[1].Score, 1e-9) {
+		t.Errorf("tied results should have same boosted score: %f vs %f", boosted[0].Score, boosted[1].Score)
+	}
+
+	// Tiebreaker: smaller ID first
+	if boosted[0].ID != "uuid-a-aaa" {
+		t.Errorf("tiebreaker: expected first ID='uuid-a-aaa', got '%s'", boosted[0].ID)
+	}
+	if boosted[1].ID != "uuid-x-bbb" {
+		t.Errorf("tiebreaker: expected second ID='uuid-x-bbb', got '%s'", boosted[1].ID)
+	}
+
+	// Determinism check: run twice, verify identical order
+	for iter := 0; iter < 2; iter++ {
+		result := ApplyRecencyBoost(results, 0.3, 180, now)
+		if result[0].ID != "uuid-a-aaa" || result[1].ID != "uuid-x-bbb" {
+			t.Errorf("iteration %d: order changed; got %s, %s", iter, result[0].ID, result[1].ID)
+		}
+	}
+}

--- a/internal/search/rrf.go
+++ b/internal/search/rrf.go
@@ -38,7 +38,11 @@ func RRFMerge(bm25Results, vectorResults []Result, k float64) []Result {
 	}
 
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].Score > out[j].Score
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		// Stable tiebreaker for deterministic cursor pagination (#358).
+		return out[i].ID < out[j].ID
 	})
 
 	return out

--- a/internal/search/rrf_test.go
+++ b/internal/search/rrf_test.go
@@ -68,6 +68,102 @@ func TestRRFMerge_CustomK(t *testing.T) {
 	}
 }
 
+func TestRRFMerge_StableTiebreaker(t *testing.T) {
+	// Two chunks with mathematically identical RRF scores: both at rank 0 in their respective lists.
+	// With k=60, score = 1.0 / (60 + 0 + 1) = 1/61 ≈ 0.016393...
+	// Chunk A: "uuid-a-zzz" (sorts first lexicographically)
+	// Chunk B: "uuid-b-aaa" (sorts second lexicographically)
+	// Expected: tied scores broken by ID, so "uuid-a-zzz" should be first.
+	bm25 := []Result{{ID: "uuid-b-aaa"}}
+	vec := []Result{{ID: "uuid-a-zzz"}}
+	k := 60.0
+
+	got := RRFMerge(bm25, vec, k)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(got))
+	}
+
+	expectedScore := 1.0 / (k + 0 + 1)
+	if !approxEqual(got[0].Score, expectedScore, 1e-9) {
+		t.Errorf("first result score = %f, want %f", got[0].Score, expectedScore)
+	}
+	if !approxEqual(got[1].Score, expectedScore, 1e-9) {
+		t.Errorf("second result score = %f, want %f", got[1].Score, expectedScore)
+	}
+
+	// Tiebreaker: smaller ID wins
+	if got[0].ID != "uuid-a-zzz" {
+		t.Errorf("tiebreaker: expected first ID='uuid-a-zzz', got '%s'", got[0].ID)
+	}
+	if got[1].ID != "uuid-b-aaa" {
+		t.Errorf("tiebreaker: expected second ID='uuid-b-aaa', got '%s'", got[1].ID)
+	}
+
+	// Determinism check: run 10 times with same input, verify identical order
+	for iter := 0; iter < 10; iter++ {
+		result := RRFMerge(bm25, vec, k)
+		if len(result) != 2 {
+			t.Fatalf("iteration %d: expected 2 results, got %d", iter, len(result))
+		}
+		if result[0].ID != "uuid-a-zzz" || result[1].ID != "uuid-b-aaa" {
+			t.Errorf("iteration %d: order changed; got %s, %s", iter, result[0].ID, result[1].ID)
+		}
+	}
+}
+
+func TestRRFMerge_PaginationConsistency(t *testing.T) {
+	// Build a list with 12 results, 3 of which have tied scores (to test tiebreaker across pagination boundary).
+	// Input: mix of scores such that we can slice [0:5] and [5:10] consistently.
+	bm25 := []Result{
+		{ID: "chunk-score-1-rank0"},
+		{ID: "chunk-score-1-rank1"},
+		{ID: "chunk-score-2-rank0"},
+		{ID: "chunk-score-2-rank1"},
+		{ID: "chunk-score-3-rank0"},
+		{ID: "chunk-score-3-rank1"},
+	}
+	vec := []Result{
+		{ID: "chunk-score-4-rank0"},
+		{ID: "chunk-score-4-rank1"},
+		{ID: "chunk-score-tied-vec0"}, // Will have tied score with some bm25
+		{ID: "chunk-score-tied-vec1"},
+		{ID: "chunk-score-tied-vec2"},
+	}
+	k := 60.0
+
+	// Merge once, get full sorted result
+	full := RRFMerge(bm25, vec, k)
+
+	// Slice as if paginating: page 1 = [0:5], page 2 = [5:10]
+	page1 := full[0:5]
+	page2 := full[5:10]
+
+	// Collect all IDs from both pages
+	pageIDs := make(map[string]int)
+	for i, r := range page1 {
+		pageIDs[r.ID] = i
+	}
+	for i, r := range page2 {
+		if _, exists := pageIDs[r.ID]; exists {
+			t.Errorf("duplicate result across pages: %s", r.ID)
+		}
+		pageIDs[r.ID] = 5 + i
+	}
+
+	// Verify union of pages == full result (no skips, no duplicates)
+	if len(pageIDs) != 10 {
+		t.Errorf("pagination union: expected 10 unique results, got %d", len(pageIDs))
+	}
+
+	// Re-merge same input and verify page slices are identical
+	full2 := RRFMerge(bm25, vec, k)
+	for i := 0; i < len(full); i++ {
+		if full[i].ID != full2[i].ID || !approxEqual(full[i].Score, full2[i].Score, 1e-12) {
+			t.Errorf("re-merge changed result at index %d: %s vs %s", i, full[i].ID, full2[i].ID)
+		}
+	}
+}
+
 func approxEqual(a, b, epsilon float64) bool {
 	return math.Abs(a-b) < epsilon
 }

--- a/internal/search/snippet.go
+++ b/internal/search/snippet.go
@@ -1,0 +1,21 @@
+package search
+
+// TruncateSnippet truncates a string to maxChars runes, preserving valid UTF-8 boundaries.
+// The function iterates over runes (not bytes), so multi-byte characters are handled correctly.
+// If maxChars <= 0, returns empty string.
+func TruncateSnippet(s string, maxChars int) string {
+	if maxChars <= 0 {
+		return ""
+	}
+	if len(s) <= maxChars {
+		return s
+	}
+	var count int
+	for i := range s {
+		if count == maxChars {
+			return s[:i]
+		}
+		count++
+	}
+	return s
+}

--- a/internal/search/snippet_test.go
+++ b/internal/search/snippet_test.go
@@ -1,0 +1,175 @@
+package search_test
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/nano-brain/nano-brain/internal/search"
+)
+
+func TestTruncateSnippet(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxChars int
+		want     string
+		checkUTF bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			maxChars: 10,
+			want:     "",
+			checkUTF: true,
+		},
+		{
+			name:     "short string unchanged",
+			input:    "hello",
+			maxChars: 10,
+			want:     "hello",
+			checkUTF: true,
+		},
+		{
+			name:     "exact boundary ASCII",
+			input:    "hello",
+			maxChars: 5,
+			want:     "hello",
+			checkUTF: true,
+		},
+		{
+			name:     "truncate ASCII to 3 runes",
+			input:    "hello world",
+			maxChars: 3,
+			want:     "hel",
+			checkUTF: true,
+		},
+		{
+			name:     "maxChars zero returns empty",
+			input:    "hello",
+			maxChars: 0,
+			want:     "",
+			checkUTF: true,
+		},
+		{
+			name:     "maxChars negative returns empty",
+			input:    "hello",
+			maxChars: -1,
+			want:     "",
+			checkUTF: true,
+		},
+		{
+			name:     "unicode accented character at boundary",
+			input:    "café",
+			maxChars: 3,
+			want:     "caf",
+			checkUTF: true,
+		},
+		{
+			name:     "unicode accented character exact",
+			input:    "café",
+			maxChars: 4,
+			want:     "café",
+			checkUTF: true,
+		},
+		{
+			name:     "chinese characters truncate",
+			input:    "你好世界",
+			maxChars: 2,
+			want:     "你好",
+			checkUTF: true,
+		},
+		{
+			name:     "mixed ASCII and unicode",
+			input:    "hello世界",
+			maxChars: 7,
+			want:     "hello世界",
+			checkUTF: true,
+		},
+		{
+			name:     "mixed ASCII and unicode truncate mid-unicode",
+			input:    "hello世界",
+			maxChars: 6,
+			want:     "hello世",
+			checkUTF: true,
+		},
+		{
+			name:     "emoji boundary",
+			input:    "hello🎉world",
+			maxChars: 6,
+			want:     "hello🎉",
+			checkUTF: true,
+		},
+		{
+			name:     "emoji truncate before",
+			input:    "hello🎉world",
+			maxChars: 5,
+			want:     "hello",
+			checkUTF: true,
+		},
+		{
+			name:     "multiple emoji",
+			input:    "🎉🎊🎈",
+			maxChars: 2,
+			want:     "🎉🎊",
+			checkUTF: true,
+		},
+		{
+			name:     "very long ASCII truncate",
+			input:    "abcdefghijklmnopqrstuvwxyz",
+			maxChars: 10,
+			want:     "abcdefghij",
+			checkUTF: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := search.TruncateSnippet(tt.input, tt.maxChars)
+			if got != tt.want {
+				t.Errorf("TruncateSnippet(%q, %d) = %q, want %q", tt.input, tt.maxChars, got, tt.want)
+			}
+			if tt.checkUTF && !utf8.ValidString(got) {
+				t.Errorf("TruncateSnippet(%q, %d) returned invalid UTF-8: %q", tt.input, tt.maxChars, got)
+			}
+		})
+	}
+}
+
+func TestTruncateSnippetRuneCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		maxChars   int
+		wantRunes  int
+	}{
+		{
+			name:       "return value has exactly maxChars runes when truncated",
+			input:      "abcdefghij",
+			maxChars:   5,
+			wantRunes:  5,
+		},
+		{
+			name:       "unicode: return value has exactly maxChars runes",
+			input:      "你好世界朋友",
+			maxChars:   3,
+			wantRunes:  3,
+		},
+		{
+			name:       "mixed: return value respects maxChars runes",
+			input:      "hello世界world",
+			maxChars:   7,
+			wantRunes:  7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := search.TruncateSnippet(tt.input, tt.maxChars)
+			gotRunes := utf8.RuneCountInString(got)
+			if gotRunes != tt.wantRunes {
+				t.Errorf("TruncateSnippet(%q, %d) returned %d runes, want %d (value: %q)", 
+					tt.input, tt.maxChars, gotRunes, tt.wantRunes, got)
+			}
+		})
+	}
+}

--- a/internal/server/handlers/search.go
+++ b/internal/server/handlers/search.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/search"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/telemetry"
 	pgvector_go "github.com/pgvector/pgvector-go"
@@ -47,17 +48,7 @@ type SearchResult struct {
 }
 
 func truncateSnippet(content string, maxLen int) string {
-	if len(content) <= maxLen {
-		return content
-	}
-	var count int
-	for i := range content {
-		if count == maxLen {
-			return content[:i]
-		}
-		count++
-	}
-	return content
+	return search.TruncateSnippet(content, maxLen)
 }
 
 type SearchResponse struct {

--- a/internal/server/handlers/wakeup.go
+++ b/internal/server/handlers/wakeup.go
@@ -87,7 +87,7 @@ func WakeUpHandler(q WakeUpQuerier, logger zerolog.Logger) echo.HandlerFunc {
 
 	docs, err := q.RecentDocuments(ctx, sqlc.RecentDocumentsParams{
 		WorkspaceHash: workspace,
-		Limit:         int32(limit),
+		MaxResults:    int32(limit),
 		Collections:   []string{"memory", "session-summary"},
 	})
 	if err != nil {

--- a/internal/server/handlers/wakeup_test.go
+++ b/internal/server/handlers/wakeup_test.go
@@ -180,8 +180,8 @@ func TestWakeUp_RecentMemoriesOrdering(t *testing.T) {
 
 	q := &mockWakeUpQuerier{
 		recentDocsFn: func(_ context.Context, arg sqlc.RecentDocumentsParams) ([]sqlc.RecentDocumentsRow, error) {
-			if arg.Limit != 10 {
-				t.Errorf("expected default limit 10, got %d", arg.Limit)
+			if arg.MaxResults != 10 {
+				t.Errorf("expected default limit 10, got %d", arg.MaxResults)
 			}
 			return []sqlc.RecentDocumentsRow{
 				{ID: id1, Title: "Recent", Tags: []string{"tag1"}, UpdatedAt: now, Snippet: "first doc content"},
@@ -240,7 +240,7 @@ func TestWakeUp_LimitParam_GET(t *testing.T) {
 	var capturedLimit int32
 	q := &mockWakeUpQuerier{
 		recentDocsFn: func(_ context.Context, arg sqlc.RecentDocumentsParams) ([]sqlc.RecentDocumentsRow, error) {
-			capturedLimit = arg.Limit
+			capturedLimit = arg.MaxResults
 			return []sqlc.RecentDocumentsRow{
 				{ID: uuid.New(), Title: "Doc1", Tags: []string{}, UpdatedAt: now, Snippet: "a"},
 				{ID: uuid.New(), Title: "Doc2", Tags: []string{}, UpdatedAt: now, Snippet: "b"},
@@ -279,7 +279,7 @@ func TestWakeUp_LimitCapped(t *testing.T) {
 	var capturedLimit int32
 	q := &mockWakeUpQuerier{
 		recentDocsFn: func(_ context.Context, arg sqlc.RecentDocumentsParams) ([]sqlc.RecentDocumentsRow, error) {
-			capturedLimit = arg.Limit
+			capturedLimit = arg.MaxResults
 			return []sqlc.RecentDocumentsRow{}, nil
 		},
 		docStatsFn: func(_ context.Context, _ string) (sqlc.WorkspaceDocStatsRow, error) {

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -75,7 +75,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = sqlc.arg(workspace_hash)
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
 LIMIT sqlc.arg(max_results);
 
 -- name: ResetEmbedStatusByCollection :execrows
@@ -104,7 +104,7 @@ SELECT e.id, e.chunk_id, e.workspace_hash,
 FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
 LIMIT sqlc.arg(max_results);
 
 -- name: VectorSearchWithTags :many
@@ -118,7 +118,7 @@ JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = sqlc.arg(workspace_hash)
   AND d.tags && sqlc.arg(tags)::text[]
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
 LIMIT sqlc.arg(max_results);
 
 -- name: VectorSearchAllWithTags :many
@@ -131,7 +131,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE d.tags && sqlc.arg(tags)::text[]
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
 LIMIT sqlc.arg(max_results);
 
 -- name: CountEmbeddingsByWorkspace :one

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -75,7 +75,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = sqlc.arg(workspace_hash)
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
 LIMIT sqlc.arg(max_results);
 
 -- name: ResetEmbedStatusByCollection :execrows
@@ -104,7 +104,7 @@ SELECT e.id, e.chunk_id, e.workspace_hash,
 FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
 LIMIT sqlc.arg(max_results);
 
 -- name: VectorSearchWithTags :many
@@ -118,7 +118,7 @@ JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = sqlc.arg(workspace_hash)
   AND d.tags && sqlc.arg(tags)::text[]
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
 LIMIT sqlc.arg(max_results);
 
 -- name: VectorSearchAllWithTags :many
@@ -131,7 +131,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE d.tags && sqlc.arg(tags)::text[]
-ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector
+ORDER BY e.embedding <=> sqlc.arg(query_embedding)::vector, c.id ASC
 LIMIT sqlc.arg(max_results);
 
 -- name: CountEmbeddingsByWorkspace :one

--- a/internal/storage/queries/wakeup.sql
+++ b/internal/storage/queries/wakeup.sql
@@ -2,10 +2,10 @@
 SELECT id, title, tags, updated_at,
        LEFT(content, 200) AS snippet
 FROM documents
-WHERE workspace_hash = $1
-  AND collection = ANY($3::text[])
+WHERE workspace_hash = sqlc.arg(workspace_hash)
+  AND collection = ANY(sqlc.arg(collections)::text[])
 ORDER BY updated_at DESC
-LIMIT $2;
+LIMIT sqlc.arg(max_results);
 
 -- name: WorkspaceDocStats :one
 SELECT count(*)::bigint AS total_documents,

--- a/internal/storage/sqlc/documents.sql.go
+++ b/internal/storage/sqlc/documents.sql.go
@@ -184,6 +184,49 @@ func (q *Queries) GetDocumentBySourcePath(ctx context.Context, arg GetDocumentBy
 	return i, err
 }
 
+const listDocumentSourcePathsAndHashes = `-- name: ListDocumentSourcePathsAndHashes :many
+SELECT id, source_path, content_hash
+FROM documents
+WHERE workspace_hash = $1
+  AND collection = $2
+  AND source_path != ''
+ORDER BY source_path
+`
+
+type ListDocumentSourcePathsAndHashesParams struct {
+	WorkspaceHash string
+	Collection    string
+}
+
+type ListDocumentSourcePathsAndHashesRow struct {
+	ID          uuid.UUID
+	SourcePath  string
+	ContentHash string
+}
+
+func (q *Queries) ListDocumentSourcePathsAndHashes(ctx context.Context, arg ListDocumentSourcePathsAndHashesParams) ([]ListDocumentSourcePathsAndHashesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listDocumentSourcePathsAndHashes, arg.WorkspaceHash, arg.Collection)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListDocumentSourcePathsAndHashesRow
+	for rows.Next() {
+		var i ListDocumentSourcePathsAndHashesRow
+		if err := rows.Scan(&i.ID, &i.SourcePath, &i.ContentHash); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDocumentsByWorkspace = `-- name: ListDocumentsByWorkspace :many
 SELECT d.id, d.workspace_hash, d.content_hash, d.title, d.source_path, d.collection, d.tags, d.created_at, d.updated_at,
        d.supersedes_id,
@@ -483,46 +526,6 @@ type UpdateDocumentsCollectionParams struct {
 func (q *Queries) UpdateDocumentsCollection(ctx context.Context, arg UpdateDocumentsCollectionParams) error {
 	_, err := q.db.ExecContext(ctx, updateDocumentsCollection, arg.Collection, arg.Collection_2, arg.WorkspaceHash)
 	return err
-}
-
-const listDocumentSourcePathsAndHashes = `-- name: ListDocumentSourcePathsAndHashes :many
-SELECT id, source_path, content_hash
-FROM documents
-WHERE workspace_hash = $1
-  AND collection = $2
-  AND source_path != ''
-ORDER BY source_path
-`
-
-type ListDocumentSourcePathsAndHashesParams struct {
-	WorkspaceHash string
-	Collection    string
-}
-
-type ListDocumentSourcePathsAndHashesRow struct {
-	ID          uuid.UUID
-	SourcePath  string
-	ContentHash string
-}
-
-func (q *Queries) ListDocumentSourcePathsAndHashes(ctx context.Context, arg ListDocumentSourcePathsAndHashesParams) ([]ListDocumentSourcePathsAndHashesRow, error) {
-	rows, err := q.db.QueryContext(ctx, listDocumentSourcePathsAndHashes, arg.WorkspaceHash, arg.Collection)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListDocumentSourcePathsAndHashesRow
-	for rows.Next() {
-		var i ListDocumentSourcePathsAndHashesRow
-		if err := rows.Scan(&i.ID, &i.SourcePath, &i.ContentHash); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	return items, rows.Err()
 }
 
 const upsertDocument = `-- name: UpsertDocument :one

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -388,7 +388,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = $2
-ORDER BY e.embedding <=> $1::vector
+ORDER BY e.embedding <=> $1::vector, c.id ASC
 LIMIT $3
 `
 
@@ -460,7 +460,7 @@ SELECT e.id, e.chunk_id, e.workspace_hash,
 FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
-ORDER BY e.embedding <=> $1::vector
+ORDER BY e.embedding <=> $1::vector, c.id ASC
 LIMIT $2
 `
 
@@ -532,7 +532,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE d.tags && $2::text[]
-ORDER BY e.embedding <=> $1::vector
+ORDER BY e.embedding <=> $1::vector, c.id ASC
 LIMIT $3
 `
 
@@ -606,7 +606,7 @@ JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = $2
   AND d.tags && $3::text[]
-ORDER BY e.embedding <=> $1::vector
+ORDER BY e.embedding <=> $1::vector, c.id ASC
 LIMIT $4
 `
 

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -388,7 +388,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = $2
-ORDER BY e.embedding <=> $1::vector, c.id ASC
+ORDER BY e.embedding <=> $1::vector
 LIMIT $3
 `
 
@@ -460,7 +460,7 @@ SELECT e.id, e.chunk_id, e.workspace_hash,
 FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
-ORDER BY e.embedding <=> $1::vector, c.id ASC
+ORDER BY e.embedding <=> $1::vector
 LIMIT $2
 `
 
@@ -532,7 +532,7 @@ FROM embeddings e
 JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE d.tags && $2::text[]
-ORDER BY e.embedding <=> $1::vector, c.id ASC
+ORDER BY e.embedding <=> $1::vector
 LIMIT $3
 `
 
@@ -606,7 +606,7 @@ JOIN chunks c ON e.chunk_id = c.id
 JOIN documents d ON c.document_id = d.id
 WHERE e.workspace_hash = $2
   AND d.tags && $3::text[]
-ORDER BY e.embedding <=> $1::vector, c.id ASC
+ORDER BY e.embedding <=> $1::vector
 LIMIT $4
 `
 

--- a/internal/storage/sqlc/wakeup.sql.go
+++ b/internal/storage/sqlc/wakeup.sql.go
@@ -62,15 +62,15 @@ SELECT id, title, tags, updated_at,
        LEFT(content, 200) AS snippet
 FROM documents
 WHERE workspace_hash = $1
-  AND collection = ANY($3::text[])
+  AND collection = ANY($2::text[])
 ORDER BY updated_at DESC
-LIMIT $2
+LIMIT $3
 `
 
 type RecentDocumentsParams struct {
 	WorkspaceHash string
-	Limit         int32
 	Collections   []string
+	MaxResults    int32
 }
 
 type RecentDocumentsRow struct {
@@ -82,7 +82,7 @@ type RecentDocumentsRow struct {
 }
 
 func (q *Queries) RecentDocuments(ctx context.Context, arg RecentDocumentsParams) ([]RecentDocumentsRow, error) {
-	rows, err := q.db.QueryContext(ctx, recentDocuments, arg.WorkspaceHash, arg.Limit, pq.Array(arg.Collections))
+	rows, err := q.db.QueryContext(ctx, recentDocuments, arg.WorkspaceHash, pq.Array(arg.Collections), arg.MaxResults)
 	if err != nil {
 		return nil, err
 	}

--- a/openspec/changes/mcp-search-snippet-pagination/.openspec.yaml
+++ b/openspec/changes/mcp-search-snippet-pagination/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/mcp-search-snippet-pagination/design.md
+++ b/openspec/changes/mcp-search-snippet-pagination/design.md
@@ -1,0 +1,186 @@
+## Context
+
+### Current state
+
+nano-brain exposes three search MCP tools (`memory_query`, `memory_search`, `memory_vsearch`) backed by the shared `internal/search/Service.HybridSearch` pipeline:
+
+```
+query → [BM25 leg | Vector leg]  (parallel, errgroup, fetchLimit = max(maxResults*3, 30))
+         ↓
+        RRF fusion (k=60, computed in Go)
+         ↓
+        Recency boost (exponential half-life decay)
+         ↓
+        Slice [0 : maxResults]
+         ↓
+        Marshal to JSON via textResult()
+```
+
+The `search.Result` struct (`internal/search/search.go:10-22`) carries both a `Snippet` field (already populated, ≤700 chars from the SQL `LEFT(content, ...)` projection or from a Go-side truncation) and a `Content` field (full chunk text, often 5–50 KB).
+
+The HTTP layer (`internal/server/handlers/search.go`) maps `search.Result` → a local `SearchResult` struct that omits `Content` entirely and emits `Snippet` only. The MCP layer marshals raw `search.Result` (or near-equivalent inline `resultRow` structs) — so `Content` ships on every result.
+
+The MCP `tools/call` response envelope (per MCP 2025-06-18 spec) has no built-in pagination cursor. Listing endpoints (`tools/list`, `resources/list`) do, but tool-call results are free-form `{content[], structuredContent?, isError?}`. Any pagination on tool-call results is therefore a **server-defined convention**, not a protocol feature.
+
+### Constraints
+
+- **Single static binary, no Redis.** Server-side cache for paginated snapshots would add lifecycle complexity (eviction, TTL, capacity). Avoid.
+- **Stateless server preferred.** Each request must be answerable from request + DB alone.
+- **Read-mostly memory workload.** Writes happen seconds–minutes apart for the same workspace; agent pagination happens in seconds. Offset-drift on a mutable index is acceptable.
+- **Embedding API call is expensive (200–800 ms).** Re-running hybrid search per page re-embeds the query each time. Acceptable now; LRU cache is tracked separately (#359).
+- **HTTP API stays untouched.** Out of scope. Different surface, different consumers, no truncation problem there.
+
+### Stakeholders
+
+- **AI coding agents** consuming nano-brain via MCP (OpenCode, Claude Code, Cursor, others). They are the only direct consumers of the search tool responses.
+- **Skill docs** (`.opencode/skills/nano-brain/SKILL.md`) — the agent-facing contract surface.
+- **CI / integration tests** — zero response-shape coverage exists today; this change must add it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+1. Reduce default MCP search response size by **≥85%** (target: ≤15 KB for `max_results=10`) so responses fit in OpenCode's ~50 KB tool-output budget without triggering truncation.
+2. Provide a **stateless, opaque cursor** so agents can paginate beyond `max_results` without dumping the entire result set in one shot.
+3. Preserve a **migration path** for existing agents that need the full content (`include_content: true` opt-in + `memory_get` recommendation).
+4. **Deterministic pagination order** — same query + same cursor on a quiescent index returns the same slice.
+5. **No new infrastructure.** No cache, no Redis, no separate service. All work in-process and stateless.
+
+**Non-Goals:**
+
+- Time-range filters (`created_after` / `created_before`). Different feature, separate issue.
+- Changing the HTTP API contract. Already correct.
+- Query-embedding LRU cache. Tracked as #359; orthogonal value.
+- Per-stage latency log instrumentation. Useful but separate.
+- Refactoring the three search tools to share a response struct. Code quality, not a user-facing fix.
+- `memory_wake_up` changes. Already snippet-only and bounded.
+- Adding pagination to non-search tools (`memory_get`, `memory_status`, etc.). Out of scope.
+
+## Decisions
+
+### D1 — Default to snippet-only, opt-in for full content
+
+**Decision:** Drop the `content` field from all three MCP search tool responses by default. Add an `include_content` boolean parameter (default `false`) that re-enables full content per request.
+
+**Why:**
+- The HTTP API already does this (`handlers/search.go:35-47`). MCP was the inconsistent outlier.
+- SKILL.md never documented `content` as a search-tool return field — only `snippet`.
+- Most agent workflows want "what matched and where" first, then full content for the 1–3 hits they care about. The `memory_get` tool already covers the full-content fetch (and supports line slicing).
+- Empirically gives the ~90% size reduction needed to fit under the truncation threshold at default settings.
+
+**Alternatives considered:**
+
+| Option | Rejected because |
+|---|---|
+| Keep `content`, add `compact: true` opt-in | Doesn't fix the default-case bloat that motivates this issue. Most agents won't opt in. |
+| Rename `content` → `snippet` (same field, just truncated) | Misleading: the same JSON key sometimes returns 700 chars, sometimes 50 KB depending on call site. Worse than removal. |
+| New tool: `memory_search_v2` etc. | Doubles the MCP tool count, splits documentation, doesn't retire the broken default. Pure tech debt. |
+
+**Trade-off:** Breaking change for any agent that consumed the undocumented `content` field. Mitigated by the `include_content` escape hatch and explicit migration text in tool descriptions + SKILL.md.
+
+### D2 — Stateless offset-based cursor with query-hash guard
+
+**Decision:** Encode the cursor as `base64url(JSON{"o": offset, "q": queryHash})` where `queryHash` is the first 16 hex chars of `sha256(query_text)`. Server decodes, verifies the hash matches the current request's query, and re-runs hybrid search with `LIMIT = offset + page_size + 1` to detect "has more".
+
+**Why:**
+- Stateless — no server cache, no TTL, no eviction. Survives server restarts. Survives load-balancer rebalances if nano-brain is ever horizontally scaled.
+- Query-hash guard prevents a foot-gun: agent passes the cursor from query A to query B and silently gets wrong-looking results.
+- Offset-based is correct on a quiescent index. On a mutating index it can drift by a small N (new docs inserted between pages), which is acceptable for memory-search workloads.
+- The cursor is fully self-describing; no shared secret or signing scheme needed. Opaque-to-client requirement is satisfied by base64.
+
+**Alternatives considered:**
+
+| Option | Rejected because |
+|---|---|
+| Score-based cursor (`score < X`) | RRF scores are computed in Go, not directly indexable. Ties between equal-score results force a secondary sort key anyway. Marginal benefit, much more complexity. |
+| Server-side snapshot cache keyed by cursor token | Adds an eviction + capacity subsystem to a single-binary server. Wrong shape for nano-brain. |
+| Composite cursor `(query_hash, snapshot_ts, offset)` | Snapshot_ts is unused without a server-side snapshot. Premature complexity. |
+| Reuse MCP `cursor` / `nextCursor` listing convention verbatim | MCP `tools/call` results have no `nextCursor` field — pagination on tool-call results is a server-defined extension. We borrow the naming convention but not a protocol field. |
+
+**Trade-off:** Each paginated page re-embeds the query (200–800 ms). Acceptable because deep pagination is rare; query-embedding cache (#359) makes the trade-off even better when shipped.
+
+### D3 — Stable tiebreaker on tied scores
+
+**Decision:** When RRF (`internal/search/rrf.go`) or recency boost (`internal/search/recency.go`) produces tied scores, break the tie by `id ASC`. Apply at both stages.
+
+**Why:**
+- Without a stable secondary sort, offset-based cursoring can silently reorder results between pages (map-iteration order in Go is randomized; PostgreSQL `LIMIT` without `ORDER BY` is undefined).
+- Tied scores already mean "equally relevant" — picking the smaller `id` is arbitrary but stable.
+- One-line change in two existing sort comparators.
+
+**Alternative considered:** Sort by `created_at ASC`. Rejected because `created_at` ties also happen on bulk imports and lack the uniqueness guarantee `id` (UUID) carries.
+
+### D4 — Snippet length = 500 chars in MCP (vs 700 in HTTP)
+
+**Decision:** Truncate snippets to 500 chars in the MCP layer, even though HTTP uses 700.
+
+**Why:**
+- MCP consumers are token-constrained AI agents; HTTP consumers are humans (curl, browser, dashboard).
+- At `max_results=10`, the difference is 2 KB (10 × 200 chars). Small enough to matter for token budgets.
+- 500 chars is roughly 80–120 tokens — long enough to disambiguate hits, short enough to scan in bulk.
+
+**Alternative considered:** Make snippet length configurable per-call (`snippet_len` parameter). Rejected to keep the parameter surface small. Easy to add later if a real use case emerges.
+
+### D5 — Re-run hybrid search per page, no caching
+
+**Decision:** Each paginated request re-runs `HybridSearch` from scratch with `maxResults = cursor.offset + page_size + 1` (the +1 detects "more pages exist").
+
+**Why:**
+- Correct under index mutation — results always reflect current data.
+- No cache lifecycle to manage.
+- PG indexed search at LIMIT 300 is sub-100 ms in practice; the bottleneck is the embedding API, which the LRU cache (#359) addresses orthogonally.
+
+**Trade-off:** Linear cost in offset for deep pages. Practical max is page 10 (offset 100, fetchLimit ≈ 300 per leg) — still well within PG capacity. If real workloads ever exceed page 10 routinely, we revisit with a snapshot-cache decision; not today.
+
+### D6 — Approximate `total` field
+
+**Decision:** Include a `total` field in the response equal to the count of results in the **current fused result set** (i.e., `len(boosted)` before slicing), not the count of all possible matches in the index.
+
+**Why:**
+- Exact total requires a separate `COUNT(*)` query on both BM25 and vector legs — adds latency without much benefit.
+- Approximate total answers the operational question the agent actually has: "did I see everything, or should I page?"
+- If `len(boosted) == requested fetchLimit` we can't be sure no more exist — that's exactly what `next_cursor` signals.
+
+**Trade-off:** `total` underestimates on later pages (the result set grows as fetchLimit grows). Documented in the field description.
+
+### D7 — Shared `truncateSnippet` helper extracted to `internal/search/snippet.go`
+
+**Decision:** Move the 12-line `truncateSnippet` function from `internal/server/handlers/search.go:49-61` to a new file `internal/search/snippet.go` and import it from both the HTTP and MCP layers.
+
+**Why:**
+- DRY across two callers, both in this codebase.
+- Lives next to `search.Result` and the other search-layer helpers.
+- Avoids drift if HTTP truncation logic ever changes.
+
+**Trade-off:** One-line import in `handlers/search.go`. Trivial.
+
+## Risks / Trade-offs
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Agents parsing the undocumented `content` field break on PR merge | High | Medium | (a) `include_content: true` escape hatch preserves old behavior. (b) Tool descriptions + SKILL.md updated with explicit migration text. (c) `memory_get` already exists for full-content fetch. (d) Document the break in CHANGELOG.md. |
+| Offset-drift on rapidly-written workspaces causes duplicate/missing results across pages | Low | Low | Memory-search workloads write minutes apart, paginate seconds apart. Documented as known limitation in the cursor field description. Escalation: revisit with snapshot-cache design if real-world reports surface. |
+| Cursor passed from query A to query B silently returns query-B results from query-A's offset | Low | Medium | Query-hash guard in cursor decode. Mismatch → `INVALID_CURSOR` error with clear text. Unit-tested. |
+| Stable-tiebreaker change reorders ties for existing search callers | Low | Low | Only affects results with mathematically identical RRF/recency scores. "Equally relevant" results getting a stable order is an improvement, not a regression. |
+| Deep pagination (page 10+) becomes slow due to fetchLimit growth | Medium | Low | Caps naturally at `max_results × 3 × current_page_offset_factor`. Practical max ~300 rows per leg. Mitigated long-term by #359 (query-embedding cache). If real workloads exhibit deep pagination, revisit with snapshot cache. |
+| New `include_content: true` agents re-introduce the original payload problem | Low | Low | Opt-in is explicit. Tool description warns about size impact. Operator can monitor via `query_ms` and request-size logs (existing telemetry). |
+| MCP integration tests are unfamiliar territory in this repo | Medium | Low | `internal/mcp/tools_test.go` already exists with `testutil.SetupTestDB`. Pattern is established. |
+| Snippet truncation breaks on multi-byte unicode boundaries | Low | Medium | `truncateSnippet` in handlers already handles this (rune-aware). Reusing it via D7 inherits the correctness. Add explicit unicode-boundary test in `snippet_test.go`. |
+
+## Migration Plan
+
+1. **Ship the change as a single PR.** No multi-phase rollout — the response shape change is the entire fix.
+2. **CHANGELOG.md entry** under the next release announces the MCP-only breaking change, the `include_content` opt-in, and the `cursor` parameter. Calls out: "HTTP API unchanged."
+3. **SKILL.md update** lands in the same PR — agent docs match the new contract on day one.
+4. **Tool descriptions** in `tools.go` updated to mention the new parameters and the snippet-by-default behavior. MCP clients auto-discover via `tools/list`.
+5. **No data migration** — no DB schema changes, no goose migration, no embedding rebuild.
+6. **Rollback:** Single-PR revert. No persistent state to undo.
+
+## Open Questions
+
+None blocking. The following are tracked or deferred:
+
+- LRU query-embedding cache → tracked as #359, independent of this change.
+- Per-stage latency log instrumentation → noted in Metis review, separate enhancement.
+- Time-range filters (`created_after` / `created_before`) → separate issue; would partially address the "last 30 days" use case.
+- Whether to expose `snippet_len` as a per-call parameter → deferred; ship with fixed 500 chars, revisit if requested.

--- a/openspec/changes/mcp-search-snippet-pagination/proposal.md
+++ b/openspec/changes/mcp-search-snippet-pagination/proposal.md
@@ -1,0 +1,52 @@
+Tracking: #358
+
+## Why
+
+The MCP search tools (`memory_query`, `memory_search`, `memory_vsearch`) currently return the FULL document `content` field on every result. With the default `max_results=10`, a single search response is typically 50–500 KB. This exceeds the host agent's tool-output threshold (~50 KB on OpenCode), forcing the agent to spawn a second subagent just to grep the truncated file — adding 30–60 seconds per memory lookup.
+
+The HTTP layer (`internal/server/handlers/search.go`) solved this years ago by mapping results to `SearchResult` with only a 700-char `Snippet` field. The MCP layer (`internal/mcp/tools.go`) bypassed that pattern and returns raw `search.Result` with both `Snippet` and `Content`. The `Content` field is also undocumented in `.opencode/skills/nano-brain/SKILL.md` for search tools, yet it is the single largest contributor to response bloat.
+
+In addition, neither the HTTP nor the MCP layer supports pagination. An agent asking "what bugs did we fix in the last 30 days" has only two options today: cap at `max_results=10` (and miss most matches) or `max_results=100` (and dump 1–5 MB of irrelevant chunks). There is no way to incrementally browse hits.
+
+## What Changes
+
+- **BREAKING (MCP only):** `memory_query`, `memory_search`, `memory_vsearch` no longer include the full `content` field in search results by default. They return a 500-char `snippet` instead. Agents that need full text MUST either pass `include_content: true` or call `memory_get` with the result's `id`/`source_path`.
+- Add **opt-in `include_content` boolean parameter** (default `false`) to all three search tools. When `true`, every result includes the full `content` field alongside `snippet` (preserves the pre-change payload for agents that genuinely need it).
+- Add **stateless cursor-based pagination** to all three search tools:
+  - New input parameter `cursor` (optional opaque string).
+  - New response field `next_cursor` (present only when more results exist beyond the current page).
+  - New response field `total` (approximate count of results available in the current fused result set, for "should I page?" decisions).
+  - Cursor format: `base64url(JSON{offset, query_hash})`. Server validates the query hash on every page to prevent cross-query cursor reuse.
+- Add new response field `query_ms` (server-side latency, useful for operator visibility — already present in HTTP responses).
+- **Stable result ordering:** Tied RRF / recency scores now break by `id ASC` (deterministic across paginated pages).
+- HTTP API (`/api/v1/search`, `/api/v1/query`, `/api/v1/vsearch`) is **unchanged** — already snippet-only, and changing it is out of scope for this PR.
+- `memory_wake_up` is **unchanged** — already returns 200-char `LEFT(content, 200)` snippets and is paginated by `limit` only.
+- `memory_get` is **unchanged** — already the canonical full-content fallback (supports `start_line`/`end_line` slicing).
+- Update `.opencode/skills/nano-brain/SKILL.md` to (a) explicitly document the `snippet` field, (b) document the new `cursor` / `include_content` parameters, (c) recommend `memory_get` for full content.
+- Add response-shape integration tests (none exist today — zero coverage on MCP search response fields).
+
+### Explicitly OUT of scope (separate issues)
+
+- Time-range filters (`created_after` / `created_before`) on search tools — would partially answer the user's "last 30 days" use case but requires SQL + new parameters; tracked as a follow-up.
+- LRU query-embedding cache — independent optimization (repeated query text → cached vector); tracked as #359.
+- Per-stage latency log instrumentation on `HybridSearch` — observability improvement; tracked separately.
+- Changing the HTTP API response shape — already snippet-only; out of scope.
+- Refactoring the three search tools to share a response struct — code quality, not a user-facing fix.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `mcp-server`: search tool response contract changes (drop `content` by default → return `snippet`; add `cursor` / `include_content` parameters; add `next_cursor` / `total` / `query_ms` response fields). Existing requirements on workspace scoping, schema, and response validity are preserved.
+- `search-pipeline`: result ordering acquires a stable tiebreaker (`id ASC` on tied scores). RRF fusion and recency boost behavior unchanged.
+
+## Impact
+
+- **Affected code:** `internal/mcp/tools.go` (three search tool registrations), `internal/search/cursor.go` (new file, ~60 lines), `internal/search/snippet.go` (new file, extracts the 12-line `truncateSnippet` helper currently inlined in `handlers/search.go`), `internal/search/rrf.go` and `internal/search/recency.go` (stable tiebreaker on tied scores), `.opencode/skills/nano-brain/SKILL.md` (documentation).
+- **Unchanged:** `internal/search/service.go` (HybridSearch signature stays; caller passes a larger `maxResults` for deep pages), `internal/search/search.go` (`Result` struct already has both `Snippet` and `Content` fields — we just stop forwarding `Content` in the MCP layer), all SQL queries in `internal/storage/queries/`, HTTP handlers in `internal/server/handlers/`.
+- **MCP clients:** Agents parsing `content` from search results will get an empty/missing field. They must adopt either `include_content: true` or `memory_get`. Documentation update + tool description text covers the migration path.
+- **Tests:** Add `internal/search/cursor_test.go`, `internal/search/snippet_test.go`, `internal/mcp/tools_pagination_integration_test.go`. No existing tests are deleted; the existing `tools_test.go` continues to cover registration and error paths.
+- **Performance:** Default-case response size drops ~90% (50–500 KB → ~5–15 KB). Deep pages (page 2+) re-run the full hybrid search with `LIMIT = offset + page_size + 1` — acceptable because (a) deep pagination is rare, (b) PG handles 300-row limits trivially, (c) embedding cache is tracked separately (#359).
+- **Risk gates touched:** `public-api-contract` (MCP tool response shape changes), `existing-behavior` (default response changes), `search-quality` (response visibility changes — hard gate), `multi-domain` (mcp + search packages). Lane: **high-risk**.

--- a/openspec/changes/mcp-search-snippet-pagination/specs/mcp-server/spec.md
+++ b/openspec/changes/mcp-search-snippet-pagination/specs/mcp-server/spec.md
@@ -1,0 +1,151 @@
+## ADDED Requirements
+
+### Requirement: Search tools default to snippet-only responses
+
+The `memory_query`, `memory_search`, and `memory_vsearch` MCP tools SHALL omit the `content` field from each search result in the default response. Each result SHALL include a `snippet` field containing at most 500 UTF-8 characters of the matched chunk text. The snippet SHALL preserve full Unicode characters (no truncation in the middle of a multi-byte rune).
+
+#### Scenario: memory_query default response excludes content
+
+- **WHEN** `memory_query` is called with `{"workspace": "<hash>", "query": "fix bug"}` (no `include_content` parameter)
+- **THEN** every object in `response.results` SHALL include a `snippet` field of length ≤ 500 characters
+- **THEN** no object in `response.results` SHALL include a `content` field (or `content` SHALL be omitted from the JSON, not present as empty string)
+
+#### Scenario: memory_search default response excludes content
+
+- **WHEN** `memory_search` is called with `{"workspace": "<hash>", "query": "test"}` (no `include_content` parameter)
+- **THEN** every object in `response.results` SHALL include a `snippet` field of length ≤ 500 characters
+- **THEN** no object in `response.results` SHALL include a `content` field
+
+#### Scenario: memory_vsearch default response excludes content
+
+- **WHEN** `memory_vsearch` is called with `{"workspace": "<hash>", "query": "test"}` (no `include_content` parameter)
+- **THEN** every object in `response.results` SHALL include a `snippet` field of length ≤ 500 characters
+- **THEN** no object in `response.results` SHALL include a `content` field
+
+#### Scenario: Snippet truncation respects UTF-8 boundaries
+
+- **WHEN** a search result's underlying chunk contains a multi-byte Unicode character (e.g., `é`, `世`, emoji) at character position 499–501
+- **THEN** the returned `snippet` SHALL NOT contain a half-character (no invalid UTF-8 sequence in the response)
+- **THEN** the snippet SHALL end at a valid character boundary at or before position 500
+
+#### Scenario: Default response payload size budget
+
+- **WHEN** any of `memory_query`, `memory_search`, `memory_vsearch` is called with `max_results: 10` and default parameters (no `include_content`)
+- **THEN** the serialized JSON response body SHALL be ≤ 20,000 bytes for a result set of 10 results with typical 50–2000 char chunks
+
+### Requirement: Search tools accept opt-in include_content parameter
+
+The `memory_query`, `memory_search`, and `memory_vsearch` MCP tools SHALL accept an optional boolean input parameter `include_content`. When `include_content: true`, the response SHALL include a `content` field on every result containing the full chunk text. When `include_content: false` or omitted, the response SHALL omit the `content` field per the snippet-only requirement above.
+
+#### Scenario: include_content=true preserves full chunk content
+
+- **WHEN** `memory_query` is called with `{"workspace": "<hash>", "query": "test", "include_content": true}`
+- **THEN** every object in `response.results` SHALL include both `snippet` (≤500 chars) and `content` (full chunk text) fields
+- **THEN** `content` field length SHALL equal the underlying `chunks.content` column value for that result
+
+#### Scenario: include_content=false matches default behavior
+
+- **WHEN** `memory_search` is called with `{"workspace": "<hash>", "query": "test", "include_content": false}`
+- **THEN** the response SHALL be byte-identical to the same call with `include_content` omitted
+
+#### Scenario: Tool schema advertises include_content parameter
+
+- **WHEN** an MCP client lists available tools via `tools/list`
+- **THEN** `memory_query`, `memory_search`, and `memory_vsearch` SHALL each show an `include_content` boolean parameter in their input schema
+- **THEN** the parameter description SHALL explain: "Set to true to include full chunk content alongside the snippet. Defaults to false. Increases response size; prefer memory_get for fetching one full document."
+
+### Requirement: Search tools support cursor-based pagination
+
+The `memory_query`, `memory_search`, and `memory_vsearch` MCP tools SHALL accept an optional string input parameter `cursor` and SHALL emit an optional string response field `next_cursor`. When `next_cursor` is present, the agent MAY pass it as the `cursor` parameter on the next call to retrieve the subsequent page. When the same call with `cursor` is made on a quiescent index, the returned page SHALL contain results that immediately follow the previously returned page (no overlap, no skip).
+
+The cursor SHALL be an opaque base64url-encoded JSON object with shape `{"o": <int offset>, "q": <string query_hash>}` where `query_hash` is the first 16 hex characters of `sha256(query_text)`. Clients MUST NOT parse or modify the cursor; servers MAY change the encoding without notice.
+
+When `cursor` is provided and the embedded `query_hash` does not match `sha256(query_text)[:16]` for the current call's query, the tool SHALL return an error response with message containing "cursor query mismatch" or equivalent.
+
+#### Scenario: First page omits cursor parameter
+
+- **WHEN** `memory_search` is called with `{"workspace": "<hash>", "query": "test", "max_results": 5}` and no `cursor`
+- **THEN** the response SHALL contain `results` (length 0–5)
+- **THEN** if there exist more than 5 matching results, the response SHALL include a non-empty `next_cursor` string
+- **THEN** if 5 or fewer results matched in total, `next_cursor` SHALL be absent from the response (not present as empty string or null)
+
+#### Scenario: Subsequent page uses cursor from previous response
+
+- **GIVEN** a workspace containing 12 documents matching the query "alpha"
+- **WHEN** `memory_search` is called with `{"workspace": "<hash>", "query": "alpha", "max_results": 5}` returning results `[r1..r5]` and `next_cursor: "C1"`
+- **AND THEN** `memory_search` is called with `{"workspace": "<hash>", "query": "alpha", "max_results": 5, "cursor": "C1"}`
+- **THEN** the response SHALL contain `results: [r6..r10]` with no overlap and no skip
+- **THEN** the response SHALL include `next_cursor: "C2"` (since 2 more results exist)
+
+#### Scenario: Final page has no next_cursor
+
+- **GIVEN** a workspace containing exactly 12 documents matching the query "alpha"
+- **WHEN** the agent paginates through to the third page (results 11–12)
+- **THEN** the response SHALL contain `results: [r11, r12]`
+- **THEN** `next_cursor` SHALL be absent from the response
+
+#### Scenario: Cursor from different query is rejected
+
+- **WHEN** `memory_search` is called with `{"workspace": "<hash>", "query": "beta", "cursor": "<cursor-encoded-for-query-alpha>"}`
+- **THEN** the tool SHALL return an error response
+- **THEN** the error message SHALL contain the substring "cursor query mismatch"
+
+#### Scenario: Malformed cursor is rejected
+
+- **WHEN** any search tool is called with `{"workspace": "<hash>", "query": "x", "cursor": "not-valid-base64!@#"}`
+- **THEN** the tool SHALL return an error response with message containing "invalid cursor"
+
+#### Scenario: Tool schema advertises cursor parameter
+
+- **WHEN** an MCP client lists available tools
+- **THEN** `memory_query`, `memory_search`, and `memory_vsearch` SHALL each show a `cursor` string parameter (optional) in their input schema
+- **THEN** the parameter description SHALL explain: "Opaque pagination cursor from the next_cursor field of a previous response. Pass the same query when paginating."
+
+### Requirement: Search responses include total and query_ms metadata
+
+The response envelope of `memory_query`, `memory_search`, and `memory_vsearch` SHALL include a `total` integer field and a `query_ms` integer field at the top level (alongside `results` and optional `next_cursor`).
+
+`total` SHALL be the count of results in the fused result set fetched on the current request (i.e., `len(results_after_fusion_and_recency_boost)` before pagination slicing), not an exact COUNT(*) over the index.
+
+`query_ms` SHALL be the server-measured elapsed milliseconds from the request entering the tool handler to the response being marshaled, rounded to the nearest integer.
+
+#### Scenario: Response includes total field
+
+- **WHEN** any search tool is called and returns ≥ 1 result
+- **THEN** the response SHALL include a `total` integer field at the top level
+- **THEN** `total` SHALL be ≥ `len(results)` in the current page
+
+#### Scenario: Response includes query_ms field
+
+- **WHEN** any search tool is called and completes successfully
+- **THEN** the response SHALL include a `query_ms` integer field at the top level
+- **THEN** `query_ms` SHALL be ≥ 0
+
+#### Scenario: Empty result set still includes both fields
+
+- **WHEN** any search tool is called with a query that matches zero documents
+- **THEN** the response SHALL include `results: []`, `total: 0`, and `query_ms: <non-negative integer>`
+- **THEN** the response SHALL NOT include `next_cursor`
+
+## MODIFIED Requirements
+
+### Requirement: Search tool parameter schema includes workspace
+
+The MCP tool registration for `memory_search`, `memory_vsearch`, and `memory_query` SHALL include `workspace` in their input schema as an optional string parameter with description explaining the scoping behavior. Additionally, all three tools SHALL include a `compact` boolean parameter (optional, defaults to false) with description: "Set to true for compact single-line results with caching. Defaults to verbose." Additionally, all three tools SHALL include the `include_content` and `cursor` parameters per the snippet-only and pagination requirements in this capability.
+
+#### Scenario: Tool schema advertises workspace parameter
+
+- **WHEN** an MCP client lists available tools
+- **THEN** `memory_search`, `memory_vsearch`, and `memory_query` each show a `workspace` parameter in their input schema
+- **THEN** the parameter description explains: omit for current workspace, `"all"` for cross-workspace search
+
+#### Scenario: Tool schema advertises compact parameter
+
+- **WHEN** an MCP client lists available tools
+- **THEN** `memory_search`, `memory_vsearch`, and `memory_query` each show a `compact` boolean parameter in their input schema
+- **THEN** the parameter description explains: defaults to false (verbose), set to true for compact single-line results
+
+#### Scenario: Tool schema advertises pagination and content parameters
+
+- **WHEN** an MCP client lists available tools
+- **THEN** `memory_search`, `memory_vsearch`, and `memory_query` each show `cursor` (string, optional) and `include_content` (boolean, optional) parameters in their input schema

--- a/openspec/changes/mcp-search-snippet-pagination/specs/search-pipeline/spec.md
+++ b/openspec/changes/mcp-search-snippet-pagination/specs/search-pipeline/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Stable result ordering on tied scores
+
+The search pipeline (`internal/search/rrf.RRFMerge` and `internal/search/recency.ApplyRecencyBoost`) SHALL produce a deterministic result order when multiple results have mathematically identical scores. When two or more results have equal RRF scores or equal recency-boosted scores, ordering between them SHALL be determined by ascending result `id` (UUID string comparison).
+
+Without this guarantee, cursor-based pagination cannot return a stable slice of a result set across paginated calls — equal-score results would reorder between page 1 and page 2 due to Go map iteration order or PostgreSQL `LIMIT` without `ORDER BY` indeterminism.
+
+#### Scenario: RRF fusion breaks ties by id ASC
+
+- **GIVEN** two BM25 candidates A and B that produce identical RRF scores after fusion
+- **WHEN** `RRFMerge` is called on a result set containing A and B
+- **THEN** the result whose `id` sorts smaller (lexicographic UUID string comparison) appears earlier in the output slice
+- **THEN** running `RRFMerge` again on the same input SHALL produce the same output order
+
+#### Scenario: Recency boost preserves stable order on tied boosted scores
+
+- **GIVEN** two results X and Y with identical pre-boost scores AND identical `created_at` timestamps (e.g., two documents inserted in the same bulk import)
+- **WHEN** `ApplyRecencyBoost` is called on the result set
+- **THEN** the result whose `id` sorts smaller appears earlier in the output slice
+- **THEN** running `ApplyRecencyBoost` again on the same input SHALL produce the same output order
+
+#### Scenario: Paginated calls return non-overlapping, non-skipping slices
+
+- **GIVEN** a quiescent index with 20 documents matching a query
+- **WHEN** the first call returns results 1–10 with stable ordering
+- **AND THEN** the second call (with cursor) returns results 11–20
+- **THEN** no result appears in both pages
+- **THEN** no result from 1–20 is absent from the union of both pages

--- a/openspec/changes/mcp-search-snippet-pagination/tasks.md
+++ b/openspec/changes/mcp-search-snippet-pagination/tasks.md
@@ -1,0 +1,94 @@
+## 1. Shared helpers (foundation, no behavior change yet)
+
+- [ ] 1.1 Create `internal/search/snippet.go` with `TruncateSnippet(s string, maxChars int) string` — rune-aware truncation; copy current logic from `internal/server/handlers/search.go:49-61`
+- [ ] 1.2 Create `internal/search/snippet_test.go` — table-driven tests covering: empty string, short string, exact-boundary, multi-byte unicode (`é`, `世`, emoji), zero/negative maxChars
+- [ ] 1.3 Replace inline `truncateSnippet` in `internal/server/handlers/search.go` to call `search.TruncateSnippet` (proves the extract is byte-identical)
+- [ ] 1.4 Run `go test -race -short ./internal/search/... ./internal/server/handlers/...` — all green
+
+## 2. Cursor encoding (foundation, no consumer yet)
+
+- [ ] 2.1 Create `internal/search/cursor.go` with `QueryHash(query string) string`, `EncodeCursor(offset int, queryHash string) string`, `DecodeCursor(token string) (offset int, queryHash string, err error)` — design per `design.md` §D2
+- [ ] 2.2 Create `internal/search/cursor_test.go` — covers: roundtrip encode/decode, invalid base64, invalid JSON payload, negative offset rejection, query hash determinism, query hash matches across calls with same query
+- [ ] 2.3 Run `go test -race -short ./internal/search/...` — all green
+
+## 3. Stable result ordering (foundation, no consumer yet)
+
+- [ ] 3.1 Edit `internal/search/rrf.go` sort comparator — when RRF scores are equal, break by `id ASC` (lexicographic string compare on UUID). Add inline `// for stable cursor pagination` comment.
+- [ ] 3.2 Edit `internal/search/recency.go` sort comparator — same tiebreaker.
+- [ ] 3.3 Add unit tests `internal/search/rrf_test.go` and `internal/search/recency_test.go` scenarios for tied-score deterministic order (per `specs/search-pipeline/spec.md`)
+- [ ] 3.4 Run `go test -race -short ./internal/search/...` — all green; verify no existing tests fail (only equal-score cases should be affected)
+
+## 4. MCP tool: input schema additions (parameter parsing only, no response shape change yet)
+
+- [ ] 4.1 In `internal/mcp/tools.go` registerMemoryQuery — add `include_content` (bool, default false) and `cursor` (string, optional) to the input schema JSON
+- [ ] 4.2 In `internal/mcp/tools.go` registerMemorySearch — add `include_content` and `cursor` to input schema
+- [ ] 4.3 In `internal/mcp/tools.go` registerMemoryVSearch — add `include_content` and `cursor` to input schema
+- [ ] 4.4 Parse new parameters in each handler (decode cursor → offset+queryHash; verify queryHash matches current query → return `cursor query mismatch` error on mismatch; invalid base64 → return `invalid cursor` error)
+- [ ] 4.5 Build: `go build ./...` — green
+
+## 5. MCP tool: response shape changes (the actual behavior change)
+
+- [ ] 5.1 Define shared `mcpSearchResponse` type (or per-tool inline) with fields: `results []searchResultItem`, `total int`, `query_ms int`, `next_cursor *string` — see `design.md` for exact shape
+- [ ] 5.2 Define `searchResultItem` matching the spec — always includes `snippet`, includes `content` only when `include_content=true` (Go pattern: omitempty on `content` field, set to full content only when flag is true)
+- [ ] 5.3 In each of 3 handlers, replace the current raw `search.Result` marshal with the new shape:
+  - Snippet = `search.TruncateSnippet(result.Content, 500)` (or use the existing `Snippet` field if already populated and ≤500)
+  - Content = `result.Content` only when `include_content=true`, else field is absent
+  - `total` = `len(boostedResults)` before pagination slice
+  - `query_ms` = elapsed ms from handler entry
+- [ ] 5.4 Implement pagination logic: `HybridSearch(..., maxResults = offset + page_size + 1)`, slice `[offset : offset+page_size]`, set `next_cursor` if `len(boostedResults) > offset+page_size`
+- [ ] 5.5 Encode `next_cursor` via `search.EncodeCursor(offset+page_size, queryHash)`
+- [ ] 5.6 Build: `go build ./...` — green
+
+## 6. Tool description updates
+
+- [ ] 6.1 Update tool description text in `tools.go` for `memory_query`, `memory_search`, `memory_vsearch` to mention: snippet-by-default, `include_content` opt-in, `cursor` for pagination, recommend `memory_get` for full content
+- [ ] 6.2 Verify via `curl -X POST .../mcp -d '{"method":"tools/list"}'` that the new schemas + descriptions surface
+
+## 7. Integration tests (response shape contracts)
+
+- [ ] 7.1 Create `internal/mcp/tools_pagination_integration_test.go` with `//go:build integration` tag
+- [ ] 7.2 Test: default response excludes `content` field — insert 3 docs, call `memory_search`, assert no result has `content` key in JSON
+- [ ] 7.3 Test: `include_content=true` includes `content` field — same setup, assert every result has `content` matching the stored chunk
+- [ ] 7.4 Test: snippet length ≤ 500 chars — insert one large doc, assert `snippet` length
+- [ ] 7.5 Test: snippet respects UTF-8 boundary — insert chunk with multi-byte char near position 500, assert no half-character in snippet
+- [ ] 7.6 Test: payload size budget — insert 10 typical chunks, call with `max_results=10`, assert response JSON size ≤ 20 KB
+- [ ] 7.7 Test: pagination roundtrip — insert 12 docs, call with `max_results=5`, get `next_cursor`, call again, get next 5, call again, get final 2 + no `next_cursor`
+- [ ] 7.8 Test: cursor query mismatch — query A returns cursor C1, pass C1 with query B, assert error contains "cursor query mismatch"
+- [ ] 7.9 Test: invalid cursor — pass `"not-base64!@#"` as cursor, assert error contains "invalid cursor"
+- [ ] 7.10 Test: empty result set — query with zero matches, assert `results: []`, `total: 0`, `query_ms ≥ 0`, no `next_cursor`
+- [ ] 7.11 Run `go test -race -tags=integration ./internal/mcp/...` — all green
+
+## 8. SKILL.md update (agent-facing contract docs)
+
+- [ ] 8.1 Edit `.opencode/skills/nano-brain/SKILL.md` — explicitly document the `snippet` field on search tool returns
+- [ ] 8.2 Document the new `include_content` and `cursor` parameters with examples
+- [ ] 8.3 Add migration note: "If you previously parsed `content` from search results, switch to `snippet` (already truncated) or call `memory_get` for one full document"
+- [ ] 8.4 Add usage pattern: "For 'find more matches' workflows, paginate by passing `cursor` from the previous response's `next_cursor`"
+
+## 9. CHANGELOG + tool description sanity check
+
+- [ ] 9.1 Add CHANGELOG.md entry under next release: announce MCP-only breaking change, `include_content` opt-in, pagination. Note: HTTP API unchanged.
+- [ ] 9.2 Manual sanity check: build binary, start server, run `curl` against `memory_search` with and without `include_content`/`cursor` — paste output as evidence in story
+
+## 10. Validation ladder
+
+- [ ] 10.1 `go build ./...` — exit 0
+- [ ] 10.2 `go test -race -short ./...` — all pass (or document pre-existing failures unrelated to this change)
+- [ ] 10.3 `go test -race -tags=integration ./internal/mcp/... ./internal/search/...` — all pass
+- [ ] 10.4 `openspec validate mcp-search-snippet-pagination --strict --no-interactive` — pass
+- [ ] 10.5 Smoke test: start binary on port 4199, `curl` 3 scenarios (default, include_content, paginated), capture output to `docs/evidence/mcp-search-snippet-pagination/smoke.md`
+
+## 11. Review Gate (high-risk lane — full review-work)
+
+- [ ] 11.1 Reviewer ≠ implementer — spawn fresh review-work session
+- [ ] 11.2 Review against every scenario in `specs/mcp-server/spec.md` and `specs/search-pipeline/spec.md`
+- [ ] 11.3 Paste verdict table in `docs/evidence/mcp-search-snippet-pagination/review-verdict.md`
+- [ ] 11.4 Proceed to PR only on PASS
+
+## 12. PR + Bot Review Loop
+
+- [ ] 12.1 Push branch `feat/358-mcp-search-response-pagination`
+- [ ] 12.2 Open PR with `Closes #358` in body, link OpenSpec change folder, paste validation output
+- [ ] 12.3 Address Gemini bot review comments (max 3 push cycles, escalate to human after)
+- [ ] 12.4 Merge → verify issue #358 auto-closes
+- [ ] 12.5 `openspec archive mcp-search-snippet-pagination` on master


### PR DESCRIPTION
Closes #358

## Summary

MCP search tools (`memory_query`, `memory_search`, `memory_vsearch`) now return a 500-char `snippet` by default instead of the full `content` field. Adds stateless cursor-based pagination for browsing beyond the default page size. Reduces typical MCP response size from 50–500 KB to 3–15 KB (~90% reduction), eliminating the host-agent tool-output truncation that previously forced a subagent grep step (~30–60 s overhead per memory lookup).

HTTP API (`/api/v1/search`, `/api/v1/query`, `/api/v1/vsearch`) is unchanged — it has been snippet-only since launch. `memory_get` remains the canonical full-content fetch.

## What changed

### MCP search tools (breaking — `content` field removed by default)

- New response envelope: `{results, total, query_ms, next_cursor?}` for all three search tools.
- Each result now exposes `snippet` (≤500 chars, rune-aware UTF-8 truncation) and OMITS the full `content` field by default.
- New tool input parameter `include_content: true` (default `false`) restores the full `content` field per result.
- New tool input parameter `cursor` (opaque base64url JSON) enables pagination. Pass the same `query` text on every page — the server validates an embedded query hash and returns `"cursor query mismatch"` if the query changes.
- Capped cursor offset at `search.MaxCursorOffset = 10_000` to prevent int32 overflow in downstream SQL LIMIT casts.

### Search internals

- Extracted shared `TruncateSnippet` helper to `internal/search/snippet.go`; HTTP and MCP layers now share one rune-aware implementation.
- Added stable tiebreaker (`id ASC`) to RRF fusion (`rrf.go`), recency boost (`recency.go`), and the four vector SQL queries (`embeddings.sql`). BM25 SQL queries already had this; vector queries did not. Without it, tied scores could reorder between paginated pages.
- New `internal/search/cursor.go`: `QueryHash`, `EncodeCursor`, `DecodeCursor`, `VerifyCursor`, sentinels `ErrInvalidCursor` and `ErrCursorQueryMismatch`.

### Sqlc side-effects

`RecentDocuments` SQL upgraded from positional `$3` to `sqlc.arg(collections)` so the generated struct keeps its `Collections` field (sqlc 1.30 would otherwise rename it to `Column3`). Callers updated from `Limit:` to `MaxResults:`.

## OpenSpec change

Full proposal under `openspec/changes/mcp-search-snippet-pagination/`:
- proposal.md, design.md (D1–D7 decisions), specs/mcp-server/spec.md (delta), specs/search-pipeline/spec.md (delta), tasks.md.
- Deep-design review: Metis (scope/risk) + Oracle (architecture). Plan review: Momus (no blocking gaps).
- `openspec validate mcp-search-snippet-pagination --strict --no-interactive` → PASS.

## Validation

| Check | Result |
|---|---|
| `go build ./...` | exit 0 |
| `go test -race -short ./...` | PASS (22 packages) |
| `go test -race -tags=integration ./internal/mcp/... ./internal/search/...` | PASS |
| `openspec validate mcp-search-snippet-pagination --strict --no-interactive` | PASS |
| Smoke test (4 scenarios via curl on running binary) | PASS — evidence in `docs/evidence/mcp-search-snippet-pagination/smoke.md` |
| Oracle Review Gate (quality + security) | PASS after addressing 2 non-blocker recommendations (offset cap + vector ORDER BY tiebreaker) |

## Test coverage

11 new integration scenarios in `internal/mcp/tools_pagination_integration_test.go` directly map to the 11 spec scenarios:
- Default response excludes `content`
- `include_content=true` includes `content`
- `include_content=false` matches default
- Snippet respects UTF-8 boundary
- Payload size ≤ 20 KB at default settings
- Pagination round-trip (12 docs / 3 pages — no overlap, no skip)
- First page omits cursor
- Cursor query mismatch returns error
- Malformed cursor returns error
- Response includes `total` and `query_ms`
- Empty result set returns `results: []`, `total: 0`

Unit tests in `internal/search/snippet_test.go`, `cursor_test.go`, and additions to `rrf_test.go` + `recency_test.go` cover the stable-tiebreaker contract and cursor validation (negative offset, > MaxCursorOffset, malformed base64, JSON parse failure, query hash mismatch).

## Out of scope (separate issues)

- Time-range filters (`created_after` / `created_before`) — would help the user's "last 30 days" use case but requires SQL + new parameters; will be tracked as a follow-up issue.
- LRU query-embedding cache (#359) — independent optimization.
- Per-stage latency log instrumentation — observability improvement.

## Lane: high-risk

Risk flags: search-quality (hard gate) + public-api-contract + existing-behavior + multi-domain.
Per docs/FEATURE_INTAKE.md high-risk lane, this PR carries full review-work evidence + smoke + integration tests.