### PR TITLE
fix(watcher): demote 'processing file' log from Info to Debug (#364)

### DIFF
--- a/docs/evidence/364-pre-merge-override.md
+++ b/docs/evidence/364-pre-merge-override.md
@@ -1,0 +1,78 @@
+# PRE-MERGE override — Issue #364 / PR #366
+
+**Date**: 2026-06-03
+
+## Baseline verification
+
+Ran integration tests + lint on **pure master `c52ab1a`** (the commit PR #366 branched from). Confirmed failures exist BEFORE this PR's single-line change.
+
+### Master baseline integration test failures
+
+```
+FAIL github.com/nano-brain/nano-brain/internal/embed [build failed]
+FAIL github.com/nano-brain/nano-brain/internal/server/handlers [build failed]
+FAIL github.com/nano-brain/nano-brain/internal/harvest
+  --- FAIL: TestOpenCodeSQLite_OrphanSession_NoWorktree_Skipped (0.28s)
+  --- FAIL: TestOpenCodeSQLite_UnregisteredWorktree_Skipped (0.34s)
+```
+
+These failures are in packages **NOT touched by PR #366**. PR #366 only modifies `internal/watcher/watcher.go` (1 line). The watcher package's integration tests PASS on this branch.
+
+### Master baseline lint failures
+
+```
+internal/server/handlers/documents_test.go:169:16: Error return value of `json.Unmarshal` is not checked (errcheck)
+internal/server/handlers/documents_test.go:195:16: (same)
+internal/server/handlers/documents_test.go:223:16: (same)
+internal/server/handlers/events_test.go:18:6: func `setupSSERequest` is unused (unused)
+internal/server/handlers/events_test.go:31:6: func `readSSEEvent` is unused (unused)
+cmd/nano-brain/cmd_detect_changes.go:215:6: func `getChangedLineRanges` is unused (unused)
+cmd/nano-brain/cmd_detect_changes.go:228:6: func `parseHunkHeaders` is unused (unused)
+internal/server/handlers/graph_neighborhood.go:176:4: S1011: should replace loop with append (gosimple)
+cmd/nano-brain/workspaces_test.go:352:27: S1030: should use out.Bytes() instead of []byte(out.String()) (gosimple)
+```
+
+All in packages **NOT touched by PR #366**.
+
+## [HARNESS-OVERRIDE] Gate 3.3 — integration tests
+
+Reason: Pre-existing build failures in `internal/embed` and `internal/server/handlers`, plus pre-existing test failures in `internal/harvest/TestOpenCodeSQLite_*`. None caused by PR #366. The watcher package's integration tests pass cleanly.
+
+## [HARNESS-OVERRIDE] Gate 3.4 — golangci-lint
+
+Reason: 9+ pre-existing lint violations in `internal/server/handlers/*_test.go`, `cmd/nano-brain/cmd_detect_changes.go`, `cmd/nano-brain/workspaces_test.go`, `internal/server/handlers/graph_neighborhood.go`. None caused by PR #366. Lint on the touched file (`internal/watcher/watcher.go`) is clean.
+
+## [HARNESS-OVERRIDE] Gate 3.12 — smoke:e2e
+
+Reason: Change-type=bug-fix triggers smoke:e2e requirement per R20. This PR demotes a log line from Info to Debug — there is no runtime surface to exercise. The equivalent verification is structural:
+
+1. `go build ./...` — clean (no API changes)
+2. `go test -race -short ./internal/watcher/` — pass (no behavior change)
+3. Code inspection: the demoted line (`internal/watcher/watcher.go:394`) is the ONLY caller of `w.logger.Info().Msg("processing file")`; no callers of this log message exist downstream.
+
+A live smoke would require: start daemon, register a workspace with ~1k files, wait 5+ minutes for `reindex_interval` to fire, tail logs, observe absence of `msg="processing file"` at INFO level. This is documented at the issue level (issue #364 "Reproduction" section) but cannot be automated in CI without a long-running test harness, which is out of scope for a 1-line log change.
+
+## All other gates
+
+| Gate | Status |
+|---|---|
+| 3.1 go build | ✅ PASS |
+| 3.2 go test -race -short | ✅ PASS |
+| 3.5 Review Verdict PASS | ⏳ pending independent review delegation |
+| 3.6 No Gemini comments / triaged | ✅ PASS (Gemini reviewed, no findings) |
+| 3.7 CI checks passing | ✅ PASS |
+| 3.8 Closes #364 | ✅ PASS |
+| 3.9 Targets master | ✅ PASS |
+| 3.10 Self-review evidence | ✅ PASS (added: `docs/evidence/self-review-364.md`) |
+| 3.11 Commit count ≤ 3 | ✅ PASS (1 commit) |
+| 3.13 smoke:ui not required | ✅ SKIP (no web change) |
+
+## Override invocation requirement
+
+Per HARNESS.md R7: only the user account can post the `[HARNESS-OVERRIDE]: <reason>` comment on the PR. This evidence file documents the rationale; user must post the actual override comment on PR #366 to lift gates 3.3 + 3.4 + 3.12.
+
+Suggested PR comment (≥ 20 chars):
+
+> [HARNESS-OVERRIDE]: PR #366 is a 1-line log severity change. Pre-existing failures in embed/handlers/harvest and lint violations in other packages predate this PR (verified against master c52ab1a). See docs/evidence/364-pre-merge-override.md for full baseline. Smoke:e2e exempted — no runtime surface for log-only change.
+
+Ready to merge after override comment posted + independent Review Verdict.

--- a/docs/evidence/review-364.md
+++ b/docs/evidence/review-364.md
@@ -1,0 +1,131 @@
+# Review Gate — Issue #364 / PR #366
+
+Review Verdict: PASS
+
+Reviewer: explore (independent, not implementing agent)
+**Date:** 2026-06-03
+**Commit reviewed:** 122121d (fix/364-watcher-log-noise)
+
+---
+
+## Diff Inspected
+
+Exact PR diff from `gh pr diff 366`:
+
+```diff
+diff --git a/internal/watcher/watcher.go b/internal/watcher/watcher.go
+index 8fa9862..f901435 100644
+--- a/internal/watcher/watcher.go
++++ b/internal/watcher/watcher.go
+@@ -391,7 +391,7 @@ func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePa
+ 		return
+ 	}
+ 
+-	w.logger.Info().
++	w.logger.Debug().
+ 		Str("path", filePath).
+ 		Str("collection", col.name).
+ 		Msg("processing file")
+```
+
+**File:** `internal/watcher/watcher.go`, line 394
+**Change:** `Info()` → `Debug()` log level demotion
+**Scope:** 1 line only, no adjacent edits, no refactors
+
+---
+
+## Per-Criterion Verdicts
+
+| Criterion | Verdict | Evidence |
+|-----------|---------|----------|
+| **Diff matches claim (1 line, Info→Debug only)** | ✅ PASS | `gh pr diff 366` output above shows exactly 1 line changed: `Info()` to `Debug()`. No other modifications. |
+| **Root cause hypothesis #1 verified in code** | ✅ PASS | Code inspection confirms: (a) `processFile` is called from `pollTicker` sweep at line 282–283 (periodic `processAll()` reindex) AND from `handleFSEvent` debounced path at line 270 (lines 279–280 invoke `processDirty()`). Both call chains reach `processFile`. |
+| **Demoted log emits BEFORE content-hash dedup** | ✅ PASS | Line 394 `Debug()` log fires immediately after binary-content check (line 414–417). Content-hash dedup short-circuit at line 426–428 comes AFTER the demoted log. Hypothesis confirmed: pre-dedup chatter was the spurious noise. |
+| **"indexed file" INFO still fires only on real work** | ✅ PASS | Line 464–468: `w.logger.Info().Msg("indexed file")` is reachable only after the dedup short-circuit at 426–428 returns. If content hash matches, function returns at line 427. INFO emission only reached when upsert succeeds (lines 447–460). Companion INFO log is correctly scoped. |
+| **Existing DEBUG style match (line 380)** | ✅ PASS | Line 380: `w.logger.Debug().Str("file", filePath).Msg("skipping binary file (extension)")` shows the same Debug-level pattern for per-file pre-processing chatter. The demoted "processing file" now matches this established style. |
+| **Self-review evidence exists** | ✅ PASS | File present: `docs/evidence/self-review-364.md`. Contains acceptance criteria checklist, diff, risk audit (0 flags, confirmed tiny lane), surgical change verification. |
+| **Pre-merge override documented** | ✅ PASS | File present: `docs/evidence/364-pre-merge-override.md`. Covers: (a) baseline verification on master c52ab1a (pre-existing embed/handlers/harvest failures NOT caused by PR #366), (b) lint pre-existing violations in other packages, (c) [HARNESS-OVERRIDE] rationale for gates 3.3 + 3.4 + 3.12, (d) override invocation requirement (user must post comment). |
+| **Unit tests pass** | ✅ PASS | `go test -race -short ./internal/watcher/` output: **PASS** — all 26 tests pass (2 skipped timing-sensitive). No test changes needed (no behavior change). |
+
+---
+
+## Root Cause Analysis — Hypothesis #1 Confirmed
+
+**Issue #364 complaint:** On idle workspaces, logs continuously fill with `msg="processing file" collection=code` at INFO level.
+
+**Sisyphus' hypothesis #1:** Periodic reindex sweep (`pollTicker` at `watcher.reindex_interval`, default 300 seconds) walks every indexed file → calls `processFile` → emits INFO log **before** the SHA-256 content-hash dedup check. On N indexed files, N spurious INFO lines per 300s sweep.
+
+**Verification by code inspection:**
+
+1. **Periodic sweep entry point** (line 282–283):
+   ```
+   case <-pollTicker.C:
+       w.processAll(ctx)
+   ```
+
+2. **Event-driven entry point** (line 270):
+   ```
+   case event, ok := <-fsw.Events:
+       w.handleFSEvent(event, debounce)
+   ```
+
+   Both call chains reach `processFile`.
+
+3. **Inside `processFile` (line 378+):**
+   - Line 394: `w.logger.Debug().Msg("processing file")` ← **NOW DEMOTED TO DEBUG** (was Info)
+   - Line 426–428: Content-hash dedup check — if `existing.ContentHash == contentHash`, return (no further processing)
+   - Line 464–468: `w.logger.Info().Msg("indexed file")` ← remains INFO, only fires if dedup short-circuit did NOT occur
+
+**Conclusion:** The "processing file" log was fired for every file in every 300s sweep, even files with unchanged content that get deduplicated. This is pre-dedup chatter and belongs in DEBUG. The companion "indexed file" INFO log fires only on real indexing work. Fix is correct and surgical.
+
+---
+
+## Code Quality Assessment
+
+- **No behavior changes:** File I/O, hashing, and indexing logic untouched. Only log severity changed.
+- **Style consistency:** Matches existing DEBUG log pattern at line 380 (`skipping binary file (extension)`).
+- **No orphans:** The demoted log message has no other callers. No imports added/removed. No dead code created.
+- **Test coverage:** 26 watcher tests pass; behavior unchanged, so no new tests needed.
+
+---
+
+## Pre-Merge Gate Status (per HARNESS.md)
+
+Per harness gate doc at `docs/harness/gates/pre-merge.md`:
+
+| Gate | Status | Notes |
+|---|---|---|
+| 3.1: `go build ./...` | ✅ PASS | Clean. |
+| 3.2: `go test -race -short ./...` | ✅ PASS | All packages pass. |
+| 3.3: integration tests | ⏳ OVERRIDE | Pre-existing failures in embed/handlers/harvest (baseline: master c52ab1a). Watcher tests pass. Override documented in `364-pre-merge-override.md`. |
+| 3.4: golangci-lint | ⏳ OVERRIDE | Pre-existing lint violations in other packages (baseline: master c52ab1a). Touched file `internal/watcher/watcher.go` is clean. Override documented in `364-pre-merge-override.md`. |
+| 3.5: Review Verdict PASS | ✅ PASS | **This document**. |
+| 3.6: No Gemini comments / triaged | ✅ PASS | Gemini code review completed, no findings. |
+| 3.7: CI checks passing | ✅ PASS | GitHub CI workflow passed. |
+| 3.8: Closes #364 | ✅ PASS | PR #366 linked to issue #364. |
+| 3.9: Targets master | ✅ PASS | PR targets master (single-trunk model). |
+| 3.10: Self-review evidence | ✅ PASS | `docs/evidence/self-review-364.md` present and complete. |
+| 3.11: Commit count ≤ 3 | ✅ PASS | 1 commit on this branch. |
+| 3.12: smoke:e2e (change-type=bug-fix) | ⏳ OVERRIDE | Log-only change, no runtime surface to exercise. Structural verification (build, tests, code inspection) confirms correctness. Override rationale in `364-pre-merge-override.md`. |
+| 3.13: smoke:ui | ✅ SKIP | No web UI changes. |
+
+---
+
+## Recommendation
+
+✅ **Ready to Merge**
+
+**Conditions:**
+1. User must post [HARNESS-OVERRIDE] comment on PR #366 per R7 of HARNESS.md (to lift gates 3.3 + 3.4 + 3.12).
+2. This Review Verdict (PASS) confirms gates 3.1, 3.2, 3.5, 3.7, 3.8, 3.9, 3.10, 3.11 all pass.
+3. All overrides documented in `docs/evidence/364-pre-merge-override.md` with clear baseline evidence.
+
+**Risk classification:** Tiny lane (0 risk flags). 1-line log severity change. No behavior, no API, no data model impact.
+
+**Gate 3.2a (post-merge): N/A** — bin/nano-brain is auto-published on merge to master via GitHub Actions release workflow; version auto-bumped from RELEASE_PAT tag push.
+
+---
+
+**Reviewer Signature:** explore (independent reviewer, not implementing agent)
+**Review Date:** 2026-06-03 / 16:40 UTC
+**Confidence:** High — all criteria verified via code inspection, test execution, and evidence file validation.

--- a/docs/evidence/self-review-364-watcher-log-noise.md
+++ b/docs/evidence/self-review-364-watcher-log-noise.md
@@ -1,0 +1,23 @@
+# Gemini Triage — Issue #364 / PR #366
+
+This file documents Gemini bot review triage for the harness async-pr-review gate (check 3.5.4). Filename matches `self-review*${slug}*.md` where slug is the branch name after `/` (= `364-watcher-log-noise`) per `scripts/check-pr-review.sh:258`.
+
+## Triage table
+
+| # | Reviewer | Commit | Comment summary | Classification | Action |
+| --- | --- | --- | --- | --- | --- |
+| 1 | gemini-code-assist | 122121defe667aba618096147d4b2d888b3529aa | "no review comments, no feedback to provide" | INVALID:no-finding | None — bot explicitly reported zero findings |
+
+## Notes
+
+- Gemini Code Assist consumer version is being sunset (cease 2026-07-17). Not a blocker for this PR.
+- Independent Review Verdict for PR #366 is PASS — see `docs/evidence/review-364.md`.
+- No VALID:critical or VALID:high findings to resolve. Gate 3.5.4 should now PASS once this triage file exists.
+
+## Triage classification key
+
+- VALID:critical — Production-blocking; must fix before merge.
+- VALID:high — Should fix before merge.
+- VALID:medium — Should fix in follow-up issue.
+- VALID:low — Optional polish.
+- INVALID:<reason> — Not a real issue.

--- a/docs/evidence/self-review-364.md
+++ b/docs/evidence/self-review-364.md
@@ -1,0 +1,65 @@
+# Self-Review: Issue #364 / PR #366 — watcher log noise
+
+**Change Type:** bug-fix
+**Story:** #364 (watcher continuously logs 'processing file collection=code' on idle workspaces)
+**Lane:** tiny (single-file, single-line log severity change)
+**Date:** 2026-06-03
+**Reviewer (Self):** Sisyphus (implementing agent — independent review delegated separately per R: no self-review)
+
+---
+
+## Summary
+
+Demoted `processing file` log emission from `Info` to `Debug` level in `internal/watcher/watcher.go:394`. No behavior change — only log severity.
+
+## Acceptance Criteria (from issue #364)
+
+- [x] **Root cause confirmed** — Hypothesis #1 from issue: periodic reindex sweep (`pollTicker` at `watcher.reindex_interval`, default 300s) walks every file → `processFile` → emitted INFO log per file BEFORE the content-hash dedup check at line 426. For N indexed files, N spurious INFO lines per sweep on idle workspaces.
+- [x] **Spurious log lines stopped** — emission demoted to DEBUG level. Operators wanting per-file tracing can flip `logging.level: debug`.
+- [x] **No real work avoided unnecessarily** — file I/O is required to compute SHA-256 dedup hash; dedup short-circuit at line 426 was already correct. Only log noise was the bug.
+
+## Diff
+
+```diff
+- w.logger.Info().
++ w.logger.Debug().
+   Str("path", filePath).
+   Str("collection", col.name).
+   Msg("processing file")
+```
+
+Single line, single file: `internal/watcher/watcher.go:394`.
+
+## Why this is correct
+
+- The companion `indexed file` INFO log at line 464 already only fires when real indexing happens (after SHA-256 dedup short-circuits no-ops at line 426). That remains the meaningful per-file signal at INFO level.
+- Per-file pre-dedup chatter is exactly what DEBUG is for. Matches the existing `skipping binary file (extension)` DEBUG log in the same function (line 380).
+- No behavior change — the file is still walked, stat'd, read, hashed, and indexed if changed.
+
+## Validation
+
+| Check | Result |
+|---|---|
+| `go build ./...` | ✅ clean |
+| `go test -race -short ./...` | ✅ all packages pass |
+| `go test -race -short ./internal/watcher/` | ✅ pass (cached, force-rerun also pass) |
+| `golangci-lint run ./internal/watcher/...` (vs master) | ✅ clean — no new issues |
+| Surgical change check | ✅ only 1 line modified, no orphans, no adjacent edits |
+
+## Risk audit (per `docs/FEATURE_INTAKE.md`)
+
+Risk flags this change carries:
+
+- ✅ **Existing behavior**: log severity change only — additive (operators can recover detail via `logging.level: debug`)
+- ✅ **External systems**: none touched
+- ✅ **Data model**: none touched
+- ✅ **Public API contract**: none — log lines are operator-facing, not API
+- ✅ **Auth/security**: none touched
+- ✅ **Search quality**: none touched
+- ✅ **Embedding/vector provider**: none touched
+
+**Total flags: 0** — confirmed **tiny lane**.
+
+## Scope discipline
+
+Touched files: `internal/watcher/watcher.go` (1 line). No adjacent edits, no refactors, no test changes needed (no behavior change to test).

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -391,7 +391,7 @@ func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePa
 		return
 	}
 
-	w.logger.Info().
+	w.logger.Debug().
 		Str("path", filePath).
 		Str("collection", col.name).
 		Msg("processing file")


### PR DESCRIPTION
## Summary

Fixes the watcher continuously logging `processing file collection=code` on idle workspaces.

## Root cause

The watcher's periodic reindex sweep (`pollTicker` fires every `watcher.reindex_interval` seconds, default **300s**) walks every file in every registered collection and calls `processFile` on each one.

`processFile` emitted an INFO log line `"processing file"` for **every file** BEFORE the content-hash dedup check at line 426. For an idle workspace with N indexed files, this produced **N spurious INFO lines every reindex_interval** — exactly the "continuous" log noise the issue reports.

This matches hypothesis #1 in the issue description.

## Fix

Single-line change in `internal/watcher/watcher.go:394`:

```diff
-	w.logger.Info().
+	w.logger.Debug().
 		Str("path", filePath).
 		Str("collection", col.name).
 		Msg("processing file")
```

## Why this is correct

- The companion **`indexed file`** INFO log at line 464 already only fires when real indexing happens (after the SHA-256 content-hash dedup short-circuits no-ops at line 426). That remains the meaningful per-file signal at INFO level.
- Per-file pre-dedup chatter is exactly what DEBUG is for. This matches the existing `"skipping binary file (extension)"` DEBUG log in the same function (line 380).
- No behavior change — only log severity. The file is still walked, stat'd, read, hashed, and indexed if changed. Operators who want per-file tracing can flip `logging.level` to `debug`.

## Acceptance criteria

- [x] Root cause confirmed (hypothesis #1 from issue: periodic reindex sweep emits log per file regardless of whether re-embedding happens)
- [x] Spurious log lines stopped on idle workspaces (demoted to DEBUG level)
- [x] No real work was being done unnecessarily — file I/O is required to compute the SHA-256 dedup hash; the dedup short-circuit was already correct. Only the **log noise** was the bug.

## Lane

**Tiny** — single-file, single-line log severity change. No risk flags. Direct patch per `docs/FEATURE_INTAKE.md`.

## Validation

- ✅ `go build ./...` — clean
- ✅ `go test -race -short ./...` — all packages pass (watcher tests included)
- ✅ Surgical change: only one line modified, no orphans, no adjacent edits

## Note

Branched from `master` (commit `c52ab1a`) in a worktree under `.opencode/worktrees/fix-364-watcher-log-noise/`. Independent of #360 (PR #365).

Closes #364