### PR TITLE
fix(embed): reindex ChunksEnqueued undercount when inflight dedup drops chunks

### DIFF
--- a/docs/evidence/fix-325-reindex-undercount/smoke-ui-output.log
+++ b/docs/evidence/fix-325-reindex-undercount/smoke-ui-output.log
@@ -1,0 +1,14 @@
+=== smoke:ui run 2026-06-05T09:29:27Z ===
+INFO: Binary built: /tmp/nano-brain-smoke/nano-brain (size=55480829 bytes)
+INFO: Server started on port 3199 (PID=19361)
+PASS: /health → 200 OK {"status":"ok","ready":true,"version":"dev","workspace_count":45}
+PASS: /ui/ Content-Type=text/html; charset=utf-8
+PASS: /ui/ body has <!DOCTYPE html>
+PASS: /ui/ HTML contains <script> tag
+PASS: /ui/assets/index-0b9C5XlC.css → 200 text/css size=14861
+PASS: /ui/assets/index-Crj1xn17.js → 200 application/javascript size=561161
+PASS: /ui/assets/query-BoNQCwfV.js → 200 application/javascript size=45437
+PASS: /ui/assets/router-UhuWy72c.js → 200 application/javascript size=229953
+INFO: Asset summary: 3 JS, 1 CSS
+=== smoke:ui PASS ===
+Server stopped (PID=19361)

--- a/docs/evidence/self-review-325.md
+++ b/docs/evidence/self-review-325.md
@@ -1,0 +1,19 @@
+# Self-Review: fix/325-reindex-undercount
+
+## Actions Taken
+- Reviewed ForceEnqueue implementation in internal/embed/queue.go
+- Verified triggerForceWipe uses ForceEnqueue in internal/server/handlers/reindex.go
+- Confirmed test TestForceEnqueue_BypassesInflight covers the fix
+
+## Files Changed
+- `internal/embed/queue.go` — added ForceEnqueue method
+- `internal/server/handlers/reindex.go` — switched Enqueue → ForceEnqueue
+- `internal/embed/queue_test.go` — new test
+
+## Findings Summary
+- No critical or major findings
+- ForceEnqueue correctly deletes inflight entry before re-enqueuing
+- Backpressure and channel capacity checks preserved from Enqueue
+
+## Resolution Status
+All clear — tiny lane fix, no risk flags.

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -130,6 +130,28 @@ func (q *Queue) Enqueue(chunkID uuid.UUID) bool {
 	}
 }
 
+// ForceEnqueue bypasses the inflight dedup check and always enqueues the chunk.
+// It deletes any existing inflight entry first, then enqueues. Returns true if successful.
+func (q *Queue) ForceEnqueue(chunkID uuid.UUID) bool {
+	if q.pending.Load() >= rejectionThreshold {
+		q.logger.Warn().Str("chunk_id", chunkID.String()).
+			Int64("pending", q.pending.Load()).
+			Msg("backpressure: rejecting force-enqueue")
+		return false
+	}
+	q.inflight.Delete(chunkID)
+	select {
+	case q.ch <- chunkID:
+		q.pending.Add(1)
+		q.logger.Debug().Str("chunk_id", chunkID.String()).Msg("chunk force-enqueued")
+		q.publishStatus()
+		return true
+	default:
+		q.logger.Warn().Str("chunk_id", chunkID.String()).Msg("queue full, chunk dropped")
+		return false
+	}
+}
+
 // Depth returns the current channel length.
 func (q *Queue) Depth() int { return len(q.ch) }
 

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -1130,3 +1130,38 @@ func TestScanPending_SkippedInflightAggregated(t *testing.T) {
 		t.Errorf("channel len = %d, want 0 (all chunks were in-flight)", len(eq.ch))
 	}
 }
+
+// TestForceEnqueue_BypassesInflight verifies that ForceEnqueue bypasses the
+// inflight dedup check and always enqueues the chunk, even if it's already
+// been marked in-flight by a prior Enqueue call.
+func TestForceEnqueue_BypassesInflight(t *testing.T) {
+	chunkID := uuid.New()
+
+	mq := &mockQuerier{}
+	eq := newTestQueue(&mockEmbedder{}, mq)
+
+	// First Enqueue: marks inflight, returns true
+	if !eq.Enqueue(chunkID) {
+		t.Error("first Enqueue returned false, want true")
+	}
+
+	// Second Enqueue: detects inflight, returns false
+	if eq.Enqueue(chunkID) {
+		t.Error("second Enqueue returned true, want false (inflight dedup)")
+	}
+
+	// ForceEnqueue: bypasses dedup, returns true
+	if !eq.ForceEnqueue(chunkID) {
+		t.Error("ForceEnqueue returned false, want true")
+	}
+
+	// Verify channel has 2 items (one from first Enqueue, one from ForceEnqueue)
+	if len(eq.ch) != 2 {
+		t.Errorf("channel len = %d, want 2", len(eq.ch))
+	}
+
+	// Verify pending count is 2
+	if p := eq.pending.Load(); p != 2 {
+		t.Errorf("pending = %d, want 2", p)
+	}
+}

--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -99,7 +99,7 @@ func triggerForceWipe(c echo.Context, queries ReindexQuerier, w *watcher.Watcher
 		}
 		if eq != nil {
 			for _, id := range ids {
-				if eq.Enqueue(id) {
+				if eq.ForceEnqueue(id) {
 					totalChunks++
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes #325 — `POST /api/v1/reindex` `ChunksEnqueued` counter undercounts when inflight dedup drops in-flight chunks.

## Changes

- **`internal/embed/queue.go`**: Add `ForceEnqueue` method that bypasses `inflight` sync.Map dedup (deletes existing entry first, then enqueues)
- **`internal/server/handlers/reindex.go`**: `triggerForceWipe` now uses `ForceEnqueue` instead of `Enqueue`
- **`internal/embed/queue_test.go`**: New test `TestForceEnqueue_BypassesInflight`

## Root Cause

After PR #323 introduced inflight dedup, `Enqueue()` returns `false` for chunks already in the inflight set. During force-wipe reindex, chunks have their `embed_status` reset to `pending` in DB, but if they were already in-flight, they were silently dropped from the enqueue count.

## Validation

- `go build ./...` ✅
- `go test -race -short ./internal/embed/... ./internal/server/handlers/...` ✅
- New test verifies ForceEnqueue bypasses inflight dedup ✅

## Lane

Tiny — single behavioral fix, no risk flags.

Closes #325