### PR TITLE
feat(watcher): recursive .gitignore loading for multi-repo workspaces

### DIFF
--- a/docs/evidence/self-review-379.md
+++ b/docs/evidence/self-review-379.md
@@ -1,0 +1,21 @@
+# Self-Review: feat/379-recursive-gitignore
+
+## Actions Taken
+- Reviewed gitignoreStack implementation in internal/watcher/filter.go
+- Verified Push/PopAbove/Matches logic
+- Confirmed scanCollection integration in watcher.go
+- Checked existing shouldSkip behavior unchanged
+
+## Files Changed
+- `internal/watcher/filter.go` — new gitignoreStack type (52 lines)
+- `internal/watcher/watcher.go` — integrate stack into scanCollection walk
+- `internal/watcher/filter_test.go` — 4 new tests
+
+## Findings Summary
+- No critical or major findings
+- Stack correctly pops stale entries when ascending directories
+- Existing fileFilter root .gitignore still applies (additive)
+- go-gitignore library already handles negation patterns
+
+## Resolution Status
+All clear — no issues found.

--- a/internal/watcher/filter.go
+++ b/internal/watcher/filter.go
@@ -9,6 +9,58 @@ import (
 	gitignore "github.com/sabhiram/go-gitignore"
 )
 
+// gitignoreStack maintains a stack of .gitignore matchers discovered during
+// directory traversal. Each entry tracks the directory path and its associated
+// gitignore matcher. The stack is used to apply nested .gitignore files in
+// multi-repo workspaces (issue #379).
+type gitignoreStack struct {
+	entries []gitignoreEntry
+}
+
+type gitignoreEntry struct {
+	dirPath string
+	matcher *gitignore.GitIgnore
+}
+
+func (s *gitignoreStack) Push(dirPath string, matcher *gitignore.GitIgnore) {
+	s.entries = append(s.entries, gitignoreEntry{
+		dirPath: dirPath,
+		matcher: matcher,
+	})
+}
+
+// PopAbove removes stack entries that are not ancestors of the given path.
+// This is called when ascending from a subdirectory during tree traversal.
+func (s *gitignoreStack) PopAbove(currentPath string) {
+	i := 0
+	for _, entry := range s.entries {
+		rel, err := filepath.Rel(entry.dirPath, currentPath)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			s.entries[i] = entry
+			i++
+		}
+	}
+	s.entries = s.entries[:i]
+}
+
+// Matches checks if the given path matches any .gitignore pattern in the stack.
+// Returns true if the path should be excluded.
+func (s *gitignoreStack) Matches(path string) bool {
+	for _, entry := range s.entries {
+		rel, err := filepath.Rel(entry.dirPath, path)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(rel, "..") {
+			continue
+		}
+		if entry.matcher.MatchesPath(rel) {
+			return true
+		}
+	}
+	return false
+}
+
 var defaultExcludeDirs = map[string]bool{
 	"node_modules": true,
 	".git":         true,

--- a/internal/watcher/filter_test.go
+++ b/internal/watcher/filter_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 func TestShouldSkip_DefaultExcludeDirs(t *testing.T) {
@@ -395,5 +397,132 @@ func TestFileFilter_LocalNanoBrainIgnorePermissionDenied(t *testing.T) {
 	}
 	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped — other filter layers still operate")
+	}
+}
+
+func TestGitignoreStack_Push(t *testing.T) {
+	root := t.TempDir()
+	stack := &gitignoreStack{}
+
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.tmp\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gi, err := gitignore.CompileIgnoreFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stack.Push(root, gi)
+
+	if len(stack.entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(stack.entries))
+	}
+	if stack.entries[0].dirPath != root {
+		t.Errorf("expected dirPath %q, got %q", root, stack.entries[0].dirPath)
+	}
+}
+
+func TestGitignoreStack_PopAbove(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "sub")
+	deepdir := filepath.Join(subdir, "deep")
+
+	stack := &gitignoreStack{}
+	gi1 := gitignore.CompileIgnoreLines("*.a")
+	gi2 := gitignore.CompileIgnoreLines("*.b")
+	gi3 := gitignore.CompileIgnoreLines("*.c")
+
+	stack.Push(root, gi1)
+	stack.Push(subdir, gi2)
+	stack.Push(deepdir, gi3)
+
+	if len(stack.entries) != 3 {
+		t.Fatalf("expected 3 entries after pushes, got %d", len(stack.entries))
+	}
+
+	stack.PopAbove(filepath.Join(subdir, "file.txt"))
+
+	if len(stack.entries) != 2 {
+		t.Errorf("expected 2 entries after PopAbove(subdir/file.txt), got %d", len(stack.entries))
+	}
+
+	stack.PopAbove(filepath.Join(root, "other.txt"))
+
+	if len(stack.entries) != 1 {
+		t.Errorf("expected 1 entry after PopAbove(root/other.txt), got %d", len(stack.entries))
+	}
+	if stack.entries[0].dirPath != root {
+		t.Errorf("expected remaining entry to be root, got %q", stack.entries[0].dirPath)
+	}
+}
+
+func TestGitignoreStack_Matches(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "sub")
+
+	stack := &gitignoreStack{}
+	gi1 := gitignore.CompileIgnoreLines("*.log")
+	gi2 := gitignore.CompileIgnoreLines("*.tmp")
+
+	stack.Push(root, gi1)
+	stack.Push(subdir, gi2)
+
+	cases := []struct {
+		path  string
+		match bool
+	}{
+		{filepath.Join(root, "app.log"), true},
+		{filepath.Join(subdir, "data.tmp"), true},
+		{filepath.Join(subdir, "other.log"), true},
+		{filepath.Join(root, "main.go"), false},
+		{filepath.Join(subdir, "file.go"), false},
+	}
+
+	for _, tc := range cases {
+		got := stack.Matches(tc.path)
+		if got != tc.match {
+			t.Errorf("Matches(%q) = %v, want %v", tc.path, got, tc.match)
+		}
+	}
+}
+
+func TestGitignoreStack_NestedGitignoreExclusion(t *testing.T) {
+	root := t.TempDir()
+	subRepo := filepath.Join(root, "sub-repo")
+	if err := os.MkdirAll(subRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.root\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subRepo, ".gitignore"), []byte("*.sub\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stack := &gitignoreStack{}
+	giRoot, _ := gitignore.CompileIgnoreFile(filepath.Join(root, ".gitignore"))
+	giSub, _ := gitignore.CompileIgnoreFile(filepath.Join(subRepo, ".gitignore"))
+
+	stack.Push(root, giRoot)
+	stack.Push(subRepo, giSub)
+
+	cases := []struct {
+		path  string
+		match bool
+	}{
+		{filepath.Join(root, "file.root"), true},
+		{filepath.Join(subRepo, "file.root"), true},
+		{filepath.Join(subRepo, "file.sub"), true},
+		{filepath.Join(root, "file.sub"), false},
+		{filepath.Join(root, "main.go"), false},
+		{filepath.Join(subRepo, "main.go"), false},
+	}
+
+	for _, tc := range cases {
+		got := stack.Matches(tc.path)
+		if got != tc.match {
+			t.Errorf("Matches(%q) = %v, want %v", tc.path, got, tc.match)
+		}
 	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -386,6 +386,8 @@ func (w *Watcher) processAll(ctx context.Context) {
 }
 
 func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
+	stack := &gitignoreStack{}
+
 	err := filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			w.logger.Warn().Err(err).Str("path", path).Msg("walk error, skipping")
@@ -394,12 +396,33 @@ func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+
+		stack.PopAbove(path)
+
+		if d.IsDir() {
+			gitignorePath := filepath.Join(path, ".gitignore")
+			if info, err := os.Stat(gitignorePath); err == nil && !info.IsDir() {
+				if gi, err := gitignore.CompileIgnoreFile(gitignorePath); err == nil {
+					stack.Push(path, gi)
+					w.logger.Debug().Str("path", gitignorePath).Msg("loaded nested .gitignore")
+				}
+			}
+		}
+
 		if col.filter != nil && col.filter.shouldSkip(path, d.IsDir()) {
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
 		}
+
+		if stack.Matches(path) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		if !d.IsDir() {
 			w.processFile(ctx, col, path)
 		}


### PR DESCRIPTION
## Summary

Implements #379 — recursive .gitignore loading for multi-repo workspaces.

## Problem

When a user registers a parent directory (e.g. `~/zengamingx`) containing multiple repos as one workspace, the file watcher only reads `.gitignore` from the collection root — not from each subdirectory repo. Sub-repo artifacts (node_modules, dist, target) pollute the index.

## Solution

Added `gitignoreStack` type that maintains nested .gitignore matchers during directory traversal:

- **`Push(dir, matcher)`** — adds a .gitignore matcher when entering a directory
- **`PopAbove(dir)`** — removes stale entries when ascending
- **`Matches(path)`** — checks if path matches any pattern in the stack

`scanCollection` now discovers .gitignore files in subdirectories during `WalkDir` and applies them to files within that subtree.

## Files Changed

- `internal/watcher/filter.go` — new `gitignoreStack` type (52 lines)
- `internal/watcher/watcher.go` — integrate stack into `scanCollection` walk
- `internal/watcher/filter_test.go` — 4 new tests (Push, PopAbove, Matches, nested integration)

## Backward Compatibility

Single-repo behavior unchanged — root .gitignore still loads via `fileFilter` as before. The stack is additive.

## Validation

- `go build ./...` ✅
- `go test -race -short ./internal/watcher/...` ✅

## Lane

Normal — user-feature, watcher subsystem only

Closes #379