### PR TITLE
feat(intelligence): memory consolidation + LLM categorization

### DIFF
--- a/docs/evidence/self-review-154.md
+++ b/docs/evidence/self-review-154.md
@@ -1,0 +1,27 @@
+# Self-Review: feat/154-memory-intelligence
+
+## Actions Taken
+- Reviewed Consolidator implementation in internal/intelligence/consolidate.go
+- Verified Categorizer implementation in internal/intelligence/categorize.go
+- Confirmed LLM interface reuses existing summarize pattern
+- Checked narrow querier interfaces (consumer-side)
+- Verified config additions
+
+## Files Changed
+- `internal/intelligence/intelligence.go` — package doc + LLM interface
+- `internal/intelligence/prompts.go` — prompt templates
+- `internal/intelligence/consolidate.go` — Consolidator
+- `internal/intelligence/categorize.go` — Categorizer
+- `internal/intelligence/consolidate_test.go` — mock LLM tests
+- `internal/intelligence/categorize_test.go` — mock LLM tests
+- `internal/config/config.go` — IntelligenceConfig
+- `internal/config/defaults.go` — defaults
+
+## Findings Summary
+- No critical or major findings
+- Dry-run mode correctly skips mutations
+- Confidence threshold filtering works as expected
+- Thompson Sampling intentionally deferred (per scope)
+
+## Resolution Status
+All clear — no issues found.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Telemetry      TelemetryConfig      `koanf:"telemetry" json:"telemetry"`
 	Logging        LoggingConfig        `koanf:"logging" json:"logging"`
 	Summarization  SummarizationConfig  `koanf:"summarization" json:"summarization"`
+	Intelligence   IntelligenceConfig   `koanf:"intelligence" json:"intelligence"`
 }
 
 // ServerConfig holds server configuration.
@@ -188,6 +189,17 @@ func (s SummarizationConfig) IsWriteToDiskEnabled() bool {
 		return true
 	}
 	return *s.WriteToDisk
+}
+
+// IntelligenceConfig holds memory consolidation and LLM categorization configuration.
+type IntelligenceConfig struct {
+	Enabled          bool   `koanf:"enabled" json:"enabled"`
+	ProviderURL      string `koanf:"provider_url" json:"provider_url"`
+	APIKey           string `koanf:"api_key" json:"api_key"`
+	Model            string `koanf:"model" json:"model"`
+	MaxTokens        int    `koanf:"max_tokens" json:"max_tokens"`
+	Concurrency      int    `koanf:"concurrency" json:"concurrency"`
+	ConsolidationAge int    `koanf:"consolidation_age" json:"consolidation_age"`
 }
 
 // Load loads configuration from file and environment variables.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -80,6 +80,15 @@ func getDefaults() *Config {
 			Concurrency: 3,
 			OutputDir:   "~/.nano-brain/summaries",
 		},
+		Intelligence: IntelligenceConfig{
+			Enabled:          false,
+			ProviderURL:      "",
+			APIKey:           "",
+			Model:            "claude-sonnet-4-5",
+			MaxTokens:        8000,
+			Concurrency:      3,
+			ConsolidationAge: 7,
+		},
 	}
 }
 

--- a/internal/intelligence/categorize.go
+++ b/internal/intelligence/categorize.go
@@ -1,0 +1,199 @@
+package intelligence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type CategorizeQuerier interface {
+	ListDocumentsWithoutSemanticTags(ctx context.Context, workspace string, maxDocs int) ([]Document, error)
+	UpdateDocumentTags(ctx context.Context, workspace, docID string, tags []string) error
+}
+
+type Categorizer struct {
+	llm        LLM
+	queries    CategorizeQuerier
+	logger     zerolog.Logger
+	confidence float64
+}
+
+func NewCategorizer(
+	llm LLM,
+	queries CategorizeQuerier,
+	logger zerolog.Logger,
+	confidenceThreshold float64,
+) *Categorizer {
+	if confidenceThreshold <= 0 || confidenceThreshold > 1 {
+		confidenceThreshold = 0.6
+	}
+	return &Categorizer{
+		llm:        llm,
+		queries:    queries,
+		logger:     logger,
+		confidence: confidenceThreshold,
+	}
+}
+
+type CategorizationResult struct {
+	Processed   int
+	Categorized int
+	Skipped     int
+	Errors      int
+}
+
+type categorizationResponse struct {
+	Tags       []string `json:"tags"`
+	Confidence float64  `json:"confidence"`
+	Reasoning  string   `json:"reasoning"`
+}
+
+var staticTags = map[string]bool{
+	"opencode": true,
+	"session":  true,
+	"claude":   true,
+	"summary":  true,
+}
+
+func (c *Categorizer) RunCategorization(ctx context.Context, workspace string, maxDocs int) (*CategorizationResult, error) {
+	c.logger.Info().
+		Str("workspace", workspace).
+		Int("max_docs", maxDocs).
+		Float64("confidence_threshold", c.confidence).
+		Msg("categorization: starting")
+
+	docs, err := c.queries.ListDocumentsWithoutSemanticTags(ctx, workspace, maxDocs)
+	if err != nil {
+		return nil, fmt.Errorf("list documents: %w", err)
+	}
+
+	c.logger.Info().Int("doc_count", len(docs)).Msg("categorization: documents loaded")
+
+	result := &CategorizationResult{
+		Processed: len(docs),
+	}
+
+	for _, doc := range docs {
+		if err := c.processDocument(ctx, workspace, doc, result); err != nil {
+			c.logger.Warn().
+				Err(err).
+				Str("doc_id", doc.ID).
+				Msg("categorization: document processing failed")
+			result.Errors++
+		}
+	}
+
+	c.logger.Info().
+		Int("processed", result.Processed).
+		Int("categorized", result.Categorized).
+		Int("skipped", result.Skipped).
+		Int("errors", result.Errors).
+		Msg("categorization: completed")
+
+	return result, nil
+}
+
+func (c *Categorizer) processDocument(ctx context.Context, workspace string, doc Document, result *CategorizationResult) error {
+	summary := DocumentSummary{
+		ID:         doc.ID,
+		Title:      doc.Title,
+		SourcePath: doc.SourcePath,
+		Content:    doc.Content,
+		Tags:       doc.Tags,
+	}
+
+	userPrompt := buildCategorizationUserPrompt(summary)
+
+	c.logger.Info().
+		Str("doc_id", doc.ID).
+		Str("title", doc.Title).
+		Msg("categorization: calling LLM")
+
+	responseText, _, err := c.llm.ChatCompletion(ctx, categorizationSystemPrompt, userPrompt)
+	if err != nil {
+		return fmt.Errorf("llm completion: %w", err)
+	}
+
+	responseText = strings.TrimSpace(responseText)
+	if strings.HasPrefix(responseText, "```json") {
+		responseText = strings.TrimPrefix(responseText, "```json")
+		responseText = strings.TrimSuffix(responseText, "```")
+		responseText = strings.TrimSpace(responseText)
+	}
+
+	var response categorizationResponse
+	if err := json.Unmarshal([]byte(responseText), &response); err != nil {
+		return fmt.Errorf("parse llm response: %w", err)
+	}
+
+	c.logger.Info().
+		Str("doc_id", doc.ID).
+		Strs("suggested_tags", response.Tags).
+		Float64("confidence", response.Confidence).
+		Str("reasoning", response.Reasoning).
+		Msg("categorization: LLM response")
+
+	if response.Confidence < c.confidence {
+		c.logger.Info().
+			Str("doc_id", doc.ID).
+			Float64("confidence", response.Confidence).
+			Float64("threshold", c.confidence).
+			Msg("categorization: confidence below threshold, skipping")
+		result.Skipped++
+		return nil
+	}
+
+	newTags := mergeWithExisting(doc.Tags, response.Tags)
+
+	if len(newTags) == len(doc.Tags) {
+		c.logger.Info().
+			Str("doc_id", doc.ID).
+			Msg("categorization: no new tags to add")
+		result.Skipped++
+		return nil
+	}
+
+	if err := c.queries.UpdateDocumentTags(ctx, workspace, doc.ID, newTags); err != nil {
+		return fmt.Errorf("update tags: %w", err)
+	}
+
+	c.logger.Info().
+		Str("doc_id", doc.ID).
+		Strs("old_tags", doc.Tags).
+		Strs("new_tags", newTags).
+		Msg("categorization: tags updated")
+
+	result.Categorized++
+	return nil
+}
+
+func mergeWithExisting(existing, suggested []string) []string {
+	tagSet := make(map[string]bool)
+	for _, tag := range existing {
+		tagSet[tag] = true
+	}
+
+	for _, tag := range suggested {
+		if !staticTags[tag] {
+			tagSet[tag] = true
+		}
+	}
+
+	var result []string
+	for tag := range tagSet {
+		result = append(result, tag)
+	}
+	return result
+}
+
+func hasSemanticTags(tags []string) bool {
+	for _, tag := range tags {
+		if !staticTags[tag] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/intelligence/categorize_test.go
+++ b/internal/intelligence/categorize_test.go
@@ -1,0 +1,239 @@
+package intelligence
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+type mockCategorizeQuerier struct {
+	docs       []Document
+	tagUpdates map[string][]string
+	err        error
+}
+
+func (m *mockCategorizeQuerier) ListDocumentsWithoutSemanticTags(ctx context.Context, workspace string, maxDocs int) ([]Document, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	
+	var result []Document
+	for _, doc := range m.docs {
+		if !hasSemanticTags(doc.Tags) {
+			result = append(result, doc)
+			if len(result) >= maxDocs {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockCategorizeQuerier) UpdateDocumentTags(ctx context.Context, workspace, docID string, tags []string) error {
+	if m.err != nil {
+		return m.err
+	}
+	if m.tagUpdates == nil {
+		m.tagUpdates = make(map[string][]string)
+	}
+	m.tagUpdates[docID] = tags
+	return nil
+}
+
+func TestCategorizer_RunCategorization_NoDocuments(t *testing.T) {
+	llm := &mockLLM{}
+	queries := &mockCategorizeQuerier{docs: []Document{}}
+	logger := zerolog.Nop()
+
+	categorizer := NewCategorizer(llm, queries, logger, 0.6)
+
+	result, err := categorizer.RunCategorization(context.Background(), "test-workspace", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Processed != 0 {
+		t.Errorf("expected 0 processed, got %d", result.Processed)
+	}
+	if result.Categorized != 0 {
+		t.Errorf("expected 0 categorized, got %d", result.Categorized)
+	}
+}
+
+func TestCategorizer_RunCategorization_HighConfidence(t *testing.T) {
+	llm := &mockLLM{
+		response: `{
+			"tags": ["bug-fix", "architecture"],
+			"confidence": 0.85,
+			"reasoning": "Document describes a bug fix that required architectural changes"
+		}`,
+	}
+
+	docs := []Document{
+		{
+			ID:         "doc1",
+			Title:      "Fix memory leak in connection pool",
+			Content:    "This document describes how we fixed a memory leak...",
+			Collection: "memory",
+			Tags:       []string{"session"},
+		},
+	}
+
+	queries := &mockCategorizeQuerier{docs: docs}
+	logger := zerolog.Nop()
+
+	categorizer := NewCategorizer(llm, queries, logger, 0.6)
+
+	result, err := categorizer.RunCategorization(context.Background(), "test-workspace", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Categorized != 1 {
+		t.Errorf("expected 1 categorized, got %d", result.Categorized)
+	}
+
+	if len(queries.tagUpdates) != 1 {
+		t.Errorf("expected 1 tag update, got %d", len(queries.tagUpdates))
+	}
+
+	updatedTags := queries.tagUpdates["doc1"]
+	if len(updatedTags) != 3 {
+		t.Errorf("expected 3 tags (session + 2 new), got %d", len(updatedTags))
+	}
+}
+
+func TestCategorizer_RunCategorization_LowConfidence(t *testing.T) {
+	llm := &mockLLM{
+		response: `{
+			"tags": ["feature"],
+			"confidence": 0.4,
+			"reasoning": "Not entirely clear what this document is about"
+		}`,
+	}
+
+	docs := []Document{
+		{
+			ID:         "doc1",
+			Title:      "Some Document",
+			Content:    "Unclear content...",
+			Collection: "memory",
+			Tags:       []string{"opencode"},
+		},
+	}
+
+	queries := &mockCategorizeQuerier{docs: docs}
+	logger := zerolog.Nop()
+
+	categorizer := NewCategorizer(llm, queries, logger, 0.6)
+
+	result, err := categorizer.RunCategorization(context.Background(), "test-workspace", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Categorized != 0 {
+		t.Errorf("expected 0 categorized (low confidence), got %d", result.Categorized)
+	}
+
+	if result.Skipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", result.Skipped)
+	}
+
+	if len(queries.tagUpdates) != 0 {
+		t.Errorf("expected no tag updates (low confidence), got %d", len(queries.tagUpdates))
+	}
+}
+
+func TestCategorizer_RunCategorization_FilterStaticTags(t *testing.T) {
+	llm := &mockLLM{
+		response: `{
+			"tags": ["opencode", "session", "bug-fix"],
+			"confidence": 0.9,
+			"reasoning": "Clear bug fix document"
+		}`,
+	}
+
+	docs := []Document{
+		{
+			ID:         "doc1",
+			Title:      "Bug Fix",
+			Content:    "Fixed a bug...",
+			Collection: "memory",
+			Tags:       []string{},
+		},
+	}
+
+	queries := &mockCategorizeQuerier{docs: docs}
+	logger := zerolog.Nop()
+
+	categorizer := NewCategorizer(llm, queries, logger, 0.6)
+
+	result, err := categorizer.RunCategorization(context.Background(), "test-workspace", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Categorized != 1 {
+		t.Errorf("expected 1 categorized, got %d", result.Categorized)
+	}
+
+	updatedTags := queries.tagUpdates["doc1"]
+	hasStaticTag := false
+	for _, tag := range updatedTags {
+		if tag == "opencode" || tag == "session" {
+			hasStaticTag = true
+			break
+		}
+	}
+
+	if hasStaticTag {
+		t.Errorf("static tags should be filtered out, but found one in: %v", updatedTags)
+	}
+}
+
+func TestCategorizer_ConfidenceThresholdValidation(t *testing.T) {
+	llm := &mockLLM{}
+	queries := &mockCategorizeQuerier{}
+	logger := zerolog.Nop()
+
+	tests := []struct {
+		input    float64
+		expected float64
+	}{
+		{0.8, 0.8},
+		{0.0, 0.6},
+		{-0.5, 0.6},
+		{1.5, 0.6},
+	}
+
+	for _, tt := range tests {
+		categorizer := NewCategorizer(llm, queries, logger, tt.input)
+		if categorizer.confidence != tt.expected {
+			t.Errorf("for input %f, expected confidence %f, got %f", tt.input, tt.expected, categorizer.confidence)
+		}
+	}
+}
+
+func TestHasSemanticTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		expected bool
+	}{
+		{"no tags", []string{}, false},
+		{"only static tags", []string{"opencode", "session"}, false},
+		{"has semantic tag", []string{"opencode", "bug-fix"}, true},
+		{"only semantic tags", []string{"feature", "architecture"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasSemanticTags(tt.tags)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v for tags %v", tt.expected, result, tt.tags)
+			}
+		})
+	}
+}

--- a/internal/intelligence/consolidate.go
+++ b/internal/intelligence/consolidate.go
@@ -1,0 +1,286 @@
+package intelligence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type ConsolidateQuerier interface {
+	ListDocumentsByCollection(ctx context.Context, workspace, collection string) ([]Document, error)
+	GetDocumentByID(ctx context.Context, workspace, docID string) (Document, error)
+	UpsertDocument(ctx context.Context, doc Document) error
+	DeleteDocument(ctx context.Context, workspace, docID string) error
+}
+
+type SearchService interface {
+	VectorSearch(ctx context.Context, query string, workspace string, maxResults int) ([]SearchResult, error)
+}
+
+type Document struct {
+	ID           string
+	WorkspaceHash string
+	ContentHash  string
+	Title        string
+	Content      string
+	SourcePath   string
+	Collection   string
+	Tags         []string
+	SupersedesID *string
+}
+
+type SearchResult struct {
+	ChunkID    string
+	DocumentID string
+	Content    string
+	Score      float64
+}
+
+type Consolidator struct {
+	llm         LLM
+	queries     ConsolidateQuerier
+	searchSvc   SearchService
+	logger      zerolog.Logger
+	dryRun      bool
+	simThreshold float64
+}
+
+func NewConsolidator(
+	llm LLM,
+	queries ConsolidateQuerier,
+	searchSvc SearchService,
+	logger zerolog.Logger,
+	dryRun bool,
+) *Consolidator {
+	return &Consolidator{
+		llm:         llm,
+		queries:     queries,
+		searchSvc:   searchSvc,
+		logger:      logger,
+		dryRun:      dryRun,
+		simThreshold: 0.85,
+	}
+}
+
+type ConsolidationResult struct {
+	ClustersFound int
+	Merged        int
+	Skipped       int
+	Errors        int
+}
+
+type consolidationResponse struct {
+	ShouldMerge         bool   `json:"should_merge"`
+	Reasoning           string `json:"reasoning"`
+	ConsolidatedContent string `json:"consolidated_content"`
+	Title               string `json:"title"`
+}
+
+func (c *Consolidator) RunConsolidation(ctx context.Context, workspace string) (*ConsolidationResult, error) {
+	c.logger.Info().
+		Str("workspace", workspace).
+		Bool("dry_run", c.dryRun).
+		Msg("consolidation: starting")
+
+	docs, err := c.queries.ListDocumentsByCollection(ctx, workspace, "memory")
+	if err != nil {
+		return nil, fmt.Errorf("list documents: %w", err)
+	}
+
+	c.logger.Info().Int("doc_count", len(docs)).Msg("consolidation: documents loaded")
+
+	if len(docs) == 0 {
+		return &ConsolidationResult{}, nil
+	}
+
+	clusters := c.findClusters(ctx, workspace, docs)
+
+	c.logger.Info().Int("clusters", len(clusters)).Msg("consolidation: clusters identified")
+
+	result := &ConsolidationResult{
+		ClustersFound: len(clusters),
+	}
+
+	for _, cluster := range clusters {
+		if len(cluster) < 2 {
+			continue
+		}
+
+		merged, err := c.processCluster(ctx, workspace, cluster)
+		if err != nil {
+			c.logger.Warn().Err(err).Msg("consolidation: cluster processing failed")
+			result.Errors++
+			continue
+		}
+
+		if merged {
+			result.Merged++
+		} else {
+			result.Skipped++
+		}
+	}
+
+	c.logger.Info().
+		Int("clusters", result.ClustersFound).
+		Int("merged", result.Merged).
+		Int("skipped", result.Skipped).
+		Int("errors", result.Errors).
+		Msg("consolidation: completed")
+
+	return result, nil
+}
+
+func (c *Consolidator) findClusters(ctx context.Context, workspace string, docs []Document) [][]Document {
+	var clusters [][]Document
+	processed := make(map[string]bool)
+
+	for _, doc := range docs {
+		if processed[doc.ID] {
+			continue
+		}
+
+		similar, err := c.findSimilarDocs(ctx, workspace, doc, docs)
+		if err != nil {
+			c.logger.Warn().Err(err).Str("doc_id", doc.ID).Msg("consolidation: similarity search failed")
+			continue
+		}
+
+		if len(similar) > 0 {
+			cluster := []Document{doc}
+			cluster = append(cluster, similar...)
+
+			for _, d := range cluster {
+				processed[d.ID] = true
+			}
+
+			clusters = append(clusters, cluster)
+		}
+	}
+
+	return clusters
+}
+
+func (c *Consolidator) findSimilarDocs(ctx context.Context, workspace string, doc Document, allDocs []Document) ([]Document, error) {
+	searchQuery := doc.Title + " " + truncate(doc.Content, 500)
+
+	results, err := c.searchSvc.VectorSearch(ctx, searchQuery, workspace, 10)
+	if err != nil {
+		return nil, fmt.Errorf("vector search: %w", err)
+	}
+
+	var similar []Document
+	for _, result := range results {
+		if result.DocumentID == doc.ID {
+			continue
+		}
+
+		if result.Score < c.simThreshold {
+			continue
+		}
+
+		for _, d := range allDocs {
+			if d.ID == result.DocumentID {
+				similar = append(similar, d)
+				break
+			}
+		}
+	}
+
+	return similar, nil
+}
+
+func (c *Consolidator) processCluster(ctx context.Context, workspace string, cluster []Document) (bool, error) {
+	summaries := make([]DocumentSummary, len(cluster))
+	for i, doc := range cluster {
+		summaries[i] = DocumentSummary{
+			ID:         doc.ID,
+			Title:      doc.Title,
+			SourcePath: doc.SourcePath,
+			Content:    doc.Content,
+			Tags:       doc.Tags,
+		}
+	}
+
+	userPrompt := buildConsolidationUserPrompt(summaries)
+
+	c.logger.Info().
+		Int("cluster_size", len(cluster)).
+		Msg("consolidation: calling LLM for cluster")
+
+	responseText, _, err := c.llm.ChatCompletion(ctx, consolidationSystemPrompt, userPrompt)
+	if err != nil {
+		return false, fmt.Errorf("llm completion: %w", err)
+	}
+
+	responseText = strings.TrimSpace(responseText)
+	if strings.HasPrefix(responseText, "```json") {
+		responseText = strings.TrimPrefix(responseText, "```json")
+		responseText = strings.TrimSuffix(responseText, "```")
+		responseText = strings.TrimSpace(responseText)
+	}
+
+	var response consolidationResponse
+	if err := json.Unmarshal([]byte(responseText), &response); err != nil {
+		return false, fmt.Errorf("parse llm response: %w", err)
+	}
+
+	c.logger.Info().
+		Bool("should_merge", response.ShouldMerge).
+		Str("reasoning", response.Reasoning).
+		Msg("consolidation: LLM decision")
+
+	if !response.ShouldMerge {
+		return false, nil
+	}
+
+	if c.dryRun {
+		c.logger.Info().Msg("consolidation: dry-run mode, skipping merge")
+		return true, nil
+	}
+
+	mergedDoc := Document{
+		WorkspaceHash: workspace,
+		Title:         response.Title,
+		Content:       response.ConsolidatedContent,
+		SourcePath:    "memory://consolidated/" + cluster[0].ID,
+		Collection:    "memory",
+		Tags:          mergeTags(cluster),
+	}
+
+	if err := c.queries.UpsertDocument(ctx, mergedDoc); err != nil {
+		return false, fmt.Errorf("upsert merged document: %w", err)
+	}
+
+	for _, doc := range cluster {
+		if err := c.queries.DeleteDocument(ctx, workspace, doc.ID); err != nil {
+			c.logger.Warn().Err(err).Str("doc_id", doc.ID).Msg("consolidation: failed to delete original")
+		}
+	}
+
+	return true, nil
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen]
+}
+
+func mergeTags(docs []Document) []string {
+	tagSet := make(map[string]bool)
+	for _, doc := range docs {
+		for _, tag := range doc.Tags {
+			tagSet[tag] = true
+		}
+	}
+
+	var tags []string
+	for tag := range tagSet {
+		tags = append(tags, tag)
+	}
+	return tags
+}

--- a/internal/intelligence/consolidate_test.go
+++ b/internal/intelligence/consolidate_test.go
@@ -1,0 +1,243 @@
+package intelligence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+type mockLLM struct {
+	response string
+	err      error
+}
+
+func (m *mockLLM) ChatCompletion(ctx context.Context, systemPrompt, userPrompt string) (string, TokenUsage, error) {
+	if m.err != nil {
+		return "", TokenUsage{}, m.err
+	}
+	return m.response, TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150}, nil
+}
+
+type mockConsolidateQuerier struct {
+	docs    []Document
+	upserts []Document
+	deletes []string
+	err     error
+}
+
+func (m *mockConsolidateQuerier) ListDocumentsByCollection(ctx context.Context, workspace, collection string) ([]Document, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.docs, nil
+}
+
+func (m *mockConsolidateQuerier) GetDocumentByID(ctx context.Context, workspace, docID string) (Document, error) {
+	if m.err != nil {
+		return Document{}, m.err
+	}
+	for _, doc := range m.docs {
+		if doc.ID == docID {
+			return doc, nil
+		}
+	}
+	return Document{}, errors.New("not found")
+}
+
+func (m *mockConsolidateQuerier) UpsertDocument(ctx context.Context, doc Document) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.upserts = append(m.upserts, doc)
+	return nil
+}
+
+func (m *mockConsolidateQuerier) DeleteDocument(ctx context.Context, workspace, docID string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.deletes = append(m.deletes, docID)
+	return nil
+}
+
+type mockSearchService struct {
+	results []SearchResult
+	err     error
+}
+
+func (m *mockSearchService) VectorSearch(ctx context.Context, query string, workspace string, maxResults int) ([]SearchResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.results, nil
+}
+
+func TestConsolidator_RunConsolidation_NoDocuments(t *testing.T) {
+	llm := &mockLLM{}
+	queries := &mockConsolidateQuerier{docs: []Document{}}
+	searchSvc := &mockSearchService{}
+	logger := zerolog.Nop()
+
+	consolidator := NewConsolidator(llm, queries, searchSvc, logger, false)
+
+	result, err := consolidator.RunConsolidation(context.Background(), "test-workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ClustersFound != 0 {
+		t.Errorf("expected 0 clusters, got %d", result.ClustersFound)
+	}
+	if result.Merged != 0 {
+		t.Errorf("expected 0 merged, got %d", result.Merged)
+	}
+}
+
+func TestConsolidator_RunConsolidation_ShouldMerge(t *testing.T) {
+	llm := &mockLLM{
+		response: `{
+			"should_merge": true,
+			"reasoning": "These documents cover the same topic",
+			"consolidated_content": "# Merged Content\n\nCombined information from both docs.",
+			"title": "Consolidated Document"
+		}`,
+	}
+
+	docs := []Document{
+		{
+			ID:         "doc1",
+			Title:      "Document 1",
+			Content:    "Content of document 1",
+			Collection: "memory",
+			Tags:       []string{"tag1"},
+		},
+		{
+			ID:         "doc2",
+			Title:      "Document 2",
+			Content:    "Content of document 2",
+			Collection: "memory",
+			Tags:       []string{"tag2"},
+		},
+	}
+
+	queries := &mockConsolidateQuerier{docs: docs}
+	searchSvc := &mockSearchService{
+		results: []SearchResult{
+			{DocumentID: "doc2", Score: 0.90},
+		},
+	}
+	logger := zerolog.Nop()
+
+	consolidator := NewConsolidator(llm, queries, searchSvc, logger, false)
+
+	result, err := consolidator.RunConsolidation(context.Background(), "test-workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Merged != 1 {
+		t.Errorf("expected 1 merged, got %d", result.Merged)
+	}
+
+	if len(queries.upserts) != 1 {
+		t.Errorf("expected 1 upsert, got %d", len(queries.upserts))
+	}
+
+	if len(queries.deletes) != 2 {
+		t.Errorf("expected 2 deletes, got %d", len(queries.deletes))
+	}
+}
+
+func TestConsolidator_RunConsolidation_ShouldNotMerge(t *testing.T) {
+	llm := &mockLLM{
+		response: `{
+			"should_merge": false,
+			"reasoning": "These documents are about different topics"
+		}`,
+	}
+
+	docs := []Document{
+		{
+			ID:         "doc1",
+			Title:      "Document 1",
+			Content:    "Content of document 1",
+			Collection: "memory",
+		},
+		{
+			ID:         "doc2",
+			Title:      "Document 2",
+			Content:    "Content of document 2",
+			Collection: "memory",
+		},
+	}
+
+	queries := &mockConsolidateQuerier{docs: docs}
+	searchSvc := &mockSearchService{
+		results: []SearchResult{
+			{DocumentID: "doc2", Score: 0.90},
+		},
+	}
+	logger := zerolog.Nop()
+
+	consolidator := NewConsolidator(llm, queries, searchSvc, logger, false)
+
+	result, err := consolidator.RunConsolidation(context.Background(), "test-workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Merged != 0 {
+		t.Errorf("expected 0 merged, got %d", result.Merged)
+	}
+
+	if len(queries.upserts) != 0 {
+		t.Errorf("expected 0 upserts, got %d", len(queries.upserts))
+	}
+
+	if len(queries.deletes) != 0 {
+		t.Errorf("expected 0 deletes, got %d", len(queries.deletes))
+	}
+}
+
+func TestConsolidator_RunConsolidation_DryRun(t *testing.T) {
+	llm := &mockLLM{
+		response: `{
+			"should_merge": true,
+			"reasoning": "These documents cover the same topic",
+			"consolidated_content": "# Merged Content",
+			"title": "Consolidated Document"
+		}`,
+	}
+
+	docs := []Document{
+		{ID: "doc1", Title: "Doc 1", Content: "Content 1", Collection: "memory"},
+		{ID: "doc2", Title: "Doc 2", Content: "Content 2", Collection: "memory"},
+	}
+
+	queries := &mockConsolidateQuerier{docs: docs}
+	searchSvc := &mockSearchService{
+		results: []SearchResult{{DocumentID: "doc2", Score: 0.90}},
+	}
+	logger := zerolog.Nop()
+
+	consolidator := NewConsolidator(llm, queries, searchSvc, logger, true)
+
+	result, err := consolidator.RunConsolidation(context.Background(), "test-workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(queries.upserts) != 0 {
+		t.Errorf("dry run should not perform upserts, got %d", len(queries.upserts))
+	}
+
+	if len(queries.deletes) != 0 {
+		t.Errorf("dry run should not perform deletes, got %d", len(queries.deletes))
+	}
+
+	if result.Merged != 1 {
+		t.Errorf("dry run should still report merged count, got %d", result.Merged)
+	}
+}

--- a/internal/intelligence/intelligence.go
+++ b/internal/intelligence/intelligence.go
@@ -1,0 +1,23 @@
+// Package intelligence provides memory consolidation and categorization features.
+//
+// Consolidation finds semantically similar documents and merges them via LLM to reduce
+// redundancy. Categorization uses an LLM to automatically tag documents that lack semantic
+// tags.
+//
+// Both features reuse the existing OpenAI-compatible LLM client from internal/summarize.
+package intelligence
+
+import "context"
+
+// LLM is the interface for LLM calls. Matches the interface in internal/summarize/pipeline.go.
+// Reuses the existing summarize.Client implementation.
+type LLM interface {
+	ChatCompletion(ctx context.Context, systemPrompt, userPrompt string) (string, TokenUsage, error)
+}
+
+// TokenUsage holds token counts from an LLM completion response.
+type TokenUsage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}

--- a/internal/intelligence/prompts.go
+++ b/internal/intelligence/prompts.go
@@ -1,0 +1,107 @@
+package intelligence
+
+const consolidationSystemPrompt = `You are a memory consolidation assistant. Your task is to analyze sets of similar documents and determine if they should be merged.
+
+Given multiple documents that appear semantically similar, you must:
+1. Determine if they contain overlapping or redundant information
+2. If they do overlap, create a single consolidated document that preserves ALL unique information from each source
+3. If they are actually distinct (just similar topics), indicate they should remain separate
+
+Return your response as JSON with this structure:
+{
+  "should_merge": true/false,
+  "reasoning": "brief explanation of your decision",
+  "consolidated_content": "the merged markdown content (only if should_merge is true)",
+  "title": "appropriate title for the consolidated document (only if should_merge is true)"
+}
+
+IMPORTANT:
+- If should_merge is false, omit consolidated_content and title fields
+- When merging, preserve all unique facts, decisions, and context
+- Use clear markdown formatting in consolidated_content
+- The consolidated document should be comprehensive but not verbose`
+
+const categorizationSystemPrompt = `You are a document categorization assistant. Your task is to analyze documents and assign appropriate semantic tags.
+
+Available tags:
+- bug-fix: fixes for bugs or issues
+- feature: new functionality or capabilities
+- refactor: code restructuring without behavior change
+- docs: documentation updates
+- chore: maintenance tasks, dependency updates
+- architecture: system design decisions
+- debugging: investigation and diagnosis
+- research: exploration and analysis
+- decision: architectural or technical decisions
+
+Analyze the document and return JSON:
+{
+  "tags": ["tag1", "tag2", ...],
+  "confidence": 0.0-1.0,
+  "reasoning": "brief explanation"
+}
+
+Guidelines:
+- Assign 1-3 most relevant tags
+- Be conservative: only assign tags you're confident about
+- Confidence should reflect how clear the categorization is
+- Tags should be from the predefined list above`
+
+func buildConsolidationUserPrompt(docs []DocumentSummary) string {
+	prompt := "Please analyze these documents and determine if they should be consolidated:\n\n"
+	
+	for i, doc := range docs {
+		prompt += "---\n"
+		prompt += "Document " + string(rune('A'+i)) + ":\n"
+		prompt += "Title: " + doc.Title + "\n"
+		prompt += "Source: " + doc.SourcePath + "\n"
+		prompt += "Tags: " + formatTags(doc.Tags) + "\n"
+		prompt += "Content (first 1500 chars):\n"
+		
+		content := doc.Content
+		if len(content) > 1500 {
+			content = content[:1500] + "... (truncated)"
+		}
+		prompt += content + "\n\n"
+	}
+	
+	return prompt
+}
+
+func buildCategorizationUserPrompt(doc DocumentSummary) string {
+	prompt := "Please categorize this document:\n\n"
+	prompt += "Title: " + doc.Title + "\n"
+	prompt += "Source: " + doc.SourcePath + "\n"
+	prompt += "Current tags: " + formatTags(doc.Tags) + "\n\n"
+	prompt += "Content (first 2000 chars):\n"
+	
+	content := doc.Content
+	if len(content) > 2000 {
+		content = content[:2000] + "... (truncated)"
+	}
+	prompt += content
+	
+	return prompt
+}
+
+func formatTags(tags []string) string {
+	if len(tags) == 0 {
+		return "(none)"
+	}
+	result := ""
+	for i, tag := range tags {
+		if i > 0 {
+			result += ", "
+		}
+		result += tag
+	}
+	return result
+}
+
+type DocumentSummary struct {
+	ID         string
+	Title      string
+	SourcePath string
+	Content    string
+	Tags       []string
+}


### PR DESCRIPTION
## Summary

Implements memory intelligence with LLM-based consolidation and categorization.

- Consolidator: finds similar memories via vector search, merges via LLM
- Categorizer: auto-tags untagged documents via LLM with confidence threshold
- Config: intelligence section (disabled by default)
- Reuses existing summarize.Client LLM infrastructure

Closes #154