### PR TITLE
feat(search): Phase 2 search quality — HyDE, dynamic RRF, reranking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,9 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sqlc-dev/pqtype v0.3.0
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/crypto v0.31.0
+	golang.org/x/net v0.28.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/time v0.9.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -30,6 +33,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
@@ -45,6 +49,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
@@ -53,9 +58,7 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.3 // indirect
-	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,7 +159,26 @@ type SearchConfig struct {
 	EntityBoostEnabled    bool                     `koanf:"entity_boost_enabled" json:"entity_boost_enabled"`
 	EntityBoostFactor     float64                  `koanf:"entity_boost_factor" json:"entity_boost_factor"`
 	QueryPreprocessing    QueryPreprocessingConfig `koanf:"query_preprocessing" json:"query_preprocessing"`
+	HyDE                  HyDEConfig               `koanf:"hyde" json:"hyde"`
+	Reranking             RerankingConfig          `koanf:"reranking" json:"reranking"`
 	BM25Language          string                   `koanf:"bm25_language" json:"bm25_language"`
+}
+
+// HyDEConfig holds HyDE (Hypothetical Document Embedding) configuration.
+type HyDEConfig struct {
+	Enabled      bool   `koanf:"enabled" json:"enabled"`
+	ProviderURL  string `koanf:"provider_url" json:"provider_url"`
+	APIKey       string `koanf:"api_key" json:"api_key"`
+	Model        string `koanf:"model" json:"model"`
+	MaxLatencyMs int    `koanf:"max_latency_ms" json:"max_latency_ms"`
+}
+
+// RerankingConfig holds cross-encoder reranking configuration.
+type RerankingConfig struct {
+	Enabled  bool   `koanf:"enabled" json:"enabled"`
+	Provider string `koanf:"provider" json:"provider"`
+	APIKey   string `koanf:"api_key" json:"api_key"`
+	TopK     int    `koanf:"top_k" json:"top_k"`
 }
 
 // QueryPreprocessingConfig holds LLM-based query preprocessing configuration.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1034,7 +1034,7 @@ func registerMemoryGet(server *mcpsdk.Server, a *Adapter) {
 			Name:        "memory_get",
 			Description: "Get a document by ID or path",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"path":       {"type": "string", "description": "Document source_path or #<uuid> for lookup by ID"},
+				"path":       {"type": "string", "description": "Document source_path, UUID (auto-detected), or #<uuid> for explicit ID lookup"},
 				"workspace":  {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"start_line": {"type": "number", "description": "Start line (1-indexed, inclusive)"},
 				"end_line":   {"type": "number", "description": "End line (1-indexed, inclusive)"},
@@ -1058,7 +1058,9 @@ func registerMemoryGet(server *mcpsdk.Server, a *Adapter) {
 			}
 
 			var doc sqlc.Document
-			if strings.HasPrefix(path, "#") {
+			switch {
+			case strings.HasPrefix(path, "#"):
+				// Explicit UUID lookup via #<uuid> prefix
 				docID, parseErr := uuid.Parse(strings.TrimPrefix(path, "#"))
 				if parseErr != nil {
 					return errResult(fmt.Sprintf("invalid document ID: %v", parseErr)), nil
@@ -1067,11 +1069,20 @@ func registerMemoryGet(server *mcpsdk.Server, a *Adapter) {
 					ID:            docID,
 					WorkspaceHash: ws,
 				})
-			} else {
-				doc, err = a.queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
-					SourcePath:    path,
-					WorkspaceHash: ws,
-				})
+			default:
+				// Try UUID-first: many clients pass the document_id (UUID) returned
+				// by memory_query / memory_search directly as the path.
+				if docID, parseErr := uuid.Parse(path); parseErr == nil {
+					doc, err = a.queries.GetDocumentByID(ctx, sqlc.GetDocumentByIDParams{
+						ID:            docID,
+						WorkspaceHash: ws,
+					})
+				} else {
+					doc, err = a.queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
+						SourcePath:    path,
+						WorkspaceHash: ws,
+					})
+				}
 			}
 			if err != nil {
 				return errResult(fmt.Sprintf("document not found: %v", err)), nil

--- a/internal/search/AGENTS.md
+++ b/internal/search/AGENTS.md
@@ -1,31 +1,40 @@
 # internal/search
 
-Hybrid search pipeline: BM25 + vector + RRF fusion + recency decay.
+Hybrid search pipeline: BM25 + vector + RRF fusion + recency decay + reranking.
 
 ## Pipeline
 
 ```
-Query → BM25 (ts_rank_cd) ──┐
-                              ├─→ RRF Fusion (k=60) → Recency Decay → Results
-Query → Vector (HNSW cos) ──┘
+Query → Preprocessor ──→ BM25 ──┐
+                                 ├─→ Dynamic RRF → Recency → Entity/PageRank → Reranker → Results
+Query ─→ HyDE ─→ Embed ─→ Vector ─┘
 ```
 
-Both legs run concurrently via `errgroup`. One leg failing degrades gracefully;
+Both search legs run concurrently via `errgroup`. One leg failing degrades gracefully;
 both failing returns an error.
+
+### Phase 2 (Search Quality)
+
+- **HyDE** (Hypothetical Document Embedding): Before the vector leg, an LLM rewrites the query as an "ideal answer" passage to improve semantic retrieval. Gated by `search.hyde.enabled`. Falls back to raw query on timeout/error.
+- **Dynamic RRF**: Adjusts the RRF `k` parameter based on BM25/vector overlap — higher overlap → lower k (more aggressive rank weighting). Uses `ComputeRRFK` + `DynamicRRFMerge`.
+- **Reranking**: A cross-encoder model reorders top-N results after all boosts. Currently supports Cohere (`rerank-v4.0-pro`). Gracefully degrades to boosted results on failure.
 
 ## Files
 
 | File | Responsibility |
 |------|---------------|
 | `service.go` | `SearchService` — `Querier` + `Embedder`, config behind `RWMutex`, `HybridSearch` |
-| `rrf.go` | `RRFMerge` — `score = Σ 1/(k + rank + 1)`, deduplicates by chunk ID |
+| `rrf.go` | `RRFMerge`, `DynamicRRFMerge`, `ComputeRRFK` — RRF fusion with dynamic k |
 | `recency.go` | `ApplyRecencyBoost` — normalizes scores to [0,1], exponential half-life decay |
-| `search.go` | `Result` struct — shared return type for all search paths |
+| `search.go` | `Result` struct, `Reranker` interface — shared return type for all search paths |
+| `hyde/` | HyDE generator — LLM-based query-to-hypothetical-document |
+| `reranking/` | Cross-encoder reranker (Cohere adapter) |
 
 ## Key Interfaces
 
 - `Querier`: `BM25Search`, `BM25SearchAll`, `VectorSearch`, `VectorSearchAll`
 - `Embedder`: `Embed(ctx, text) ([]float32, error)`, `Dimension() int`
+- `Reranker`: `Rerank(ctx, query, docs, topK) ([]Result, error)`
 
 `*All` variants ignore workspace scoping (used for cross-workspace queries).
 
@@ -33,16 +42,32 @@ both failing returns an error.
 
 | Field | Default | Effect |
 |-------|---------|--------|
-| `rrf_k` | 60 | Smoothing constant — higher = rank position matters less |
+| `rrf_k` | 60 | Base smoothing constant — dynamic when HyDE/reranking enabled |
 | `recency_weight` | 0.3 | Recency vs relevance blend |
 | `recency_half_life_days` | 180 | Days until recency multiplier halves |
 | `limit` | 20 | Default max results |
+| `hyde.enabled` | false | Enable HyDE hypothetical document generation |
+| `hyge.provider_url` | "" | OpenAI-compatible LLM endpoint for HyDE |
+| `hyde.api_key` | "" | API key for HyDE LLM |
+| `hyde.model` | "" | Model name for HyDE |
+| `hyde.max_latency_ms` | 500 | Timeout for HyDE LLM call |
+| `reranking.enabled` | false | Enable cross-encoder reranking |
+| `reranking.provider` | "" | Reranker provider (cohere) |
+| `reranking.api_key` | "" | Cohere API key |
+| `reranking.top_k` | 20 | Number of results to rerank |
 
 `UpdateConfig` swaps config atomically under a write lock.
 
 ## Recency Formula
 
 `final = (1 - weight) * normalized_rrf + weight * exp(-ln2 * age / half_life)`
+
+## Dynamic RRF
+
+`ComputeRRFK` computes overlap ratio between BM25 and vector result sets, then adjusts k:
+- High overlap (both legs agree) → lower k (aggressive rank-based separation)
+- Low overlap (legs diverge) → higher k (conservative, let both legs contribute)
+- Clamped to `[0.5 * baseK, 2.0 * baseK]`
 
 ## Workspace Isolation
 

--- a/internal/search/hyde/generator.go
+++ b/internal/search/hyde/generator.go
@@ -1,0 +1,137 @@
+// Package hyde implements Hypothetical Document Embedding (HyDE) generation.
+package hyde
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/rs/zerolog"
+)
+
+// Generator implements HyDE (Hypothetical Document Embedding) generation.
+// It takes a search query, asks an LLM to "write a passage that would be the ideal answer to this query",
+// and returns that hypothetical document text for embedding.
+type Generator struct {
+	httpClient  *http.Client
+	providerURL string
+	apiKey      string
+	model       string
+	logger      zerolog.Logger
+}
+
+// NewGenerator creates a new HyDE generator from configuration.
+func NewGenerator(cfg config.HyDEConfig, logger zerolog.Logger) *Generator {
+	timeout := time.Duration(cfg.MaxLatencyMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 500 * time.Millisecond
+	}
+	return &Generator{
+		httpClient:  &http.Client{Timeout: timeout},
+		providerURL: strings.TrimRight(cfg.ProviderURL, "/"),
+		apiKey:      cfg.APIKey,
+		model:       cfg.Model,
+		logger:      logger,
+	}
+}
+
+// Generate takes a search query and returns a hypothetical document text that would
+// be the ideal answer to the query. On any error or timeout, returns an empty string.
+func (g *Generator) Generate(ctx context.Context, query string) (string, error) {
+	if g.providerURL == "" || g.model == "" {
+		return "", nil
+	}
+
+	result, err := g.callLLM(ctx, query)
+	if err != nil {
+		g.logger.Warn().Err(err).Msg("hyde: LLM call failed, returning empty")
+		return "", nil
+	}
+
+	return result, nil
+}
+
+const systemPrompt = `You are a technical documentation writer. Given a search query, write a concise paragraph (80-120 words) that would be the ideal answer to the query. Write in a factual, technical documentation style. Focus on explaining concepts clearly. Respond with ONLY the paragraph text, no JSON, no markdown.
+
+Example:
+Query: "How to handle rate limiting in Go"
+Response: "Rate limiting in Go is commonly implemented using token bucket or leaky bucket algorithms. The standard library provides rate.Limiter which implements a token bucket. For distributed rate limiting, you can use Redis with Lua scripts to ensure atomic operations. Middleware patterns in web frameworks like Echo or Gin allow centralized rate limiting across all endpoints. Monitoring key metrics like request rate, throttle rate, and error rates is essential for tuning limits effectively."
+
+Now, respond with only the paragraph for the given query.`
+
+type chatRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Stream   bool          `json:"stream"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func (g *Generator) callLLM(ctx context.Context, query string) (string, error) {
+	reqBody := chatRequest{
+		Model: g.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: query},
+		},
+		Stream: false,
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("hyde: marshal request: %w", err)
+	}
+
+	endpoint := g.providerURL + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("hyde: create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if g.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+g.apiKey)
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("hyde: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return "", fmt.Errorf("hyde: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var chatResp chatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&chatResp); err != nil {
+		return "", fmt.Errorf("hyde: decode response: %w", err)
+	}
+
+	if len(chatResp.Choices) == 0 {
+		return "", fmt.Errorf("hyde: empty choices in response")
+	}
+
+	content := strings.TrimSpace(chatResp.Choices[0].Message.Content)
+	content = strings.TrimPrefix(content, "```")
+	content = strings.TrimSuffix(content, "```")
+	return strings.TrimSpace(content), nil
+}

--- a/internal/search/hyde/generator_test.go
+++ b/internal/search/hyde/generator_test.go
@@ -73,7 +73,7 @@ func TestGenerate_Success(t *testing.T) {
 		}`
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
+		_, _ = w.Write([]byte(response))
 	}))
 	defer server.Close()
 
@@ -98,7 +98,7 @@ func TestGenerate_Success(t *testing.T) {
 func TestGenerate_HTTPError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal server error"))
+		_, _ = w.Write([]byte("internal server error"))
 	}))
 	defer server.Close()
 
@@ -124,7 +124,7 @@ func TestGenerate_Timeout(t *testing.T) {
 		response := `{"choices": [{"message": {"content": "response"}}]}`
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
+		_, _ = w.Write([]byte(response))
 	}))
 	defer server.Close()
 
@@ -149,7 +149,7 @@ func TestGenerate_EmptyChoices(t *testing.T) {
 		response := `{"choices": []}`
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
+		_, _ = w.Write([]byte(response))
 	}))
 	defer server.Close()
 
@@ -173,7 +173,7 @@ func TestGenerate_JSONParseError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("invalid json"))
+		_, _ = w.Write([]byte("invalid json"))
 	}))
 	defer server.Close()
 

--- a/internal/search/hyde/generator_test.go
+++ b/internal/search/hyde/generator_test.go
@@ -1,0 +1,208 @@
+package hyde
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGenerator(t *testing.T) {
+	cfg := config.HyDEConfig{
+		Enabled:      true,
+		ProviderURL:  "http://example.com",
+		APIKey:       "test-key",
+		Model:        "test-model",
+		MaxLatencyMs: 1000,
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	assert.NotNil(t, generator)
+	assert.Equal(t, "http://example.com", generator.providerURL)
+	assert.Equal(t, "test-model", generator.model)
+	assert.Equal(t, "test-key", generator.apiKey)
+}
+
+func TestGenerate_EmptyProviderURL(t *testing.T) {
+	cfg := config.HyDEConfig{
+		Enabled: true,
+		Model:   "test-model",
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "test query")
+	assert.NoError(t, err)
+	assert.Equal(t, "", text)
+}
+
+func TestGenerate_EmptyModel(t *testing.T) {
+	cfg := config.HyDEConfig{
+		Enabled:     true,
+		ProviderURL: "http://example.com",
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "test query")
+	assert.NoError(t, err)
+	assert.Equal(t, "", text)
+}
+
+func TestGenerate_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/chat/completions", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		response := `{
+			"choices": [{
+				"message": {
+					"content": "This is a hypothetical document about rate limiting in Go. Rate limiting is implemented using token bucket algorithms and middleware patterns."
+				}
+			}]
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	cfg := config.HyDEConfig{
+		Enabled:      true,
+		ProviderURL:  server.URL,
+		APIKey:       "test-key",
+		Model:        "test-model",
+		MaxLatencyMs: 5000,
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "How to handle rate limiting in Go")
+	assert.NoError(t, err)
+	assert.Contains(t, text, "hypothetical document")
+	assert.Contains(t, text, "rate limiting")
+	assert.Contains(t, text, "token bucket")
+}
+
+func TestGenerate_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	cfg := config.HyDEConfig{
+		Enabled:      true,
+		ProviderURL:  server.URL,
+		APIKey:       "test-key",
+		Model:        "test-model",
+		MaxLatencyMs: 5000,
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "test query")
+	assert.NoError(t, err)
+	assert.Equal(t, "", text)
+}
+
+func TestGenerate_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		response := `{"choices": [{"message": {"content": "response"}}]}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	cfg := config.HyDEConfig{
+		Enabled:      true,
+		ProviderURL:  server.URL,
+		APIKey:       "test-key",
+		Model:        "test-model",
+		MaxLatencyMs: 50,
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "test query")
+	assert.NoError(t, err)
+	assert.Equal(t, "", text)
+}
+
+func TestGenerate_EmptyChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{"choices": []}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	cfg := config.HyDEConfig{
+		Enabled:      true,
+		ProviderURL:  server.URL,
+		APIKey:       "test-key",
+		Model:        "test-model",
+		MaxLatencyMs: 5000,
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "test query")
+	assert.NoError(t, err)
+	assert.Equal(t, "", text)
+}
+
+func TestGenerate_JSONParseError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("invalid json"))
+	}))
+	defer server.Close()
+
+	cfg := config.HyDEConfig{
+		Enabled:      true,
+		ProviderURL:  server.URL,
+		APIKey:       "test-key",
+		Model:        "test-model",
+		MaxLatencyMs: 5000,
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	text, err := generator.Generate(context.Background(), "test query")
+	assert.NoError(t, err)
+	assert.Equal(t, "", text)
+}
+
+func TestGenerate_DefaultTimeout(t *testing.T) {
+	cfg := config.HyDEConfig{
+		Enabled:     true,
+		ProviderURL: "http://example.com",
+		APIKey:      "test-key",
+		Model:       "test-model",
+	}
+	logger := zerolog.Nop()
+
+	generator := NewGenerator(cfg, logger)
+
+	assert.Equal(t, 500*time.Millisecond, generator.httpClient.Timeout)
+}

--- a/internal/search/reranking/reranker.go
+++ b/internal/search/reranking/reranker.go
@@ -1,0 +1,178 @@
+// Package reranking provides cross-encoder reranking for search results.
+// It can reorder candidate documents using API-based reranking models.
+package reranking
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/rs/zerolog"
+)
+
+// Config holds reranker configuration.
+type Config struct {
+	Enabled  bool   `koanf:"enabled" json:"enabled"`
+	Provider string `koanf:"provider" json:"provider"`
+	APIKey   string `koanf:"api_key" json:"api_key"`
+	TopK     int    `koanf:"top_k" json:"top_k"`
+}
+
+// CohereReranker implements the search.Reranker interface using Cohere's rerank API.
+type CohereReranker struct {
+	apiKey     string
+	model      string
+	topK       int
+	logger     zerolog.Logger
+	httpClient *http.Client
+}
+
+// NewCohereReranker creates a new CohereReranker with the given configuration.
+func NewCohereReranker(cfg Config, logger zerolog.Logger) *CohereReranker {
+	if cfg.TopK <= 0 {
+		cfg.TopK = 20
+	}
+
+	return &CohereReranker{
+		apiKey: cfg.APIKey,
+		model:  "rerank-v4.0-pro",
+		topK:   cfg.TopK,
+		logger: logger,
+		httpClient: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+	}
+}
+
+// Rerank implements the Reranker interface for Cohere.
+func (r *CohereReranker) Rerank(ctx context.Context, query string, docs []search.Result, topK int) ([]search.Result, error) {
+	// If disabled or no documents, return original
+	if r.apiKey == "" || len(docs) == 0 {
+		return docs, nil
+	}
+
+	// Use parameter topK if provided, otherwise use configured topK
+	if topK <= 0 {
+		topK = r.topK
+	}
+	if topK > len(docs) {
+		topK = len(docs)
+	}
+
+	// Prepare documents for API call
+	docTexts := make([]string, len(docs))
+	for i, doc := range docs {
+		// Prefer snippet if available, otherwise content
+		if doc.Snippet != "" {
+			docTexts[i] = doc.Snippet
+		} else {
+			docTexts[i] = doc.Content
+		}
+	}
+
+	// Call Cohere API
+	rerankedDocs, err := r.callAPI(ctx, query, docTexts, topK)
+	if err != nil {
+		r.logger.Warn().Err(err).Str("query", query).Msg("reranking failed, returning original results")
+		return docs, nil // Graceful degradation: return original docs
+	}
+
+	// Map reranked indices back to original documents
+	result := make([]search.Result, len(rerankedDocs))
+	for i, idx := range rerankedDocs {
+		if idx < 0 || idx >= len(docs) {
+			// This shouldn't happen, but be safe
+			r.logger.Warn().Int("index", idx).Int("max", len(docs)-1).Msg("invalid reranked index")
+			return docs, nil
+		}
+		result[i] = docs[idx]
+	}
+
+	return result, nil
+}
+
+func (r *CohereReranker) callAPI(ctx context.Context, query string, documents []string, topN int) ([]int, error) {
+	reqBody := map[string]interface{}{
+		"model":             r.model,
+		"query":             query,
+		"documents":         documents,
+		"top_n":             topN,
+		"return_documents":  false,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.cohere.com/v2/rerank", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+r.apiKey)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("cohere API HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp struct {
+		Results []struct {
+			Index           int     `json:"index"`
+			RelevanceScore  float64 `json:"relevance_score"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	indices := make([]int, len(apiResp.Results))
+	for i, result := range apiResp.Results {
+		if result.Index < 0 || result.Index >= len(documents) {
+			return nil, fmt.Errorf("invalid index %d for document count %d", result.Index, len(documents))
+		}
+		indices[i] = result.Index
+	}
+
+	return indices, nil
+}
+
+func NewReranker(cfg config.RerankingConfig, logger zerolog.Logger) search.Reranker {
+	if !cfg.Enabled {
+		return &noopReranker{}
+	}
+
+	switch strings.ToLower(cfg.Provider) {
+	case "cohere":
+		return NewCohereReranker(Config{
+			Enabled:  cfg.Enabled,
+			Provider: cfg.Provider,
+			APIKey:   cfg.APIKey,
+			TopK:     cfg.TopK,
+		}, logger)
+	default:
+		logger.Warn().Str("provider", cfg.Provider).Msg("unknown reranker provider, using noop")
+		return &noopReranker{}
+	}
+}
+
+type noopReranker struct{}
+
+func (r *noopReranker) Rerank(ctx context.Context, query string, docs []search.Result, topK int) ([]search.Result, error) {
+	return docs, nil
+}

--- a/internal/search/reranking/reranker_test.go
+++ b/internal/search/reranking/reranker_test.go
@@ -1,0 +1,83 @@
+package reranking_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/nano-brain/nano-brain/internal/search/reranking"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopReranker(t *testing.T) {
+	cfg := config.RerankingConfig{Enabled: false}
+	logger := zerolog.Nop()
+	reranker := reranking.NewReranker(cfg, logger)
+
+	docs := []search.Result{
+		{ID: "1", Snippet: "doc1", Score: 0.5},
+		{ID: "2", Snippet: "doc2", Score: 0.3},
+	}
+
+	result, err := reranker.Rerank(context.Background(), "test query", docs, 10)
+	require.NoError(t, err)
+	assert.Equal(t, docs, result)
+}
+
+func TestUnknownProvider(t *testing.T) {
+	cfg := config.RerankingConfig{
+		Enabled:  true,
+		Provider: "unknown",
+		APIKey:   "test-key",
+		TopK:     20,
+	}
+	logger := zerolog.Nop()
+	reranker := reranking.NewReranker(cfg, logger)
+
+	docs := []search.Result{
+		{ID: "1", Snippet: "doc1", Score: 0.5},
+		{ID: "2", Snippet: "doc2", Score: 0.3},
+	}
+
+	result, err := reranker.Rerank(context.Background(), "test query", docs, 10)
+	require.NoError(t, err)
+	assert.Equal(t, docs, result)
+}
+
+func TestCohereNoAPIKey(t *testing.T) {
+	cfg := config.RerankingConfig{
+		Enabled:  true,
+		Provider: "cohere",
+		APIKey:   "",
+		TopK:     20,
+	}
+	logger := zerolog.Nop()
+	reranker := reranking.NewReranker(cfg, logger)
+
+	docs := []search.Result{
+		{ID: "1", Snippet: "doc1", Score: 0.5},
+		{ID: "2", Snippet: "doc2", Score: 0.3},
+	}
+
+	result, err := reranker.Rerank(context.Background(), "test query", docs, 10)
+	require.NoError(t, err)
+	assert.Equal(t, docs, result)
+}
+
+func TestEmptyDocs(t *testing.T) {
+	cfg := config.RerankingConfig{
+		Enabled:  true,
+		Provider: "cohere",
+		APIKey:   "test-key",
+		TopK:     20,
+	}
+	logger := zerolog.Nop()
+	reranker := reranking.NewReranker(cfg, logger)
+
+	result, err := reranker.Rerank(context.Background(), "test query", nil, 10)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}

--- a/internal/search/rrf.go
+++ b/internal/search/rrf.go
@@ -2,6 +2,56 @@ package search
 
 import "sort"
 
+// ComputeRRFK calculates an adjusted k value for RRF based on signal confidence.
+func ComputeRRFK(bm25Results, vectorResults []Result, baseK float64) float64 {
+	if len(bm25Results) < 3 || len(vectorResults) < 3 {
+		return baseK
+	}
+
+	bm25Set := make(map[string]bool)
+	for _, r := range bm25Results {
+		bm25Set[r.ID] = true
+	}
+
+	var overlap int
+	for _, r := range vectorResults {
+		if bm25Set[r.ID] {
+			overlap++
+		}
+	}
+
+	minLen := len(bm25Results)
+	if len(vectorResults) < minLen {
+		minLen = len(vectorResults)
+	}
+	
+	if minLen == 0 {
+		return baseK
+	}
+	
+	overlapRatio := float64(overlap) / float64(minLen)
+	adjustedK := baseK * (1.5 - overlapRatio)
+	
+	minK := baseK * 0.5
+	maxK := baseK * 2.0
+	
+	if adjustedK < minK {
+		return minK
+	}
+	if adjustedK > maxK {
+		return maxK
+	}
+	
+	return adjustedK
+}
+
+// DynamicRRFMerge combines two ranked result lists using Reciprocal Rank Fusion
+// with a dynamically adjusted k parameter based on signal confidence.
+func DynamicRRFMerge(bm25Results, vectorResults []Result, baseK float64) []Result {
+	k := ComputeRRFK(bm25Results, vectorResults, baseK)
+	return RRFMerge(bm25Results, vectorResults, k)
+}
+
 // RRFMerge merges two ranked result lists using Reciprocal Rank Fusion.
 // score = Σ 1/(k + rank + 1) for each list the result appears in.
 // When a chunk appears in both lists, metadata is kept from the first occurrence (BM25).

--- a/internal/search/rrf_test.go
+++ b/internal/search/rrf_test.go
@@ -167,3 +167,98 @@ func TestRRFMerge_PaginationConsistency(t *testing.T) {
 func approxEqual(a, b, epsilon float64) bool {
 	return math.Abs(a-b) < epsilon
 }
+
+func TestComputeRRFK_HighOverlap(t *testing.T) {
+	// High overlap -> should return k smaller than baseK
+	bm25 := []Result{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}, {ID: "e"}}
+	vector := []Result{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "f"}, {ID: "g"}}
+	baseK := 60.0
+
+	k := ComputeRRFK(bm25, vector, baseK)
+	if k >= baseK {
+		t.Errorf("High overlap should produce k < baseK (%.2f), got %.2f", baseK, k)
+	}
+	if k < baseK*0.5 {
+		t.Errorf("k should be >= baseK*0.5 (%.2f), got %.2f", baseK*0.5, k)
+	}
+}
+
+func TestComputeRRFK_LowOverlap(t *testing.T) {
+	// Low overlap -> should return k larger than baseK
+	bm25 := []Result{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}, {ID: "e"}}
+	vector := []Result{{ID: "f"}, {ID: "g"}, {ID: "h"}, {ID: "i"}, {ID: "j"}}
+	baseK := 60.0
+
+	k := ComputeRRFK(bm25, vector, baseK)
+	if k <= baseK {
+		t.Errorf("Low overlap should produce k > baseK (%.2f), got %.2f", baseK, k)
+	}
+	if k > baseK*2.0 {
+		t.Errorf("k should be <= baseK*2.0 (%.2f), got %.2f", baseK*2.0, k)
+	}
+}
+
+func TestComputeRRFK_SmallLists(t *testing.T) {
+	// Lists too small -> should return baseK
+	bm25 := []Result{{ID: "a"}, {ID: "b"}}
+	vector := []Result{{ID: "c"}, {ID: "d"}}
+	baseK := 60.0
+
+	k := ComputeRRFK(bm25, vector, baseK)
+	if !approxEqual(k, baseK, 1e-9) {
+		t.Errorf("Small lists should return baseK (%.2f), got %.2f", baseK, k)
+	}
+}
+
+func TestComputeRRFK_EmptyVector(t *testing.T) {
+	// Empty vector list -> should return baseK
+	bm25 := []Result{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}, {ID: "e"}}
+	vector := []Result{}
+	baseK := 60.0
+
+	k := ComputeRRFK(bm25, vector, baseK)
+	if !approxEqual(k, baseK, 1e-9) {
+		t.Errorf("Empty vector list should return baseK (%.2f), got %.2f", baseK, k)
+	}
+}
+
+func TestComputeRRFK_EmptyBM25(t *testing.T) {
+	// Empty BM25 list -> should return baseK
+	bm25 := []Result{}
+	vector := []Result{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}, {ID: "e"}}
+	baseK := 60.0
+
+	k := ComputeRRFK(bm25, vector, baseK)
+	if !approxEqual(k, baseK, 1e-9) {
+		t.Errorf("Empty BM25 list should return baseK (%.2f), got %.2f", baseK, k)
+	}
+}
+
+func TestComputeRRFK_BothEmpty(t *testing.T) {
+	// Both lists empty -> should return baseK
+	bm25 := []Result{}
+	vector := []Result{}
+	baseK := 60.0
+
+	k := ComputeRRFK(bm25, vector, baseK)
+	if !approxEqual(k, baseK, 1e-9) {
+		t.Errorf("Both empty lists should return baseK (%.2f), got %.2f", baseK, k)
+	}
+}
+
+func TestDynamicRRFMerge_Basic(t *testing.T) {
+	bm25 := []Result{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+	vector := []Result{{ID: "d"}, {ID: "e"}, {ID: "f"}}
+	baseK := 60.0
+
+	results := DynamicRRFMerge(bm25, vector, baseK)
+	if len(results) != 6 {
+		t.Errorf("Expected 6 results, got %d", len(results))
+	}
+
+	for i := 0; i < len(results)-1; i++ {
+		if results[i].Score < results[i+1].Score {
+			t.Error("Results not sorted descending")
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,7 +1,10 @@
 // Package search handles semantic and keyword search queries.
 package search
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Result represents a single search result from any search method.
 // JSON tags use snake_case to match the public API + MCP tool response contract.
@@ -20,4 +23,9 @@ type Result struct {
 	SourcePath    string    `json:"source_path"`
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// Reranker is the interface for search result reranking.
+type Reranker interface {
+	Rerank(ctx context.Context, query string, docs []Result, topK int) ([]Result, error)
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/search/hyde"
 	"github.com/nano-brain/nano-brain/internal/search/preprocess"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	pgvector_go "github.com/pgvector/pgvector-go"
@@ -49,6 +50,8 @@ type SearchService struct {
 	logger         zerolog.Logger
 	pagerankLoader PageRankLoader
 	preprocessor   *preprocess.Preprocessor
+	hydeGenerator  *hyde.Generator
+	reranker       Reranker
 }
 
 func NewSearchService(queries Querier, embedder Embedder, cfg config.SearchConfig, logger zerolog.Logger) *SearchService {
@@ -65,6 +68,14 @@ func (s *SearchService) SetPageRankLoader(loader PageRankLoader) {
 
 func (s *SearchService) SetPreprocessor(pp *preprocess.Preprocessor) {
 	s.preprocessor = pp
+}
+
+func (s *SearchService) SetHydeGenerator(hg *hyde.Generator) {
+	s.hydeGenerator = hg
+}
+
+func (s *SearchService) SetReranker(rr Reranker) {
+	s.reranker = rr
 }
 
 // UpdateConfig updates the search configuration with thread-safe locking.
@@ -110,6 +121,21 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 			}
 			if result.TimeFilter.Before != nil && timeRange.UpdatedBefore == nil {
 				timeRange.UpdatedBefore = result.TimeFilter.Before
+			}
+		}
+	}
+
+	// HyDE: generate a hypothetical document for embedding if enabled
+	embedQuery := query
+	if s.hydeGenerator != nil {
+		s.configMutex.RLock()
+		hydeEnabled := s.config.HyDE.Enabled
+		s.configMutex.RUnlock()
+		if hydeEnabled {
+			hypothetical, err := s.hydeGenerator.Generate(ctx, query)
+			if err == nil && hypothetical != "" {
+				s.logger.Debug().Str("original", query).Str("hyde", hypothetical).Msg("hyde: generated hypothetical document")
+				embedQuery = hypothetical
 			}
 		}
 	}
@@ -273,7 +299,7 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 		if s.embedder == nil {
 			return nil
 		}
-		vec, err := s.embedder.Embed(gctx, query)
+		vec, err := s.embedder.Embed(gctx, embedQuery)
 		if err != nil {
 			vectorErr = err
 			s.logger.Warn().Err(err).Msg("embed failed, degrading")
@@ -421,7 +447,7 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 		return nil, fmt.Errorf("all search legs failed: bm25: %v, vector: %v", bm25Err, vectorErr)
 	}
 
-	merged := RRFMerge(bm25Results, vectorResults, rrfK)
+	merged := DynamicRRFMerge(bm25Results, vectorResults, rrfK)
 
 	boosted := ApplyRecencyBoost(merged, recencyWeight, recencyHalfLifeDays, time.Now())
 
@@ -460,9 +486,26 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 		}
 	}
 
-	if len(boosted) > maxResults {
-		boosted = boosted[:maxResults]
+	// Apply reranking if enabled
+	reranked := boosted
+	if s.reranker != nil {
+		s.configMutex.RLock()
+		rerankEnabled := s.config.Reranking.Enabled
+		rerankTopK := s.config.Reranking.TopK
+		s.configMutex.RUnlock()
+		if rerankEnabled && rerankTopK > 0 {
+			var err error
+			reranked, err = s.reranker.Rerank(ctx, query, boosted, rerankTopK)
+			if err != nil {
+				s.logger.Warn().Err(err).Msg("reranking failed, using boosted results")
+				reranked = boosted
+			}
+		}
 	}
 
-	return boosted, nil
+	if len(reranked) > maxResults {
+		reranked = reranked[:maxResults]
+	}
+
+	return reranked, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,7 +17,9 @@ import (
 	"github.com/nano-brain/nano-brain/internal/links"
 	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/nano-brain/nano-brain/internal/search"
+	"github.com/nano-brain/nano-brain/internal/search/hyde"
 	"github.com/nano-brain/nano-brain/internal/search/preprocess"
+	"github.com/nano-brain/nano-brain/internal/search/reranking"
 	"github.com/nano-brain/nano-brain/internal/server/handlers"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/telemetry"
@@ -85,6 +87,16 @@ func New(fullCfg *config.Config, configPath string, pool PoolChecker, db *sql.DB
 		if fullCfg.Search.QueryPreprocessing.Enabled && queries != nil {
 			preprocessor := preprocess.NewPreprocessor(fullCfg.Search.QueryPreprocessing, logger)
 			ss.SetPreprocessor(preprocessor)
+		}
+		// Create and inject HyDE generator if enabled
+		if fullCfg.Search.HyDE.Enabled {
+			hg := hyde.NewGenerator(fullCfg.Search.HyDE, logger)
+			ss.SetHydeGenerator(hg)
+		}
+		// Create and inject reranker if enabled
+		if fullCfg.Search.Reranking.Enabled {
+			rr := reranking.NewReranker(fullCfg.Search.Reranking, logger)
+			ss.SetReranker(rr)
 		}
 	}
 


### PR DESCRIPTION
Closes #409

## Summary

Implements Phase 2 of the search quality improvements (follow-on from #407 / PR #408).

### Pipeline

```
Query → Preprocessor → BM25 ──┐
                 └→ HyDE → Embed → Vector ┘ → Dynamic RRF → Recency → Entity/PageRank → Reranking → Results
```

### Components

**HyDE** (`internal/search/hyde/`)
- Before vector embedding, calls an LLM to rewrite the query as an ideal-answer passage
- OpenAI-compatible `/chat/completions` endpoint, configurable model/timeout
- Falls back to raw query on error (graceful degradation)

**Dynamic RRF** (`internal/search/rrf.go`)
- `ComputeRRFK` adjusts `k` based on BM25/vector overlap ratio
- High overlap → lower k (aggressive rank separation)
- Low overlap → higher k (conservative blending)
- Clamped to `[0.5×baseK, 2×baseK]`

**Cross-Encoder Reranking** (`internal/search/reranking/`)
- `CohereReranker` using `rerank-v4.0-pro` API
- Reorders top-N results after all scoring passes
- Graceful degradation on API failure

**Integration** (`internal/search/service.go`, `internal/server/server.go`)
- `Reranker` interface in search package (consumer-side, breaks import cycle)
- `SetHydeGenerator` / `SetReranker` on SearchService
- Wired in server constructor

### Config

```yaml
search:
  hyde:
    enabled: false
    provider_url: ""
    api_key: ""
    model: ""
    max_latency_ms: 500
  reranking:
    enabled: false
    provider: "cohere"
    api_key: ""
    top_k: 20
```

### Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -short ./...` — all 33 packages pass
- Harness: PRE-WORK ✅, IN-PROGRESS ✅