### PR TITLE
fix(embed): break scan loop when all items in batch are already in-flight

### DIFF
--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -234,6 +234,7 @@ func (q *Queue) scanByStatus(ctx context.Context, failed bool) (enqueued int, sk
 			q.logger.Error().Err(err).Bool("failed", failed).Msg("failed to scan chunks")
 			return enqueued, skipped
 		}
+		batchSkipped := 0
 		for _, id := range ids {
 			if failed {
 				q.clearRetries(id)
@@ -243,12 +244,21 @@ func (q *Queue) scanByStatus(ctx context.Context, failed bool) (enqueued int, sk
 					q.logger.Info().Int("total", enqueued).Bool("failed", failed).Msg("scan stopped (queue full)")
 					return enqueued, skipped
 				}
+				batchSkipped++
 				skipped++
 				continue
 			}
 			enqueued++
 		}
 		if len(ids) < scanBatchSize {
+			break
+		}
+		// All items in this batch are already in-flight; SQL has no OFFSET so the same
+		// rows would be returned again, causing an infinite loop. Stop scanning until
+		// the next rescan ticker fires and some workers have completed.
+		if batchSkipped == len(ids) {
+			q.logger.Warn().Int("total", enqueued).Int("batch", batchSkipped).Bool("failed", failed).
+				Msg("scan stopped: all items in batch already in-flight")
 			break
 		}
 	}


### PR DESCRIPTION
## Problem

When the embed queue scan loop returns a batch where all items are already in-flight (`skipped == scanBatchSize`), the SQL has no OFFSET so every rescan returns the same rows. This creates an **infinite loop** — no new work gets dispatched even when there are pending chunks.

Root cause: `scanByStatus` only breaks when `len(ids) < scanBatchSize` (no more rows), but doesn't check whether \*all\* returned rows were already claimed by other workers.

## Fix

Add a break condition when `skipped == scanBatchSize` — all items in the batch are already in-flight. The scan stops and waits for the next rescan ticker to fire, by which time some workers should have completed and freed capacity.

## Impact

Without this fix, the embed queue gets permanently stuck with 1000+ pending chunks. No embedding progress until server restart.