### PR TITLE
feat(mcp): add direction parameter to memory_impact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Symbol-level analysis (requires the workspace to be indexed by the daemon's watc
 |---|---|
 | Find 1-hop callers/callees of a symbol | `memory_graph` |
 | Assess risk of changing a symbol (reverse impact BFS) | `memory_impact` |
+| Find what a symbol depends on (forward traversal) | `memory_impact` (direction="out") |
 | Trace forward call chain from an entry point | `memory_trace` |
 | Find a symbol by name/kind across the workspace | `memory_symbols` |
 
@@ -58,6 +59,7 @@ Symbol-level analysis (requires the workspace to be indexed by the daemon's watc
 - **"How does this concept work here?"** → both (memory for past context + grep for current code)
 - **"What calls this function?"** → `memory_graph(node="<name>", direction="in")`
 - **"What breaks if I change X?"** → `memory_impact(node="<name>", max_depth=2)`
+- **"What does X depend on?"** → `memory_impact(node="<name>", direction="out")`
 - **"Walk the call chain from entry point X"** → `memory_trace(node="<name>", max_depth=5)`
 
 See `.opencode/skills/nano-brain/SKILL.md` for the full reference (all MCP tools, recipes, troubleshooting).

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1748,6 +1748,7 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"node":      {"type": "string", "description": "The node to analyze (file path or file::symbol). Accepts workspace-relative or absolute."},
+				"direction": {"type": "string", "description": "Edge direction: \"in\" (default, what affects the node), \"out\" (what the node affects)"},
 				"edge_type": {"type": "string", "description": "Filter by edge type: imports, calls (empty = all)"},
 				"max_depth": {"type": "number", "description": "Traversal depth 1-3 (default 1)"},
 				"paths":     {"type": "string", "description": "Output path style: \"absolute\" (default) or \"relative\""},
@@ -1771,6 +1772,10 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 				return errResult(err.Error()), nil
 			}
 			edgeType := argString(args, "edge_type")
+			direction := argString(args, "direction")
+			if direction == "" {
+				direction = "in"
+			}
 			maxDepth := argInt(args, "max_depth", 1, 3)
 			pathStyle := argString(args, "paths")
 
@@ -1785,28 +1790,54 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 			var impacted []impactItem
 
 			for depth := 1; depth <= maxDepth && len(frontier) > 0; depth++ {
-				rows, err := a.queries.GetImpactorsByTargets(ctx, sqlc.GetImpactorsByTargetsParams{
-					WorkspaceHash: ws,
-					Column2:       frontier,
-					Column3:       edgeType,
-				})
-				if err != nil {
-					return errResult(fmt.Sprintf("impact query failed: %v", err)), nil
-				}
-				var next []string
-				for _, r := range rows {
-					if seen[r.SourceNode] {
-						continue
-					}
-					seen[r.SourceNode] = true
-					impacted = append(impacted, impactItem{
-						Node:     r.SourceNode,
-						Depth:    depth,
-						EdgeType: r.EdgeType,
+				switch direction {
+				case "out":
+					rows, err := a.queries.GetOutgoingEdgesBySources(ctx, sqlc.GetOutgoingEdgesBySourcesParams{
+						WorkspaceHash: ws,
+						Column2:       frontier,
+						Column3:       edgeType,
 					})
-					next = append(next, r.SourceNode)
+					if err != nil {
+						return errResult(fmt.Sprintf("impact query failed: %v", err)), nil
+					}
+					var next []string
+					for _, r := range rows {
+						if seen[r.TargetNode] {
+							continue
+						}
+						seen[r.TargetNode] = true
+						impacted = append(impacted, impactItem{
+							Node:     r.TargetNode,
+							Depth:    depth,
+							EdgeType: r.EdgeType,
+						})
+						next = append(next, r.TargetNode)
+					}
+					frontier = next
+				default:
+					rows, err := a.queries.GetImpactorsByTargets(ctx, sqlc.GetImpactorsByTargetsParams{
+						WorkspaceHash: ws,
+						Column2:       frontier,
+						Column3:       edgeType,
+					})
+					if err != nil {
+						return errResult(fmt.Sprintf("impact query failed: %v", err)), nil
+					}
+					var next []string
+					for _, r := range rows {
+						if seen[r.SourceNode] {
+							continue
+						}
+						seen[r.SourceNode] = true
+						impacted = append(impacted, impactItem{
+							Node:     r.SourceNode,
+							Depth:    depth,
+							EdgeType: r.EdgeType,
+						})
+						next = append(next, r.SourceNode)
+					}
+					frontier = next
 				}
-				frontier = next
 			}
 
 			var wsRoot string

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1776,6 +1776,9 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 			if direction == "" {
 				direction = "in"
 			}
+			if direction != "in" && direction != "out" {
+				return errResult("direction must be \"in\" or \"out\""), nil
+			}
 			maxDepth := argInt(args, "max_depth", 1, 3)
 			pathStyle := argString(args, "paths")
 

--- a/internal/storage/queries/graph.sql
+++ b/internal/storage/queries/graph.sql
@@ -42,6 +42,13 @@ WHERE workspace_hash = $1 AND target_node = ANY($2::text[])
   AND ($3::text = '' OR edge_type = $3)
 ORDER BY edge_type, source_node;
 
+-- name: GetOutgoingEdgesBySources :many
+SELECT DISTINCT source_node, target_node, edge_type
+FROM graph_edges
+WHERE workspace_hash = $1 AND source_node = ANY($2::text[])
+  AND ($3::text = '' OR edge_type = $3)
+ORDER BY edge_type, target_node;
+
 -- name: ListDocIDsByTitle :many
 SELECT id FROM documents
 WHERE workspace_hash = $1 AND lower(title) = lower($2);

--- a/internal/storage/sqlc/graph.sql.go
+++ b/internal/storage/sqlc/graph.sql.go
@@ -260,6 +260,49 @@ func (q *Queries) GetOutgoingEdges(ctx context.Context, arg GetOutgoingEdgesPara
 	return items, nil
 }
 
+const getOutgoingEdgesBySources = `-- name: GetOutgoingEdgesBySources :many
+SELECT DISTINCT source_node, target_node, edge_type
+FROM graph_edges
+WHERE workspace_hash = $1 AND source_node = ANY($2::text[])
+  AND ($3::text = '' OR edge_type = $3)
+ORDER BY edge_type, target_node
+`
+
+type GetOutgoingEdgesBySourcesParams struct {
+	WorkspaceHash string
+	Column2       []string
+	Column3       string
+}
+
+type GetOutgoingEdgesBySourcesRow struct {
+	SourceNode string
+	TargetNode string
+	EdgeType   string
+}
+
+func (q *Queries) GetOutgoingEdgesBySources(ctx context.Context, arg GetOutgoingEdgesBySourcesParams) ([]GetOutgoingEdgesBySourcesRow, error) {
+	rows, err := q.db.QueryContext(ctx, getOutgoingEdgesBySources, arg.WorkspaceHash, pq.Array(arg.Column2), arg.Column3)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetOutgoingEdgesBySourcesRow
+	for rows.Next() {
+		var i GetOutgoingEdgesBySourcesRow
+		if err := rows.Scan(&i.SourceNode, &i.TargetNode, &i.EdgeType); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const graphStats = `-- name: GraphStats :one
 SELECT
     COUNT(*) FILTER (WHERE edge_type = 'contains') AS contains_count,


### PR DESCRIPTION
## Summary

Adds direction parameter to the memory_impact MCP tool.

- direction=in (default): finds what affects the node (backward compatible)
- direction=out: finds what the node affects (forward traversal)

Also adds GetOutgoingEdgesBySources SQL query for outgoing edge traversal.

## Changes

- internal/mcp/tools.go: Add direction parameter + switch logic
- internal/storage/queries/graph.sql: Add GetOutgoingEdgesBySources query
- internal/storage/sqlc/graph.sql.go: Regenerated sqlc

## Testing

- go build ./... — PASS
- go test -race -short ./... — PASS
- smoke:e2e (server start + health check) — PASS

Closes #419