### PR TITLE
fix(review): address PR #424 review comments

### DIFF
--- a/internal/bench/benchmark_nanobrain_test.go
+++ b/internal/bench/benchmark_nanobrain_test.go
@@ -91,8 +91,12 @@ func saveResults(t *testing.T, results *BenchmarkResults) {
 }
 
 func TestBenchmarkNanoBrain(t *testing.T) {
+	baseURL := os.Getenv("NANO_BRAIN_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:3199"
+	}
 	searcher := &httpSearcher{
-		baseURL:    "http://localhost:3100",
+		baseURL:    baseURL,
 		workspace:  "7f443561795a6fea64b6e8d35a9b06ed4d216b8a27af5e10e7137b261ade061f",
 		httpClient: &http.Client{Timeout: 90 * time.Second},
 	}

--- a/internal/graph/echo_extractor.go
+++ b/internal/graph/echo_extractor.go
@@ -61,6 +61,9 @@ func (e *EchoRouteExtractor) ExtractEdges(filePath string, content []byte) ([]Ed
 		varName := ""
 		for i := 0; i < int(left.ChildCount()); i++ {
 			child := left.Child(i)
+			if child == nil {
+				continue
+			}
 			if child.Type(lang) == "identifier" {
 				varName = bt.NodeText(child)
 				break
@@ -72,6 +75,9 @@ func (e *EchoRouteExtractor) ExtractEdges(filePath string, content []byte) ([]Ed
 		// Get first call_expression on right.
 		for i := 0; i < int(right.ChildCount()); i++ {
 			child := right.Child(i)
+			if child == nil {
+				continue
+			}
 			if child.Type(lang) == "call_expression" {
 				callToVar[child.StartByte()] = varName
 				break
@@ -226,6 +232,9 @@ func echoArgNode(argList *gotreesitter.Node, lang *gotreesitter.Language, n int)
 	idx := 0
 	for i := 0; i < int(argList.ChildCount()); i++ {
 		child := argList.Child(i)
+		if child == nil {
+			continue
+		}
 		t := child.Type(lang)
 		if t == "," || t == "(" || t == ")" {
 			continue
@@ -248,6 +257,9 @@ func echoArgNames(bt *gotreesitter.BoundTree, argList *gotreesitter.Node, lang *
 	idx := 0
 	for i := 0; i < int(argList.ChildCount()); i++ {
 		child := argList.Child(i)
+		if child == nil {
+			continue
+		}
 		t := child.Type(lang)
 		if t == "," || t == "(" || t == ")" {
 			continue

--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -367,25 +367,24 @@ func publishReindex(pub eventbus.Publisher, workspace, state string, enqueued, e
 func TriggerUpdate(w *watcher.Watcher, logger zerolog.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		workspace := c.Get("workspace").(string)
-		start := time.Now()
 
-		var edgeCount, symCount int
 		if w != nil {
-			edgeCount = w.ReextractEdgesForWorkspace(c.Request().Context(), workspace)
-			symCount = w.ReextractSymbolsForWorkspace(c.Request().Context(), workspace)
+			go func() {
+				ctx := context.Background()
+				start := time.Now()
+				edgeCount := w.ReextractEdgesForWorkspace(ctx, workspace)
+				symCount := w.ReextractSymbolsForWorkspace(ctx, workspace)
+				logger.Info().
+					Str("workspace", workspace).
+					Int("edges_files", edgeCount).
+					Int("symbols_files", symCount).
+					Dur("duration", time.Since(start)).
+					Msg("update re-extraction complete")
+			}()
 		}
-
-		reqLog := LoggerFromCtx(c, logger)
-		reqLog.Info().
-			Str("workspace", workspace).
-			Int("edges_files", edgeCount).
-			Int("symbols_files", symCount).
-			Dur("duration", time.Since(start)).
-			Msg("update re-extraction complete")
 
 		return c.JSON(http.StatusAccepted, reindexResponse{
 			Status:  "queued",
-			Scanned: edgeCount,
 			Message: fmt.Sprintf("Update queued for all collections in workspace %s", workspace),
 		})
 	}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -808,7 +808,10 @@ func (w *Watcher) ReextractSymbolsForWorkspace(ctx context.Context, workspaceHas
 	var count int
 	for _, col := range cols {
 		_ = filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() || ctx.Err() != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if err != nil || d.IsDir() {
 				return nil
 			}
 			if col.filter != nil && col.filter.shouldSkip(path, false) {
@@ -825,7 +828,6 @@ func (w *Watcher) ReextractSymbolsForWorkspace(ctx context.Context, workspaceHas
 	}
 	return count
 }
-
 
 // ReextractEdgesForWorkspace re-runs graph edge extraction for every file in
 // the workspace's collections, bypassing the content-hash early-exit. This is
@@ -848,7 +850,10 @@ func (w *Watcher) ReextractEdgesForWorkspace(ctx context.Context, workspaceHash 
 	var count int
 	for _, col := range cols {
 		_ = filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() || ctx.Err() != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if err != nil || d.IsDir() {
 				return nil
 			}
 			if col.filter != nil && col.filter.shouldSkip(path, false) {


### PR DESCRIPTION
## Summary

Addresses all meaningful Gemini review comments on #424:

- **Context cancellation**: `ReextractSymbolsForWorkspace` and `ReextractEdgesForWorkspace` now return `ctx.Err()` from WalkDir callbacks, halting the walk immediately on cancellation instead of continuing
- **Async TriggerUpdate**: `POST /api/v1/update` re-extraction now runs in a background goroutine — avoids HTTP timeouts on large workspaces (response status was already `"queued"`)
- **Nil checks in echo_extractor**: Added defensive `child == nil` guards in `echoArgNode`, `echoArgNames`, and the route group walker — prevents panic on malformed ASTs
- **Benchmark isolation**: `TestBenchmarkNanoBrain` defaults to `:3199` (test server) and respects `NANO_BRAIN_URL` env var

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test -race -short ./...` passes