### PR TITLE
feat(search): improve search quality — dedup, code-aware ranking, query-relevant snippets

### DIFF
--- a/internal/search/ranking.go
+++ b/internal/search/ranking.go
@@ -48,6 +48,32 @@ func ApplyCodeAwareBoost(results []Result, query string, boostPathFactor, boostT
 	return results
 }
 
+// codeExtensions maps file extensions that should receive a code boost.
+var codeExtensions = map[string]bool{
+	".go": true, ".js": true, ".ts": true, ".py": true,
+	".jsx": true, ".tsx": true, ".rb": true, ".rs": true, ".java": true,
+}
+
+// docExtensions maps file extensions that should receive no boost (neutral or slight penalty).
+var docExtensions = map[string]bool{
+	".md": true, ".txt": true, ".rst": true,
+}
+
+// ApplyExtensionBoost applies a blanket multiplicative boost to code files over documentation.
+// Code files receive codeBoostFactor; doc files receive docBoostFactor (typically <= 1.0).
+func ApplyExtensionBoost(results []Result, codeBoostFactor, docBoostFactor float64) []Result {
+	for i := range results {
+		ext := strings.ToLower(path.Ext(results[i].SourcePath))
+		switch {
+		case codeExtensions[ext]:
+			results[i].Score *= codeBoostFactor
+		case docExtensions[ext]:
+			results[i].Score *= docBoostFactor
+		}
+	}
+	return results
+}
+
 // extractQueryKeywords extracts meaningful keywords from a search query.
 // It removes common stop words and short tokens, then lowercases.
 func extractQueryKeywords(query string) []string {

--- a/internal/search/ranking_test.go
+++ b/internal/search/ranking_test.go
@@ -101,3 +101,30 @@ func TestExtractQueryKeywords_ShortTokens(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyExtensionBoost_CodeAndDoc(t *testing.T) {
+	results := []Result{
+		{ID: "1", SourcePath: "service.go", Score: 1.0},
+		{ID: "2", SourcePath: "handler.ts", Score: 1.0},
+		{ID: "3", SourcePath: "README.md", Score: 1.0},
+		{ID: "4", SourcePath: "notes.txt", Score: 1.0},
+		{ID: "5", SourcePath: "data.json", Score: 1.0},
+	}
+	out := ApplyExtensionBoost(results, 1.1, 0.9)
+
+	if out[0].Score != 1.1 {
+		t.Errorf(".go: expected 1.1, got %f", out[0].Score)
+	}
+	if out[1].Score != 1.1 {
+		t.Errorf(".ts: expected 1.1, got %f", out[1].Score)
+	}
+	if out[2].Score != 0.9 {
+		t.Errorf(".md: expected 0.9, got %f", out[2].Score)
+	}
+	if out[3].Score != 0.9 {
+		t.Errorf(".txt: expected 0.9, got %f", out[3].Score)
+	}
+	if out[4].Score != 1.0 {
+		t.Errorf(".json: expected 1.0 (no change), got %f", out[4].Score)
+	}
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -450,8 +450,9 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 	merged := DynamicRRFMerge(bm25Results, vectorResults, rrfK)
 	deduped := DeduplicateResults(merged)
 	codeAware := ApplyCodeAwareBoost(deduped, query, 1.2, 1.3)
+	extBoosted := ApplyExtensionBoost(codeAware, 1.1, 0.9)
 
-	boosted := ApplyRecencyBoost(codeAware, recencyWeight, recencyHalfLifeDays, time.Now())
+	boosted := ApplyRecencyBoost(extBoosted, recencyWeight, recencyHalfLifeDays, time.Now())
 
 	s.configMutex.RLock()
 	entityEnabled := s.config.EntityBoostEnabled

--- a/openspec/changes/improve-search-quality/tasks.md
+++ b/openspec/changes/improve-search-quality/tasks.md
@@ -1,0 +1,30 @@
+## 1. Result Deduplication
+
+- [x] 1.1 Create `internal/search/dedup.go` with deduplication logic
+- [x] 1.2 Implement content hashing (SHA-256) for duplicate detection
+- [x] 1.3 Add path normalization (case-insensitive, slash normalization, `.agent/` vs `.agents/`)
+- [x] 1.4 Integrate deduplication into `HybridSearch` after RRF merge (in `service.go`)
+- [ ] 1.5 Add `deduplicated_from` field to search response (deferred — low-value API surface change)
+
+## 2. Context-Aware Snippets
+
+- [x] 2.1 Implement query-relevant snippet extraction (centering window around first lexical match)
+- [x] 2.2 Handle vector-only results with graceful head-truncation fallback
+- [x] 2.3 Preserve UTF-8 boundaries and add ellipsis indicators for truncated windows
+- [x] 2.4 Handle empty/short content and zero-length queries correctly
+- [x] 2.5 Update `handlers/search.go` to use `Snippet` field with `ExtractRelevantSnippet`
+
+## 3. Code-Aware Ranking
+
+- [x] 3.1 Add post-RRF boost for results where query tokens appear in file path (1.2x)
+- [x] 3.2 Add post-RRF boost for results where query tokens appear in title/symbol name (1.3x)
+- [x] 3.3 Add boost for code file extensions (`.go`, `.js`, `.ts`, `.py` → 1.1x) over docs (`.md` → 0.9x)
+- [x] 3.4 Integrate boosts into `HybridSearch` after RRF merge and before recency boost
+
+## 4. Testing and Benchmarking
+
+- [x] 4.1 Write unit tests for deduplication logic (`dedup_test.go`)
+- [x] 4.2 Write unit tests for snippet generation (`snippet_test.go`) and ranking (`ranking_test.go`)
+- [ ] 4.3 Run integration tests with real zengamingx workspace
+- [ ] 4.4 Benchmark search performance (ensure P50 < 10ms)
+- [ ] 4.5 Build meaningful benchmark with file-path ground truth (not generic keywords)


### PR DESCRIPTION
## Summary

Improves search result quality for real-world code queries:

- **Result deduplication** (`dedup.go`): removes duplicate results by DocumentID (keeps highest-scored chunk) and by content hash after path normalization (keeps shorter path). Handles `.agent/` vs `.agents/` path variants.
- **Query-relevant snippets** (`snippet.go`): replaces fixed head-truncation with a window centered around the first lexical query match, with ellipsis indicators and UTF-8 boundary preservation.
- **Code-aware ranking** (`ranking.go`): two-layer post-RRF boost — (1) 1.2x path / 1.3x title boost when query keywords appear in source path or symbol name; (2) blanket 1.1x for code files (`.go`, `.js`, `.ts`, `.py`, etc.) and 0.9x for docs (`.md`, `.txt`, `.rst`).

All boosts are applied after RRF merge, before recency and entity boosts. Unit tests cover all three features.

## Test plan

- [x] `go test -race -short ./internal/search/...` — all pass
- [x] `CGO_ENABLED=0 go build ./...` — clean build
- [ ] Integration: run capability benchmark against test server at :3199