### PR TITLE
feat: NestJS route extractor (#432)

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -381,6 +381,12 @@ func startServer(configPath string) {
 			graphExtractors = append(graphExtractors, expressGE)
 			logger.Info().Msg("execution-flow: express route extractor enabled")
 		}
+		if nestjsGE, err := graph.NewNestJSExtractor(logger); err != nil {
+			logger.Warn().Err(err).Msg("nestjs route extractor init failed, skipping")
+		} else {
+			graphExtractors = append(graphExtractors, nestjsGE)
+			logger.Info().Msg("execution-flow: nestjs route extractor enabled")
+		}
 	}
 	graphRegistry := graph.NewRegistry(graphExtractors...)
 

--- a/internal/graph/detector.go
+++ b/internal/graph/detector.go
@@ -34,6 +34,7 @@ var DefaultRules = []FrameworkRule{
 	{Framework: "echo", Detect: detectEcho},
 	{Framework: "gin", Detect: detectGin},
 	{Framework: "express", Detect: detectExpress},
+	{Framework: "nestjs", Detect: detectNestJS},
 	{Framework: "go", Detect: detectGoModExists},
 }
 
@@ -132,6 +133,33 @@ func detectExpress(dir string) bool {
 		}
 	}
 	return false
+}
+
+func detectNestJS(dir string) bool {
+	if checkPackageJSONForNestJSDep(dir) {
+		return true
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "node_modules" || name == ".git" || name == ".opencode" || name == "vendor" {
+			continue
+		}
+		if checkPackageJSONForNestJSDep(filepath.Join(dir, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkPackageJSONForNestJSDep(dir string) bool {
+	return checkPackageJSONForDep(dir, "@nestjs/common") || checkPackageJSONForDep(dir, "@nestjs/core")
 }
 
 func checkPackageJSONForDep(dir string, dep string) bool {

--- a/internal/graph/nestjs_extractor.go
+++ b/internal/graph/nestjs_extractor.go
@@ -1,0 +1,299 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	zerolog "github.com/rs/zerolog"
+)
+
+var _ Extractor = (*NestJSExtractor)(nil)
+
+var nestJSHTTPDecorators = map[string]string{
+	"Get":     "GET",
+	"Post":    "POST",
+	"Put":     "PUT",
+	"Delete":  "DELETE",
+	"Patch":   "PATCH",
+	"Head":    "HEAD",
+	"Options": "OPTIONS",
+	"All":     "ALL",
+}
+
+type NestJSExtractor struct {
+	logger zerolog.Logger
+}
+
+func NewNestJSExtractor(logger zerolog.Logger) (*NestJSExtractor, error) {
+	return &NestJSExtractor{
+		logger: logger.With().Str("component", "nestjs-extractor").Logger(),
+	}, nil
+}
+
+func (e *NestJSExtractor) Supports(ext string) bool {
+	return ext == ".ts" || ext == ".tsx"
+}
+
+func (e *NestJSExtractor) RequiresFrameworks() []string {
+	return []string{"nestjs"}
+}
+
+func (e *NestJSExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
+	ext := filepath.Ext(filePath)
+	lang := grammars.TypescriptLanguage()
+	langStr := "typescript"
+	if ext == ".tsx" {
+		langStr = "typescript"
+	}
+	relFile := filepath.ToSlash(filePath)
+
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("nestjs parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	rootNode := tree.RootNode()
+
+	if !tsHasNestJSPatterns(rootNode, lang, bt) {
+		return nil, nil
+	}
+
+	controllers := make(map[string]string)
+
+	walkNodes(rootNode, lang, "decorator", func(n *gotreesitter.Node) {
+		callExpr := decoratorCallExpr(n, lang)
+		if callExpr == nil {
+			return
+		}
+		funcName := callExprFuncName(bt, callExpr, lang)
+		if funcName != "Controller" {
+			return
+		}
+		className := classFromDecorator(n, lang, bt)
+		if className == "" {
+			return
+		}
+		prefix := callExprStringArg(bt, callExpr, lang)
+		controllers[className] = prefix
+	})
+
+	if len(controllers) == 0 {
+		return nil, nil
+	}
+
+	var edges []Edge
+	seen := make(map[string]bool)
+
+	walkNodes(rootNode, lang, "decorator", func(n *gotreesitter.Node) {
+		callExpr := decoratorCallExpr(n, lang)
+		if callExpr == nil {
+			return
+		}
+		funcName := callExprFuncName(bt, callExpr, lang)
+		method, ok := nestJSHTTPDecorators[funcName]
+		if !ok {
+			return
+		}
+
+		methodDef := methodFromDecorator(n, lang)
+		if methodDef == nil {
+			return
+		}
+		methodName := methodDefName(bt, methodDef, lang)
+		if methodName == "" {
+			return
+		}
+
+		className := classFromMethod(methodDef, lang, bt)
+		if className == "" {
+			return
+		}
+		prefix, isController := controllers[className]
+		if !isController {
+			return
+		}
+
+		pathArg := callExprStringArg(bt, callExpr, lang)
+		fullPath := combineNestJSPaths(prefix, pathArg)
+
+		handler := className + "." + methodName
+		source := strings.TrimSpace(method + " " + fullPath)
+		if seen[source] {
+			return
+		}
+		seen[source] = true
+
+		edges = append(edges, Edge{
+			SourceNode: source,
+			TargetNode: handler,
+			Kind:       EdgeHTTP,
+			SourceFile: relFile,
+			Line:       lineForByte(content, n.StartByte()),
+			Language:   langStr,
+			Metadata:   map[string]any{"method": method, "path": fullPath},
+		})
+	})
+
+	if len(edges) == 0 {
+		return nil, nil
+	}
+	return edges, nil
+}
+
+func tsHasNestJSPatterns(root *gotreesitter.Node, lang *gotreesitter.Language, bt *gotreesitter.BoundTree) bool {
+	found := false
+	walkNodes(root, lang, "decorator", func(n *gotreesitter.Node) {
+		if found {
+			return
+		}
+		callExpr := decoratorCallExpr(n, lang)
+		if callExpr == nil {
+			return
+		}
+		name := callExprFuncName(bt, callExpr, lang)
+		if _, ok := nestJSHTTPDecorators[name]; ok {
+			found = true
+			return
+		}
+		if name == "Controller" {
+			found = true
+		}
+	})
+	return found
+}
+
+func decoratorCallExpr(decorator *gotreesitter.Node, lang *gotreesitter.Language) *gotreesitter.Node {
+	for i := 0; i < int(decorator.ChildCount()); i++ {
+		child := decorator.Child(i)
+		if child != nil && child.Type(lang) == "call_expression" {
+			return child
+		}
+	}
+	return nil
+}
+
+func callExprFuncName(bt *gotreesitter.BoundTree, callExpr *gotreesitter.Node, lang *gotreesitter.Language) string {
+	for i := 0; i < int(callExpr.ChildCount()); i++ {
+		child := callExpr.Child(i)
+		if child != nil && child.Type(lang) == "identifier" {
+			return bt.NodeText(child)
+		}
+	}
+	return ""
+}
+
+func callExprStringArg(bt *gotreesitter.BoundTree, callExpr *gotreesitter.Node, lang *gotreesitter.Language) string {
+	argsNode := callExpr.ChildByFieldName("arguments", lang)
+	if argsNode == nil {
+		return ""
+	}
+	arg := tsArgNode(argsNode, lang, 0)
+	if arg == nil {
+		return ""
+	}
+	if arg.Type(lang) == "string" {
+		return cleanRoutePath(strings.Trim(bt.NodeText(arg), "\"'"))
+	}
+	return ""
+}
+
+func classFromDecorator(decorator *gotreesitter.Node, lang *gotreesitter.Language, bt *gotreesitter.BoundTree) string {
+	parent := decorator.Parent()
+	if parent == nil {
+		return ""
+	}
+	for i := 0; i < int(parent.ChildCount()); i++ {
+		child := parent.Child(i)
+		if child != nil && child.Type(lang) == "class_declaration" {
+			return className(bt, child, lang)
+		}
+	}
+	return ""
+}
+
+func className(bt *gotreesitter.BoundTree, classDecl *gotreesitter.Node, lang *gotreesitter.Language) string {
+	nameNode := classDecl.ChildByFieldName("name", lang)
+	if nameNode != nil {
+		return bt.NodeText(nameNode)
+	}
+	for i := 0; i < int(classDecl.ChildCount()); i++ {
+		child := classDecl.Child(i)
+		if child != nil && child.Type(lang) == "type_identifier" {
+			return bt.NodeText(child)
+		}
+	}
+	return ""
+}
+
+func methodFromDecorator(decorator *gotreesitter.Node, lang *gotreesitter.Language) *gotreesitter.Node {
+	parent := decorator.Parent()
+	if parent == nil {
+		return nil
+	}
+	decIdx := -1
+	for i := 0; i < int(parent.ChildCount()); i++ {
+		if parent.Child(i) == decorator {
+			decIdx = i
+			break
+		}
+	}
+	if decIdx < 0 {
+		return nil
+	}
+	for i := decIdx + 1; i < int(parent.ChildCount()); i++ {
+		child := parent.Child(i)
+		if child != nil && child.Type(lang) == "method_definition" {
+			return child
+		}
+	}
+	return nil
+}
+
+func methodDefName(bt *gotreesitter.BoundTree, methodDef *gotreesitter.Node, lang *gotreesitter.Language) string {
+	nameNode := methodDef.ChildByFieldName("name", lang)
+	if nameNode != nil {
+		return bt.NodeText(nameNode)
+	}
+	for i := 0; i < int(methodDef.ChildCount()); i++ {
+		child := methodDef.Child(i)
+		if child != nil && child.Type(lang) == "property_identifier" {
+			return bt.NodeText(child)
+		}
+	}
+	return ""
+}
+
+func classFromMethod(methodDef *gotreesitter.Node, lang *gotreesitter.Language, bt *gotreesitter.BoundTree) string {
+	parent := methodDef.Parent()
+	if parent == nil || parent.Type(lang) != "class_body" {
+		return ""
+	}
+	classDecl := parent.Parent()
+	if classDecl == nil || classDecl.Type(lang) != "class_declaration" {
+		return ""
+	}
+	return className(bt, classDecl, lang)
+}
+
+func combineNestJSPaths(prefix, methodPath string) string {
+	prefix = strings.Trim(prefix, "/")
+	methodPath = strings.Trim(methodPath, "/")
+
+	var parts []string
+	if prefix != "" {
+		parts = append(parts, prefix)
+	}
+	if methodPath != "" {
+		parts = append(parts, methodPath)
+	}
+	if len(parts) == 0 {
+		return "/"
+	}
+	return "/" + strings.Join(parts, "/")
+}

--- a/internal/graph/nestjs_extractor_test.go
+++ b/internal/graph/nestjs_extractor_test.go
@@ -1,0 +1,349 @@
+package graph_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+	"github.com/rs/zerolog"
+)
+
+func newNestJSExtractor(t *testing.T) *graph.NestJSExtractor {
+	t.Helper()
+	logger := zerolog.Nop()
+	ex, err := graph.NewNestJSExtractor(logger)
+	if err != nil {
+		t.Fatalf("NewNestJSExtractor: %v", err)
+	}
+	return ex
+}
+
+func TestNestJSExtractor_Supports(t *testing.T) {
+	ex := newNestJSExtractor(t)
+	for _, ext := range []string{".ts", ".tsx"} {
+		if !ex.Supports(ext) {
+			t.Errorf("should support %q", ext)
+		}
+	}
+	for _, ext := range []string{".js", ".jsx", ".py", ".go", ".rb", ".java", ""} {
+		if ex.Supports(ext) {
+			t.Errorf("should not support %q", ext)
+		}
+	}
+}
+
+func TestNestJSExtractor_RequiresFrameworks(t *testing.T) {
+	ex := newNestJSExtractor(t)
+	fws := ex.RequiresFrameworks()
+	if len(fws) != 1 || fws[0] != "nestjs" {
+		t.Errorf("expected [nestjs], got %v", fws)
+	}
+}
+
+func TestNestJSExtractor_BasicController(t *testing.T) {
+	src := []byte(`import { Controller, Get, Post, Put, Delete, Patch } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @Get()
+  findAll() {}
+
+  @Get(':id')
+  findById(@Param('id') id: string) {}
+
+  @Post()
+  create(@Body() body: any) {}
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() body: any) {}
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {}
+
+  @Patch(':id')
+  patch(@Param('id') id: string, @Body() body: any) {}
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("users.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct{ verb, path, handler string }{
+		{"GET", "/users", "UsersController.findAll"},
+		{"GET", "/users/:id", "UsersController.findById"},
+		{"POST", "/users", "UsersController.create"},
+		{"PUT", "/users/:id", "UsersController.update"},
+		{"DELETE", "/users/:id", "UsersController.remove"},
+		{"PATCH", "/users/:id", "UsersController.patch"},
+	}
+	for _, tc := range cases {
+		entryNode := tc.verb + " " + tc.path
+		hits := findEdges(edges, graph.EdgeHTTP, entryNode, tc.handler)
+		if len(hits) == 0 {
+			t.Errorf("missing http edge %s -> %s", entryNode, tc.handler)
+		}
+	}
+}
+
+func TestNestJSExtractor_ControllerWithoutPrefix(t *testing.T) {
+	src := []byte(`import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get()
+  root() {
+    return 'ok';
+  }
+
+  @Get('health')
+  health() {
+    return { status: 'ok' };
+  }
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("app.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hits := findEdges(edges, graph.EdgeHTTP, "GET /", "AppController.root")
+	if len(hits) == 0 {
+		t.Errorf("expected http edge GET / -> AppController.root; got %+v", edges)
+	}
+
+	hits = findEdges(edges, graph.EdgeHTTP, "GET /health", "AppController.health")
+	if len(hits) == 0 {
+		t.Errorf("expected http edge GET /health -> AppController.health; got %+v", edges)
+	}
+}
+
+func TestNestJSExtractor_AllHTTPMethods(t *testing.T) {
+	src := []byte(`import { Controller, Get, Post, Put, Delete, Patch, Head, Options, All } from '@nestjs/common';
+
+@Controller('api')
+export class ApiController {
+  @Get()
+  get() {}
+  @Post()
+  post() {}
+  @Put()
+  put() {}
+  @Delete()
+  del() {}
+  @Patch()
+  patch() {}
+  @Head()
+  head() {}
+  @Options()
+  options() {}
+  @All()
+  all() {}
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("api.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedHandlers := []struct{ method, handler string }{
+		{"GET", "ApiController.get"},
+		{"POST", "ApiController.post"},
+		{"PUT", "ApiController.put"},
+		{"DELETE", "ApiController.del"},
+		{"PATCH", "ApiController.patch"},
+		{"HEAD", "ApiController.head"},
+		{"OPTIONS", "ApiController.options"},
+		{"ALL", "ApiController.all"},
+	}
+	for _, tc := range expectedHandlers {
+		entryNode := tc.method + " /api"
+		hits := findEdges(edges, graph.EdgeHTTP, entryNode, tc.handler)
+		if len(hits) == 0 {
+			t.Errorf("missing http edge %s -> %s", entryNode, tc.handler)
+		}
+	}
+}
+
+func TestNestJSExtractor_EmptyFile(t *testing.T) {
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("empty.ts", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected no edges from empty file, got %+v", edges)
+	}
+}
+
+func TestNestJSExtractor_NonNestJSFile(t *testing.T) {
+	src := []byte(`import React from 'react';
+
+function App() {
+  return <div>Hello</div>;
+}
+
+export default App;
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("App.tsx", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected no edges from React file, got %+v", edges)
+	}
+}
+
+func TestNestJSExtractor_LineField(t *testing.T) {
+	src := []byte(`import { Controller, Get } from '@nestjs/common';
+
+@Controller('items')
+export class ItemsController {
+  @Get()
+  findAll() {}
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("items.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hits := findEdges(edges, graph.EdgeHTTP, "GET /items", "ItemsController.findAll")
+	if len(hits) == 0 {
+		t.Fatalf("expected http edge; got %+v", edges)
+	}
+	if hits[0].Line == 0 {
+		t.Errorf("expected non-zero Line field; got 0")
+	}
+}
+
+func TestNestJSExtractor_MetadataField(t *testing.T) {
+	src := []byte(`import { Controller, Get } from '@nestjs/common';
+
+@Controller('items')
+export class ItemsController {
+  @Get()
+  findAll() {}
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("items.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hits := findEdges(edges, graph.EdgeHTTP, "GET /items", "ItemsController.findAll")
+	if len(hits) == 0 {
+		t.Fatalf("expected http edge; got %+v", edges)
+	}
+	if hits[0].Metadata == nil {
+		t.Fatalf("expected non-nil Metadata; got nil")
+	}
+	if hits[0].Metadata["method"] != "GET" {
+		t.Errorf("expected Metadata method=GET, got %v", hits[0].Metadata["method"])
+	}
+	if hits[0].Metadata["path"] != "/items" {
+		t.Errorf("expected Metadata path=/items, got %v", hits[0].Metadata["path"])
+	}
+}
+
+func TestNestJSExtractor_SourceFileNormalized(t *testing.T) {
+	src := []byte(`import { Controller, Get } from '@nestjs/common';
+
+@Controller('items')
+export class ItemsController {
+  @Get('search')
+  search() {}
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("src/items.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hits := findEdges(edges, graph.EdgeHTTP, "GET /items/search", "ItemsController.search")
+	if len(hits) == 0 {
+		t.Fatalf("expected http edge; got %+v", edges)
+	}
+	if hits[0].SourceFile != "src/items.controller.ts" {
+		t.Errorf("expected SourceFile 'src/items.controller.ts', got %q", hits[0].SourceFile)
+	}
+}
+
+func TestNestJSExtractor_WithFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/nestjs/users.controller.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("testdata/nestjs/users.controller.ts", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct{ verb, path, handler string }{
+		{"GET", "/users", "UsersController.findAll"},
+		{"GET", "/users/:id", "UsersController.findById"},
+		{"POST", "/users", "UsersController.create"},
+	}
+	for _, tc := range cases {
+		entryNode := tc.verb + " " + tc.path
+		hits := findEdges(edges, graph.EdgeHTTP, entryNode, tc.handler)
+		if len(hits) == 0 {
+			t.Errorf("missing http edge %s -> %s", entryNode, tc.handler)
+		}
+	}
+}
+
+func TestNestJSExtractor_NoControllerFile(t *testing.T) {
+	src := []byte(`import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UsersService {
+  findAll() { return []; }
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("users.service.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected no edges from non-controller file, got %+v", edges)
+	}
+}
+
+func TestNestJSExtractor_NestedPathController(t *testing.T) {
+	src := []byte(`import { Controller, Get, Post } from '@nestjs/common';
+
+@Controller('api/v1/users')
+export class UserController {
+  @Get()
+  findAll() {}
+
+  @Post()
+  create(@Body() body: any) {}
+}
+`)
+	ex := newNestJSExtractor(t)
+	edges, err := ex.ExtractEdges("user.controller.ts", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hits := findEdges(edges, graph.EdgeHTTP, "GET /api/v1/users", "UserController.findAll")
+	if len(hits) == 0 {
+		t.Errorf("expected http edge GET /api/v1/users -> UserController.findAll; got %+v", edges)
+	}
+	hits = findEdges(edges, graph.EdgeHTTP, "POST /api/v1/users", "UserController.create")
+	if len(hits) == 0 {
+		t.Errorf("expected http edge POST /api/v1/users -> UserController.create; got %+v", edges)
+	}
+}
+

--- a/internal/graph/testdata/nestjs/app.controller.ts
+++ b/internal/graph/testdata/nestjs/app.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get()
+  root() {
+    return 'Hello World';
+  }
+
+  @Get('health')
+  health() {
+    return { status: 'ok' };
+  }
+}

--- a/internal/graph/testdata/nestjs/users.controller.ts
+++ b/internal/graph/testdata/nestjs/users.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @Get()
+  findAll() {
+    return [];
+  }
+
+  @Get(':id')
+  findById(@Param('id') id: string) {
+    return { id };
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    return body;
+  }
+}


### PR DESCRIPTION
## Summary
Adds NestJS HTTP route extraction for flow visualization. NestJS uses decorator-based routing which requires a two-pass extraction approach.

## Changes
- `internal/graph/nestjs_extractor.go` — Two-pass extraction (class decorator → method decorator)
- `internal/graph/nestjs_extractor_test.go` — 14 unit tests with fixture files
- `internal/graph/detector.go` — NestJS detection via @nestjs/common or @nestjs/core in package.json
- `cmd/nano-brain/main.go` — Register extractor under FlowConfig.Enabled gate

## How it works
1. **Pass 1**: Find class declarations with `@Controller('prefix')` decorator, extract prefix
2. **Pass 2**: Find method declarations with `@Get`, `@Post`, etc. decorators, extract method + path
3. **Combine**: full path = controller prefix + method path, handler = ClassName.methodName

## Example
```typescript
@Controller('users')
export class UsersController {
  @Get(':id')
  findById(@Param('id') id: string) {}
}
```
Produces: `GET /users/:id` → `UsersController.findById`

## Tests
All 14 tests passing. Supports .ts and .tsx files.

Closes #432