### PR TITLE
feat(reindex-cfg): respect .nano-brainignore by reusing watcher filter

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -471,7 +471,7 @@ func startServer(configPath string) {
 	}
 	fw.WithPublisher(bus)
 
-	srv := server.New(cfg, configPath, pool, db, queries, fw, eq, embedder, bus, logger, Version, migrationVersion)
+	srv := server.New(cfg, configPath, pool, db, queries, fw, eq, embedder, bus, logger, Version, migrationVersion, graphRegistry)
 
 	if cfg.Server.ServeOnly {
 		logger.Info().Msg("serve_only mode — skipping collection watcher registration")

--- a/internal/graph/AGENTS.md
+++ b/internal/graph/AGENTS.md
@@ -49,6 +49,18 @@ start node produce no CFG.
   `go_extractor.go`). `gotreesitter.Node` has **no** `StartLine`/`EndLine` —
   always derive lines from byte offsets.
 
+### Fixed (v2)
+
+- **Junk nodes:** `buildBlock` now skips punctuation tokens (`{`, `}`, `;`) and
+  comment nodes (`comment`, `line_comment`, `block_comment`) via
+  `isIgnoredStatement()`. CFGs no longer contain step nodes for non-statements.
+- **Absolute paths:** `ExtractCFGs` strips absolute paths to the basename, and
+  the start node label is now the function name (not the full `file::func`
+  entry). The `Entry` field still stores `relfile::funcName` for lookup.
+- **Wrapped handlers:** `findAssignedName()` walks up the AST from an
+  `arrow_function` to find the nearest `variable_declarator` ancestor, enabling
+  extraction of wrapped idioms like `const fn = catchAsync(async () => {...})`.
+
 ## Registry (`registry.go`)
 
 `NewRegistry(extractors...)` holds edge extractors; CFG extractors are added

--- a/internal/graph/js_cflow.go
+++ b/internal/graph/js_cflow.go
@@ -578,10 +578,10 @@ func (b *cfgbuilder) buildTry(stmt *gotreesitter.Node, preds map[string]bool) ma
 	var tryExits map[string]bool
 	if tryBody != nil {
 		tryExits = b.buildBlock(tryBody, map[string]bool{tryID: true}, map[string]string{tryID: "try"})
+		tryExits = b.relabelPreds(tryExits, tryID)
 	} else {
 		tryExits = map[string]bool{tryID: true}
 	}
-	tryExits = b.relabelPreds(tryExits, tryID)
 
 	var catchExits map[string]bool
 	catchClause := stmt.ChildByFieldName("handler", b.lang)
@@ -589,13 +589,13 @@ func (b *cfgbuilder) buildTry(stmt *gotreesitter.Node, preds map[string]bool) ma
 		catchBody := catchClause.ChildByFieldName("body", b.lang)
 		if catchBody != nil {
 			catchExits = b.buildBlock(catchBody, map[string]bool{tryID: true}, map[string]string{tryID: "catch"})
+			catchExits = b.relabelPreds(catchExits, tryID)
 		} else {
 			catchExits = map[string]bool{tryID: true}
 		}
 	} else {
 		catchExits = map[string]bool{tryID: true}
 	}
-	catchExits = b.relabelPreds(catchExits, tryID)
 
 	merged := mergePreds(tryExits, catchExits)
 
@@ -852,9 +852,14 @@ func isIgnoredStatement(stmtType string) bool {
 }
 
 func findAssignedName(bt *gotreesitter.BoundTree, n *gotreesitter.Node, lang *gotreesitter.Language) string {
-	cur := n
+	cur := n.Parent()
 	for cur != nil {
-		if cur.Type(lang) == "variable_declarator" {
+		nodeType := cur.Type(lang)
+		if nodeType == "function_declaration" || nodeType == "function" ||
+			nodeType == "arrow_function" || nodeType == "method_definition" {
+			break
+		}
+		if nodeType == "variable_declarator" {
 			nameNode := cur.ChildByFieldName("name", lang)
 			if nameNode != nil {
 				return bt.NodeText(nameNode)

--- a/internal/graph/js_cflow.go
+++ b/internal/graph/js_cflow.go
@@ -54,6 +54,9 @@ func (x *JSControlFlowExtractor) ExtractCFGs(filePath string, content []byte) ([
 
 	root := tree.RootNode()
 	relFile := filepath.ToSlash(filePath)
+	if filepath.IsAbs(relFile) {
+		relFile = filepath.Base(relFile)
+	}
 
 	var funcs []funcDef
 
@@ -100,18 +103,17 @@ func (x *JSControlFlowExtractor) ExtractCFGs(filePath string, content []byte) ([
 		if bodyType != "statement_block" && bodyType != "expression" {
 			return
 		}
-		parent := n.Parent()
-		if parent != nil && parent.Type(lang) == "variable_declarator" {
-			nameNode := parent.ChildByFieldName("name", lang)
-			if nameNode != nil {
-				funcs = append(funcs, funcDef{
-					name:      bt.NodeText(nameNode),
-					startLine: lineForByte(content, n.StartByte()),
-					endLine:   lineForByte(content, n.EndByte()),
-					bodyNode:  n,
-				})
-			}
+
+		varName := findAssignedName(bt, n, lang)
+		if varName == "" {
+			return
 		}
+		funcs = append(funcs, funcDef{
+			name:      varName,
+			startLine: lineForByte(content, n.StartByte()),
+			endLine:   lineForByte(content, n.EndByte()),
+			bodyNode:  n,
+		})
 	})
 
 	var cfgs []CFG
@@ -151,14 +153,14 @@ func (x *JSControlFlowExtractor) extractOne(bt *gotreesitter.BoundTree, lang *go
 
 	startNode := builder.addNode(CFGNode{
 		Type:  "start",
-		Label: entry,
+		Label: fd.name,
 		Line:  fd.startLine,
 	})
 
 	if fd.bodyNode.Type(lang) == "arrow_function" {
 		bodyNode := fd.bodyNode.ChildByFieldName("body", lang)
 		if bodyNode != nil && bodyNode.Type(lang) == "statement_block" {
-			exits := builder.buildBlock(bodyNode, map[string]bool{startNode: true})
+			exits := builder.buildBlock(bodyNode, map[string]bool{startNode: true}, nil)
 			if len(exits) > 0 {
 				builder.addMergeToTerminal(exits)
 			}
@@ -177,7 +179,7 @@ func (x *JSControlFlowExtractor) extractOne(bt *gotreesitter.BoundTree, lang *go
 			builder.addEdge(stepID, termID, "next")
 		}
 	} else {
-		exits := builder.buildBlock(fd.bodyNode, map[string]bool{startNode: true})
+		exits := builder.buildBlock(fd.bodyNode, map[string]bool{startNode: true}, nil)
 		if len(exits) > 0 {
 			builder.addMergeToTerminal(exits)
 		}
@@ -195,14 +197,15 @@ func (x *JSControlFlowExtractor) extractOne(bt *gotreesitter.BoundTree, lang *go
 }
 
 type cfgbuilder struct {
-	bt      *gotreesitter.BoundTree
-	lang    *gotreesitter.Language
-	content []byte
-	relFile string
-	entry   string
-	nodeID  int
-	cfg     *CFG
-	capped  bool
+	bt              *gotreesitter.BoundTree
+	lang            *gotreesitter.Language
+	content         []byte
+	relFile         string
+	entry           string
+	nodeID          int
+	cfg             *CFG
+	capped          bool
+	branchOverrides map[string]string // temporary: override branch labels for from→to edges
 }
 
 // lineOf returns the 1-based source line of a node's start.
@@ -232,6 +235,11 @@ func (b *cfgbuilder) addNode(n CFGNode) string {
 func (b *cfgbuilder) addEdge(from, to, branch string) {
 	if from == "" || to == "" {
 		return
+	}
+	if b.branchOverrides != nil {
+		if override, ok := b.branchOverrides[from]; ok {
+			branch = override
+		}
 	}
 	b.cfg.Edges = append(b.cfg.Edges, CFGEdge{
 		From:   from,
@@ -268,10 +276,13 @@ func (b *cfgbuilder) addMergeToStep(preds map[string]bool, label string, line in
 	return mergeID
 }
 
-func (b *cfgbuilder) buildBlock(block *gotreesitter.Node, preds map[string]bool) map[string]bool {
+func (b *cfgbuilder) buildBlock(block *gotreesitter.Node, preds map[string]bool, branchOverrides map[string]string) map[string]bool {
 	if block == nil {
 		return preds
 	}
+
+	oldOverrides := b.branchOverrides
+	b.branchOverrides = branchOverrides
 
 	cur := preds
 	childCount := int(block.ChildCount())
@@ -282,6 +293,10 @@ func (b *cfgbuilder) buildBlock(block *gotreesitter.Node, preds map[string]bool)
 			continue
 		}
 		stmtType := stmt.Type(b.lang)
+
+		if isIgnoredStatement(stmtType) {
+			continue
+		}
 
 		switch stmtType {
 		case "if_statement":
@@ -313,6 +328,7 @@ func (b *cfgbuilder) buildBlock(block *gotreesitter.Node, preds map[string]bool)
 		}
 	}
 
+	b.branchOverrides = oldOverrides
 	return cur
 }
 
@@ -342,9 +358,9 @@ func (b *cfgbuilder) buildIf(stmt *gotreesitter.Node, preds map[string]bool) map
 	var thenExits map[string]bool
 	if consequence != nil {
 		if consequence.Type(b.lang) == "statement_block" {
-			thenExits = b.buildBlock(consequence, map[string]bool{decisionID: true})
+			thenExits = b.buildBlock(consequence, map[string]bool{decisionID: true}, map[string]string{decisionID: "yes"})
 		} else {
-			thenExits = b.buildBlock(wrapInBlock(consequence), map[string]bool{decisionID: true})
+			thenExits = b.buildBlock(wrapInBlock(consequence), map[string]bool{decisionID: true}, map[string]string{decisionID: "yes"})
 		}
 	} else {
 		thenExits = map[string]bool{decisionID: true}
@@ -354,9 +370,9 @@ func (b *cfgbuilder) buildIf(stmt *gotreesitter.Node, preds map[string]bool) map
 	var elseExits map[string]bool
 	if alternative != nil {
 		if altBlock, ok := isBlock(alternative, b.lang); ok {
-			elseExits = b.buildBlock(altBlock, map[string]bool{decisionID: true})
+			elseExits = b.buildBlock(altBlock, map[string]bool{decisionID: true}, map[string]string{decisionID: "no"})
 		} else {
-			elseExits = b.buildBlock(wrapInBlock(alternative), map[string]bool{decisionID: true})
+			elseExits = b.buildBlock(wrapInBlock(alternative), map[string]bool{decisionID: true}, map[string]string{decisionID: "no"})
 		}
 	} else {
 		elseExits = map[string]bool{decisionID: true}
@@ -407,23 +423,16 @@ func (b *cfgbuilder) buildSwitch(stmt *gotreesitter.Node, preds map[string]bool)
 				continue
 			}
 			switch child.Type(b.lang) {
-			case "case":
-				hasDefault = false
+			case "switch_case":
 				valNode := child.ChildByFieldName("value", b.lang)
-				caseLabel := ""
-				if valNode != nil {
-					caseLabel = "case:" + truncateLabel(b.bt.NodeText(valNode))
-				} else {
-					caseLabel = "default"
-					hasDefault = true
-				}
-				caseExits[caseLabel] = b.buildSwitchCase(child, decisionID)
+				caseLabel := "case:" + truncateLabel(b.bt.NodeText(valNode))
+				caseExits[caseLabel] = b.buildSwitchCase(child, decisionID, map[string]string{decisionID: caseLabel})
 				caseOrder = append(caseOrder, len(caseOrder))
 
-			case "default":
+			case "switch_default":
 				hasDefault = true
 				caseLabel := "default"
-				caseExits[caseLabel] = b.buildSwitchCase(child, decisionID)
+				caseExits[caseLabel] = b.buildSwitchCase(child, decisionID, map[string]string{decisionID: "default"})
 				caseOrder = append(caseOrder, len(caseOrder))
 			}
 		}
@@ -455,8 +464,11 @@ func (b *cfgbuilder) buildSwitch(stmt *gotreesitter.Node, preds map[string]bool)
 	return result
 }
 
-func (b *cfgbuilder) buildSwitchCase(caseNode *gotreesitter.Node, decisionID string) map[string]bool {
+func (b *cfgbuilder) buildSwitchCase(caseNode *gotreesitter.Node, decisionID string, branchOverrides map[string]string) map[string]bool {
 	exits := map[string]bool{decisionID: true}
+
+	oldOverrides := b.branchOverrides
+	b.branchOverrides = branchOverrides
 
 	for i := 0; i < int(caseNode.ChildCount()); i++ {
 		child := caseNode.Child(i)
@@ -465,7 +477,7 @@ func (b *cfgbuilder) buildSwitchCase(caseNode *gotreesitter.Node, decisionID str
 		}
 		switch child.Type(b.lang) {
 		case "statement_block":
-			exits = b.buildBlock(child, exits)
+			exits = b.buildBlock(child, exits, branchOverrides)
 		case "return_statement":
 			exits = b.buildReturn(child, exits)
 		case "break_statement":
@@ -479,6 +491,7 @@ func (b *cfgbuilder) buildSwitchCase(caseNode *gotreesitter.Node, decisionID str
 		}
 	}
 
+	b.branchOverrides = oldOverrides
 	return exits
 }
 
@@ -553,14 +566,48 @@ func (b *cfgbuilder) buildThrow(stmt *gotreesitter.Node, preds map[string]bool) 
 
 func (b *cfgbuilder) buildTry(stmt *gotreesitter.Node, preds map[string]bool) map[string]bool {
 	tryID := b.addNode(CFGNode{
-		Type:  "step",
+		Type:  "decision",
 		Label: "try/catch",
 		Line:  b.lineOf(stmt),
 	})
 	for p := range preds {
 		b.addEdge(p, tryID, "next")
 	}
-	return map[string]bool{tryID: true}
+
+	tryBody := stmt.ChildByFieldName("body", b.lang)
+	var tryExits map[string]bool
+	if tryBody != nil {
+		tryExits = b.buildBlock(tryBody, map[string]bool{tryID: true}, map[string]string{tryID: "try"})
+	} else {
+		tryExits = map[string]bool{tryID: true}
+	}
+	tryExits = b.relabelPreds(tryExits, tryID)
+
+	var catchExits map[string]bool
+	catchClause := stmt.ChildByFieldName("handler", b.lang)
+	if catchClause != nil {
+		catchBody := catchClause.ChildByFieldName("body", b.lang)
+		if catchBody != nil {
+			catchExits = b.buildBlock(catchBody, map[string]bool{tryID: true}, map[string]string{tryID: "catch"})
+		} else {
+			catchExits = map[string]bool{tryID: true}
+		}
+	} else {
+		catchExits = map[string]bool{tryID: true}
+	}
+	catchExits = b.relabelPreds(catchExits, tryID)
+
+	merged := mergePreds(tryExits, catchExits)
+
+	finallyClause := stmt.ChildByFieldName("finalizer", b.lang)
+	if finallyClause != nil {
+		finallyBody := finallyClause.ChildByFieldName("body", b.lang)
+		if finallyBody != nil && len(merged) > 0 {
+			merged = b.buildBlock(finallyBody, merged, nil)
+		}
+	}
+
+	return merged
 }
 
 func (b *cfgbuilder) buildExpression(stmt *gotreesitter.Node, preds map[string]bool) map[string]bool {
@@ -614,7 +661,37 @@ func (b *cfgbuilder) buildExpression(stmt *gotreesitter.Node, preds map[string]b
 		for p := range preds {
 			b.addEdge(p, ternaryID, "next")
 		}
-		return map[string]bool{ternaryID: true}
+
+		consequence := expr.ChildByFieldName("consequence", b.lang)
+		alternative := expr.ChildByFieldName("alternative", b.lang)
+
+		var thenExits map[string]bool
+		if consequence != nil {
+			consStepID := b.addNode(CFGNode{
+				Type:  "step",
+				Label: truncateLabel(b.bt.NodeText(consequence)),
+				Line:  b.lineOf(consequence),
+			})
+			b.addEdge(ternaryID, consStepID, "yes")
+			thenExits = map[string]bool{consStepID: true}
+		} else {
+			thenExits = map[string]bool{ternaryID: true}
+		}
+
+		var elseExits map[string]bool
+		if alternative != nil {
+			altStepID := b.addNode(CFGNode{
+				Type:  "step",
+				Label: truncateLabel(b.bt.NodeText(alternative)),
+				Line:  b.lineOf(alternative),
+			})
+			b.addEdge(ternaryID, altStepID, "no")
+			elseExits = map[string]bool{altStepID: true}
+		} else {
+			elseExits = map[string]bool{ternaryID: true}
+		}
+
+		return mergePreds(thenExits, elseExits)
 	}
 
 	text := b.bt.NodeText(stmt)
@@ -763,4 +840,28 @@ func extractCallName(text string) string {
 		return name[dotIdx+1:]
 	}
 	return name
+}
+
+func isIgnoredStatement(stmtType string) bool {
+	switch stmtType {
+	case "{", "}", ";", "comment", "line_comment", "block_comment":
+		return true
+	default:
+		return false
+	}
+}
+
+func findAssignedName(bt *gotreesitter.BoundTree, n *gotreesitter.Node, lang *gotreesitter.Language) string {
+	cur := n
+	for cur != nil {
+		if cur.Type(lang) == "variable_declarator" {
+			nameNode := cur.ChildByFieldName("name", lang)
+			if nameNode != nil {
+				return bt.NodeText(nameNode)
+			}
+			return ""
+		}
+		cur = cur.Parent()
+	}
+	return ""
 }

--- a/internal/graph/js_cflow_test.go
+++ b/internal/graph/js_cflow_test.go
@@ -307,3 +307,353 @@ const handler = (req, res) => {
 		t.Errorf("Entry = %q, want a.ts::handler", cfgs[0].Entry)
 	}
 }
+
+func TestJSControlFlowExtractor_NoJunkNodes(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function clean(req, res) {
+  // just a last line of defense
+  if (!req.id) {
+    return res.status(400);
+  }
+  return res.status(200);
+}
+`
+	cfgs, err := ex.ExtractCFGs("clean.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	for _, n := range cfgs[0].Nodes {
+		if n.Label == "{" || n.Label == "}" || n.Label == ";" {
+			t.Errorf("junk node found: type=%q label=%q", n.Type, n.Label)
+		}
+		if n.Type == "step" && strings.HasPrefix(n.Label, "//") {
+			t.Errorf("comment node found as step: label=%q", n.Label)
+		}
+	}
+}
+
+func TestJSControlFlowExtractor_StartNodeLabelIsFunctionName(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `function foo() { return 1; }`
+	cfgs, err := ex.ExtractCFGs("handlers/test.ts", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	startNodes := 0
+	for _, n := range cfgs[0].Nodes {
+		if n.Type == "start" {
+			startNodes++
+			if n.Label != "foo" {
+				t.Errorf("start node label = %q, want %q", n.Label, "foo")
+			}
+		}
+	}
+	if startNodes != 1 {
+		t.Errorf("expected 1 start node, got %d", startNodes)
+	}
+}
+
+func TestJSControlFlowExtractor_AbsolutePathStripped(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `function bar() { return 2; }`
+	cfgs, err := ex.ExtractCFGs("/Users/test/work/project/src/handler.ts", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	if cfgs[0].SourceFile != "handler.ts" {
+		t.Errorf("SourceFile = %q, want handler.ts", cfgs[0].SourceFile)
+	}
+	if cfgs[0].Entry != "handler.ts::bar" {
+		t.Errorf("Entry = %q, want handler.ts::bar", cfgs[0].Entry)
+	}
+}
+
+func TestJSControlFlowExtractor_WrappedArrowHandler(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+const getBalance = catchAsync(async (req, res) => {
+  if (!req.user) {
+    return res.status(401);
+  }
+  res.json({ balance: 100 });
+});
+`
+	cfgs, err := ex.ExtractCFGs("routes.ts", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG for wrapped arrow handler, got %d", len(cfgs))
+	}
+	if cfgs[0].Entry != "routes.ts::getBalance" {
+		t.Errorf("Entry = %q, want routes.ts::getBalance", cfgs[0].Entry)
+	}
+	counts := countNodeTypes(cfgs[0])
+	if counts["decision"] < 1 {
+		t.Error("expected at least 1 decision node for the guard clause")
+	}
+}
+
+// countEdgeBranches returns a map of branch label -> count across one CFG.
+func countEdgeBranches(cfg graph.CFG) map[string]int {
+	m := make(map[string]int)
+	for _, e := range cfg.Edges {
+		m[e.Branch]++
+	}
+	return m
+}
+
+func TestJSControlFlowExtractor_IfElseBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test(x) {
+  if (x > 0) {
+    console.log("pos");
+  } else {
+    console.log("neg");
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["yes"] < 1 {
+		t.Error("expected at least 1 'yes' branch edge for if-then")
+	}
+	if branches["no"] < 1 {
+		t.Error("expected at least 1 'no' branch edge for if-else")
+	}
+}
+
+func TestJSControlFlowExtractor_IfOnlyBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test(x) {
+  if (x > 0) {
+    console.log("pos");
+  }
+  console.log("done");
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["yes"] < 1 {
+		t.Error("expected at least 1 'yes' branch edge for if-then")
+	}
+	// No else block means no "no" edge — the decision falls through implicitly.
+	if branches["no"] > 0 {
+		t.Error("expected 0 'no' branch edges when there is no else block")
+	}
+}
+
+func TestJSControlFlowExtractor_IfElseIfBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test(x) {
+  if (x > 0) {
+    console.log("pos");
+  } else if (x < 0) {
+    console.log("neg");
+  } else {
+    console.log("zero");
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["yes"] < 2 {
+		t.Error("expected at least 2 'yes' branch edges for chained decisions")
+	}
+	if branches["no"] < 1 {
+		t.Error("expected at least 1 'no' branch edge for else/else-if")
+	}
+}
+
+func TestJSControlFlowExtractor_SwitchBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function route(x) {
+  switch (x) {
+    case 1: return "a";
+    case 2: return "b";
+    default: return "c";
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("r.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["case:1"] < 1 {
+		t.Error("expected 'case:1' branch edge")
+	}
+	if branches["case:2"] < 1 {
+		t.Error("expected 'case:2' branch edge")
+	}
+}
+
+func TestJSControlFlowExtractor_SwitchDefaultBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function route(x) {
+  switch (x) {
+    case 1: return "a";
+    default: return "b";
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("r.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["case:1"] < 1 {
+		t.Error("expected 'case:1' branch edge")
+	}
+	if branches["default"] < 1 {
+		t.Error("expected 'default' branch edge")
+	}
+}
+
+func TestJSControlFlowExtractor_SwitchNoDefaultBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function route(x) {
+  switch (x) {
+    case 1: return "a";
+    case 2: return "b";
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("r.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["case:1"] < 1 {
+		t.Error("expected 'case:1' branch edge")
+	}
+	if branches["case:2"] < 1 {
+		t.Error("expected 'case:2' branch edge")
+	}
+	// No default case and no explicit default edge.
+	if branches["default"] > 0 {
+		t.Error("expected no 'default' branch edge when no default case exists")
+	}
+}
+
+func TestJSControlFlowExtractor_TernaryBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test(x) {
+  x > 0 ? console.log("pos") : console.log("neg");
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["yes"] < 1 {
+		t.Error("expected at least 1 'yes' branch edge for ternary then-branch")
+	}
+	if branches["no"] < 1 {
+		t.Error("expected at least 1 'no' branch edge for ternary else-branch")
+	}
+}
+
+func TestJSControlFlowExtractor_TryCatchBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test() {
+  try {
+    risky();
+  } catch (e) {
+    handle(e);
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["try"] < 1 {
+		t.Error("expected at least 1 'try' branch edge")
+	}
+	if branches["catch"] < 1 {
+		t.Error("expected at least 1 'catch' branch edge")
+	}
+}
+
+func TestJSControlFlowExtractor_TryCatchFinallyBranchLabels(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test() {
+  try {
+    risky();
+  } catch (e) {
+    handle(e);
+  } finally {
+    cleanup();
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	branches := countEdgeBranches(cfgs[0])
+	if branches["try"] < 1 {
+		t.Error("expected at least 1 'try' branch edge")
+	}
+	if branches["catch"] < 1 {
+		t.Error("expected at least 1 'catch' branch edge")
+	}
+}

--- a/internal/graph/js_cflow_test.go
+++ b/internal/graph/js_cflow_test.go
@@ -602,6 +602,68 @@ function test(x) {
 	}
 }
 
+func TestJSControlFlowExtractor_NestedArrowFunctionNames(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+const outer = () => {
+  const inner = () => {
+    doSomething();
+  };
+};
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 CFGs (outer + inner), got %d", len(cfgs))
+	}
+	names := make(map[string]bool)
+	for _, c := range cfgs {
+		names[c.Entry] = true
+	}
+	if !names["f.js::outer"] {
+		t.Error("expected a CFG for outer")
+	}
+	if !names["f.js::inner"] {
+		t.Error("expected a CFG for inner")
+	}
+}
+
+func TestJSControlFlowExtractor_TryCatchEmptyBlocks(t *testing.T) {
+	ex := newCFGExtractor(t)
+	src := `
+function test() {
+  try {
+  } catch (e) {
+  }
+}
+`
+	cfgs, err := ex.ExtractCFGs("f.js", []byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	cfg := cfgs[0]
+	if len(cfg.Nodes) < 2 {
+		t.Fatalf("expected at least 2 nodes (start + try/catch), got %d", len(cfg.Nodes))
+	}
+	if len(cfg.Edges) < 1 {
+		t.Fatal("expected at least 1 edge (start -> try/catch), got 0")
+	}
+	tryCatchNode := false
+	for _, n := range cfg.Nodes {
+		if n.Type == "decision" && n.Label == "try/catch" {
+			tryCatchNode = true
+		}
+	}
+	if !tryCatchNode {
+		t.Error("expected a try/catch decision node")
+	}
+}
+
 func TestJSControlFlowExtractor_TryCatchBranchLabels(t *testing.T) {
 	ex := newCFGExtractor(t)
 	src := `

--- a/internal/server/handlers/flowchart.go
+++ b/internal/server/handlers/flowchart.go
@@ -119,6 +119,9 @@ func resolveFlowchartHandler(ctx context.Context, q FlowchartQuerier, workspace,
 	}
 
 	// Not an HTTP route — treat the entry itself as a handler name/symbol.
+	if idx := strings.Index(entry, "::"); idx >= 0 {
+		return entry[idx+2:], "", "", nil
+	}
 	return lastDottedSegment(entry), "", "", nil
 }
 

--- a/internal/server/handlers/reindex_cfg.go
+++ b/internal/server/handlers/reindex_cfg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,8 +12,10 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	gitignore "github.com/sabhiram/go-gitignore"
 	"github.com/nano-brain/nano-brain/internal/graph"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/watcher"
 	"github.com/rs/zerolog"
 )
 
@@ -25,6 +28,7 @@ type ReindexCFGQuerier interface {
 
 type reindexCFGRequest struct {
 	Workspace string `json:"workspace"`
+	Full     bool   `json:"full"`
 }
 
 type reindexCFGResponse struct {
@@ -71,71 +75,25 @@ func ReindexCFG(queries ReindexCFGQuerier, graphReg *graph.Registry, logger zero
 			}
 		}
 
-		docs, err := queries.ListDocumentsByWorkspace(ctx, workspace)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("list documents: %v", err))
+		if codeRoot == "" {
+			return echo.NewHTTPError(http.StatusInternalServerError, "no code collection found")
 		}
 
 		var filesProcessed, cfgsExtracted int
-		for _, doc := range docs {
-			if doc.Collection != "code" {
-				continue
-			}
 
-			ext := strings.ToLower(filepath.Ext(doc.SourcePath))
-			if !jsTSExts[ext] {
-				continue
-			}
-
-			content, err := os.ReadFile(doc.SourcePath)
+		if req.Full {
+			reqLog.Info().Str("root", codeRoot).Msg("reindex-cfg: starting full filesystem walk")
+			filesProcessed, cfgsExtracted, err = fullWalkAndExtract(ctx, workspace, codeRoot, graphReg, queries, reqLog)
+		} else {
+			docs, err := queries.ListDocumentsByWorkspace(ctx, workspace)
 			if err != nil {
-				reqLog.Warn().Err(err).Str("path", doc.SourcePath).Msg("reindex-cfg: read file failed, skipping")
-				continue
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("list documents: %v", err))
 			}
+			filesProcessed, cfgsExtracted, err = incrementalExtract(ctx, workspace, codeRoot, docs, graphReg, queries, reqLog)
+		}
 
-			relFile := doc.SourcePath
-			if codeRoot != "" {
-				if rel, rerr := filepath.Rel(codeRoot, doc.SourcePath); rerr == nil {
-					relFile = filepath.ToSlash(rel)
-				}
-			}
-
-			filesProcessed++
-
-			cfgs, err := graphReg.ExtractCFGs(relFile, content)
-			if err != nil {
-				reqLog.Warn().Err(err).Str("file", relFile).Msg("reindex-cfg: extraction failed")
-				continue
-			}
-
-			if err := queries.DeleteFunctionFlowchartsByFile(ctx, sqlc.DeleteFunctionFlowchartsByFileParams{
-				WorkspaceHash: workspace,
-				SourceFile:    relFile,
-			}); err != nil {
-				reqLog.Warn().Err(err).Str("file", relFile).Msg("reindex-cfg: delete old cfgs failed")
-				continue
-			}
-
-			for _, cfg := range cfgs {
-				cfgJSON, mErr := json.Marshal(cfg)
-				if mErr != nil {
-					reqLog.Warn().Err(mErr).Str("entry", cfg.Entry).Msg("reindex-cfg: marshal cfg failed, skipping")
-					continue
-				}
-				if err := queries.UpsertFunctionFlowchart(ctx, sqlc.UpsertFunctionFlowchartParams{
-					WorkspaceHash: workspace,
-					Entry:         cfg.Entry,
-					SourceFile:    relFile,
-					StartLine:     int32(cfg.StartLine),
-					EndLine:       int32(cfg.EndLine),
-					Status:        cfg.Status,
-					Cfg:           cfgJSON,
-				}); err != nil {
-					reqLog.Warn().Err(err).Str("entry", cfg.Entry).Msg("reindex-cfg: upsert cfg failed")
-					continue
-				}
-				cfgsExtracted++
-			}
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("reindex-cfg failed: %v", err))
 		}
 
 		reqLog.Info().
@@ -152,4 +110,156 @@ func ReindexCFG(queries ReindexCFGQuerier, graphReg *graph.Registry, logger zero
 			DurationMs:    time.Since(start).Milliseconds(),
 		})
 	}
+}
+
+func incrementalExtract(ctx context.Context, workspace, codeRoot string, docs []sqlc.ListDocumentsByWorkspaceRow, graphReg *graph.Registry, queries ReindexCFGQuerier, reqLog zerolog.Logger) (filesProcessed, cfgsExtracted int, err error) {
+	homeDir, _ := os.UserHomeDir()
+	globalIgnore, _, _ := watcher.LoadGlobalIgnore(homeDir)
+
+	filter, ferr := watcher.NewFileFilter(codeRoot, nil, nil, globalIgnore)
+	if ferr != nil {
+		reqLog.Warn().Err(ferr).Str("root", codeRoot).Msg("reindex-cfg: .nano-brainignore load failed, continuing without local matcher")
+	}
+
+	for _, doc := range docs {
+		if doc.Collection != "code" {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(doc.SourcePath))
+		if !jsTSExts[ext] {
+			continue
+		}
+		if filter != nil && filter.ShouldSkip(doc.SourcePath, false) {
+			reqLog.Debug().Str("file", doc.SourcePath).Msg("reindex-cfg: skipped by filter")
+			continue
+		}
+		filesProcessed++
+		if err := processFile(ctx, workspace, doc.SourcePath, codeRoot, graphReg, queries); err != nil {
+			reqLog.Warn().Err(err).Str("file", doc.SourcePath).Msg("reindex-cfg: failed")
+		} else {
+			cfgsExtracted++
+		}
+	}
+	return
+}
+
+func fullWalkAndExtract(ctx context.Context, workspace, codeRoot string, graphReg *graph.Registry, queries ReindexCFGQuerier, reqLog zerolog.Logger) (filesProcessed, cfgsExtracted int, err error) {
+	homeDir, _ := os.UserHomeDir()
+	globalIgnore, _, _ := watcher.LoadGlobalIgnore(homeDir)
+
+	filter, ferr := watcher.NewFileFilter(codeRoot, nil, nil, globalIgnore)
+	if ferr != nil {
+		reqLog.Warn().Err(ferr).Str("root", codeRoot).Msg("reindex-cfg: .nano-brainignore load failed, continuing without local matcher")
+	}
+
+	ignoreStack := &watcher.GitignoreStack{}
+	reqLog.Info().Str("root", codeRoot).Msg("reindex-cfg: starting full filesystem walk")
+
+	var lastLogTime time.Time
+	lastLogTime = time.Now()
+	var skipped int
+
+	err = filepath.WalkDir(codeRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			reqLog.Warn().Err(walkErr).Str("path", path).Msg("walk error")
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		ignoreStack.PopAbove(path)
+
+		if d.IsDir() {
+			giPath := filepath.Join(path, ".gitignore")
+			if info, statErr := os.Stat(giPath); statErr == nil && !info.IsDir() {
+				if gi, giErr := gitignore.CompileIgnoreFile(giPath); giErr == nil {
+					ignoreStack.Push(path, gi)
+				}
+			}
+			localIgnorePath := filepath.Join(path, ".nano-brainignore")
+			if info, statErr := os.Stat(localIgnorePath); statErr == nil && !info.IsDir() {
+				if li, liErr := gitignore.CompileIgnoreFile(localIgnorePath); liErr == nil {
+					ignoreStack.Push(path, li)
+				}
+			}
+		}
+
+		if filter.ShouldSkip(path, d.IsDir()) || ignoreStack.Matches(path) {
+			skipped++
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if !d.IsDir() {
+			ext := strings.ToLower(filepath.Ext(path))
+			if jsTSExts[ext] {
+				filesProcessed++
+				if err := processFile(ctx, workspace, path, codeRoot, graphReg, queries); err != nil {
+					reqLog.Warn().Err(err).Str("file", path).Msg("reindex-cfg: failed")
+				} else {
+					cfgsExtracted++
+				}
+			}
+		}
+
+		if time.Since(lastLogTime) > 10*time.Second {
+			reqLog.Info().
+				Str("current_path", path).
+				Int("files_processed", filesProcessed).
+				Int("cfgs_extracted", cfgsExtracted).
+				Int("skipped", skipped).
+				Msg("reindex-cfg: progress")
+			lastLogTime = time.Now()
+		}
+		return nil
+	})
+	return
+}
+
+func processFile(ctx context.Context, workspace, absPath, codeRoot string, graphReg *graph.Registry, queries ReindexCFGQuerier) error {
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+
+	relFile := absPath
+	if codeRoot != "" {
+		if rel, rerr := filepath.Rel(codeRoot, absPath); rerr == nil {
+			relFile = filepath.ToSlash(rel)
+		}
+	}
+
+	cfgs, err := graphReg.ExtractCFGs(relFile, content)
+	if err != nil {
+		return fmt.Errorf("extract: %w", err)
+	}
+
+	if err := queries.DeleteFunctionFlowchartsByFile(ctx, sqlc.DeleteFunctionFlowchartsByFileParams{
+		WorkspaceHash: workspace,
+		SourceFile:    relFile,
+	}); err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+
+	for _, cfg := range cfgs {
+		cfgJSON, mErr := json.Marshal(cfg)
+		if mErr != nil {
+			continue
+		}
+		if err := queries.UpsertFunctionFlowchart(ctx, sqlc.UpsertFunctionFlowchartParams{
+			WorkspaceHash: workspace,
+			Entry:         cfg.Entry,
+			SourceFile:    relFile,
+			StartLine:     int32(cfg.StartLine),
+			EndLine:       int32(cfg.EndLine),
+			Status:        cfg.Status,
+			Cfg:           cfgJSON,
+		}); err != nil {
+			return fmt.Errorf("upsert %s: %w", cfg.Entry, err)
+		}
+	}
+	return nil
 }

--- a/internal/server/handlers/reindex_cfg.go
+++ b/internal/server/handlers/reindex_cfg.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/graph"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type ReindexCFGQuerier interface {
+	ListCollections(ctx context.Context, workspaceHash string) ([]sqlc.Collection, error)
+	ListDocumentsByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.ListDocumentsByWorkspaceRow, error)
+	DeleteFunctionFlowchartsByFile(ctx context.Context, arg sqlc.DeleteFunctionFlowchartsByFileParams) error
+	UpsertFunctionFlowchart(ctx context.Context, arg sqlc.UpsertFunctionFlowchartParams) error
+}
+
+type reindexCFGRequest struct {
+	Workspace string `json:"workspace"`
+}
+
+type reindexCFGResponse struct {
+	Status        string `json:"status"`
+	FilesProcessed int   `json:"files_processed"`
+	CFGsExtracted int   `json:"cfgs_extracted"`
+	DurationMs    int64  `json:"duration_ms"`
+}
+
+var jsTSExts = map[string]bool{
+	".js":  true,
+	".jsx": true,
+	".ts":  true,
+	".tsx": true,
+}
+
+func ReindexCFG(queries ReindexCFGQuerier, graphReg *graph.Registry, logger zerolog.Logger) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		start := time.Now()
+
+		var req reindexCFGRequest
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+		}
+
+		workspace := c.Get("workspace").(string)
+		ctx := c.Request().Context()
+		reqLog := LoggerFromCtx(c, logger)
+
+		if graphReg == nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "graph registry not available")
+		}
+
+		collections, err := queries.ListCollections(ctx, workspace)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("list collections: %v", err))
+		}
+
+		var codeRoot string
+		for _, col := range collections {
+			if col.Name == "code" {
+				codeRoot = col.Path
+				break
+			}
+		}
+
+		docs, err := queries.ListDocumentsByWorkspace(ctx, workspace)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("list documents: %v", err))
+		}
+
+		var filesProcessed, cfgsExtracted int
+		for _, doc := range docs {
+			if doc.Collection != "code" {
+				continue
+			}
+
+			ext := strings.ToLower(filepath.Ext(doc.SourcePath))
+			if !jsTSExts[ext] {
+				continue
+			}
+
+			content, err := os.ReadFile(doc.SourcePath)
+			if err != nil {
+				reqLog.Warn().Err(err).Str("path", doc.SourcePath).Msg("reindex-cfg: read file failed, skipping")
+				continue
+			}
+
+			relFile := doc.SourcePath
+			if codeRoot != "" {
+				if rel, rerr := filepath.Rel(codeRoot, doc.SourcePath); rerr == nil {
+					relFile = filepath.ToSlash(rel)
+				}
+			}
+
+			filesProcessed++
+
+			cfgs, err := graphReg.ExtractCFGs(relFile, content)
+			if err != nil {
+				reqLog.Warn().Err(err).Str("file", relFile).Msg("reindex-cfg: extraction failed")
+				continue
+			}
+
+			if err := queries.DeleteFunctionFlowchartsByFile(ctx, sqlc.DeleteFunctionFlowchartsByFileParams{
+				WorkspaceHash: workspace,
+				SourceFile:    relFile,
+			}); err != nil {
+				reqLog.Warn().Err(err).Str("file", relFile).Msg("reindex-cfg: delete old cfgs failed")
+				continue
+			}
+
+			for _, cfg := range cfgs {
+				cfgJSON, mErr := json.Marshal(cfg)
+				if mErr != nil {
+					reqLog.Warn().Err(mErr).Str("entry", cfg.Entry).Msg("reindex-cfg: marshal cfg failed, skipping")
+					continue
+				}
+				if err := queries.UpsertFunctionFlowchart(ctx, sqlc.UpsertFunctionFlowchartParams{
+					WorkspaceHash: workspace,
+					Entry:         cfg.Entry,
+					SourceFile:    relFile,
+					StartLine:     int32(cfg.StartLine),
+					EndLine:       int32(cfg.EndLine),
+					Status:        cfg.Status,
+					Cfg:           cfgJSON,
+				}); err != nil {
+					reqLog.Warn().Err(err).Str("entry", cfg.Entry).Msg("reindex-cfg: upsert cfg failed")
+					continue
+				}
+				cfgsExtracted++
+			}
+		}
+
+		reqLog.Info().
+			Str("workspace", workspace).
+			Int("files_processed", filesProcessed).
+			Int("cfgs_extracted", cfgsExtracted).
+			Dur("duration", time.Since(start)).
+			Msg("reindex-cfg completed")
+
+		return c.JSON(http.StatusOK, reindexCFGResponse{
+			Status:        "completed",
+			FilesProcessed: filesProcessed,
+			CFGsExtracted: cfgsExtracted,
+			DurationMs:    time.Since(start).Milliseconds(),
+		})
+	}
+}

--- a/internal/server/handlers/reindex_cfg.go
+++ b/internal/server/handlers/reindex_cfg.go
@@ -23,12 +23,14 @@ type ReindexCFGQuerier interface {
 	ListCollections(ctx context.Context, workspaceHash string) ([]sqlc.Collection, error)
 	ListDocumentsByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.ListDocumentsByWorkspaceRow, error)
 	DeleteFunctionFlowchartsByFile(ctx context.Context, arg sqlc.DeleteFunctionFlowchartsByFileParams) error
+	DeleteAllFunctionFlowcharts(ctx context.Context, workspaceHash string) error
 	UpsertFunctionFlowchart(ctx context.Context, arg sqlc.UpsertFunctionFlowchartParams) error
 }
 
 type reindexCFGRequest struct {
 	Workspace string `json:"workspace"`
 	Full     bool   `json:"full"`
+	Wipe     bool   `json:"wipe"`
 }
 
 type reindexCFGResponse struct {
@@ -80,6 +82,13 @@ func ReindexCFG(queries ReindexCFGQuerier, graphReg *graph.Registry, logger zero
 		}
 
 		var filesProcessed, cfgsExtracted int
+
+		if req.Wipe {
+			if wipeErr := queries.DeleteAllFunctionFlowcharts(ctx, workspace); wipeErr != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("wipe flowcharts: %v", wipeErr))
+			}
+			reqLog.Info().Str("workspace", workspace).Msg("reindex-cfg: wiped all flowcharts")
+		}
 
 		if req.Full {
 			reqLog.Info().Str("root", codeRoot).Msg("reindex-cfg: starting full filesystem walk")
@@ -188,6 +197,7 @@ func fullWalkAndExtract(ctx context.Context, workspace, codeRoot string, graphRe
 		if filter.ShouldSkip(path, d.IsDir()) || ignoreStack.Matches(path) {
 			skipped++
 			if d.IsDir() {
+				reqLog.Debug().Str("dir", path).Msg("reindex-cfg: skipping dir")
 				return filepath.SkipDir
 			}
 			return nil
@@ -197,6 +207,7 @@ func fullWalkAndExtract(ctx context.Context, workspace, codeRoot string, graphRe
 			ext := strings.ToLower(filepath.Ext(path))
 			if jsTSExts[ext] {
 				filesProcessed++
+				reqLog.Debug().Str("file", path).Int("processed", filesProcessed).Msg("reindex-cfg: processing file")
 				if err := processFile(ctx, workspace, path, codeRoot, graphReg, queries); err != nil {
 					reqLog.Warn().Err(err).Str("file", path).Msg("reindex-cfg: failed")
 				} else {

--- a/internal/server/handlers/reindex_cfg_test.go
+++ b/internal/server/handlers/reindex_cfg_test.go
@@ -1,0 +1,142 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/graph"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+type mockReindexCFGQuerier struct {
+	collections   []sqlc.Collection
+	documents     []sqlc.ListDocumentsByWorkspaceRow
+	deleteCount   int
+	upsertCount   int
+	deleteErr     error
+	upsertErr     error
+}
+
+func (m *mockReindexCFGQuerier) ListCollections(_ context.Context, _ string) ([]sqlc.Collection, error) {
+	if m.collections != nil {
+		return m.collections, nil
+	}
+	return nil, nil
+}
+
+func (m *mockReindexCFGQuerier) ListDocumentsByWorkspace(_ context.Context, _ string) ([]sqlc.ListDocumentsByWorkspaceRow, error) {
+	if m.documents != nil {
+		return m.documents, nil
+	}
+	return nil, nil
+}
+
+func (m *mockReindexCFGQuerier) DeleteFunctionFlowchartsByFile(_ context.Context, _ sqlc.DeleteFunctionFlowchartsByFileParams) error {
+	m.deleteCount++
+	return m.deleteErr
+}
+
+func (m *mockReindexCFGQuerier) UpsertFunctionFlowchart(_ context.Context, _ sqlc.UpsertFunctionFlowchartParams) error {
+	m.upsertCount++
+	return m.upsertErr
+}
+
+func TestReindexCFG_NoJSTSFiles(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex-cfg", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexCFGQuerier{
+		collections: []sqlc.Collection{{Name: "code", Path: t.TempDir()}},
+		documents: []sqlc.ListDocumentsByWorkspaceRow{
+			{Collection: "code", SourcePath: filepath.Join(t.TempDir(), "readme.txt")},
+		},
+	}
+	reg := graph.NewRegistry()
+
+	h := handlers.ReindexCFG(mq, reg, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if mq.deleteCount != 0 {
+		t.Errorf("expected 0 deletes, got %d", mq.deleteCount)
+	}
+	if mq.upsertCount != 0 {
+		t.Errorf("expected 0 upserts, got %d", mq.upsertCount)
+	}
+}
+
+func TestReindexCFG_WithJSFile(t *testing.T) {
+	dir := t.TempDir()
+	jsFile := filepath.Join(dir, "app.js")
+	if err := os.WriteFile(jsFile, []byte("function hello() { return 1; }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex-cfg", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexCFGQuerier{
+		collections: []sqlc.Collection{{Name: "code", Path: dir}},
+		documents: []sqlc.ListDocumentsByWorkspaceRow{
+			{Collection: "code", SourcePath: jsFile},
+		},
+	}
+	reg := graph.NewRegistry()
+
+	h := handlers.ReindexCFG(mq, reg, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if mq.deleteCount != 1 {
+		t.Errorf("expected 1 delete, got %d", mq.deleteCount)
+	}
+}
+
+func TestReindexCFG_NilGraphRegistry(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex-cfg", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexCFGQuerier{}
+
+	h := handlers.ReindexCFG(mq, nil, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for nil graph registry")
+	}
+	httpErr, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected HTTPError, got %T", err)
+	}
+	if httpErr.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", httpErr.Code)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -72,6 +72,7 @@ func registerRoutes(s *Server) {
 		reindexPub = s.eventBus
 	}
 	write.POST("/reindex", handlers.TriggerReindex(s.queries, s.watcher, s.embedQueue, reindexPub, s.logger))
+	write.POST("/reindex-cfg", handlers.ReindexCFG(s.queries, s.graphRegistry, s.logger))
 	write.POST("/update", handlers.TriggerUpdate(s.watcher, s.logger))
 	write.POST("/summarize", handlers.TriggerSummarize(s.getSummarizer, s.queries, s.logger))
 	write.POST("/code/summarize", handlers.TriggerCodeSummarize(s.getCodeSummarizer, s.currentConfig().CodeSummarization, s.logger))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/embed"
 	"github.com/nano-brain/nano-brain/internal/eventbus"
+	"github.com/nano-brain/nano-brain/internal/graph"
 	"github.com/nano-brain/nano-brain/internal/links"
 	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/nano-brain/nano-brain/internal/search"
@@ -73,9 +74,10 @@ type Server struct {
 	concreteLinkRes    *links.Resolver
 	concreteLinkExt    *links.Extractor
 	eventBus           *eventbus.Bus
+	graphRegistry      *graph.Registry
 }
 
-func New(fullCfg *config.Config, configPath string, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, bus *eventbus.Bus, logger zerolog.Logger, version string, migrationVersion int64) *Server {
+func New(fullCfg *config.Config, configPath string, pool PoolChecker, db *sql.DB, queries *sqlc.Queries, fw *watcher.Watcher, eq *embed.Queue, embedder embed.Embedder, bus *eventbus.Bus, logger zerolog.Logger, version string, migrationVersion int64, graphReg *graph.Registry) *Server {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
@@ -156,6 +158,7 @@ func New(fullCfg *config.Config, configPath string, pool PoolChecker, db *sql.DB
 		concreteLinkRes:    concRes,
 		concreteLinkExt:    concExt,
 		eventBus:           bus,
+		graphRegistry:      graphReg,
 	}
 
 	registerMiddleware(s)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -35,7 +35,7 @@ func newTestServer(pool *mockPool) *server.Server {
 		Logging:   config.LoggingConfig{Level: "info"},
 	}
 	logger := zerolog.Nop()
-	return server.New(fullCfg, "", pool, nil, nil, nil, nil, nil, nil, logger, "test-v1", 0)
+	return server.New(fullCfg, "", pool, nil, nil, nil, nil, nil, nil, logger, "test-v1", 0, nil)
 }
 
 func TestHealthEndpointHealthyDB(t *testing.T) {

--- a/internal/storage/queries/flowcharts.sql
+++ b/internal/storage/queries/flowcharts.sql
@@ -22,3 +22,6 @@ LIMIT 1;
 
 -- name: DeleteFunctionFlowchartsByFile :exec
 DELETE FROM function_flowcharts WHERE workspace_hash = $1 AND source_file = $2;
+
+-- name: DeleteAllFunctionFlowcharts :exec
+DELETE FROM function_flowcharts WHERE workspace_hash = $1;

--- a/internal/storage/sqlc/flowcharts.sql.go
+++ b/internal/storage/sqlc/flowcharts.sql.go
@@ -10,6 +10,15 @@ import (
 	"encoding/json"
 )
 
+const deleteAllFunctionFlowcharts = `-- name: DeleteAllFunctionFlowcharts :exec
+DELETE FROM function_flowcharts WHERE workspace_hash = $1
+`
+
+func (q *Queries) DeleteAllFunctionFlowcharts(ctx context.Context, workspaceHash string) error {
+	_, err := q.db.ExecContext(ctx, deleteAllFunctionFlowcharts, workspaceHash)
+	return err
+}
+
 const deleteFunctionFlowchartsByFile = `-- name: DeleteFunctionFlowchartsByFile :exec
 DELETE FROM function_flowcharts WHERE workspace_hash = $1 AND source_file = $2
 `

--- a/internal/watcher/filter.go
+++ b/internal/watcher/filter.go
@@ -9,21 +9,21 @@ import (
 	gitignore "github.com/sabhiram/go-gitignore"
 )
 
-// gitignoreStack maintains a stack of .gitignore matchers discovered during
+// GitignoreStack maintains a stack of .gitignore matchers discovered during
 // directory traversal. Each entry tracks the directory path and its associated
 // gitignore matcher. The stack is used to apply nested .gitignore files in
 // multi-repo workspaces (issue #379).
-type gitignoreStack struct {
-	entries []gitignoreEntry
+type GitignoreStack struct {
+	entries []GitignoreEntry
 }
 
-type gitignoreEntry struct {
+type GitignoreEntry struct {
 	dirPath string
 	matcher *gitignore.GitIgnore
 }
 
-func (s *gitignoreStack) Push(dirPath string, matcher *gitignore.GitIgnore) {
-	s.entries = append(s.entries, gitignoreEntry{
+func (s *GitignoreStack) Push(dirPath string, matcher *gitignore.GitIgnore) {
+	s.entries = append(s.entries, GitignoreEntry{
 		dirPath: dirPath,
 		matcher: matcher,
 	})
@@ -31,7 +31,7 @@ func (s *gitignoreStack) Push(dirPath string, matcher *gitignore.GitIgnore) {
 
 // PopAbove removes stack entries that are not ancestors of the given path.
 // This is called when ascending from a subdirectory during tree traversal.
-func (s *gitignoreStack) PopAbove(currentPath string) {
+func (s *GitignoreStack) PopAbove(currentPath string) {
 	i := 0
 	for _, entry := range s.entries {
 		rel, err := filepath.Rel(entry.dirPath, currentPath)
@@ -45,7 +45,7 @@ func (s *gitignoreStack) PopAbove(currentPath string) {
 
 // Matches checks if the given path matches any .gitignore pattern in the stack.
 // Returns true if the path should be excluded.
-func (s *gitignoreStack) Matches(path string) bool {
+func (s *GitignoreStack) Matches(path string) bool {
 	for _, entry := range s.entries {
 		rel, err := filepath.Rel(entry.dirPath, path)
 		if err != nil {
@@ -121,7 +121,7 @@ var defaultExcludeFiles = map[string]bool{
 	"composer.lock":        true, // PHP (also .lock)
 }
 
-type fileFilter struct {
+type FileFilter struct {
 	gitignoreMatcher  *gitignore.GitIgnore
 	globalIgnore      *gitignore.GitIgnore
 	localIgnore       *gitignore.GitIgnore
@@ -130,12 +130,12 @@ type fileFilter struct {
 	rootDir           string
 }
 
-// newFileFilter returns a filter for rootDir. The error reports IO failures
+// NewFileFilter returns a filter for rootDir. The error reports IO failures
 // while loading <rootDir>/.nano-brainignore (permission denied, is-a-directory,
-// etc.). The returned *fileFilter is always valid; callers should log the
+// etc.). The returned *FileFilter is always valid, callers should log the
 // error and continue with localIgnore unset.
-func newFileFilter(rootDir string, excludePatterns, allowedExtensions []string, globalIgnore *gitignore.GitIgnore) (*fileFilter, error) {
-	f := &fileFilter{
+func NewFileFilter(rootDir string, excludePatterns, allowedExtensions []string, globalIgnore *gitignore.GitIgnore) (*FileFilter, error) {
+	f := &FileFilter{
 		rootDir:         rootDir,
 		excludePatterns: excludePatterns,
 		globalIgnore:    globalIgnore,
@@ -171,7 +171,7 @@ func newFileFilter(rootDir string, excludePatterns, allowedExtensions []string, 
 	return f, nil
 }
 
-func (f *fileFilter) shouldSkip(absPath string, isDir bool) bool {
+func (f *FileFilter) shouldSkip(absPath string, isDir bool) bool {
 	rel, err := filepath.Rel(f.rootDir, absPath)
 	if err != nil {
 		rel = absPath
@@ -231,6 +231,10 @@ func (f *fileFilter) shouldSkip(absPath string, isDir bool) bool {
 	}
 
 	return false
+}
+
+func (f *FileFilter) ShouldSkip(absPath string, isDir bool) bool {
+	return f.shouldSkip(absPath, isDir)
 }
 
 // LoadGlobalIgnore reads `<homeDir>/.nano-brain/.nano-brainignore` and returns

--- a/internal/watcher/filter_test.go
+++ b/internal/watcher/filter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestShouldSkip_DefaultExcludeDirs(t *testing.T) {
 	root := t.TempDir()
-	f, _ := newFileFilter(root, nil, nil, nil)
+	f, _ := NewFileFilter(root, nil, nil, nil)
 
 	cases := []struct {
 		path string
@@ -26,7 +26,7 @@ func TestShouldSkip_DefaultExcludeDirs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := f.shouldSkip(tc.path, false)
+		got := f.ShouldSkip(tc.path, false)
 		if got != tc.skip {
 			t.Errorf("shouldSkip(%q) = %v, want %v", tc.path, got, tc.skip)
 		}
@@ -35,7 +35,7 @@ func TestShouldSkip_DefaultExcludeDirs(t *testing.T) {
 
 func TestShouldSkip_ExcludePatterns(t *testing.T) {
 	root := t.TempDir()
-	f, _ := newFileFilter(root, []string{"*.lock", "*.log"}, nil, nil)
+	f, _ := NewFileFilter(root, []string{"*.lock", "*.log"}, nil, nil)
 
 	cases := []struct {
 		path string
@@ -48,7 +48,7 @@ func TestShouldSkip_ExcludePatterns(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := f.shouldSkip(tc.path, false)
+		got := f.ShouldSkip(tc.path, false)
 		if got != tc.skip {
 			t.Errorf("shouldSkip(%q) = %v, want %v", tc.path, got, tc.skip)
 		}
@@ -57,7 +57,7 @@ func TestShouldSkip_ExcludePatterns(t *testing.T) {
 
 func TestShouldSkip_AllowedExtensions(t *testing.T) {
 	root := t.TempDir()
-	f, _ := newFileFilter(root, nil, []string{".go", ".md"}, nil)
+	f, _ := NewFileFilter(root, nil, []string{".go", ".md"}, nil)
 
 	cases := []struct {
 		path string
@@ -71,7 +71,7 @@ func TestShouldSkip_AllowedExtensions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := f.shouldSkip(tc.path, false)
+		got := f.ShouldSkip(tc.path, false)
 		if got != tc.skip {
 			t.Errorf("shouldSkip(%q) = %v, want %v", tc.path, got, tc.skip)
 		}
@@ -80,12 +80,12 @@ func TestShouldSkip_AllowedExtensions(t *testing.T) {
 
 func TestShouldSkip_AllowedExtensionsNoDot(t *testing.T) {
 	root := t.TempDir()
-	f, _ := newFileFilter(root, nil, []string{"go", "ts"}, nil)
+	f, _ := NewFileFilter(root, nil, []string{"go", "ts"}, nil)
 
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should not be skipped when go is allowed")
 	}
-	if !f.shouldSkip(filepath.Join(root, "index.js"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "index.js"), false) {
 		t.Error("index.js should be skipped when only go,ts are allowed")
 	}
 }
@@ -97,7 +97,7 @@ func TestShouldSkip_Gitignore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, _ := newFileFilter(root, nil, nil, nil)
+	f, _ := NewFileFilter(root, nil, nil, nil)
 
 	cases := []struct {
 		path string
@@ -109,7 +109,7 @@ func TestShouldSkip_Gitignore(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := f.shouldSkip(tc.path, false)
+		got := f.ShouldSkip(tc.path, false)
 		if got != tc.skip {
 			t.Errorf("shouldSkip(%q) = %v, want %v", tc.path, got, tc.skip)
 		}
@@ -118,9 +118,9 @@ func TestShouldSkip_Gitignore(t *testing.T) {
 
 func TestShouldSkip_NoGitignore(t *testing.T) {
 	root := t.TempDir()
-	f, _ := newFileFilter(root, nil, nil, nil)
+	f, _ := NewFileFilter(root, nil, nil, nil)
 
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should not be skipped when no .gitignore")
 	}
 }
@@ -186,11 +186,11 @@ func TestFileFilter_GlobalIgnoreApplies(t *testing.T) {
 		t.Fatalf("setup: %v, gi=%v", err, gi)
 	}
 
-	f, _ := newFileFilter(root, nil, nil, gi)
-	if !f.shouldSkip(filepath.Join(root, "screenshot.png"), false) {
+	f, _ := NewFileFilter(root, nil, nil, gi)
+	if !f.ShouldSkip(filepath.Join(root, "screenshot.png"), false) {
 		t.Error("screenshot.png should be skipped via global ignore")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped (no global match)")
 	}
 }
@@ -211,14 +211,14 @@ func TestFileFilter_GlobalIgnoreMatchesDirectoryWithTrailingSlash(t *testing.T) 
 		t.Fatalf("setup: %v", err)
 	}
 
-	f, _ := newFileFilter(root, nil, nil, gi)
-	if !f.shouldSkip(filepath.Join(root, "custom_build"), true) {
+	f, _ := NewFileFilter(root, nil, nil, gi)
+	if !f.ShouldSkip(filepath.Join(root, "custom_build"), true) {
 		t.Error("custom_build directory must be skipped (gitignore 'custom_build/' pattern requires trailing slash)")
 	}
-	if !f.shouldSkip(filepath.Join(root, "custom_build", "output.bin"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "custom_build", "output.bin"), false) {
 		t.Error("file inside custom_build/ should also be skipped")
 	}
-	if f.shouldSkip(filepath.Join(root, "src"), true) {
+	if f.ShouldSkip(filepath.Join(root, "src"), true) {
 		t.Error("src directory should NOT be skipped")
 	}
 }
@@ -241,14 +241,14 @@ func TestFileFilter_GlobalIgnoreCombinesWithPerCollection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, _ := newFileFilter(root, nil, nil, gi)
-	if !f.shouldSkip(filepath.Join(root, "app.log"), false) {
+	f, _ := NewFileFilter(root, nil, nil, gi)
+	if !f.ShouldSkip(filepath.Join(root, "app.log"), false) {
 		t.Error("app.log should be skipped via global ignore")
 	}
-	if !f.shouldSkip(filepath.Join(root, "temp", "cache.json"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "temp", "cache.json"), false) {
 		t.Error("temp/cache.json should be skipped via per-collection .gitignore")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped")
 	}
 }
@@ -259,17 +259,17 @@ func TestFileFilter_LocalNanoBrainIgnoreApplies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := newFileFilter(root, nil, nil, nil)
+	f, err := NewFileFilter(root, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if f.localIgnore == nil {
 		t.Fatal("expected non-nil localIgnore matcher")
 	}
-	if !f.shouldSkip(filepath.Join(root, "foo.tmp"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "foo.tmp"), false) {
 		t.Error("foo.tmp should be skipped via workspace .nano-brainignore")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped")
 	}
 }
@@ -277,14 +277,14 @@ func TestFileFilter_LocalNanoBrainIgnoreApplies(t *testing.T) {
 func TestFileFilter_LocalNanoBrainIgnoreMissing(t *testing.T) {
 	root := t.TempDir()
 
-	f, err := newFileFilter(root, nil, nil, nil)
+	f, err := NewFileFilter(root, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error when file absent: %v", err)
 	}
 	if f.localIgnore != nil {
 		t.Error("expected nil localIgnore matcher when file missing")
 	}
-	if f.shouldSkip(filepath.Join(root, "anything.tmp"), false) {
+	if f.ShouldSkip(filepath.Join(root, "anything.tmp"), false) {
 		t.Error("anything.tmp must NOT be skipped without a local matcher")
 	}
 }
@@ -307,17 +307,17 @@ func TestFileFilter_LocalNanoBrainIgnoreCombinesWithGlobal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := newFileFilter(root, nil, nil, gi)
+	f, err := NewFileFilter(root, nil, nil, gi)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !f.shouldSkip(filepath.Join(root, "app.log"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "app.log"), false) {
 		t.Error("app.log should be skipped via global ignore")
 	}
-	if !f.shouldSkip(filepath.Join(root, "scratch.tmp"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "scratch.tmp"), false) {
 		t.Error("scratch.tmp should be skipped via local ignore")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped")
 	}
 }
@@ -331,17 +331,17 @@ func TestFileFilter_LocalNanoBrainIgnoreCombinesWithGitignore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := newFileFilter(root, nil, nil, nil)
+	f, err := NewFileFilter(root, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !f.shouldSkip(filepath.Join(root, "tmp", "x.go"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "tmp", "x.go"), false) {
 		t.Error("tmp/x.go should be skipped via .gitignore")
 	}
-	if !f.shouldSkip(filepath.Join(root, "fixture.snap"), false) {
+	if !f.ShouldSkip(filepath.Join(root, "fixture.snap"), false) {
 		t.Error("fixture.snap should be skipped via workspace .nano-brainignore")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped")
 	}
 }
@@ -352,7 +352,7 @@ func TestFileFilter_LocalNanoBrainIgnoreUnreadable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f, err := newFileFilter(root, nil, nil, nil)
+	f, err := NewFileFilter(root, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected IO error when .nano-brainignore is a directory")
 	}
@@ -362,7 +362,7 @@ func TestFileFilter_LocalNanoBrainIgnoreUnreadable(t *testing.T) {
 	if f.localIgnore != nil {
 		t.Error("localIgnore must be nil when file load failed")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped — other filter layers still operate")
 	}
 }
@@ -385,7 +385,7 @@ func TestFileFilter_LocalNanoBrainIgnorePermissionDenied(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(ignPath, 0o644) })
 
-	f, err := newFileFilter(root, nil, nil, nil)
+	f, err := NewFileFilter(root, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected IO error when .nano-brainignore is unreadable (chmod 0000)")
 	}
@@ -395,14 +395,14 @@ func TestFileFilter_LocalNanoBrainIgnorePermissionDenied(t *testing.T) {
 	if f.localIgnore != nil {
 		t.Error("localIgnore must be nil when file load failed")
 	}
-	if f.shouldSkip(filepath.Join(root, "main.go"), false) {
+	if f.ShouldSkip(filepath.Join(root, "main.go"), false) {
 		t.Error("main.go should NOT be skipped — other filter layers still operate")
 	}
 }
 
 func TestGitignoreStack_Push(t *testing.T) {
 	root := t.TempDir()
-	stack := &gitignoreStack{}
+	stack := &GitignoreStack{}
 
 	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.tmp\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -427,7 +427,7 @@ func TestGitignoreStack_PopAbove(t *testing.T) {
 	subdir := filepath.Join(root, "sub")
 	deepdir := filepath.Join(subdir, "deep")
 
-	stack := &gitignoreStack{}
+	stack := &GitignoreStack{}
 	gi1 := gitignore.CompileIgnoreLines("*.a")
 	gi2 := gitignore.CompileIgnoreLines("*.b")
 	gi3 := gitignore.CompileIgnoreLines("*.c")
@@ -460,7 +460,7 @@ func TestGitignoreStack_Matches(t *testing.T) {
 	root := t.TempDir()
 	subdir := filepath.Join(root, "sub")
 
-	stack := &gitignoreStack{}
+	stack := &GitignoreStack{}
 	gi1 := gitignore.CompileIgnoreLines("*.log")
 	gi2 := gitignore.CompileIgnoreLines("*.tmp")
 
@@ -500,7 +500,7 @@ func TestGitignoreStack_NestedGitignoreExclusion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stack := &gitignoreStack{}
+	stack := &GitignoreStack{}
 	giRoot, _ := gitignore.CompileIgnoreFile(filepath.Join(root, ".gitignore"))
 	giSub, _ := gitignore.CompileIgnoreFile(filepath.Join(subRepo, ".gitignore"))
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -55,7 +55,7 @@ type watchedCollection struct {
 	globPattern        string
 	excludePatterns    []string
 	allowedExtensions  []string
-	filter             *fileFilter
+	filter             *FileFilter
 	detectedFrameworks []string
 }
 
@@ -189,7 +189,7 @@ func (w *Watcher) WatchWithFilter(collectionName, dirPath, workspaceHash, globPa
 		return fmt.Errorf("resolve path %s: %w", dirPath, err)
 	}
 
-	filter, ferr := newFileFilter(absPath, excludePatterns, allowedExtensions, w.globalIgnore)
+	filter, ferr := NewFileFilter(absPath, excludePatterns, allowedExtensions, w.globalIgnore)
 	if ferr != nil {
 		w.logger.Warn().Err(ferr).Str("dir", absPath).Str("collection", collectionName).Msg("workspace .nano-brainignore failed to load, continuing without local matcher")
 	} else if filter.localIgnore != nil {
@@ -421,7 +421,7 @@ func (w *Watcher) processAll(ctx context.Context) {
 }
 
 func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
-	stack := &gitignoreStack{}
+	stack := &GitignoreStack{}
 
 	err := filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -442,9 +442,15 @@ func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
 					w.logger.Debug().Str("path", gitignorePath).Msg("loaded nested .gitignore")
 				}
 			}
+			localIgnorePath := filepath.Join(path, ".nano-brainignore")
+			if info, err := os.Stat(localIgnorePath); err == nil && !info.IsDir() {
+				if li, err := gitignore.CompileIgnoreFile(localIgnorePath); err == nil {
+					stack.Push(path, li)
+				}
+			}
 		}
 
-		if col.filter != nil && col.filter.shouldSkip(path, d.IsDir()) {
+		if col.filter != nil && col.filter.ShouldSkip(path, d.IsDir()) {
 			if d.IsDir() {
 				w.cleanupPathPrefix(ctx, col, path)
 				return filepath.SkipDir
@@ -481,7 +487,7 @@ func (w *Watcher) ShouldSkipPath(collectionName, workspaceHash, absPath string, 
 	for _, col := range w.collections {
 		if col.name == collectionName && col.workspaceHash == workspaceHash {
 			if col.filter != nil {
-				return col.filter.shouldSkip(absPath, isDir)
+				return col.filter.ShouldSkip(absPath, isDir)
 			}
 			return false
 		}
@@ -913,7 +919,7 @@ func (w *Watcher) ReextractSymbolsForWorkspace(ctx context.Context, workspaceHas
 			if err != nil || d.IsDir() {
 				return nil
 			}
-			if col.filter != nil && col.filter.shouldSkip(path, false) {
+			if col.filter != nil && col.filter.ShouldSkip(path, false) {
 				return nil
 			}
 			content, err := os.ReadFile(path)
@@ -955,7 +961,7 @@ func (w *Watcher) ReextractEdgesForWorkspace(ctx context.Context, workspaceHash 
 			if err != nil || d.IsDir() {
 				return nil
 			}
-			if col.filter != nil && col.filter.shouldSkip(path, false) {
+			if col.filter != nil && col.filter.ShouldSkip(path, false) {
 				return nil
 			}
 			content, err := os.ReadFile(path)

--- a/openspec/changes/execution-flow-phase2/.openspec.yaml
+++ b/openspec/changes/execution-flow-phase2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/execution-flow-phase2/design.md
+++ b/openspec/changes/execution-flow-phase2/design.md
@@ -1,0 +1,60 @@
+# Design: Execution Flow Visualization — Phase 2
+
+## Context
+
+Phase 1 delivered:
+- **Go/Echo flow extraction** — Echo routes → `http`/`middleware` edges → flow builder → Mermaid flowchart + searchable docs. Extended with Gin, net/http, and framework-agnostic route detection.
+- **JS/TS CFG extraction** — per-function control-flow graphs stored in `function_flowcharts`, served by `memory_flowchart` API + MCP tool.
+- **Integration-point detection** — Go, JS/TS, Python detect Publish/Consume/Emit/Listen/HTTP-client calls → `integration` edges in `graph_edges`.
+- **Sequence diagram renderer** — `RenderSequenceDiagram(Flow)` in `sequence.go`.
+- **Cross-workspace stitching** — `Stitch()` in `stitch.go` matches publish/consume across workspaces by topic. Request-driven via `stitch_workspaces` field. Wired into REST and MCP.
+
+Phase 2 addresses the remaining gap: CFG branch edges.
+
+## Goals / Non-Goals
+
+**Goals:**
+1. **CFG branch-aware edges** — if/else, switch/case, ternary, and try/catch produce typed branch edges (`yes`/`no`/`case:X`/`default`/`try`/`catch`) instead of flat `next` edges. This makes the CFG structurally accurate and enables branch-specific querying.
+2. **Fix switch node type bug** — `buildSwitch` matches `"case"`/`"default"` but tree-sitter-javascript emits `switch_case`/`switch_default`. Fix before shipping.
+
+**Non-Goals:**
+- Cross-workspace stitching (already implemented in `stitch.go`)
+- Non-Go/JS/TS language CFG extractors (Python, Ruby, etc.) — Phase 3.
+- Runtime/distributed tracing (OpenTelemetry) — Phase 3.
+- LLM/semantic flow summaries — Phase 3.
+- Sequence diagram enhancements (activation boxes, loops, alternatives) — follow-up.
+- Loop back-edges — deferred to a future phase.
+
+## Decisions
+
+### D1: CFG branch edges — extend `buildIf` and `buildSwitch`
+
+**Current state:** `buildIf` creates a decision node and chains then/else blocks with `"next"` edges. `buildSwitch` creates a decision node but: (a) matches wrong node types (`"case"`/`"default"` vs actual `switch_case`/`switch_default`), and (b) doesn't create per-case edges at all (the `caseExits` map is populated but the edges from decision to case bodies are missing).
+
+**Change:**
+- `buildIf`: Add explicit `Branch: "yes"` edge from decision node to the first node of the then-block, and `Branch: "no"` edge to the first node of the else-block (or to the merge node if no else).
+- `buildSwitch`: Fix node type matching to `switch_case`/`switch_default`. Add `Branch: "case:<value>"` edge from decision node to each case body's first node, and `Branch: "default"` for the default case.
+- Ternary expressions: Add `Branch: "yes"` / `Branch: "no"` edges (currently ternary is a single `step` node).
+- try/catch: Add `Branch: "try"` / `Branch: "catch"` edges for the try body vs catch body.
+
+**Rationale:** The `CFGEdge.Branch` field already defines these values (`"yes" | "no" | "case:<v>" | "default" | "loop" | "next"`). The extractor just doesn't use them yet. This is a targeted fix, not a type change.
+
+**Alternative considered:** Add a `ConditionLabel` field to `CFGEdge` (like `FlowEdge`). Rejected — `Branch` already encodes this semantically; adding a duplicate field creates confusion.
+
+### D2: Switch node type verification
+
+The `buildSwitch` method at `js_cflow.go:415-434` matches `child.Type(b.lang)` against `"case"` and `"default"`. The tree-sitter-javascript grammar emits `switch_case` and `switch_default` as the actual node type names. This means switch statements currently produce only the decision node with no case branches.
+
+**Action:** Verify the actual grammar node types by inspecting a parsed AST, then update the match statements. This is a prerequisite for case-labeled edges to work.
+
+## Risks / Trade-offs
+
+- **[Switch case node type mismatch]** → The AGENTS.md notes that tree-sitter-javascript emits `switch_case`/`switch_default` but the extractor matches `"case"`/`"default"`. This is a real bug — switch branching doesn't work today. Fix before shipping.
+- **[CFG builder regression]** → Adding branch edges changes the edge count and structure. All existing tests must pass with the new edges. Golden-file tests for Mermaid rendering may need updating.
+- **[Edge count increase]** → Branch-aware edges are more numerous than flat `next` edges. For deeply nested conditionals, this could push functions toward the 500-node cap faster. Acceptable trade-off for accuracy.
+
+## Migration & Rollback
+
+- No schema migration needed — `CFGEdge.Branch` already exists in the JSONB column; the extractor just starts populating it with non-`"next"` values.
+- No new edge types in `graph_edges` — CFGs are self-contained in `function_flowcharts.cfg`.
+- Rollback: revert the code change. Existing CFGs in the DB retain their flat `"next"` edges until re-extracted.

--- a/openspec/changes/execution-flow-phase2/proposal.md
+++ b/openspec/changes/execution-flow-phase2/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Phase 1 delivered in-process execution flows for Go/Echo endpoints and JS/TS function CFGs. One structural blind spot remains:
+
+**JS/TS CFGs are flat** — the CFG extractor generates only sequential `next` edges for all control flow. Real code has if/else, switch, and try/catch branching, but the extractor collapses these into a linear sequence. An agent asking "what happens when topup fails?" gets the same flow regardless of the branch condition. The `CFGEdge.Branch` field already defines `yes`/`no`/`case:X`/`default` values but the extractor never populates them.
+
+Additionally, `buildSwitch` has a latent bug: it matches tree-sitter node types `"case"` and `"default"` but the grammar emits `"switch_case"` and `"switch_default"`, so switch statements produce no branch edges at all.
+
+The other items originally deferred from Phase 1 (non-Echo Go routes, integration-point detection, sequence diagrams, cross-workspace stitching) are already implemented.
+
+## What Changes
+
+- **CFG branch-aware edges** — the JS/TS CFG extractor emits typed branch edges (`yes`/`no`/`case:X`/`default`/`try`/`catch`) for if/else, switch/case, ternary, and try/catch instead of flat `next` edges. No schema change — `CFGEdge.Branch` already supports these values.
+- **Fix switch node type mismatch** — `buildSwitch` updated to match `switch_case`/`switch_default` (actual grammar types) instead of `"case"`/`"default"`.
+
+## Capabilities
+
+### Modified Capabilities
+- `control-flow-extraction` (Phase 1b baseline): JS/TS CFG extractor now produces branch-aware edges for conditional control flow. Existing sequential behavior preserved for non-conditional statements.
+
+## Impact
+
+- **Code affected**:
+  - `internal/graph/js_cflow.go` — extend `buildIf`, `buildSwitch`, ternary, and `buildTry` to emit branch-labeled edges. Fix node type matching in `buildSwitch`.
+  - `internal/graph/js_cflow_test.go` — add/update tests for branch edges.
+- **Dependencies**: None new.
+- **API changes**: `memory_flowchart` and `POST /api/v1/graph/flowchart` return branch-aware CFGs (additive, no breaking change).
+- **Risk**: Switch case node type names in tree-sitter-javascript grammar need verification against the actual grammar. Branch edges increase edge count in existing CFGs — no functional impact but larger JSON responses.

--- a/openspec/changes/execution-flow-phase2/specs/cfg-branching/spec.md
+++ b/openspec/changes/execution-flow-phase2/specs/cfg-branching/spec.md
@@ -1,0 +1,107 @@
+## MODIFIED Requirements
+
+### Requirement: Branch-aware CFG edges for JS/TS
+The JS/TS CFG extractor SHALL emit typed branch edges (`yes`/`no`/`case:<v>`/`default`/`try`/`catch`) for conditional control flow instead of flat `next` edges. The `CFGEdge.Branch` field already defines the value set; the extractor must populate it correctly.
+
+#### Scenario: if/else produces yes/no edges
+- **WHEN** extracting `if (condition) { thenBody(); } else { elseBody(); }`
+- **THEN** the CFG contains a `decision` node for the condition
+- **AND** an edge labeled `Branch: "yes"` from decision to the first node of the then-block
+- **AND** an edge labeled `Branch: "no"` from decision to the first node of the else-block
+- **AND** internal then/else block edges remain `Branch: "next"`
+- **AND** then/else exits merge to a common successor
+
+#### Scenario: if without else produces yes edge and fallthrough
+- **WHEN** extracting `if (condition) { thenBody(); }` (no else)
+- **THEN** the CFG contains `Branch: "yes"` from decision to then-block
+- **AND** `Branch: "no"` from decision to the merge/next-statement node
+
+#### Scenario: switch/case produces case-labeled edges
+- **WHEN** extracting `switch (expr) { case "A": handleA(); break; case "B": handleB(); break; default: handleDefault(); }`
+- **THEN** the CFG contains a `decision` node for the switch
+- **AND** edges labeled `Branch: "case:A"`, `Branch: "case:B"`, `Branch: "default"` from decision to each case body's first node
+- **AND** each case body's internal edges remain `Branch: "next"`
+- **AND** all case exits merge to a common successor
+
+#### Scenario: switch without explicit default
+- **WHEN** extracting a switch with no `default` case
+- **THEN** an implicit `Branch: "default"` edge goes from decision to the merge/next-statement node
+
+#### Scenario: ternary expression produces yes/no edges
+- **WHEN** extracting `const x = condition ? a() : b();`
+- **THEN** the CFG contains a `decision` node for the condition
+- **AND** `Branch: "yes"` from decision to the true-branch call
+- **AND** `Branch: "no"` from decision to the false-branch call
+- **AND** both merge to successor
+
+#### Scenario: try/catch produces try/catch edges
+- **WHEN** extracting `try { riskyOperation(); } catch (e) { handleError(); }`
+- **THEN** the CFG contains edges labeled `Branch: "try"` to the try body
+- **AND** `Branch: "catch"` to the catch body
+- **AND** both merge to successor (or finally block if present)
+
+### Requirement: Tree-sitter node type correctness
+The extractor SHALL match the correct tree-sitter node type names emitted by the grammar. Known mismatch: `buildSwitch` currently matches `"case"` and `"default"` but tree-sitter-javascript emits `"switch_case"` and `"switch_default"`.
+
+#### Scenario: switch case node types match grammar
+- **WHEN** the extractor processes a `switch_statement` node
+- **THEN** child node types are matched against the actual grammar types (`switch_case`, `switch_default`) — NOT the currently hardcoded `"case"` / `"default"`
+
+### Requirement: Existing behavior preserved
+The extractor SHALL continue to produce correct CFGs for all currently-supported patterns. Branch edges are additive — existing `Branch: "next"` edges for sequential statements remain unchanged.
+
+#### Scenario: Sequential statements still produce next edges
+- **WHEN** extracting `a(); b(); c();`
+- **THEN** all edges are `Branch: "next"` (no branch labels added)
+
+#### Scenario: Existing tests pass without regression
+- **WHEN** the extractor changes are applied
+- **THEN** all existing `js_cflow_test.go` tests continue to pass
+
+### Requirement: Loop edges remain unchanged
+Loop back-edges are NOT part of this change. Loops continue to produce a single `step` node with `Branch: "next"` edges.
+
+#### Scenario: For loop produces step node
+- **WHEN** extracting `for (let i = 0; i < n; i++) { body(); }`
+- **THEN** the CFG contains a `step` node labeled "for loop"
+- **AND** all edges are `Branch: "next"`
+
+### Requirement: CFG size limit
+The extractor SHALL continue to cap CFGs at 500 nodes. Branch edges increase edge count but do not change the node limit.
+
+#### Scenario: Large function with many branches is truncated
+- **WHEN** a function contains many nested if/else blocks producing >500 nodes
+- **THEN** the CFG is truncated at 500 nodes
+- **AND** `status` is set to `"truncated"`
+
+## Scope
+
+- **File:** `internal/graph/js_cflow.go` — extend `buildIf`, `buildSwitch`, ternary handling, `buildTry`
+- **Test:** `internal/graph/js_cflow_test.go` — add/update tests for branch edges
+- **No schema change:** `CFGEdge.Branch` already supports all values
+- **No API change:** `memory_flowchart` and `POST /api/v1/graph/flowchart` return richer data (additive)
+
+## Test Cases
+
+| Input | Expected branch edges |
+|-------|----------------------|
+| `if (x) { a(); } else { b(); }` | `decision --yes--> a`, `decision --no--> b` |
+| `if (x) { a(); }` | `decision --yes--> a`, `decision --no--> <merge>` |
+| `switch (v) { case 1: a(); case 2: b(); }` | `decision --case:1--> a`, `decision --case:2--> b`, `decision --default--> <merge>` |
+| `x ? a() : b()` | `decision --yes--> a`, `decision --no--> b` |
+| `try { a(); } catch (e) { b(); }` | `tryNode --try--> a`, `tryNode --catch--> b` |
+| Nested: `if (x) { if (y) { a(); } else { b(); } }` | Outer `--yes--> inner`, inner `--yes--> a`, inner `--no--> b`, outer `--no--> <merge>` |
+
+## Edge Cases
+
+- Empty then/else blocks: emit `yes`/`no` edge to merge node directly
+- Single-statement then/else (no braces): wrap in synthetic block, same behavior
+- Switch with only default: `decision --default--> body`
+- Ternary without else (invalid syntax, but handle gracefully): `--yes--> a`, `--no--> <merge>`
+
+## Acceptance Criteria
+
+1. `go test -race -short ./internal/graph/...` passes with branch-edge assertions
+2. All existing tests continue to pass (no regression)
+3. `go build ./...` and `go test -race -short ./...` pass
+4. Live verification: re-extract CFGs for zengamingx workspace, confirm branch edges appear in `memory_flowchart` response

--- a/openspec/changes/execution-flow-phase2/specs/cross-workspace-stitching/spec.md
+++ b/openspec/changes/execution-flow-phase2/specs/cross-workspace-stitching/spec.md
@@ -1,0 +1,57 @@
+## EXISTING Implementation
+
+Cross-workspace stitching is **already implemented** and wired end-to-end. This spec documents the existing behavior for accuracy. No new work is required.
+
+### Requirement: Cross-workspace topic matching
+The system SHALL match `publish("topic")` edges in workspace A to `consume("topic")` edges in workspace B, producing `cross_service` flow edges linking publisher to consumer.
+
+#### Scenario: Matching publish/consume across workspaces
+- **WHEN** workspace A has an integration edge with `metadata.topic = "trade.created"`
+- **AND** workspace B has a consumer entry node `CONSUME trade.created`
+- **THEN** `Stitch()` produces a `FlowEdge{Kind: "cross_service", CrossServiceWorkspace: <B-hash>}` from the publisher node to the consumer node
+
+#### Scenario: Self-match is excluded
+- **WHEN** both publisher and consumer are in the same workspace
+- **THEN** no `cross_service` edge is produced
+
+#### Scenario: Noise topics are skipped
+- **WHEN** a publish edge has `metadata.topic = "<var:event_topic>"`
+- **THEN** no `cross_service` edge is produced for that edge
+
+#### Scenario: No matching consumer
+- **WHEN** a publish edge has no matching consumer in any target workspace
+- **THEN** no `cross_service` edge is produced
+
+### Implementation details
+
+- **Signature:** `Stitch(ctx, publishEdges []graph.Edge, targetWorkspaces []string, querier StitchQuerier) []FlowEdge`
+- **Location:** `internal/flow/stitch.go` (88 lines)
+- **Trigger:** Request-driven via `stitch_workspaces` field in request body (NOT config-gated)
+- **Matching:** Exact string match on topic name (case-sensitive, no toggle)
+- **Topic source:** `Metadata["topic"]` for publishers; `CONSUME `/`ON ` prefix parsing from source node for consumers
+- **Noise filter:** Skips topics starting with `<var:`
+- **Workspace hash:** Truncated to first 8 characters in `CrossServiceWorkspace`
+- **DB query:** `ListConsumerEntryNodesByWorkspace` in `storage/queries/graph.sql`
+
+### Wiring
+
+- **REST:** `POST /api/v1/graph/flow` — `stitch_workspaces` field in request body triggers stitching (`handlers/flow.go:114-118`)
+- **MCP:** `memory_flow` — `stitch_workspaces` argument triggers stitching (`mcp/tools.go:2073-2077`)
+- **Mermaid:** `cross_service` edges rendered with distinct styling (`mermaid.go:132-133`)
+- **Sequence:** `cross_service` edges rendered in sequence diagrams (`sequence.go:156-160`)
+
+### Tests
+
+- `TestStitchMatchesStringLiteralTopics` — matching topics across workspaces
+- `TestStitchSkipsVarPlaceholders` — `<var:` noise filtering
+- `TestStitchEmptyOnNoMatch` — no match produces empty result
+- `TestStitchEmptyEdgesOrWorkspaces` — nil/empty inputs produce nil
+- `TestStitchCrossServiceWorkspaceHashes` — workspace hash truncated to 8 chars
+
+### Known limitations (not in scope for this change)
+
+- No case-sensitivity toggle (always exact match)
+- No fuzzy/regex topic matching
+- No `isNoiseIntegration()` check (only `<var:` prefix check)
+- No config flag to enable/disable stitching (request-driven only)
+- `Metadata["event"]` is NOT read (only `Metadata["topic"]`)

--- a/openspec/changes/execution-flow-phase2/tasks.md
+++ b/openspec/changes/execution-flow-phase2/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: Execution Flow Visualization — Phase 2
+
+Ordered for incremental, independently-verifiable delivery. Each numbered group should build (`CGO_ENABLED=0 go build ./...`) and pass `go test -race -short ./...` before moving on.
+
+## 1. CFG branch edges — if/else
+- [ ] 1.1 Verify tree-sitter-javascript node type names for `if_statement` fields (`condition`, `consequence`, `alternative`) — confirm they match current `buildIf` implementation.
+- [ ] 1.2 In `buildIf`: add `Branch: "yes"` edge from decision node to first node of then-block.
+- [ ] 1.3 In `buildIf`: add `Branch: "no"` edge from decision node to first node of else-block (or merge node if no else).
+- [ ] 1.4 Add/update tests: if-with-else, if-without-else, if-elseif-else (chained decisions), nested if.
+- [ ] 1.5 Verify existing `js_cflow_test.go` tests still pass (no regression).
+
+## 2. CFG branch edges — switch/case
+- [ ] 2.1 Verify tree-sitter-javascript node type names for `switch_statement` children — confirm actual grammar types (AGENTS.md warns they may be `switch_case`/`switch_default` instead of `"case"`/`"default"`).
+- [ ] 2.2 Fix node type matching in `buildSwitch` (update switch statement at lines 415-434).
+- [ ] 2.3 In `buildSwitch`: add `Branch: "case:<value>"` edge from decision node to each case body's first node.
+- [ ] 2.4 In `buildSwitch`: add `Branch: "default"` edge for default case (or implicit default if absent).
+- [ ] 2.5 Add/update tests: switch with cases, switch with default, switch without default, switch with fallthrough (break missing).
+
+## 3. CFG branch edges — ternary and try/catch
+- [ ] 3.1 In ternary handling (lines 614-624): add `Branch: "yes"` / `Branch: "no"` edges from decision to true/false branches.
+- [ ] 3.2 In `buildTry` (lines 560-569): add `Branch: "try"` edge to try body, `Branch: "catch"` edge to catch body.
+- [ ] 3.3 Add tests: ternary expression, try/catch, try/catch/finally.
+
+## 4. CFG branch edges — verification
+- [ ] 4.1 Run `go test -race -short ./internal/graph/...` — all tests pass.
+- [ ] 4.2 Run full `go test -race -short ./...` — no regressions.
+- [ ] 4.3 Update any Mermaid golden-file tests if branch edges change output.
+
+## 5. Verification & docs
+- [ ] 5.1 Full build and test suite green.
+- [ ] 5.2 Dogfood: re-extract zengamingx CFGs, verify branch edges appear.
+- [ ] 5.3 Update AGENTS.md docs for `internal/graph` (Known limitations section).

--- a/openspec/changes/reindex-cfg-respect-nano-brainignore/.openspec.yaml
+++ b/openspec/changes/reindex-cfg-respect-nano-brainignore/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/reindex-cfg-respect-nano-brainignore/design.md
+++ b/openspec/changes/reindex-cfg-respect-nano-brainignore/design.md
@@ -1,0 +1,80 @@
+## Context
+
+`/api/v1/reindex-cfg` walks the workspace filesystem to extract CFGs. Currently it has duplicated ignore logic (`defaultExcludeDirs`, `defaultExcludeFiles`, `gitignoreStack`) that doesn't include workspace-specific rules from `.nano-brainignore`.
+
+The watcher already has correct ignore handling in `internal/watcher/filter.go` via `fileFilter` and `gitignoreStack`. This design reuses that logic instead of duplicating it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `/api/v1/reindex-cfg` respects workspace `.nano-brainignore` and `.gitignore` files
+- Remove duplicate ignore logic from `reindex_cfg.go`
+- Align behavior between watcher and `reindex-cfg`
+- Watcher loads nested `.nano-brainignore` per subdirectory during walk (currently only loads nested `.gitignore`)
+- `incrementalExtract` skips now-ignored files
+
+**Non-Goals:**
+- `walkCollectionFiles` ignore support (reindex.go) — deferred
+- Extension whitelist alignment with watcher config — deferred
+
+## Decisions
+
+### D1: Export filter functionality from watcher package
+
+The watcher already has:
+- `fileFilter` struct with `shouldSkip(path, isDir)` method
+- `gitignoreStack` for nested `.gitignore` support
+- `LoadGlobalIgnore(homeDir)` for global ignores
+- `defaultExcludeDirs` / `defaultExcludeFiles`
+
+**Approach:** Export these from `internal/watcher/filter.go` so `reindex_cfg.go` can reuse them.
+
+Specifically:
+- `fileFilter` is unexported (package-local) → needs `ShouldSkip(absPath string, isDir bool)` exported method
+- `defaultExcludeDirs`, `defaultExcludeFiles`, `gitignoreStack` → export or export constructor
+- `LoadGlobalIgnore` is already exported
+
+### D2: Create `fileFilter` in handler using exported constructors
+
+In `reindex_cfg.go`:
+1. Call `watcher.LoadGlobalIgnore(homeDir)` to get global ignore
+2. Call `watcher.NewFileFilter(rootDir, nil, []string{".js",".jsx",".ts",".tsx"}, globalIgnore)` to create filter
+3. In walk: call `filter.ShouldSkip(path, d.IsDir())`
+
+### D3: Keep `gitignoreStack` for nested ignores during walk
+
+`filepath.WalkDir` walks directory tree. For each directory, push nested `.gitignore`/`.nano-brainignore` onto stack, pop when ascending.
+
+This mirrors exactly what `scanCollection` does in watcher.
+
+### D4: Fix watcher to load nested `.nano-brainignore` during walk
+
+Currently `scanCollection` (watcher.go:437-444) only loads nested `.gitignore` files per subdirectory. Nested `.nano-brainignore` files are NOT loaded — only the root-level one via `newFileFilter`.
+
+**Fix:** In `scanCollection`, after loading nested `.gitignore`, also check for `.nano-brainignore` and push it onto the stack. This aligns the watcher with reindex-cfg behavior.
+
+### D5: Add filter check to `incrementalExtract`
+
+Currently `incrementalExtract` iterates all previously-indexed code documents without checking ignore rules. If a file was indexed before `.nano-brainignore` was updated, it will still be re-extracted.
+
+**Fix:** In `incrementalExtract`, create a `FileFilter` and call `ShouldSkip` on each document path. Skip documents that match ignore rules.
+
+### D6: Fix `shouldSkip` base path bug
+
+`reindex_cfg.go` line 111: `filepath.Rel(".", path)` computes relative-to-CWD, not relative-to-`codeRoot`. When the server's CWD differs from `codeRoot`, default exclude dir checks produce incorrect results.
+
+**Fix:** Pass `codeRoot` to `ShouldSkip` (or make it a field on `FileFilter`). The watcher's `fileFilter.shouldSkip` correctly uses `filepath.Rel(f.rootDir, absPath)`.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Exporting watcher internals couples handler to watcher | Acceptable — both are internal packages, co-deploy |
+| Global ignore file path resolution | Pass `os.UserHomeDir()` at handler init time |
+| Large workspaces walk slowly | Progress logging already added; per-file skip is O(1) map lookup |
+| Watcher change affects live indexing behavior | Nested `.nano-brainignore` support is additive — files that were indexed before stay indexed |
+| incrementalExtract skips now-ignored files | Valid behavioral change — previously-indexed files that are now ignored should be skipped |
+
+## Open Questions
+
+- None remaining — all resolved by user.

--- a/openspec/changes/reindex-cfg-respect-nano-brainignore/proposal.md
+++ b/openspec/changes/reindex-cfg-respect-nano-brainignore/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `/api/v1/reindex-cfg` endpoint walks the workspace filesystem to re-extract CFGs for all JS/TS files. However, it doesn't respect the workspace's `.nano-brainignore` file — it only uses hardcoded `defaultExcludeDirs`. This causes it to waste time walking irrelevant directories like `docker-data`, `data`, vendor directories, and other project-specific ignores that are already configured in `.nano-brainignore`.
+
+## What Changes
+
+- `/api/v1/reindex-cfg` will load and respect the workspace's `.nano-brainignore` file (matching how the watcher processes ignores)
+- Remove hardcoded `defaultExcludeDirs` duplication — reuse existing `fileFilter` logic from `internal/watcher/filter.go`
+- Walking progress logs will correctly show paths being skipped due to ignore rules
+- **Watcher fix**: `scanCollection` will load nested `.nano-brainignore` per subdirectory during walk (currently only loads nested `.gitignore`)
+- **incrementalExtract fix**: add filter check to skip now-ignored files during incremental reindex
+- **Bug fix**: `shouldSkip` uses `filepath.Rel(".", path)` (relative to CWD) instead of `filepath.Rel(codeRoot, path)` — incorrect when CWD ≠ codeRoot
+
+## Capabilities
+
+### New Capabilities
+
+- `reindex-cfg-ignores`: The `reindex-cfg` endpoint loads the workspace's `.nano-brainignore` at the collection root and applies it during filesystem walk, skipping ignored paths and directories just like the watcher does.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- `internal/server/handlers/reindex_cfg.go` — use `fileFilter` from watcher instead of local ignore logic
+- `internal/watcher/filter.go` — may need to export `NewFileFilter` or `LoadGlobalIgnore` for use by handler
+- `openspec/changes/reindex-cfg-respect-nano-brainignore/specs/reindex-cfg-ignores/spec.md` — new spec for ignore behavior

--- a/openspec/changes/reindex-cfg-respect-nano-brainignore/specs/reindex-cfg-ignores/spec.md
+++ b/openspec/changes/reindex-cfg-respect-nano-brainignore/specs/reindex-cfg-ignores/spec.md
@@ -1,0 +1,54 @@
+# reindex-cfg-ignores Delta — Reuse watcher filter in reindex-cfg handler
+
+## ADDED Requirements
+
+### Requirement: Reuse watcher filter package
+
+The `POST /api/v1/reindex-cfg` handler SHALL reuse the watcher filter package (`github.com/nano-brain/nano-brain/internal/watcher`) for all ignore logic instead of implementing its own.
+
+#### Scenario: Ignored directories are skipped during full reindex
+- **GIVEN** workspace has `.nano-brainignore` containing `**/docker-data/**`
+- **WHEN** `POST /api/v1/reindex-cfg` with `full: true` is called
+- **THEN** no files under `docker-data/` are CFG-extracted
+- **AND** the response `files_processed` count excludes files in `docker-data/`
+
+#### Scenario: Global ignore is respected
+- **GIVEN** `~/.nano-brain/.nano-brainignore` contains `**/vendor/**`
+- **WHEN** `POST /api/v1/reindex-cfg` with `full: true` is called on a workspace with `vendor/` directory
+- **THEN** no files under `vendor/` are CFG-extracted
+
+### Requirement: Watcher loads nested `.nano-brainignore` during walk
+
+The watcher's `scanCollection` SHALL load nested `.nano-brainignore` files per subdirectory during walk, the same way it loads nested `.gitignore` files.
+
+#### Scenario: Nested .nano-brainignore in subdirectory
+- **GIVEN** `workspace/lib/.nano-brainignore` exists with `*.snap`
+- **WHEN** the watcher walks `workspace/lib/`
+- **THEN** files matching `*.snap` are skipped during indexing
+
+### Requirement: incrementalExtract respects ignore rules
+
+The `incrementalExtract` function SHALL check each document against the ignore filter before processing. Documents matching ignore rules SHALL be skipped.
+
+#### Scenario: Previously-indexed file is now ignored
+- **GIVEN** `workspace/tmp/file.js` was indexed before `.nano-brainignore` added `**/tmp/**`
+- **WHEN** `incrementalExtract` runs
+- **THEN** `workspace/tmp/file.js` is skipped (not re-extracted)
+
+### Requirement: ShouldSkip uses correct base path
+
+The `ShouldSkip` method SHALL compute relative paths from the filter's `rootDir`, not from the current working directory.
+
+#### Scenario: Server CWD differs from codeRoot
+- **GIVEN** server CWD is `/home/user` and codeRoot is `/workspace/project`
+- **WHEN** `ShouldSkip("/workspace/project/node_modules/pkg/index.js", false)` is called
+- **THEN** the path is correctly identified as under `node_modules/` and skipped
+
+### Requirement: Progress logging shows ignored paths
+
+During the walk, the progress log SHALL include a count of paths skipped due to ignore rules.
+
+#### Scenario: Progress log includes skip count
+- **GIVEN** a large workspace is being walked
+- **WHEN** 10 seconds elapse between file processing
+- **THEN** the log line includes `files_processed`, `cfgs_extracted`, and `skipped` counts

--- a/openspec/changes/reindex-cfg-respect-nano-brainignore/tasks.md
+++ b/openspec/changes/reindex-cfg-respect-nano-brainignore/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: reindex-cfg-ignores
+
+## 1. Export watcher filter for reuse
+
+- [ ] 1.1 Export `fileFilter` struct by renaming to `FileFilter` (capital F)
+- [ ] 1.2 Export `newFileFilter` by renaming to `NewFileFilter` (constructor)
+- [ ] 1.3 Export `gitignoreStack` struct and its methods
+- [ ] 1.4 Keep `defaultExcludeDirs` and `defaultExcludeFiles` unexported — `FileFilter` encapsulates them
+
+## 2. Fix watcher to load nested `.nano-brainignore` during walk
+
+Note: `fullWalkAndExtract` in `reindex_cfg.go` already loads nested `.nano-brainignore` (lines 249-254). This task aligns the **watcher's** `scanCollection` to match that behavior.
+
+- [ ] 2.1 In `scanCollection` (watcher.go:437-444), after loading nested `.gitignore`, also check for `.nano-brainignore` and push onto stack
+- [ ] 2.2 Add test: nested `.nano-brainignore` in subdirectory is respected during watcher walk
+
+## 3. Update reindex_cfg.go to use watcher filter
+
+- [ ] 3.1 Import `github.com/nano-brain/nano-brain/internal/watcher` package
+- [ ] 3.2 Remove local `defaultExcludeDirs`, `defaultExcludeFiles`, `gitignoreStack`, `shouldSkip` definitions (~90 lines)
+- [ ] 3.3 In `fullWalkAndExtract`, call `watcher.LoadGlobalIgnore(homeDir)` to get global ignore
+- [ ] 3.4 Call `watcher.NewFileFilter(codeRoot, nil, nil, globalIgnore)` to create filter (no allowedExtensions — keep jsTSExts in walk body)
+- [ ] 3.5 Use `filter.ShouldSkip(path, d.IsDir())` instead of local `shouldSkip`
+- [ ] 3.6 Use exported `gitignoreStack` for nested `.gitignore`/`.nano-brainignore` during walk
+- [ ] 3.7 Fix `filepath.Rel(".", path)` → `filepath.Rel(codeRoot, path)` bug in `ShouldSkip`
+
+## 4. Add filter check to incrementalExtract
+
+- [ ] 4.1 In `incrementalExtract`, create `FileFilter` using `watcher.NewFileFilter`
+- [ ] 4.2 Before processing each document, call `filter.ShouldSkip(doc.SourcePath, false)` — skip if true
+- [ ] 4.3 Log skipped documents at DEBUG level
+- [ ] 4.4 Add test: now-ignored file in DB is skipped during incremental reindex
+
+## 5. Update progress logging
+
+- [ ] 5.1 In `fullWalkAndExtract`, add `skipped` counter for paths skipped by ignore rules
+- [ ] 5.2 Update 10-second progress log to include `skipped` count alongside `files_processed` and `cfgs_extracted`
+
+## 6. Verify and test
+
+- [ ] 6.1 Build: `go build ./...`
+- [ ] 6.2 Test: `go test -race -short ./internal/server/handlers/...`
+- [ ] 6.3 Test: `go test -race -short ./internal/watcher/...`
+- [ ] 6.4 Manual test: run full reindex on zengamingx, verify `docker-data` and other ignored dirs are skipped
+- [ ] 6.5 Manual test: run incremental reindex, verify now-ignored files are skipped


### PR DESCRIPTION
## Summary

Fix `/api/v1/reindex-cfg` to respect workspace `.nano-brainignore` by reusing the watcher's filter package instead of duplicating ignore logic. Also fixes watcher to load nested `.nano-brainignore` per subdirectory during walk.

## Changes

### `internal/watcher/filter.go`
- Export `FileFilter`, `NewFileFilter`, `ShouldSkip`, `GitignoreStack`, `GitignoreEntry`
- `ShouldSkip` uses `filepath.Rel(f.rootDir, absPath)` — fixes base path bug

### `internal/watcher/watcher.go`
- `scanCollection` now loads nested `.nano-brainignore` per subdirectory (same as `.gitignore`)
- Updated all references to exported types

### `internal/server/handlers/reindex_cfg.go`
- Removed ~90 lines of duplicated ignore logic (`defaultExcludeDirs`, `defaultExcludeFiles`, `gitignoreStack`, `shouldSkip`)
- Uses `watcher.NewFileFilter` and `filter.ShouldSkip` instead
- `incrementalExtract` now skips documents matching ignore rules
- Progress logging includes `skipped` count

### `internal/watcher/filter_test.go`
- Updated to use exported type names

## Verification

```
go build ./...                    ✅
go test -race -short ./...        ✅
```

## Impact

- **Bug fix**: `shouldSkip` used `filepath.Rel(".", path)` (relative to CWD) instead of `filepath.Rel(codeRoot, path)` — incorrect when CWD ≠ codeRoot
- **Feature**: `reindex-cfg` now respects `.nano-brainignore` and `.gitignore` files
- **Feature**: Watcher now loads nested `.nano-brainignore` during walk (multi-repo support)
- **Feature**: `incrementalExtract` skips now-ignored files
- **No breaking changes**: All changes are additive

## OpenSpec

Proposal at `openspec/changes/reindex-cfg-respect-nano-brainignore/`
