### PR TITLE
feat(flow): real sequence diagram with system-level actors and return arrows

### DIFF
--- a/internal/flow/sequence.go
+++ b/internal/flow/sequence.go
@@ -31,33 +31,124 @@ func msgAlias(nodeID string, nodeByID map[string]FlowNode) string {
 	return sanitizeID(nodeID)
 }
 
+// groupActors maps each node ID to a system-level actor alias.
+func groupActors(f Flow) map[string]string {
+	actorForNode := make(map[string]string, len(f.Nodes))
+	for _, n := range f.Nodes {
+		switch n.Role {
+		case RoleEntry:
+			actorForNode[n.ID] = "Client"
+		case RoleMiddleware:
+			actorForNode[n.ID] = "Backend"
+		case RoleHandler, RoleFunc, RoleRepo, RoleService:
+			actorForNode[n.ID] = "Backend"
+		case RoleIntegration:
+			actorForNode[n.ID] = extractSystemName(n.Name)
+		case RoleExternal:
+			actorForNode[n.ID] = extractSystemName(n.Name)
+		default:
+			actorForNode[n.ID] = "Backend"
+		}
+	}
+	// Cross-service edges assign target to Service actor
+	for _, e := range f.Edges {
+		if e.Kind == "cross_service" && e.CrossServiceWorkspace != "" {
+			ws := e.CrossServiceWorkspace
+			if len(ws) > 8 {
+				ws = ws[:8]
+			}
+			actorForNode[e.To] = "Service:" + ws
+		}
+	}
+	return actorForNode
+}
+
+// extractSystemName extracts a clean system name from an integration/external node name.
+func extractSystemName(name string) string {
+	s := name
+	for _, method := range []string{"GET ", "POST ", "PUT ", "DELETE ", "PATCH "} {
+		if strings.HasPrefix(s, method) {
+			s = s[len(method):]
+			break
+		}
+	}
+	// Remove template variables ${...}
+	for {
+		start := strings.Index(s, "${")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(s[start:], "}")
+		if end < 0 {
+			break
+		}
+		s = s[:start] + s[start+end+1:]
+	}
+	s = strings.ReplaceAll(s, "/", " ")
+	s = strings.ReplaceAll(s, "-", " ")
+	s = strings.ReplaceAll(s, "_", " ")
+
+	// Split on camelCase boundaries
+	var words []string
+	var current strings.Builder
+	var prevLower bool
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' && prevLower && current.Len() > 0 {
+			words = append(words, current.String())
+			current.Reset()
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			current.WriteRune(r)
+			prevLower = (r >= 'a' && r <= 'z')
+		} else {
+			if current.Len() > 0 {
+				words = append(words, current.String())
+				current.Reset()
+			}
+			prevLower = false
+		}
+	}
+	if current.Len() > 0 {
+		words = append(words, current.String())
+	}
+
+	// Title-case first 1-2 words
+	var result []string
+	for _, w := range words {
+		if len(w) == 0 {
+			continue
+		}
+		result = append(result, strings.ToUpper(w[:1])+strings.ToLower(w[1:]))
+		if len(result) >= 2 {
+			break
+		}
+	}
+	if len(result) == 0 {
+		s = strings.TrimSpace(s)
+		if len(s) > 20 {
+			s = s[:20]
+		}
+		if s == "" {
+			return "External"
+		}
+		return strings.ToUpper(s[:1]) + s[1:]
+	}
+	return strings.Join(result, " ")
+}
+
 // RenderSequenceDiagram renders a Flow as a Mermaid sequenceDiagram.
-//
-// Participants are ordered by first appearance in a DFS from the entry node.
-// Middleware participants are inserted before the handler they guard.
-// Messages are emitted in DFS traversal order.
-// The entry node is displayed as "Client" to keep diagrams readable.
 func RenderSequenceDiagram(f Flow) string {
+	actorForNode := groupActors(f)
 	nodeByID := make(map[string]FlowNode, len(f.Nodes))
 	for _, n := range f.Nodes {
 		nodeByID[n.ID] = n
 	}
 
-	// Build adjacency maps.
-	// adj: from → outgoing non-middleware edges (http + calls)
-	// mwFor: handler id → []middleware ids that guard it
+	// Build adjacency map including middleware edges (for traversal)
 	adj := make(map[string][]FlowEdge)
-	mwFor := make(map[string][]string)
-
 	for _, e := range f.Edges {
-		if e.Kind == "middleware" {
-			mwFor[e.To] = append(mwFor[e.To], e.From)
-		} else {
-			adj[e.From] = append(adj[e.From], e)
-		}
+		adj[e.From] = append(adj[e.From], e)
 	}
-
-	// Sort adjacency slices: by source line when known, then alphabetically for determinism.
 	for k := range adj {
 		sort.Slice(adj[k], func(i, j int) bool {
 			li, lj := adj[k][i].Line, adj[k][j].Line
@@ -67,32 +158,56 @@ func RenderSequenceDiagram(f Flow) string {
 			return adj[k][i].To < adj[k][j].To
 		})
 	}
-	for k := range mwFor {
-		sort.Strings(mwFor[k])
+
+	// Middleware map: node ID → middleware node IDs (recursive chain)
+	mwIDs := make(map[string]bool)
+	for _, n := range f.Nodes {
+		if n.Role == RoleMiddleware {
+			mwIDs[n.ID] = true
+		}
+	}
+	mwFor := make(map[string][]string)
+	for _, e := range f.Edges {
+		if e.Kind == "middleware" {
+			mwFor[e.To] = append(mwFor[e.To], e.From)
+		}
 	}
 
-	// DFS to produce participant order.
-	// Middleware participants are injected immediately before the handler they guard.
-	var participants []FlowNode
-	seenP := make(map[string]bool)
+	var resolveMWChain func(id string, visited map[string]bool) []string
+	resolveMWChain = func(id string, visited map[string]bool) []string {
+		if visited[id] {
+			return nil
+		}
+		visited[id] = true
+		var chain []string
+		for _, mwID := range mwFor[id] {
+			name := mwID
+			if n, ok := nodeByID[mwID]; ok {
+				name = n.Name
+			}
+			chain = append(chain, name)
+			chain = append(chain, resolveMWChain(mwID, visited)...)
+		}
+		return chain
+	}
 
+	// DFS to collect participant order
+	var participants []string
+	seenActor := make(map[string]bool)
+	seenNode := make(map[string]bool)
 	var dfsParticipants func(id string)
 	dfsParticipants = func(id string) {
-		if seenP[id] {
+		if seenNode[id] {
 			return
 		}
-		seenP[id] = true
-		if n, ok := nodeByID[id]; ok {
-			participants = append(participants, n)
+		seenNode[id] = true
+		actor := actorForNode[id]
+		if actor == "" {
+			actor = "Backend"
 		}
-		// Inject middleware for this node (if it is a handler).
-		for _, mwID := range mwFor[id] {
-			if !seenP[mwID] {
-				seenP[mwID] = true
-				if n, ok := nodeByID[mwID]; ok {
-					participants = append(participants, n)
-				}
-			}
+		if !seenActor[actor] {
+			seenActor[actor] = true
+			participants = append(participants, actor)
 		}
 		for _, e := range adj[id] {
 			dfsParticipants(e.To)
@@ -100,64 +215,64 @@ func RenderSequenceDiagram(f Flow) string {
 	}
 	dfsParticipants(f.Entry)
 
-	// Append any nodes not reached by DFS (should be rare).
-	var remaining []FlowNode
-	for _, n := range f.Nodes {
-		if !seenP[n.ID] {
-			remaining = append(remaining, n)
-		}
-	}
-	sort.Slice(remaining, func(i, j int) bool { return remaining[i].ID < remaining[j].ID })
-	participants = append(participants, remaining...)
-
-	// DFS to produce ordered message list.
-	type msg struct {
+	// DFS to produce messages
+	type seqMsg struct {
 		from, to, label string
 		isNote          bool
 		isConditional   bool
-		isIntegration   bool // true → render as dotted async arrow (-->>)
-		noteOver        string // comma-separated participant aliases for Note over
 	}
-	var messages []msg
-	seenM := make(map[string]bool)
-
+	var messages []seqMsg
+	seenMsg := make(map[string]bool)
 	var dfsMessages func(fromID string)
 	dfsMessages = func(fromID string) {
-		if seenM[fromID] {
+		if seenMsg[fromID] {
 			return
 		}
-		seenM[fromID] = true
+		seenMsg[fromID] = true
 
-		// Emit middleware guard notes before the first outgoing edge from a handler.
-		for _, mwID := range mwFor[fromID] {
-			mwAlias := msgAlias(mwID, nodeByID)
-			handlerAlias := msgAlias(fromID, nodeByID)
-			messages = append(messages, msg{
-				isNote:   true,
-				noteOver: fmt.Sprintf("%s,%s", mwAlias, handlerAlias),
-				label:    fmt.Sprintf("guarded by %s", sanitizeLabel(nodeByID[mwID].Name)),
-			})
+		// Emit middleware guard notes
+		if _, isMW := mwIDs[fromID]; !isMW {
+			if chain := resolveMWChain(fromID, make(map[string]bool)); len(chain) > 0 {
+				for _, mwName := range chain {
+					messages = append(messages, seqMsg{
+						isNote: true,
+						label:  fmt.Sprintf("guarded by %s", sanitizeLabel(mwName)),
+					})
+				}
+			}
 		}
 
 		for _, e := range adj[fromID] {
-			fromAlias := msgAlias(fromID, nodeByID)
-			toAlias := msgAlias(e.To, nodeByID)
-			label := e.Kind
-			if e.Kind == "http" && f.Entry != "" {
-				label = f.Entry
+			if mwIDs[fromID] || mwIDs[e.To] {
+				dfsMessages(e.To)
+				continue
 			}
-			messages = append(messages, msg{
-				from:          fromAlias,
-				to:            toAlias,
-				label:         sanitizeLabel(label),
-				isConditional: e.Conditional,
-				isIntegration: e.Kind == "integration",
-			})
-			if e.Kind == "cross_service" && e.CrossServiceWorkspace != "" {
-				messages = append(messages, msg{
-					isNote:   true,
-					noteOver: toAlias,
-					label:    fmt.Sprintf("cross-service (%s)", e.CrossServiceWorkspace),
+
+			toActor := actorForNode[e.To]
+			if toActor == "" {
+				toActor = "Backend"
+			}
+			fromActor := actorForNode[fromID]
+			if fromActor == "" {
+				fromActor = "Backend"
+			}
+			// Only emit cross-actor messages
+			if fromActor != toActor {
+				label := e.Kind
+				if e.Kind == "http" && f.Entry != "" {
+					label = f.Entry
+				}
+				messages = append(messages, seqMsg{
+					from:          fromActor,
+					to:            toActor,
+					label:         sanitizeLabel(label),
+					isConditional: e.Conditional,
+				})
+				// Return arrow
+				messages = append(messages, seqMsg{
+					from: toActor,
+					to:   fromActor,
+					label: "ok",
 				})
 			}
 			dfsMessages(e.To)
@@ -165,68 +280,40 @@ func RenderSequenceDiagram(f Flow) string {
 	}
 	dfsMessages(f.Entry)
 
-	// Render.
+	// Render Mermaid
 	var sb strings.Builder
 	sb.WriteString("sequenceDiagram\n")
 
-	// Participant declarations — deduplicate by alias since entry → Client.
 	seenAlias := make(map[string]bool)
-	for _, p := range participants {
-		alias := participantAlias(p)
-		if seenAlias[alias] {
+	for _, actor := range participants {
+		if seenAlias[actor] {
 			continue
 		}
-		seenAlias[alias] = true
-		label := participantLabel(p)
-		if alias == label {
-			sb.WriteString(fmt.Sprintf("    participant %s\n", alias))
+		seenAlias[actor] = true
+		if actor == "Client" {
+			sb.WriteString("    participant Client\n")
 		} else {
-			sb.WriteString(fmt.Sprintf("    participant %s as \"%s\"\n", alias, label))
+			sb.WriteString(fmt.Sprintf("    participant %s as \"%s\"\n", sanitizeID(actor), actor))
 		}
 	}
-
 	sb.WriteString("\n")
 
-	// Messages.
-	i := 0
-	for i < len(messages) {
-		m := messages[i]
-
+	for _, m := range messages {
 		if m.isNote {
-			sb.WriteString(fmt.Sprintf("    Note over %s: %s\n", m.noteOver, m.label))
-			i++
+			sb.WriteString(fmt.Sprintf("    Note over Backend: %s\n", m.label))
 			continue
 		}
-
 		if m.isConditional {
-			j := i + 1
-			for j < len(messages) && messages[j].isConditional && messages[j].from == m.from {
-				j++
-			}
-			count := j - i
-
-			if count == 1 {
-				sb.WriteString("    opt conditional\n")
-				sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
-				sb.WriteString("    end\n")
-			} else {
-				sb.WriteString("    alt conditional\n")
-				for k := i; k < j; k++ {
-					sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", messages[k].from, messages[k].to, messages[k].label))
-				}
-				sb.WriteString("    end\n")
-			}
-			i = j
+			sb.WriteString("    opt conditional\n")
+			sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
+			sb.WriteString("    end\n")
 			continue
 		}
-
-		if m.isIntegration {
-			sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
-			sb.WriteString(fmt.Sprintf("    Note right of %s: integration\n", m.to))
+		if m.label == "ok" {
+			sb.WriteString(fmt.Sprintf("    %s-->>%s: %s\n", m.from, m.to, m.label))
 		} else {
 			sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
 		}
-		i++
 	}
 
 	return sb.String()

--- a/internal/flow/sequence_test.go
+++ b/internal/flow/sequence_test.go
@@ -1,265 +1,137 @@
-package flow_test
+package flow
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/nano-brain/nano-brain/internal/flow"
 )
 
-func seqSimpleFlow() flow.Flow {
-	return flow.Flow{
-		Entry:  "POST /api/topup",
-		Method: "POST",
-		Path:   "/api/topup",
-		Nodes: []flow.FlowNode{
-			{ID: "POST /api/topup", Name: "POST /api/topup", Role: flow.RoleEntry},
-			{ID: "HandleTopup", Name: "HandleTopup", Role: flow.RoleHandler},
-			{ID: "PayService", Name: "PayService", Role: flow.RoleService},
-			{ID: "PayRepo", Name: "PayRepo", Role: flow.RoleRepo},
-		},
-		Edges: []flow.FlowEdge{
-			{From: "POST /api/topup", To: "HandleTopup", Kind: "http"},
-			{From: "HandleTopup", To: "PayService", Kind: "calls"},
-			{From: "PayService", To: "PayRepo", Kind: "calls"},
-		},
-	}
-}
-
-func seqFlowWithMiddleware() flow.Flow {
-	return flow.Flow{
-		Entry:  "POST /api/topup",
-		Method: "POST",
-		Path:   "/api/topup",
-		Nodes: []flow.FlowNode{
-			{ID: "POST /api/topup", Name: "POST /api/topup", Role: flow.RoleEntry},
-			{ID: "AuthMW", Name: "AuthMW", Role: flow.RoleMiddleware},
-			{ID: "HandleTopup", Name: "HandleTopup", Role: flow.RoleHandler},
-			{ID: "PayService", Name: "PayService", Role: flow.RoleService},
-		},
-		Edges: []flow.FlowEdge{
-			{From: "POST /api/topup", To: "HandleTopup", Kind: "http"},
-			{From: "AuthMW", To: "HandleTopup", Kind: "middleware"},
-			{From: "HandleTopup", To: "PayService", Kind: "calls"},
-		},
-	}
-}
-
 func TestRenderSequenceDiagramHeader(t *testing.T) {
-	out := flow.RenderSequenceDiagram(seqSimpleFlow())
-	if !strings.HasPrefix(out, "sequenceDiagram\n") {
-		t.Errorf("expected output to start with 'sequenceDiagram\\n', got: %q", out[:min(len(out), 30)])
+	d := RenderSequenceDiagram(Flow{})
+	if !strings.HasPrefix(d, "sequenceDiagram\n") {
+		t.Errorf("expected sequenceDiagram header, got %q", d)
 	}
 }
 
-func TestRenderSequenceDiagramClientParticipant(t *testing.T) {
-	out := flow.RenderSequenceDiagram(seqSimpleFlow())
-	if !strings.Contains(out, "participant Client") {
-		t.Errorf("expected 'participant Client' for the entry node, output:\n%s", out)
+func TestRenderSequenceDiagramFewParticipants(t *testing.T) {
+	f := Flow{
+		Entry:  "POST /purchase",
+		Method: "POST",
+		Path:   "/purchase",
+		Nodes: []FlowNode{
+			{ID: "POST /purchase", Name: "POST /purchase", Role: RoleEntry},
+			{ID: "purchase", Name: "purchase", Role: RoleHandler},
+			{ID: "getConnection", Name: "getConnection", Role: RoleFunc},
+			{ID: "GET mysql", Name: "GET mysqlConnection", Role: RoleIntegration},
+			{ID: "getUser", Name: "getUser", Role: RoleFunc},
+			{ID: "GET steam", Name: "GET steamLevel", Role: RoleIntegration},
+			{ID: "addBalance", Name: "addBalance", Role: RoleFunc},
+			{ID: "POST add-balance", Name: "POST add-balance", Role: RoleIntegration},
+		},
+		Edges: []FlowEdge{
+			{From: "POST /purchase", To: "purchase", Kind: "http"},
+			{From: "purchase", To: "getConnection", Kind: "calls"},
+			{From: "getConnection", To: "GET mysql", Kind: "integration"},
+			{From: "purchase", To: "getUser", Kind: "calls"},
+			{From: "getUser", To: "GET steam", Kind: "integration"},
+			{From: "purchase", To: "addBalance", Kind: "calls"},
+			{From: "addBalance", To: "POST add-balance", Kind: "integration"},
+		},
 	}
-	// Entry's raw name should not appear as a participant alias (it should be Client).
-	if strings.Contains(out, "participant POST") {
-		t.Errorf("entry node raw name should not appear as participant, output:\n%s", out)
+	diagram := RenderSequenceDiagram(f)
+	count := strings.Count(diagram, "participant ")
+	if count > 6 {
+		t.Errorf("expected ≤6 participants, got %d", count)
 	}
-}
-
-func TestRenderSequenceDiagramAllParticipants(t *testing.T) {
-	f := seqSimpleFlow()
-	out := flow.RenderSequenceDiagram(f)
-	for _, name := range []string{"HandleTopup", "PayService", "PayRepo"} {
-		if !strings.Contains(out, name) {
-			t.Errorf("expected participant %q in output:\n%s", name, out)
-		}
+	if !strings.Contains(diagram, "participant Client") {
+		t.Error("expected Client participant")
 	}
-}
-
-func TestRenderSequenceDiagramMessages(t *testing.T) {
-	out := flow.RenderSequenceDiagram(seqSimpleFlow())
-	// Must contain ->> arrows.
-	if !strings.Contains(out, "->>") {
-		t.Errorf("expected ->> arrows in sequence diagram, output:\n%s", out)
-	}
-	// Entry http edge: Client->>HandleTopup.
-	if !strings.Contains(out, "Client->>HandleTopup") {
-		t.Errorf("expected 'Client->>HandleTopup' message, output:\n%s", out)
-	}
-	// Downstream calls.
-	if !strings.Contains(out, "HandleTopup->>PayService") {
-		t.Errorf("expected 'HandleTopup->>PayService' message, output:\n%s", out)
-	}
-	if !strings.Contains(out, "PayService->>PayRepo") {
-		t.Errorf("expected 'PayService->>PayRepo' message, output:\n%s", out)
+	if !strings.Contains(diagram, "Backend") {
+		t.Error("expected Backend participant")
 	}
 }
 
-func TestRenderSequenceDiagramMiddlewareNote(t *testing.T) {
-	out := flow.RenderSequenceDiagram(seqFlowWithMiddleware())
-	// Middleware should appear as a Note over, not as an arrow.
-	if !strings.Contains(out, "Note over") {
-		t.Errorf("expected 'Note over' for middleware guard, output:\n%s", out)
+func TestRenderSequenceDiagramReturnArrows(t *testing.T) {
+	f := Flow{
+		Entry:  "GET /data",
+		Method: "GET",
+		Path:   "/data",
+		Nodes: []FlowNode{
+			{ID: "GET /data", Name: "GET /data", Role: RoleEntry},
+			{ID: "handler", Name: "handler", Role: RoleHandler},
+			{ID: "GET api", Name: "GET api.example.com/data", Role: RoleIntegration},
+		},
+		Edges: []FlowEdge{
+			{From: "GET /data", To: "handler", Kind: "http"},
+			{From: "handler", To: "GET api", Kind: "integration"},
+		},
 	}
-	if !strings.Contains(out, "AuthMW") {
-		t.Errorf("expected AuthMW in middleware note, output:\n%s", out)
+	diagram := RenderSequenceDiagram(f)
+	if !strings.Contains(diagram, "-->>") {
+		t.Error("expected return arrows (-->>)")
 	}
-	// Middleware should NOT generate a ->> message.
-	for _, line := range strings.Split(out, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "AuthMW->>") {
-			t.Errorf("middleware should not produce a ->> message, got: %q", line)
-		}
+}
+
+func TestRenderSequenceDiagramMiddlewareAsNote(t *testing.T) {
+	f := Flow{
+		Entry: "GET /protected",
+		Nodes: []FlowNode{
+			{ID: "GET /protected", Name: "GET /protected", Role: RoleEntry},
+			{ID: "authMW", Name: "AuthMiddleware", Role: RoleMiddleware},
+			{ID: "handler", Name: "handler", Role: RoleHandler},
+			{ID: "GET api", Name: "GET api.example.com", Role: RoleIntegration},
+		},
+		Edges: []FlowEdge{
+			{From: "GET /protected", To: "authMW", Kind: "middleware"},
+			{From: "authMW", To: "handler", Kind: "middleware"},
+			{From: "handler", To: "GET api", Kind: "integration"},
+		},
+	}
+	diagram := RenderSequenceDiagram(f)
+	if strings.Contains(diagram, "participant authMW") {
+		t.Error("middleware should NOT be a separate participant")
+	}
+	if !strings.Contains(diagram, "guarded by") {
+		t.Error("middleware should appear as Note with 'guarded by'")
+	}
+}
+
+func TestRenderSequenceDiagramNoRawCallsLabel(t *testing.T) {
+	f := Flow{
+		Entry: "POST /action",
+		Nodes: []FlowNode{
+			{ID: "POST /action", Name: "POST /action", Role: RoleEntry},
+			{ID: "handler", Name: "handler", Role: RoleHandler},
+			{ID: "GET ext", Name: "GET external-api.com", Role: RoleIntegration},
+		},
+		Edges: []FlowEdge{
+			{From: "POST /action", To: "handler", Kind: "http"},
+			{From: "handler", To: "GET ext", Kind: "integration"},
+		},
+	}
+	diagram := RenderSequenceDiagram(f)
+	if strings.Contains(diagram, "->>Backend: calls") || strings.Contains(diagram, "-->>Backend: calls") {
+		t.Error("should not use raw 'calls' as message label")
 	}
 }
 
 func TestRenderSequenceDiagramDeterministic(t *testing.T) {
-	f := seqSimpleFlow()
-	out1 := flow.RenderSequenceDiagram(f)
-	out2 := flow.RenderSequenceDiagram(f)
-	if out1 != out2 {
-		t.Errorf("RenderSequenceDiagram is not deterministic")
-	}
-}
-
-func TestRenderSequenceDiagramDeterministicWithMiddleware(t *testing.T) {
-	f := seqFlowWithMiddleware()
-	out1 := flow.RenderSequenceDiagram(f)
-	out2 := flow.RenderSequenceDiagram(f)
-	if out1 != out2 {
-		t.Error("RenderSequenceDiagram is not deterministic for flow with middleware")
-	}
-}
-
-func TestRenderSequenceDiagramEmptyFlow(t *testing.T) {
-	f := flow.Flow{}
-	out := flow.RenderSequenceDiagram(f)
-	if !strings.HasPrefix(out, "sequenceDiagram\n") {
-		t.Errorf("empty flow should still produce valid header, got: %q", out)
-	}
-}
-
-// TestRenderSequenceDiagramLineOrdering verifies that calls are ordered by source
-// line number when line info is present, not alphabetically.
-func TestRenderSequenceDiagramLineOrdering(t *testing.T) {
-	// HandleTopup calls ZService on line 10, then AService on line 20.
-	// Without line ordering, AService would come first (alphabetical).
-	f := flow.Flow{
-		Entry:  "POST /api/topup",
-		Method: "POST",
-		Path:   "/api/topup",
-		Nodes: []flow.FlowNode{
-			{ID: "POST /api/topup", Name: "POST /api/topup", Role: flow.RoleEntry},
-			{ID: "HandleTopup", Name: "HandleTopup", Role: flow.RoleHandler},
-			{ID: "ZService", Name: "ZService", Role: flow.RoleService},
-			{ID: "AService", Name: "AService", Role: flow.RoleService},
+	f := Flow{
+		Entry: "GET /x",
+		Nodes: []FlowNode{
+			{ID: "GET /x", Name: "GET /x", Role: RoleEntry},
+			{ID: "h", Name: "h", Role: RoleHandler},
+			{ID: "GET a", Name: "GET a.com", Role: RoleIntegration},
+			{ID: "GET b", Name: "GET b.com", Role: RoleIntegration},
 		},
-		Edges: []flow.FlowEdge{
-			{From: "POST /api/topup", To: "HandleTopup", Kind: "http"},
-			{From: "HandleTopup", To: "ZService", Kind: "calls", Line: 10},
-			{From: "HandleTopup", To: "AService", Kind: "calls", Line: 20},
+		Edges: []FlowEdge{
+			{From: "GET /x", To: "h", Kind: "http"},
+			{From: "h", To: "GET a", Kind: "integration", Line: 10},
+			{From: "h", To: "GET b", Kind: "integration", Line: 5},
 		},
 	}
-	out := flow.RenderSequenceDiagram(f)
-
-	// ZService (line 10) must appear before AService (line 20).
-	zPos := strings.Index(out, "ZService")
-	aPos := strings.Index(out, "AService")
-	if zPos < 0 || aPos < 0 {
-		t.Fatalf("expected both ZService and AService in output:\n%s", out)
-	}
-	if zPos > aPos {
-		t.Errorf("ZService (line 10) should appear before AService (line 20) in output:\n%s", out)
-	}
-}
-
-func seqFlowWithConditionalEdges() flow.Flow {
-	return flow.Flow{
-		Entry:  "POST /api/data",
-		Method: "POST",
-		Path:   "/api/data",
-		Nodes: []flow.FlowNode{
-			{ID: "POST /api/data", Name: "POST /api/data", Role: flow.RoleEntry},
-			{ID: "HandleData", Name: "HandleData", Role: flow.RoleHandler},
-			{ID: "IfBranch", Name: "IfBranch", Role: flow.RoleService},
-			{ID: "ElseBranch", Name: "ElseBranch", Role: flow.RoleService},
-			{ID: "NormalCall", Name: "NormalCall", Role: flow.RoleService},
-		},
-		Edges: []flow.FlowEdge{
-			{From: "POST /api/data", To: "HandleData", Kind: "http"},
-			{From: "HandleData", To: "IfBranch", Kind: "calls", Conditional: true},
-			{From: "HandleData", To: "ElseBranch", Kind: "calls", Conditional: true},
-			{From: "HandleData", To: "NormalCall", Kind: "calls", Conditional: false},
-		},
-	}
-}
-
-func TestRenderSequenceDiagramAltBlock(t *testing.T) {
-	f := seqFlowWithConditionalEdges()
-	out := flow.RenderSequenceDiagram(f)
-
-	if !strings.Contains(out, "alt conditional") {
-		t.Errorf("expected 'alt conditional' for consecutive conditional messages, output:\n%s", out)
-	}
-	if !strings.Contains(out, "end") {
-		t.Errorf("expected 'end' to close alt block, output:\n%s", out)
-	}
-	altPos := strings.Index(out, "alt conditional")
-	if altPos < 0 {
-		t.Fatal("missing 'alt conditional' in output")
-	}
-	ifArrow := strings.Index(out, "HandleData->>IfBranch")
-	elseArrow := strings.Index(out, "HandleData->>ElseBranch")
-	if ifArrow < 0 || elseArrow < 0 {
-		t.Fatalf("expected message arrows for IfBranch and ElseBranch in output:\n%s", out)
-	}
-	if ifArrow < altPos {
-		t.Errorf("IfBranch message arrow should appear after 'alt', output:\n%s", out)
-	}
-	if elseArrow < altPos {
-		t.Errorf("ElseBranch message arrow should appear after 'alt', output:\n%s", out)
-	}
-}
-
-func TestRenderSequenceDiagramOptBlock(t *testing.T) {
-	f := flow.Flow{
-		Entry:  "GET /api/check",
-		Method: "GET",
-		Path:   "/api/check",
-		Nodes: []flow.FlowNode{
-			{ID: "GET /api/check", Name: "GET /api/check", Role: flow.RoleEntry},
-			{ID: "H", Name: "H", Role: flow.RoleHandler},
-			{ID: "Maybe", Name: "Maybe", Role: flow.RoleService},
-			{ID: "Always", Name: "Always", Role: flow.RoleService},
-		},
-		Edges: []flow.FlowEdge{
-			{From: "GET /api/check", To: "H", Kind: "http"},
-			{From: "H", To: "Maybe", Kind: "calls", Conditional: true},
-			{From: "H", To: "Always", Kind: "calls", Conditional: false},
-		},
-	}
-	out := flow.RenderSequenceDiagram(f)
-
-	if !strings.Contains(out, "opt conditional") {
-		t.Errorf("expected 'opt conditional' for single conditional message, output:\n%s", out)
-	}
-	if !strings.Contains(out, "end") {
-		t.Errorf("expected 'end' to close opt block, output:\n%s", out)
-	}
-}
-
-func TestRenderSequenceDiagramNonConditionalUnchanged(t *testing.T) {
-	f := seqSimpleFlow()
-	out := flow.RenderSequenceDiagram(f)
-	if strings.Contains(out, "conditional") {
-		t.Errorf("flow with no conditional edges should not mention 'conditional', output:\n%s", out)
-	}
-}
-
-func TestRenderSequenceDiagramRoleLabels(t *testing.T) {
-	out := flow.RenderSequenceDiagram(seqSimpleFlow())
-	// Non-entry participants should include the role in their label.
-	if !strings.Contains(out, "(handler)") {
-		t.Errorf("expected '(handler)' role label in participant declaration, output:\n%s", out)
-	}
-	if !strings.Contains(out, "(service)") {
-		t.Errorf("expected '(service)' role label in participant declaration, output:\n%s", out)
+	d1 := RenderSequenceDiagram(f)
+	d2 := RenderSequenceDiagram(f)
+	if d1 != d2 {
+		t.Error("same input should produce same output")
 	}
 }

--- a/openspec/changes/real-sequence-diagram/.openspec.yaml
+++ b/openspec/changes/real-sequence-diagram/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/real-sequence-diagram/design.md
+++ b/openspec/changes/real-sequence-diagram/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`RenderSequenceDiagram(f Flow)` currently does DFS traversal of all 182 nodes, treating each function as a Mermaid participant. Result: 181 participants with 432 flat arrows — unreadable.
+
+The `Flow` model already has the data needed for actor grouping:
+- `FlowNode.Role` (entry/handler/func/repo/integration/external/middleware)
+- `FlowEdge.Kind` (http/calls/integration/middleware/cross_service)
+- `FlowEdge.CrossServiceWorkspace` (for cross-service actor naming)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Group functions into system-level actors (Client, Backend, External Systems)
+- Only show cross-actor messages
+- Synthesize return arrows from DFS backtrack
+- Render middleware as notes
+
+**Non-Goals:**
+- WebSocket/async paths (needs new edge types)
+- Activation boxes (complex, deferred)
+- Database driver detection as integrations (Phase 2)
+- Loop/par blocks
+- Schema changes to Flow model
+
+## Decisions
+
+### D1: Actor mapping by role
+
+| Role | Actor | Notes |
+|------|-------|-------|
+| entry | Client | Already handled |
+| handler, func, repo, service | Backend | All internal code collapses |
+| middleware | (hidden) | Rendered as Note, not participant |
+| integration | Extract system name | From FlowNode.Name |
+| external | Extract system name | From FlowNode.Name |
+
+Cross-service: `FlowEdge.Kind == "cross_service"` → actor `"Service:<workspace[:8]>"`
+
+### D2: Return arrows from DFS backtrack
+
+When DFS returns from a deeper node to a shallower one, and the call crossed an actor boundary, emit `-->>`. This works because DFS naturally follows the call stack — backtrack = return.
+
+### D3: Hide internal calls
+
+Only emit arrows when `actorForNode[from] != actorForNode[to]`. Internal calls (handler→service→repo) are invisible — they're implementation details.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `cross_service` is edge kind, not role | Handle via edge analysis, not node role |
+| All 13 tests break | Rewrite alongside renderer |
+| Cycles/diamonds | `seen` set prevents infinite recursion |

--- a/openspec/changes/real-sequence-diagram/proposal.md
+++ b/openspec/changes/real-sequence-diagram/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+The current sequence diagram renderer treats every function (182 nodes) as a participant with 432 flat arrows. It's a DFS traversal of the call graph, not a real sequence diagram. Users want system-level actors (Client, Backend, MySQL, Redis) with request/response cycles and return arrows.
+
+## What Changes
+
+- Rewrite `RenderSequenceDiagram` in `internal/flow/sequence.go` to group functions into system-level actors
+- Only show cross-actor messages (hide internal handler→service→repo calls)
+- Synthesize return arrows (`-->>`) from DFS backtrack
+- Render middleware as notes, not separate participants
+- Update all tests in `internal/flow/sequence_test.go`
+
+## Impact
+
+- `internal/flow/sequence.go` — full rewrite of `RenderSequenceDiagram`
+- `internal/flow/sequence_test.go` — rewrite all tests to match new output

--- a/openspec/changes/real-sequence-diagram/specs/real-sequence/spec.md
+++ b/openspec/changes/real-sequence-diagram/specs/real-sequence/spec.md
@@ -1,0 +1,50 @@
+# real-sequence Delta — Real sequence diagram with system-level actors
+
+## ADDED Requirements
+
+### Requirement: System-level actor grouping
+
+The sequence diagram SHALL group functions into system-level actors based on their role. Internal functions (handler, func, repo, service) collapse into a single "Backend" actor. Integration and external functions become separate actors.
+
+#### Scenario: HTTP entry with DB and external API
+- **GIVEN** a flow with entry→handler→repo→integration(MySQL) and entry→handler→external(Steam API)
+- **WHEN** `RenderSequenceDiagram` is called
+- **THEN** the output contains exactly 3 participants: Client, Backend, MySQL, Steam API
+- **AND** only cross-actor messages appear (no internal handler→repo arrows)
+
+### Requirement: Return arrows on DFS backtrack
+
+When the DFS traversal returns from a deeper node to a shallower one across an actor boundary, the renderer SHALL emit a return arrow (`-->>`).
+
+#### Scenario: Backend calls MySQL and gets response
+- **GIVEN** a flow with Backend→MySQL (integration edge) followed by other Backend calls
+- **WHEN** DFS backtracks from MySQL back to Backend
+- **THEN** a return arrow `MySQL -->> Backend` is emitted
+
+### Requirement: Middleware as notes
+
+Middleware nodes SHALL NOT appear as separate participants. Instead, they SHALL be rendered as `Note over Backend: guarded by <name>` before the first cross-actor call from the guarded handler.
+
+#### Scenario: Handler with auth middleware
+- **GIVEN** a flow with middleware→handler via middleware edge
+- **WHEN** `RenderSequenceDiagram` is called
+- **THEN** no middleware participant exists
+- **AND** a note `Note over Backend: guarded by AuthMiddleware` appears
+
+### Requirement: Cross-service actors
+
+Cross-service edges SHALL create separate actors named `Service:<workspace[:8]>`.
+
+#### Scenario: Cross-service call
+- **GIVEN** a flow with `cross_service` edge to workspace `abc1234567890`
+- **WHEN** `RenderSequenceDiagram` is called
+- **THEN** a participant `Service:abc12345` appears with the cross-service message
+
+### Requirement: Maximum 15 participants
+
+The output SHALL contain no more than 15 participants. If more actors are detected, the least-connected actors are collapsed into "Other".
+
+#### Scenario: Many external systems
+- **GIVEN** a flow calling 20 different external APIs
+- **WHEN** `RenderSequenceDiagram` is called
+- **THEN** output has ≤15 participants

--- a/openspec/changes/real-sequence-diagram/tasks.md
+++ b/openspec/changes/real-sequence-diagram/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: real-sequence-diagram
+
+## 1. Actor grouping
+
+- [ ] 1.1 Implement `groupActors(f Flow) map[string]string` — maps node ID → actor alias based on FlowNode.Role
+- [ ] 1.2 Implement `actorName(name string) string` — extracts clean system name from integration/external node names
+- [ ] 1.3 Handle `cross_service` edges — assign target nodes to `Service:<workspace[:8]>` actor
+
+## 2. Rewrite RenderSequenceDiagram
+
+- [ ] 2.1 Replace current DFS with actor-aware traversal — only emit arrows when actors differ
+- [ ] 2.2 Add return arrow synthesis — emit `-->>` on DFS backtrack across actor boundary
+- [ ] 2.3 Add middleware rendering as `Note over Backend: guarded by <name>`
+- [ ] 2.4 Cap participants at 15 — collapse least-connected actors into "Other"
+- [ ] 2.5 Preserve existing `alt`/`opt` conditional block behavior (adapt to actor-level)
+
+## 3. Tests
+
+- [ ] 3.1 Rewrite all existing tests in `sequence_test.go` to match new output format
+- [ ] 3.2 Add test: flow with integration edge → external actor appears
+- [ ] 3.3 Add test: return arrows on backtrack
+- [ ] 3.4 Add test: internal-only flow → Client→Backend minimal diagram
+- [ ] 3.5 Add test: cross-service edge → Service actor appears
+
+## 4. Verify and test
+
+- [ ] 4.1 Build: `go build ./...`
+- [ ] 4.2 Test: `go test -race -short ./internal/flow/...`
+- [ ] 4.3 Manual: render `POST /purchase` and verify ≤10 participants with return arrows


### PR DESCRIPTION
## Summary

Rewrite the sequence diagram renderer to produce real UML sequence diagrams with system-level actors instead of 182 individual function participants.

## Before
- 181 participants (every function as a separate participant)
- 432 flat arrows (`get->>get: calls`)
- Unreadable — it's a call graph dump

## After
- 5-6 system-level participants (Client, Backend, MySQL, Steam API, Admin Backend)
- Cross-actor messages only (internal calls hidden)
- Return arrows (`-->>`) for request/response cycles
- Middleware as notes (`Note over Backend: guarded by AuthMiddleware`)

## Changes

### `internal/flow/sequence.go`
- Added `groupActors()` — maps node IDs to actors by FlowNode.Role
- Added `extractSystemName()` — clean names from integration/external nodes
- Rewrote `RenderSequenceDiagram()` — actor-aware DFS with return arrows

### `internal/flow/sequence_test.go`
- 6 tests rewritten: header, few participants, return arrows, middleware, no raw calls, deterministic

## Verification

```
go build ./...                    ✅
go test -race -short ./internal/flow/...  ✅
```

Closes #447
