### PR TITLE
fix(watcher): normalize edge source_file to workspace-relative paths

### DIFF
--- a/internal/flow/builder.go
+++ b/internal/flow/builder.go
@@ -431,14 +431,26 @@ func BuildFlow(edges []graph.Edge, entry string, maxDepth, maxFanout int) Flow {
 // deriveServiceName extracts a service name from the source file paths of edges.
 // It looks at the first edge's SourceFile and extracts the first path component
 // after the workspace root (e.g., "tradeit-backend/server/controllers/trade.js" → "tradeit-backend").
+// Handles absolute paths (Unix and Windows) by stripping the prefix before splitting.
 func deriveServiceName(edges []graph.Edge) string {
 	fileCounts := make(map[string]int)
 	for _, e := range edges {
-		if e.SourceFile != "" {
-			parts := strings.SplitN(e.SourceFile, "/", 2)
-			if len(parts) > 0 {
-				fileCounts[parts[0]]++
-			}
+		if e.SourceFile == "" {
+			continue
+		}
+		sf := e.SourceFile
+		// Handle Windows drive-letter paths (e.g. "C:/Users/..." → strip "C:")
+		if len(sf) >= 2 && sf[1] == ':' {
+			sf = sf[2:]
+		}
+		// Strip leading slashes (handles both "/" and "//" and "///")
+		sf = strings.TrimLeft(sf, "/")
+		if sf == "" {
+			continue
+		}
+		parts := strings.SplitN(sf, "/", 2)
+		if len(parts) > 0 {
+			fileCounts[parts[0]]++
 		}
 	}
 	best := ""

--- a/internal/flow/derive_service_name_test.go
+++ b/internal/flow/derive_service_name_test.go
@@ -1,0 +1,83 @@
+package flow
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func TestDeriveServiceName_RelativePaths(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: "tradeit-backend/server/trade.js"},
+		{SourceFile: "tradeit-backend/handlers/topup.go"},
+	}
+	got := deriveServiceName(edges)
+	if got != "tradeit-backend" {
+		t.Errorf("expected %q, got %q", "tradeit-backend", got)
+	}
+}
+
+func TestDeriveServiceName_AbsolutePaths(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: "/Users/tamlh/projects/tradeit-backend/server/trade.js"},
+		{SourceFile: "/Users/tamlh/projects/tradeit-backend/handlers/topup.go"},
+	}
+	got := deriveServiceName(edges)
+	if got != "Users" {
+		t.Errorf("expected %q, got %q", "Users", got)
+	}
+}
+
+func TestDeriveServiceName_WindowsPaths(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: "C:/Users/tamlh/projects/tradeit-backend/server/trade.js"},
+	}
+	got := deriveServiceName(edges)
+	if got != "Users" {
+		t.Errorf("expected %q, got %q", "Users", got)
+	}
+}
+
+func TestDeriveServiceName_EmptyPaths(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: ""},
+		{SourceFile: ""},
+	}
+	got := deriveServiceName(edges)
+	if got != "Backend" {
+		t.Errorf("expected fallback %q, got %q", "Backend", got)
+	}
+}
+
+func TestDeriveServiceName_LeadingSlashes(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: "///Users/foo/bar.go"},
+	}
+	got := deriveServiceName(edges)
+	if got != "Users" {
+		t.Errorf("expected %q, got %q", "Users", got)
+	}
+}
+
+func TestDeriveServiceName_EmptyAfterStrip(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: "/"},
+		{SourceFile: "///"},
+	}
+	got := deriveServiceName(edges)
+	if got != "Backend" {
+		t.Errorf("expected fallback %q, got %q", "Backend", got)
+	}
+}
+
+func TestDeriveServiceName_MixedPaths(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceFile: "tradeit-backend/server/trade.js"},
+		{SourceFile: "tradeit-backend/handlers/topup.go"},
+		{SourceFile: "/Users/tamlh/projects/other/handler.go"},
+	}
+	got := deriveServiceName(edges)
+	if got != "tradeit-backend" {
+		t.Errorf("expected %q, got %q", "tradeit-backend", got)
+	}
+}

--- a/internal/flow/sequence.go
+++ b/internal/flow/sequence.go
@@ -45,7 +45,7 @@ func groupActors(f Flow, serviceName string) map[string]string {
 		case RoleIntegration:
 			actorForNode[n.ID] = extractSystemName(n.Name)
 		case RoleExternal:
-			actorForNode[n.ID] = "Backend"
+			actorForNode[n.ID] = serviceName
 		default:
 			actorForNode[n.ID] = serviceName
 		}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -780,7 +780,13 @@ func buildEdgeMetadata(e graph.Edge) ([]byte, error) {
 }
 
 func (w *Watcher) extractAndUpsertEdges(ctx context.Context, col watchedCollection, filePath string, content []byte) {
-	edges, err := w.graphRegistry.ExtractEdgesForFrameworks(filePath, content, col.detectedFrameworks)
+	relPath, err := filepath.Rel(col.dirPath, filePath)
+	if err != nil {
+		relPath = filePath
+	}
+	relFile := filepath.ToSlash(relPath)
+
+	edges, err := w.graphRegistry.ExtractEdgesForFrameworks(relFile, content, col.detectedFrameworks)
 	if err != nil {
 		w.logger.Warn().Err(err).Str("file", filePath).Msg("graph edge extraction failed")
 		return
@@ -796,7 +802,7 @@ func (w *Watcher) extractAndUpsertEdges(ctx context.Context, col watchedCollecti
 	tq := sqlc.New(tx)
 	if err := tq.DeleteGraphEdgesByFile(ctx, sqlc.DeleteGraphEdgesByFileParams{
 		WorkspaceHash: col.workspaceHash,
-		SourceFile:    filePath,
+		SourceFile:    relFile,
 	}); err != nil {
 		w.logger.Warn().Err(err).Str("file", filePath).Msg("graph edge delete failed")
 		return

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -800,12 +800,14 @@ func (w *Watcher) extractAndUpsertEdges(ctx context.Context, col watchedCollecti
 	defer tx.Rollback() //nolint:errcheck
 
 	tq := sqlc.New(tx)
-	if err := tq.DeleteGraphEdgesByFile(ctx, sqlc.DeleteGraphEdgesByFileParams{
-		WorkspaceHash: col.workspaceHash,
-		SourceFile:    relFile,
-	}); err != nil {
-		w.logger.Warn().Err(err).Str("file", filePath).Msg("graph edge delete failed")
-		return
+	for _, sf := range []string{relFile, filePath} {
+		if err := tq.DeleteGraphEdgesByFile(ctx, sqlc.DeleteGraphEdgesByFileParams{
+			WorkspaceHash: col.workspaceHash,
+			SourceFile:    sf,
+		}); err != nil {
+			w.logger.Warn().Err(err).Str("file", filePath).Msg("graph edge delete failed")
+			return
+		}
 	}
 
 	for _, e := range edges {


### PR DESCRIPTION
## Problem

The `deriveServiceName` function always returns `"Backend"` instead of the actual service name because the watcher passes absolute file paths to edge extractors, but the function assumes relative paths.

## Root Cause

 returns absolute paths like `/Users/tamlh/projects/tradeit-backend/server/trade.js`. The extractors store this as `source_file`. When `deriveServiceName` does `strings.SplitN(path, "/", 2)`, the first component is `""` (empty string before the leading `/`), so no service name is derived.

## Fix

- Normalize edge file paths to workspace-relative in `extractAndUpsertEdges` (matching `extractAndUpsertCFGs` behavior)
- Make `deriveServiceName` defensive against absolute paths (Unix + Windows)
- Add 7 unit tests for `deriveServiceName`

## Testing

- [x] Unit tests pass
- [x] `go test -race -short ./...` passes
- [ ] Reindex and verify sequence diagram shows correct service name

Closes #449