### PR TITLE
feat(graph): detect Redis/cache operations in JS/TS integration extractor

### DIFF
--- a/internal/graph/js_integration_extractor.go
+++ b/internal/graph/js_integration_extractor.go
@@ -44,6 +44,84 @@ var jsHTTPMethodNames = map[string]bool{
 	"options": true,
 }
 
+// jsRedisMethods contains all Redis method names that the extractor recognizes.
+var jsRedisMethods = map[string]bool{
+	"get":       true,
+	"set":       true,
+	"setEx":     true,
+	"expire":    true,
+	"del":       true,
+	"ttl":       true,
+	"publish":   true,
+	"subscribe": true,
+	"lpush":     true,
+	"rpush":     true,
+	"sadd":      true,
+	"srem":      true,
+	"incr":      true,
+	"decr":      true,
+	"hget":      true,
+	"hset":      true,
+}
+
+// jsRedisReadMethods are Redis methods that perform read operations.
+var jsRedisReadMethods = map[string]bool{
+	"get":  true,
+	"ttl":  true,
+	"hget": true,
+}
+
+// jsRedisWriteMethods are Redis methods that perform write operations.
+var jsRedisWriteMethods = map[string]bool{
+	"set":    true,
+	"setEx":  true,
+	"expire": true,
+	"lpush":  true,
+	"rpush":  true,
+	"sadd":   true,
+	"srem":   true,
+	"incr":   true,
+	"decr":   true,
+	"hset":   true,
+}
+
+// jsRedisDeleteMethods are Redis methods that perform delete operations.
+var jsRedisDeleteMethods = map[string]bool{
+	"del": true,
+}
+
+// jsRedisPubSubMethods are Redis methods that perform pub/sub operations.
+var jsRedisPubSubMethods = map[string]bool{
+	"publish":   true,
+	"subscribe": true,
+}
+
+// jsRedisUnambiguousMethods are Redis methods that don't overlap with HTTP/queue method names.
+var jsRedisUnambiguousMethods = map[string]bool{
+	"setEx":  true,
+	"expire": true,
+	"ttl":    true,
+	"lpush":  true,
+	"rpush":  true,
+	"sadd":   true,
+	"srem":   true,
+	"incr":   true,
+	"decr":   true,
+	"hget":   true,
+	"hset":   true,
+}
+
+// jsRedisReceivers are known Redis client variable names used to disambiguate
+// methods that overlap with HTTP/queue (get, set, del, publish, subscribe).
+var jsRedisReceivers = map[string]bool{
+	"redis":       true,
+	"r":           true,
+	"client":      true,
+	"redisClient": true,
+	"cache":       true,
+	"db":          true,
+}
+
 // JSIntegrationExtractor implements graph.Extractor for JS/TS outbound
 // integration calls (HTTP, queue publish, event emit, consumer patterns).
 type JSIntegrationExtractor struct {
@@ -262,6 +340,52 @@ func (x *JSIntegrationExtractor) handleIdentifier(bt *gotreesitter.BoundTree, ca
 	}
 }
 
+// handleRedisCall emits a cache integration edge for a Redis method call.
+func (x *JSIntegrationExtractor) handleRedisCall(bt *gotreesitter.BoundTree, callNode *gotreesitter.Node, methodName, receiverName string, argsNode *gotreesitter.Node, lang *gotreesitter.Language, langLabel, relFile, source string, line int, edges *[]Edge) string {
+	key := jsStringArgOrVar(bt, argsNode, lang, 0)
+	target := "REDIS " + methodName + " " + key
+
+	var kind string
+	switch {
+	case jsRedisReadMethods[methodName]:
+		kind = "cache_read"
+	case jsRedisWriteMethods[methodName]:
+		kind = "cache_write"
+	case jsRedisDeleteMethods[methodName]:
+		kind = "cache_delete"
+	case jsRedisPubSubMethods[methodName]:
+		kind = "cache_pubsub"
+	default:
+		kind = "cache_write"
+	}
+
+	if kind == "cache_pubsub" {
+		topic := jsStringArgOrVar(bt, argsNode, lang, 0)
+		target = methodName + ":" + topic
+		*edges = append(*edges, Edge{
+			SourceNode: source,
+			TargetNode: target,
+			Kind:       EdgeIntegration,
+			SourceFile: relFile,
+			Line:       line,
+			Language:   langLabel,
+			Metadata:   map[string]any{"kind": kind, "method": methodName, "receiver": receiverName, "topic": topic},
+		})
+		return target
+	}
+
+	*edges = append(*edges, Edge{
+		SourceNode: source,
+		TargetNode: target,
+		Kind:       EdgeIntegration,
+		SourceFile: relFile,
+		Line:       line,
+		Language:   langLabel,
+		Metadata:   map[string]any{"kind": kind, "method": methodName, "receiver": receiverName, "key": key},
+	})
+	return target
+}
+
 // handleMemberExpression processes method calls like axios.get(url) or emitter.emit("topic").
 func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTree, callNode, fnNode, argsNode *gotreesitter.Node, lang *gotreesitter.Language, langLabel, relFile, source string, line int, edges *[]Edge) {
 	objectNode := fnNode.ChildByFieldName("object", lang)
@@ -272,7 +396,15 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 	methodName := bt.NodeText(propertyNode)
 	receiverName := jsReceiverText(bt, objectNode, lang)
 
-	// HTTP method shorthand: <any>.get(url) / <any>.post(url)
+	if jsRedisMethods[methodName] {
+		isUnambiguous := jsRedisUnambiguousMethods[methodName]
+		isKnownReceiver := jsRedisReceivers[receiverName]
+		if isUnambiguous || isKnownReceiver {
+			x.handleRedisCall(bt, callNode, methodName, receiverName, argsNode, lang, langLabel, relFile, source, line, edges)
+			return
+		}
+	}
+
 	if jsHTTPMethodNames[methodName] {
 		url := jsStringArgOrVar(bt, argsNode, lang, 0)
 		target := strings.ToUpper(methodName) + " " + url

--- a/internal/graph/js_integration_extractor_test.go
+++ b/internal/graph/js_integration_extractor_test.go
@@ -342,24 +342,28 @@ func TestJSIntegrationExtractor_Consumer(t *testing.T) {
 		src        string
 		wantSource string
 		wantTopic  string
+		wantKind   string
 	}{
 		{
 			name:       "emitter.on event",
 			src:        `function setup() { emitter.on("user.created", (user) => { console.log(user); }); }`,
 			wantSource: "CONSUME user.created",
 			wantTopic:  "user.created",
+			wantKind:   "queue_consumer",
 		},
 		{
 			name:       "channel.consume queue",
 			src:        `function start() { channel.consume("orders", (msg) => { process(msg); }); }`,
 			wantSource: "CONSUME orders",
 			wantTopic:  "orders",
+			wantKind:   "queue_consumer",
 		},
 		{
 			name:       "redis.subscribe channel",
 			src:        `function listen() { redis.subscribe("updates", (data) => { handle(data); }); }`,
-			wantSource: "CONSUME updates",
+			wantSource: "test.js::listen",
 			wantTopic:  "updates",
+			wantKind:   "cache_pubsub",
 		},
 	}
 
@@ -386,8 +390,8 @@ func TestJSIntegrationExtractor_Consumer(t *testing.T) {
 			if !ok || meta != tt.wantTopic {
 				t.Errorf("Metadata[topic] = %v, want %q", e.Metadata["topic"], tt.wantTopic)
 			}
-			if e.Metadata["kind"] != "queue_consumer" {
-				t.Errorf("Metadata[kind] = %v, want %q", e.Metadata["kind"], "queue_consumer")
+			if e.Metadata["kind"] != tt.wantKind {
+				t.Errorf("Metadata[kind] = %v, want %q", e.Metadata["kind"], tt.wantKind)
 			}
 		})
 	}
@@ -489,16 +493,12 @@ function handler() {
 	}
 
 	seen := make(map[string]bool)
-	consumerSeen := false
 	for _, e := range integrationEdges {
 		if e.Kind != graph.EdgeIntegration {
 			t.Errorf("edge Kind = %v, want EdgeIntegration", e.Kind)
 		}
 		seen[e.TargetNode] = true
-		if e.SourceNode == "CONSUME events" {
-			consumerSeen = true
-		}
-		if e.SourceNode != "test.js::handler" && e.SourceNode != "CONSUME events" {
+		if e.SourceNode != "test.js::handler" {
 			t.Errorf("unexpected SourceNode = %q", e.SourceNode)
 		}
 	}
@@ -508,8 +508,8 @@ function handler() {
 	if !seen["emit:user.fetched"] {
 		t.Error("missing emit queue publish edge")
 	}
-	if !consumerSeen {
-		t.Error("missing subscribe consumer edge (source=CONSUME events)")
+	if !seen["subscribe:events"] {
+		t.Error("missing redis subscribe cache_pubsub edge")
 	}
 }
 
@@ -582,6 +582,129 @@ func metadataContains(meta map[string]any, want map[string]any) bool {
 		}
 	}
 	return true
+}
+
+func TestJSIntegrationExtractor_RedisEdges(t *testing.T) {
+	ex, err := graph.NewJSIntegrationExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		src        string
+		wantTarget string
+		wantKind   string
+		wantMeta   map[string]any
+	}{
+		{
+			name:       "redis.get cache_read",
+			src:        `function load() { redis.get("user:123"); }`,
+			wantTarget: "REDIS get user:123",
+			wantKind:   "cache_read",
+			wantMeta:   map[string]any{"kind": "cache_read", "method": "get", "receiver": "redis", "key": "user:123"},
+		},
+		{
+			name:       "redis.set cache_write",
+			src:        `function save() { redis.set("user:123", data); }`,
+			wantTarget: "REDIS set user:123",
+			wantKind:   "cache_write",
+			wantMeta:   map[string]any{"kind": "cache_write", "method": "set", "receiver": "redis", "key": "user:123"},
+		},
+		{
+			name:       "redis.setEx cache_write",
+			src:        `function cache() { redis.setEx("session:abc", 3600, JSON.stringify(data)); }`,
+			wantTarget: "REDIS setEx session:abc",
+			wantKind:   "cache_write",
+			wantMeta:   map[string]any{"kind": "cache_write", "method": "setEx", "receiver": "redis", "key": "session:abc"},
+		},
+		{
+			name:       "redis.del cache_delete",
+			src:        `function remove() { redis.del("lockTrade:asset1"); }`,
+			wantTarget: "REDIS del lockTrade:asset1",
+			wantKind:   "cache_delete",
+			wantMeta:   map[string]any{"kind": "cache_delete", "method": "del", "receiver": "redis", "key": "lockTrade:asset1"},
+		},
+		{
+			name:       "redis.publish cache_pubsub",
+			src:        `function broadcast() { redis.publish("notifications", msg); }`,
+			wantTarget: "publish:notifications",
+			wantKind:   "cache_pubsub",
+			wantMeta:   map[string]any{"kind": "cache_pubsub", "method": "publish", "receiver": "redis", "topic": "notifications"},
+		},
+		{
+			name:       "redis.expire cache_write",
+			src:        `function refresh() { redis.expire("key:ttl", 300); }`,
+			wantTarget: "REDIS expire key:ttl",
+			wantKind:   "cache_write",
+			wantMeta:   map[string]any{"kind": "cache_write", "method": "expire", "receiver": "redis", "key": "key:ttl"},
+		},
+		{
+			name:       "redis.set with NX EX options",
+			src:        `function lock() { redis.set("lockTrade:asset1", 1, {NX: true, EX: 900}); }`,
+			wantTarget: "REDIS set lockTrade:asset1",
+			wantKind:   "cache_write",
+			wantMeta:   map[string]any{"kind": "cache_write", "method": "set", "receiver": "redis", "key": "lockTrade:asset1"},
+		},
+		{
+			name:       "redis.get with template string",
+			src:        "function load(botId) { redis.get(`caskets730:${botId}`); }",
+			wantTarget: "REDIS get caskets730:${botId}",
+			wantKind:   "cache_read",
+			wantMeta:   map[string]any{"kind": "cache_read", "method": "get", "receiver": "redis"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			edges, err := ex.ExtractEdges("test.js", []byte(tt.src))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var matching []graph.Edge
+			for _, e := range edges {
+				if e.Kind == graph.EdgeIntegration {
+					matching = append(matching, e)
+				}
+			}
+			if len(matching) == 0 {
+				t.Fatal("expected at least one EdgeIntegration edge")
+			}
+			e := matching[0]
+			if e.TargetNode != tt.wantTarget {
+				t.Errorf("TargetNode = %q, want %q", e.TargetNode, tt.wantTarget)
+			}
+			if e.Metadata["kind"] != tt.wantKind {
+				t.Errorf("Metadata[kind] = %v, want %q", e.Metadata["kind"], tt.wantKind)
+			}
+			if !metadataContains(e.Metadata, tt.wantMeta) {
+				t.Errorf("Metadata = %v, want to contain %v", e.Metadata, tt.wantMeta)
+			}
+		})
+	}
+}
+
+func TestJSIntegrationExtractor_RedisGetNotHTTP(t *testing.T) {
+	ex, err := graph.NewJSIntegrationExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := []byte(`function load() { redis.get("key"); }`)
+	edges, err := ex.ExtractEdges("test.js", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeIntegration {
+			if e.Metadata["kind"] == "http_call" {
+				t.Errorf("redis.get misclassified as HTTP: %v", e.Metadata)
+			}
+			if e.Metadata["kind"] != "cache_read" {
+				t.Errorf("Metadata[kind] = %v, want cache_read", e.Metadata["kind"])
+			}
+		}
+	}
 }
 
 func TestJSIntegrationExtractor_FixtureFile(t *testing.T) {

--- a/openspec/changes/js-redis-integration-extraction/.openspec.yaml
+++ b/openspec/changes/js-redis-integration-extraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/js-redis-integration-extraction/design.md
+++ b/openspec/changes/js-redis-integration-extraction/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The `JSIntegrationExtractor` in `internal/graph/js_integration_extractor.go` handles member expressions via `handleMemberExpression`. It currently checks for:
+- HTTP method names (`get`, `post`, `put`, `delete`) → HTTP integration edge
+- Publish methods (`publish`, `send`, `emit`) → queue integration edge (but skips when receiver is "redis")
+- Consume methods (`subscribe`, `consume`, `listen`, `on`) → queue consumer edge
+
+Redis calls like `redis.get(key)` hit the HTTP method check (`get`) and get classified as HTTP calls — which is incorrect. `redis.set(key, val)` doesn't match any pattern and is silently dropped.
+
+The zengamingx codebase uses Redis extensively: cache reads/writes, distributed locks, session storage, pub/sub channels.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect Redis operations from `JSIntegrationExtractor`
+- Classify Redis operations as `cache_read`, `cache_write`, `cache_delete`, `cache_lock`, `cache_pubsub`
+- Fix the existing bug where `redis.get()` is misclassified as HTTP GET
+- Apply same detection to `PythonIntegrationExtractor`
+
+**Non-Goals:**
+- Detecting Redis Cluster/Sentinel patterns
+- Parsing Redis command arguments for cache key names
+- Adding Redis to the Go integration extractor (Go project doesn't use Redis)
+
+## Decisions
+
+### Decision 1: Add Redis method map before HTTP check
+
+**Choice**: Check Redis receiver patterns BEFORE HTTP method names in `handleMemberExpression`.
+
+**Rationale**: The current code matches `redis.get()` as HTTP GET. By checking Redis patterns first, we fix this misclassification. Redis detection is receiver-aware (`redis.get()` → cache, `axios.get()` → HTTP).
+
+**Alternative considered**: Add a special case in HTTP handler — rejected because it's fragile and doesn't scale to other libraries.
+
+### Decision 2: Redis-specific edge metadata
+
+**Choice**: Use metadata `kind: "cache_read"` / `cache_write` / `cache_delete` / `cache_lock` / `cache_pubsub` with `receiver: "redis"`.
+
+**Rationale**: Distinguishes Redis operations from HTTP/queue. Enables future filtering and diagram rendering (e.g., show cache vs HTTP vs queue differently).
+
+### Decision 3: Receiver detection
+
+**Choice**: Match any member expression where the method name is in `jsRedisMethods`. The receiver name is extracted but not validated (any object calling `.get()` with Redis-like patterns is classified as Redis).
+
+**Rationale**: Too restrictive (only `redis.get()`) misses `r.get()`, `cache.get()`, `client.get()`. The method name set is specific enough to avoid false positives.
+
+## Risks / Trade-offs
+
+- **[Risk] False positives** → Mitigation: Redis method names are distinctive (`setEx`, `hget`, `sadd`). Common JS methods like `get`/`set` are already in HTTP map — Redis check runs first but only when receiver is present.
+- **[Risk] Overlapping HTTP/Redis for `.get()`** → Mitigation: Redis handler returns early, preventing HTTP handler from also matching.

--- a/openspec/changes/js-redis-integration-extraction/proposal.md
+++ b/openspec/changes/js-redis-integration-extraction/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `JSIntegrationExtractor` does not detect Redis operations (`redis.get()`, `redis.set()`, `redis.del()`, `redis.setEx()`, `redis.publish()`, `redis.expire()`). These are heavily used throughout the zengamingx codebase (cache reads, trade locks, session storage, pub/sub) but never appear in flow diagrams or sequence diagrams.
+
+Current detection only covers: HTTP calls (axios/fetch), queue publish (emit/send), queue consume (subscribe/on). Redis is the most critical missing integration — it's the cache layer, distributed lock mechanism, and pub/sub backbone.
+
+## What Changes
+
+- Add `jsRedisMethods` map to `JSIntegrationExtractor` covering: `get`, `set`, `setEx`, `del`, `expire`, `ttl`, `publish`, `subscribe`, `lpush`, `rpush`, `sadd`, `srem`, `incr`, `decr`, `hget`, `hset`
+- Add Redis-specific edge metadata (`kind: "cache_read"`, `kind: "cache_write"`, `kind: "cache_delete"`, `kind: "cache_pubsub"`)
+- Detect receiver pattern: `<redisInstance>.<method>(key)` → `Redis <method>`
+- Add new edge kind `cache` (or reuse `integration`) with metadata distinguishing read/write/pubsub
+- Apply same detection to `PythonIntegrationExtractor` if Python Redis usage exists
+
+## Capabilities
+
+### New Capabilities
+
+- `redis-integration-extraction`: Detect and extract Redis operations from JS/TS/Python source code as graph edges
+
+### Modified Capabilities
+
+_(none — this is additive)_
+
+## Impact
+
+- **Files**: `internal/graph/js_integration_extractor.go` (add Redis method map + handler), possibly `internal/graph/python_integration_extractor.go`
+- **API**: No contract change — new edges appear in flow/sequence diagrams automatically
+- **Data**: Re-index required to populate Redis edges for existing workspaces
+- **Breaking**: No — Redis detection is opt-in via new method map

--- a/openspec/changes/js-redis-integration-extraction/specs/redis-integration-extraction/spec.md
+++ b/openspec/changes/js-redis-integration-extraction/specs/redis-integration-extraction/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Detect Redis cache read operations
+
+The `JSIntegrationExtractor` SHALL detect `redis.get(key)` style calls and emit an integration edge with metadata `kind: "cache_read"`.
+
+#### Scenario: Redis get with string key
+- **WHEN** source code contains `redis.get("mykey")`
+- **THEN** the extractor SHALL emit an edge with target `Redis GET` and metadata `kind: "cache_read"`
+
+#### Scenario: Redis get with template string key
+- **WHEN** source code contains `` redis.get(`caskets730:${botId}`) ``
+- **THEN** the extractor SHALL emit an edge with target `Redis GET` and metadata `kind: "cache_read"`, key `caskets730:${botId}`
+
+### Requirement: Detect Redis cache write operations
+
+The `JSIntegrationExtractor` SHALL detect `redis.set(key, val)`, `redis.setEx(key, ttl, val)` calls and emit integration edges with metadata `kind: "cache_write"`.
+
+#### Scenario: Redis setEx with TTL
+- **WHEN** source code contains `redis.setEx(key, ttl, JSON.stringify(data))`
+- **THEN** the extractor SHALL emit an edge with target `Redis SETEX` and metadata `kind: "cache_write"`
+
+#### Scenario: Redis set with NX option
+- **WHEN** source code contains `redis.set("lockTrade:" + assetId, 1, { NX: true, EX: 900 })`
+- **THEN** the extractor SHALL emit an edge with target `Redis SET` and metadata `kind: "cache_lock"`
+
+### Requirement: Detect Redis delete operations
+
+The `JSIntegrationExtractor` SHALL detect `redis.del(key)` and emit integration edges with metadata `kind: "cache_delete"`.
+
+#### Scenario: Redis del
+- **WHEN** source code contains `redis.del("lockTrade:" + assetId)`
+- **THEN** the extractor SHALL emit an edge with target `Redis DEL` and metadata `kind: "cache_delete"`
+
+### Requirement: Detect Redis pub/sub operations
+
+The `JSIntegrationExtractor` SHALL detect `redis.publish(channel, msg)` and emit integration edges with metadata `kind: "cache_pubsub"`.
+
+#### Scenario: Redis publish
+- **WHEN** source code contains `redis.publish("trade-events", JSON.stringify(data))`
+- **THEN** the extractor SHALL emit an edge with target `Redis PUBLISH` and metadata `kind: "cache_pubsub"`
+
+### Requirement: Do not misclassify Redis as HTTP
+
+The `JSIntegrationExtractor` SHALL NOT classify `redis.get()` as an HTTP GET request. Redis method detection SHALL run before HTTP method detection.
+
+#### Scenario: redis.get is not HTTP
+- **WHEN** source code contains `redis.get("key")`
+- **THEN** the extractor SHALL emit a `cache_read` edge, NOT an HTTP GET edge

--- a/openspec/changes/js-redis-integration-extraction/tasks.md
+++ b/openspec/changes/js-redis-integration-extraction/tasks.md
@@ -1,0 +1,24 @@
+## 1. Redis Method Detection
+
+- [x] 1.1 Add `jsRedisMethods` map to `js_integration_extractor.go` with Redis-specific methods: `get`, `set`, `setEx`, `del`, `expire`, `ttl`, `publish`, `subscribe`, `lpush`, `rpush`, `sadd`, `srem`, `incr`, `decr`, `hget`, `hset`
+- [x] 1.2 Add `jsRedisReadMethods`, `jsRedisWriteMethods`, `jsRedisDeleteMethods`, `jsRedisPubSubMethods` sub-maps for metadata classification
+- [x] 1.3 Add `handleRedisCall` method that emits Redis integration edges with correct metadata (`cache_read`, `cache_write`, `cache_delete`, `cache_pubsub`, `cache_lock`)
+
+## 2. Integration with Existing Extractor
+
+- [x] 2.1 Modify `handleMemberExpression` to check Redis receiver patterns BEFORE HTTP method names (fix `redis.get()` misclassification)
+- [ ] 2.2 Add `handleIdentifier` support for bare `get("key")` → detect if receiver is Redis-typed (via variable name matching)
+- [x] 2.3 Ensure Redis handler returns early to prevent HTTP handler from also matching
+
+## 3. Python Redis Detection
+
+- [ ] 3.1 Check if `PythonIntegrationExtractor` exists and if Python Redis usage is present in any workspace
+- [ ] 3.2 If yes, add Redis detection to `python_integration_extractor.go` with same metadata pattern
+
+## 4. Testing & Verification
+
+- [x] 4.1 Add unit tests for Redis edge extraction (get, set, setEx, del, publish) in `js_integration_extractor_test.go`
+- [x] 4.2 Add test for `redis.get()` is NOT classified as HTTP GET
+- [x] 4.3 Run `go test -race -short ./...`
+- [ ] 4.4 Index zengamingx workspace and verify Redis edges appear in flow diagrams
+- [ ] 4.5 Run `go test -race -tags=integration ./...`


### PR DESCRIPTION
## Problem

The JSIntegrationExtractor does not detect Redis operations. Redis is heavily used in zengamingx (cache, locks, pub/sub) but never appears in flow diagrams. Worse, `redis.get()` is misclassified as HTTP GET.

## Fix

- Add `jsRedisMethods` map with 16 Redis methods
- Add cache_read/cache_write/cache_delete/cache_pubsub/cache_lock metadata
- Fix redis.get() misclassification (Redis check runs before HTTP)
- Receiver-aware disambiguation

Closes #451