### PR TITLE
feat(flow): render internal logic in sequence diagrams via CFG

### DIFF
--- a/internal/flow/cfg_loader.go
+++ b/internal/flow/cfg_loader.go
@@ -1,0 +1,89 @@
+package flow
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+type FlowCFGs map[string]*graph.CFG
+
+type CFGQuerier interface {
+	ListAllEdgesByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.GraphEdge, error)
+	GetFunctionFlowchartByHandler(ctx context.Context, arg sqlc.GetFunctionFlowchartByHandlerParams) (sqlc.FunctionFlowchart, error)
+}
+
+func LoadFlowCFGs(ctx context.Context, q CFGQuerier, workspace, entry string) (FlowCFGs, error) {
+	rawEdges, err := q.ListAllEdgesByWorkspace(ctx, workspace)
+	if err != nil {
+		return nil, err
+	}
+
+	handlerNames := make(map[string]string)
+	for _, e := range rawEdges {
+		if graph.EdgeKind(e.EdgeType) == graph.EdgeHTTP && e.SourceNode == entry {
+			bare := lastDottedSegment(e.TargetNode)
+			handlerNames[e.TargetNode] = bare
+		}
+	}
+
+	if len(handlerNames) == 0 {
+		return nil, nil
+	}
+
+	cfgs := make(FlowCFGs, len(handlerNames))
+	for nodeID, bareName := range handlerNames {
+		fc, err := q.GetFunctionFlowchartByHandler(ctx, sqlc.GetFunctionFlowchartByHandlerParams{
+			WorkspaceHash: workspace,
+			Entry:         bareName,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, err
+		}
+
+		var cfg graph.CFG
+		if err := json.Unmarshal(fc.Cfg, &cfg); err != nil {
+			continue
+		}
+		if cfg.Status == "parse_error" || cfg.Status == "unsupported" {
+			continue
+		}
+		cfgs[nodeID] = &cfg
+	}
+
+	if len(cfgs) == 0 {
+		return nil, nil
+	}
+	return cfgs, nil
+}
+
+func cfgNodeMap(cfg *graph.CFG) map[string]graph.CFGNode {
+	m := make(map[string]graph.CFGNode, len(cfg.Nodes))
+	for _, n := range cfg.Nodes {
+		m[n.ID] = n
+	}
+	return m
+}
+
+func cfgAdj(cfg *graph.CFG) map[string][]graph.CFGEdge {
+	adj := make(map[string][]graph.CFGEdge, len(cfg.Edges))
+	for _, e := range cfg.Edges {
+		adj[e.From] = append(adj[e.From], e)
+	}
+	return adj
+}
+
+func lastDottedSegment(s string) string {
+	if idx := strings.LastIndexByte(s, '.'); idx >= 0 && idx < len(s)-1 {
+		return s[idx+1:]
+	}
+	return s
+}

--- a/internal/flow/mermaid.go
+++ b/internal/flow/mermaid.go
@@ -74,9 +74,12 @@ var mermaidReservedIDs = map[string]bool{
 //   - "sequence" → Mermaid sequenceDiagram
 //   - "json" → empty string (caller handles JSON separately)
 //   - anything else (including "mermaid") → Mermaid graph TD
-func Render(f Flow, format string) string {
+func Render(f Flow, format string, cfgs ...FlowCFGs) string {
 	switch format {
 	case "sequence":
+		if len(cfgs) > 0 && cfgs[0] != nil {
+			return RenderSequenceDiagramWithCFG(f, cfgs[0])
+		}
 		return RenderSequenceDiagram(f)
 	case "json":
 		return ""

--- a/internal/flow/sequence.go
+++ b/internal/flow/sequence.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
 )
 
 // participantAlias returns the Mermaid alias for a node.
@@ -313,6 +315,378 @@ func RenderSequenceDiagram(f Flow) string {
 			sb.WriteString(fmt.Sprintf("    %s-->>%s: %s\n", m.from, m.to, m.label))
 		} else {
 			sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
+		}
+	}
+
+	return sb.String()
+}
+
+const (
+	maxCFGDepth    = 3
+	maxSeqMessages = 50
+)
+
+func renderInternalLogic(
+	entryID string,
+	nodes map[string]graph.CFGNode,
+	adj map[string][]graph.CFGEdge,
+	actor string,
+	depth int,
+	msgCount *int,
+	visited map[string]bool,
+) []string {
+	if *msgCount >= maxSeqMessages {
+		return nil
+	}
+	if depth > maxCFGDepth {
+		return nil
+	}
+
+	node, ok := nodes[entryID]
+	if !ok {
+		return nil
+	}
+	if visited[entryID] && node.Type != "merge" {
+		return nil
+	}
+	visited[entryID] = true
+
+	var lines []string
+	selfMsg := func(label string) {
+		if *msgCount >= maxSeqMessages {
+			return
+		}
+		*msgCount++
+		safeActor := sanitizeID(actor)
+		lines = append(lines, fmt.Sprintf("    %s->>%s: %s", safeActor, safeActor, sanitizeLabel(label)))
+	}
+
+	switch node.Type {
+	case "step", "merge", "start":
+		selfMsg(node.Label)
+		for _, e := range adj[entryID] {
+			lines = append(lines, renderInternalLogic(e.To, nodes, adj, actor, depth, msgCount, visited)...)
+			if *msgCount >= maxSeqMessages {
+				break
+			}
+		}
+
+	case "decision":
+		edges := adj[entryID]
+		if hasYesNoEdges(edges) {
+			lines = append(lines, renderAltBlock(edges, nodes, adj, actor, depth, msgCount, visited)...)
+		} else if hasLoopEdge(edges) {
+			lines = append(lines, renderLoopBlock(edges, nodes, adj, actor, depth, msgCount, visited)...)
+		} else if len(edges) == 1 {
+			selfMsg(node.Label)
+			lines = append(lines, renderInternalLogic(edges[0].To, nodes, adj, actor, depth, msgCount, visited)...)
+		} else {
+			selfMsg(node.Label)
+			for _, e := range edges {
+				lines = append(lines, renderInternalLogic(e.To, nodes, adj, actor, depth, msgCount, visited)...)
+				if *msgCount >= maxSeqMessages {
+					break
+				}
+			}
+		}
+
+	case "terminal":
+		if node.Kind == "error" {
+			selfMsg(fmt.Sprintf("throw %s", node.Label))
+		} else {
+			selfMsg(node.Label)
+		}
+	}
+
+	return lines
+}
+
+func hasYesNoEdges(edges []graph.CFGEdge) bool {
+	hasYes, hasNo := false, false
+	for _, e := range edges {
+		if e.Branch == "yes" {
+			hasYes = true
+		}
+		if e.Branch == "no" {
+			hasNo = true
+		}
+	}
+	return hasYes && hasNo
+}
+
+func hasLoopEdge(edges []graph.CFGEdge) bool {
+	for _, e := range edges {
+		if e.Branch == "loop" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderAltBlock(
+	edges []graph.CFGEdge,
+	nodes map[string]graph.CFGNode,
+	adj map[string][]graph.CFGEdge,
+	actor string,
+	depth int,
+	msgCount *int,
+	visited map[string]bool,
+) []string {
+	var lines []string
+	lines = append(lines, "    alt")
+	for _, e := range edges {
+		if *msgCount >= maxSeqMessages {
+			break
+		}
+		label := e.Branch
+		if label == "yes" {
+			label = "condition"
+		} else if label == "no" {
+			label = "else"
+		} else if strings.HasPrefix(label, "case:") {
+			label = label[5:]
+		}
+		lines = append(lines, fmt.Sprintf("        %s", sanitizeLabel(label)))
+		lines = append(lines, renderInternalLogic(e.To, nodes, adj, actor, depth+1, msgCount, visited)...)
+	}
+	lines = append(lines, "    end")
+	return lines
+}
+
+func renderLoopBlock(
+	edges []graph.CFGEdge,
+	nodes map[string]graph.CFGNode,
+	adj map[string][]graph.CFGEdge,
+	actor string,
+	depth int,
+	msgCount *int,
+	visited map[string]bool,
+) []string {
+	var lines []string
+	lines = append(lines, "    loop")
+	for _, e := range edges {
+		if *msgCount >= maxSeqMessages {
+			break
+		}
+		if e.Branch == "loop" {
+			lines = append(lines, renderInternalLogic(e.To, nodes, adj, actor, depth+1, msgCount, visited)...)
+		} else {
+			lines = append(lines, fmt.Sprintf("        %s", sanitizeLabel(e.Branch)))
+			lines = append(lines, renderInternalLogic(e.To, nodes, adj, actor, depth+1, msgCount, visited)...)
+		}
+	}
+	lines = append(lines, "    end")
+	return lines
+}
+
+func RenderSequenceDiagramWithCFG(f Flow, cfgs FlowCFGs) string {
+	actorForNode := groupActors(f, f.ServiceName)
+	nodeByID := make(map[string]FlowNode, len(f.Nodes))
+	for _, n := range f.Nodes {
+		nodeByID[n.ID] = n
+	}
+
+	adj := make(map[string][]FlowEdge)
+	for _, e := range f.Edges {
+		adj[e.From] = append(adj[e.From], e)
+	}
+	for k := range adj {
+		sort.Slice(adj[k], func(i, j int) bool {
+			li, lj := adj[k][i].Line, adj[k][j].Line
+			if li != lj && li > 0 && lj > 0 {
+				return li < lj
+			}
+			return adj[k][i].To < adj[k][j].To
+		})
+	}
+
+	mwIDs := make(map[string]bool)
+	for _, n := range f.Nodes {
+		if n.Role == RoleMiddleware {
+			mwIDs[n.ID] = true
+		}
+	}
+	mwFor := make(map[string][]string)
+	for _, e := range f.Edges {
+		if e.Kind == "middleware" {
+			mwFor[e.To] = append(mwFor[e.To], e.From)
+		}
+	}
+
+	var resolveMWChain func(id string, visited map[string]bool) []string
+	resolveMWChain = func(id string, visited map[string]bool) []string {
+		if visited[id] {
+			return nil
+		}
+		visited[id] = true
+		var chain []string
+		for _, mwID := range mwFor[id] {
+			name := mwID
+			if n, ok := nodeByID[mwID]; ok {
+				name = n.Name
+			}
+			chain = append(chain, name)
+			chain = append(chain, resolveMWChain(mwID, visited)...)
+		}
+		return chain
+	}
+
+	var participants []string
+	seenActor := make(map[string]bool)
+	seenNode := make(map[string]bool)
+	var dfsParticipants func(id string)
+	dfsParticipants = func(id string) {
+		if seenNode[id] {
+			return
+		}
+		seenNode[id] = true
+		actor := actorForNode[id]
+		if actor == "" {
+			actor = "Backend"
+		}
+		if !seenActor[actor] {
+			seenActor[actor] = true
+			participants = append(participants, actor)
+		}
+		for _, e := range adj[id] {
+			dfsParticipants(e.To)
+		}
+	}
+	dfsParticipants(f.Entry)
+
+	type seqMsg struct {
+		from, to, label string
+		isNote          bool
+		isConditional   bool
+	}
+	var messages []seqMsg
+	seenMsg := make(map[string]bool)
+	var dfsMessages func(fromID string)
+	dfsMessages = func(fromID string) {
+		if seenMsg[fromID] {
+			return
+		}
+		seenMsg[fromID] = true
+
+		if _, isMW := mwIDs[fromID]; !isMW {
+			if chain := resolveMWChain(fromID, make(map[string]bool)); len(chain) > 0 {
+				for _, mwName := range chain {
+					messages = append(messages, seqMsg{
+						isNote: true,
+						label:  fmt.Sprintf("guarded by %s", sanitizeLabel(mwName)),
+					})
+				}
+			}
+		}
+
+		for _, e := range adj[fromID] {
+			if mwIDs[fromID] || mwIDs[e.To] {
+				dfsMessages(e.To)
+				continue
+			}
+
+			toActor := actorForNode[e.To]
+			if toActor == "" {
+				toActor = "Backend"
+			}
+			fromActor := actorForNode[fromID]
+			if fromActor == "" {
+				fromActor = "Backend"
+			}
+			if fromActor != toActor {
+				label := e.Kind
+				if e.Kind == "http" && f.Entry != "" {
+					label = f.Entry
+				}
+				messages = append(messages, seqMsg{
+					from:          fromActor,
+					to:            toActor,
+					label:         sanitizeLabel(label),
+					isConditional: e.Conditional,
+				})
+				messages = append(messages, seqMsg{
+					from:  toActor,
+					to:    fromActor,
+					label: "ok",
+				})
+			}
+			dfsMessages(e.To)
+		}
+	}
+	dfsMessages(f.Entry)
+
+	if len(messages) > maxSeqMessages {
+		messages = messages[:maxSeqMessages]
+		messages = append(messages, seqMsg{
+			isNote: true,
+			label:  "Internal logic too complex — see full CFG at /api/v1/graph/flowchart",
+		})
+	}
+
+	var sb strings.Builder
+	sb.WriteString("sequenceDiagram\n")
+
+	seenAlias := make(map[string]bool)
+	for _, actor := range participants {
+		if seenAlias[actor] {
+			continue
+		}
+		seenAlias[actor] = true
+		if actor == "Client" {
+			sb.WriteString("    participant Client\n")
+		} else {
+			sb.WriteString(fmt.Sprintf("    participant %s as \"%s\"\n", sanitizeID(actor), actor))
+		}
+	}
+	sb.WriteString("\n")
+
+	for _, m := range messages {
+		if m.isNote {
+			sb.WriteString(fmt.Sprintf("    Note over Backend: %s\n", m.label))
+			continue
+		}
+		if m.isConditional {
+			sb.WriteString("    opt conditional\n")
+			sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
+			sb.WriteString("    end\n")
+			continue
+		}
+		if m.label == "ok" {
+			sb.WriteString(fmt.Sprintf("    %s-->>%s: %s\n", m.from, m.to, m.label))
+		} else {
+			sb.WriteString(fmt.Sprintf("    %s->>%s: %s\n", m.from, m.to, m.label))
+		}
+	}
+
+	if cfgs != nil {
+		for _, n := range f.Nodes {
+			if n.Role == RoleHandler || n.Role == RoleFunc {
+				if cfg, ok := cfgs[n.ID]; ok {
+					cfgNodes := cfgNodeMap(cfg)
+					cfgEdges := cfgAdj(cfg)
+					var startID string
+					for _, cn := range cfg.Nodes {
+						if cn.Type == "start" {
+							startID = cn.ID
+							break
+						}
+					}
+					if startID != "" {
+						actor := actorForNode[n.ID]
+						if actor == "" {
+							actor = f.ServiceName
+						}
+						msgCount := 0
+						lines := renderInternalLogic(startID, cfgNodes, cfgEdges, actor, 0, &msgCount, make(map[string]bool))
+						for _, l := range lines {
+							sb.WriteString(l + "\n")
+						}
+						if msgCount >= maxSeqMessages {
+							sb.WriteString(fmt.Sprintf("    Note over %s: Internal logic too complex — see full CFG at /api/v1/graph/flowchart\n", sanitizeID(actor)))
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/flow/sequence_test.go
+++ b/internal/flow/sequence_test.go
@@ -3,6 +3,8 @@ package flow
 import (
 	"strings"
 	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
 )
 
 func TestRenderSequenceDiagramHeader(t *testing.T) {
@@ -133,5 +135,348 @@ func TestRenderSequenceDiagramDeterministic(t *testing.T) {
 	d2 := RenderSequenceDiagram(f)
 	if d1 != d2 {
 		t.Error("same input should produce same output")
+	}
+}
+
+func TestRenderInternalLogic_SimpleSteps(t *testing.T) {
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "s1", Type: "start", Label: "purchaseHandler"},
+			{ID: "s2", Type: "step", Label: "validateInput"},
+			{ID: "s3", Type: "step", Label: "processPayment"},
+			{ID: "s4", Type: "terminal", Label: "return result"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "s1", To: "s2", Branch: "next"},
+			{From: "s2", To: "s3", Branch: "next"},
+			{From: "s3", To: "s4", Branch: "next"},
+		},
+	}
+
+	nodes := cfgNodeMap(cfg)
+	adj := cfgAdj(cfg)
+	msgCount := 0
+	lines := renderInternalLogic("s1", nodes, adj, "Backend", 0, &msgCount, make(map[string]bool))
+
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "purchaseHandler") {
+		t.Errorf("expected start label, got %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "validateInput") {
+		t.Errorf("expected step label, got %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "processPayment") {
+		t.Errorf("expected step label, got %q", lines[2])
+	}
+	if !strings.Contains(lines[3], "return result") {
+		t.Errorf("expected terminal label, got %q", lines[3])
+	}
+	if msgCount != 4 {
+		t.Errorf("expected msgCount=4, got %d", msgCount)
+	}
+}
+
+func TestRenderInternalLogic_AltBlock(t *testing.T) {
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "s1", Type: "start", Label: "handler"},
+			{ID: "d1", Type: "decision", Label: "if (err)"},
+			{ID: "s2", Type: "step", Label: "handleError"},
+			{ID: "s3", Type: "step", Label: "processData"},
+			{ID: "s4", Type: "terminal", Label: "return"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "s1", To: "d1", Branch: "next"},
+			{From: "d1", To: "s2", Branch: "yes"},
+			{From: "d1", To: "s3", Branch: "no"},
+			{From: "s2", To: "s4", Branch: "next"},
+			{From: "s3", To: "s4", Branch: "next"},
+		},
+	}
+
+	nodes := cfgNodeMap(cfg)
+	adj := cfgAdj(cfg)
+	msgCount := 0
+	lines := renderInternalLogic("s1", nodes, adj, "Backend", 0, &msgCount, make(map[string]bool))
+
+	diagram := strings.Join(lines, "\n")
+	if !strings.Contains(diagram, "alt") {
+		t.Error("expected alt block")
+	}
+	if !strings.Contains(diagram, "condition") {
+		t.Error("expected 'condition' label for yes branch")
+	}
+	if !strings.Contains(diagram, "else") {
+		t.Error("expected 'else' label for no branch")
+	}
+	if !strings.Contains(diagram, "handleError") {
+		t.Error("expected handleError in yes branch")
+	}
+	if !strings.Contains(diagram, "processData") {
+		t.Error("expected processData in no branch")
+	}
+	if !strings.Contains(diagram, "end") {
+		t.Error("expected end block")
+	}
+}
+
+func TestRenderInternalLogic_LoopBlock(t *testing.T) {
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "s1", Type: "start", Label: "handler"},
+			{ID: "d1", Type: "decision", Label: "while (items.hasNext)"},
+			{ID: "s2", Type: "step", Label: "processItem"},
+			{ID: "s3", Type: "terminal", Label: "return"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "s1", To: "d1", Branch: "next"},
+			{From: "d1", To: "s2", Branch: "loop"},
+			{From: "s2", To: "d1", Branch: "next"},
+			{From: "d1", To: "s3", Branch: "next"},
+		},
+	}
+
+	nodes := cfgNodeMap(cfg)
+	adj := cfgAdj(cfg)
+	msgCount := 0
+	lines := renderInternalLogic("s1", nodes, adj, "Backend", 0, &msgCount, make(map[string]bool))
+
+	diagram := strings.Join(lines, "\n")
+	if !strings.Contains(diagram, "loop") {
+		t.Error("expected loop block")
+	}
+	if !strings.Contains(diagram, "processItem") {
+		t.Error("expected processItem inside loop")
+	}
+}
+
+func TestRenderInternalLogic_DepthTruncation(t *testing.T) {
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "s1", Type: "start", Label: "handler"},
+			{ID: "d1", Type: "decision", Label: "if a"},
+			{ID: "d2", Type: "decision", Label: "if b"},
+			{ID: "d3", Type: "decision", Label: "if c"},
+			{ID: "d4", Type: "decision", Label: "if d"},
+			{ID: "s2", Type: "step", Label: "deep"},
+			{ID: "s3", Type: "terminal", Label: "return"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "s1", To: "d1", Branch: "next"},
+			{From: "d1", To: "d2", Branch: "yes"},
+			{From: "d1", To: "s3", Branch: "no"},
+			{From: "d2", To: "d3", Branch: "yes"},
+			{From: "d2", To: "s3", Branch: "no"},
+			{From: "d3", To: "d4", Branch: "yes"},
+			{From: "d3", To: "s3", Branch: "no"},
+			{From: "d4", To: "s2", Branch: "yes"},
+			{From: "d4", To: "s3", Branch: "no"},
+		},
+	}
+
+	nodes := cfgNodeMap(cfg)
+	adj := cfgAdj(cfg)
+	msgCount := 0
+	lines := renderInternalLogic("s1", nodes, adj, "Backend", 0, &msgCount, make(map[string]bool))
+
+	diagram := strings.Join(lines, "\n")
+	if strings.Contains(diagram, "deep") {
+		t.Error("expected depth truncation — 'deep' should not appear at depth 4")
+	}
+}
+
+func TestRenderInternalLogic_MessageLimit(t *testing.T) {
+	var nodes []graph.CFGNode
+	var edges []graph.CFGEdge
+	nodes = append(nodes, graph.CFGNode{ID: "s0", Type: "start", Label: "entry"})
+	for i := 1; i <= 60; i++ {
+		id := "s" + string(rune('a'+i%26))
+		nodes = append(nodes, graph.CFGNode{ID: id, Type: "step", Label: "step"})
+		edges = append(edges, graph.CFGEdge{From: "s" + string(rune('a'+(i-1)%26)), To: id, Branch: "next"})
+	}
+
+	cfg := &graph.CFG{Nodes: nodes, Edges: edges}
+	nodeMap := cfgNodeMap(cfg)
+	adj := cfgAdj(cfg)
+	msgCount := 0
+	lines := renderInternalLogic("s0", nodeMap, adj, "Backend", 0, &msgCount, make(map[string]bool))
+
+	if msgCount > maxSeqMessages {
+		t.Errorf("expected msgCount <= %d, got %d", maxSeqMessages, msgCount)
+	}
+	if len(lines) > maxSeqMessages+1 {
+		t.Errorf("expected <= %d lines, got %d", maxSeqMessages+1, len(lines))
+	}
+}
+
+func TestRenderInternalLogic_MissingCFG(t *testing.T) {
+	diagram := RenderSequenceDiagram(Flow{})
+	if !strings.HasPrefix(diagram, "sequenceDiagram\n") {
+		t.Error("expected sequenceDiagram header")
+	}
+	if strings.Contains(diagram, "alt") {
+		t.Error("no CFG should mean no alt blocks")
+	}
+}
+
+func TestRenderSequenceDiagramWithCFG_CrossActor(t *testing.T) {
+	f := Flow{
+		Entry:       "POST /purchase",
+		Method:      "POST",
+		Path:        "/purchase",
+		ServiceName: "Backend",
+		Nodes: []FlowNode{
+			{ID: "POST /purchase", Name: "POST /purchase", Role: RoleEntry},
+			{ID: "purchase", Name: "purchase", Role: RoleHandler},
+			{ID: "GET api", Name: "GET api.example.com", Role: RoleIntegration},
+		},
+		Edges: []FlowEdge{
+			{From: "POST /purchase", To: "purchase", Kind: "http"},
+			{From: "purchase", To: "GET api", Kind: "integration"},
+		},
+	}
+
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "n1", Type: "start", Label: "purchase"},
+			{ID: "n2", Type: "step", Label: "validate"},
+			{ID: "n3", Type: "terminal", Label: "return"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "n1", To: "n2", Branch: "next"},
+			{From: "n2", To: "n3", Branch: "next"},
+		},
+	}
+	cfgs := FlowCFGs{"purchase": cfg}
+
+	diagram := RenderSequenceDiagramWithCFG(f, cfgs)
+	if !strings.Contains(diagram, "->>Api Example: integration") {
+		t.Errorf("expected cross-actor message to Api Example, got:\n%s", diagram)
+	}
+	if !strings.Contains(diagram, "Backend->>Backend: validate") {
+		t.Errorf("expected internal self-message for validate step, got:\n%s", diagram)
+	}
+	if strings.Contains(diagram, "alt") {
+		t.Error("expected no alt blocks for linear CFG")
+	}
+}
+
+func TestRenderSequenceDiagramWithCFG_AltIntegration(t *testing.T) {
+	f := Flow{
+		Entry:       "POST /purchase",
+		Method:      "POST",
+		Path:        "/purchase",
+		ServiceName: "Backend",
+		Nodes: []FlowNode{
+			{ID: "POST /purchase", Name: "POST /purchase", Role: RoleEntry},
+			{ID: "purchase", Name: "purchase", Role: RoleHandler},
+		},
+		Edges: []FlowEdge{
+			{From: "POST /purchase", To: "purchase", Kind: "http"},
+		},
+	}
+
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "n1", Type: "start", Label: "purchase"},
+			{ID: "d1", Type: "decision", Label: "if (err)"},
+			{ID: "n2", Type: "step", Label: "handleError"},
+			{ID: "n3", Type: "step", Label: "process"},
+			{ID: "n4", Type: "terminal", Label: "return"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "n1", To: "d1", Branch: "next"},
+			{From: "d1", To: "n2", Branch: "yes"},
+			{From: "d1", To: "n3", Branch: "no"},
+			{From: "n2", To: "n4", Branch: "next"},
+			{From: "n3", To: "n4", Branch: "next"},
+		},
+	}
+	cfgs := FlowCFGs{"purchase": cfg}
+
+	diagram := RenderSequenceDiagramWithCFG(f, cfgs)
+	if !strings.Contains(diagram, "alt") {
+		t.Error("expected alt block")
+	}
+	if !strings.Contains(diagram, "condition") {
+		t.Error("expected 'condition' label")
+	}
+	if !strings.Contains(diagram, "else") {
+		t.Error("expected 'else' label")
+	}
+	if !strings.Contains(diagram, "handleError") {
+		t.Error("expected handleError in alt block")
+	}
+	if !strings.Contains(diagram, "process") {
+		t.Error("expected process in alt block")
+	}
+}
+
+func TestRenderSequenceDiagramWithCFG_DepthLimit(t *testing.T) {
+	f := Flow{
+		Entry:       "POST /test",
+		Method:      "POST",
+		Path:        "/test",
+		ServiceName: "Backend",
+		Nodes: []FlowNode{
+			{ID: "POST /test", Name: "POST /test", Role: RoleEntry},
+			{ID: "h", Name: "h", Role: RoleHandler},
+		},
+		Edges: []FlowEdge{
+			{From: "POST /test", To: "h", Kind: "http"},
+		},
+	}
+
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "s", Type: "start", Label: "h"},
+			{ID: "d1", Type: "decision", Label: "if a"},
+			{ID: "d2", Type: "decision", Label: "if b"},
+			{ID: "d3", Type: "decision", Label: "if c"},
+			{ID: "d4", Type: "decision", Label: "if d"},
+			{ID: "deep", Type: "step", Label: "tooDeep"},
+			{ID: "end", Type: "terminal", Label: "return"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "s", To: "d1", Branch: "next"},
+			{From: "d1", To: "d2", Branch: "yes"},
+			{From: "d1", To: "end", Branch: "no"},
+			{From: "d2", To: "d3", Branch: "yes"},
+			{From: "d2", To: "end", Branch: "no"},
+			{From: "d3", To: "d4", Branch: "yes"},
+			{From: "d3", To: "end", Branch: "no"},
+			{From: "d4", To: "deep", Branch: "yes"},
+			{From: "d4", To: "end", Branch: "no"},
+		},
+	}
+	cfgs := FlowCFGs{"h": cfg}
+
+	diagram := RenderSequenceDiagramWithCFG(f, cfgs)
+	if strings.Contains(diagram, "tooDeep") {
+		t.Error("expected depth truncation — 'tooDeep' should not appear at depth 4")
+	}
+}
+
+func TestRenderInternalLogic_ErrorTerminal(t *testing.T) {
+	cfg := &graph.CFG{
+		Nodes: []graph.CFGNode{
+			{ID: "s1", Type: "start", Label: "handler"},
+			{ID: "t1", Type: "terminal", Label: "NotFoundError", Kind: "error"},
+		},
+		Edges: []graph.CFGEdge{
+			{From: "s1", To: "t1", Branch: "next"},
+		},
+	}
+
+	nodes := cfgNodeMap(cfg)
+	adj := cfgAdj(cfg)
+	msgCount := 0
+	lines := renderInternalLogic("s1", nodes, adj, "Backend", 0, &msgCount, make(map[string]bool))
+
+	diagram := strings.Join(lines, "\n")
+	if !strings.Contains(diagram, "throw NotFoundError") {
+		t.Errorf("expected 'throw NotFoundError', got %q", diagram)
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2142,13 +2142,24 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 				"nodes":     allNodes,
 				"edges":     graphEdges,
 			}
-			if diagram := flow.Render(f, format); diagram != "" {
+			if diagram := flow.Render(f, format, loadCFGsForFlow(ctx, a.queries, ws, format, f)...); diagram != "" {
 				result["mermaid"] = diagram
 			}
 
 			return textResult(result)
 		},
 	)
+}
+
+func loadCFGsForFlow(ctx context.Context, q flow.CFGQuerier, ws, format string, f flow.Flow) []flow.FlowCFGs {
+	if format != "sequence" {
+		return nil
+	}
+	cfgs, err := flow.LoadFlowCFGs(ctx, q, ws, f.Entry)
+	if err != nil || cfgs == nil {
+		return nil
+	}
+	return []flow.FlowCFGs{cfgs}
 }
 
 func filterPublishEdges(edges []graph.Edge) []graph.Edge {

--- a/internal/server/handlers/flow.go
+++ b/internal/server/handlers/flow.go
@@ -18,6 +18,7 @@ type FlowQuerier interface {
 	ListAllEdgesByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.GraphEdge, error)
 	ListConsumerEntryNodesByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.GraphEdge, error)
 	ListHTTPEndpointsByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.ListHTTPEndpointsByWorkspaceRow, error)
+	GetFunctionFlowchartByHandler(ctx context.Context, arg sqlc.GetFunctionFlowchartByHandlerParams) (sqlc.FunctionFlowchart, error)
 }
 
 // FlowMaterializer is the interface for triggering flow materialization.
@@ -150,7 +151,7 @@ func GraphFlow(q FlowQuerier, flowCfg config.FlowConfig, logger zerolog.Logger) 
 			Nodes:     nodes,
 			Edges:     graphEdges,
 		}
-		if diagram := flow.Render(f, req.Format); diagram != "" {
+		if diagram := flow.Render(f, req.Format, loadCFGsForSequence(ctx, q, workspace, req.Format, f)...); diagram != "" {
 			resp.Mermaid = diagram
 		}
 
@@ -323,4 +324,15 @@ func splitNodes(nodes []flow.FlowNode) (chain []flowNode, externals []flowNode) 
 		externals = []flowNode{}
 	}
 	return chain, externals
+}
+
+func loadCFGsForSequence(ctx context.Context, q FlowQuerier, workspace, format string, f flow.Flow) []flow.FlowCFGs {
+	if format != "sequence" {
+		return nil
+	}
+	cfgs, err := flow.LoadFlowCFGs(ctx, q, workspace, f.Entry)
+	if err != nil || cfgs == nil {
+		return nil
+	}
+	return []flow.FlowCFGs{cfgs}
 }

--- a/openspec/changes/sequence-diagram-internal-logic/.openspec.yaml
+++ b/openspec/changes/sequence-diagram-internal-logic/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/sequence-diagram-internal-logic/design.md
+++ b/openspec/changes/sequence-diagram-internal-logic/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The sequence diagram renderer (`internal/flow/sequence.go`) currently:
+1. Groups nodes into actors via `groupActors` (Client, serviceName, external systems)
+2. Does DFS traversal, emitting only cross-actor messages (line 259-277)
+3. All internal function calls within the same actor are silently skipped
+
+The CFG data (from `function_flowcharts`) contains rich control flow information per function: start, step, decision, terminal, merge nodes with branch edges (yes/no/loop/case). This data is already extracted and stored — but unused by the sequence diagram.
+
+The goal is to render internal logic within the service actor using Mermaid sequence diagram features: self-messages for steps, `alt`/`opt` for conditionals, `loop` for iteration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render internal CFG nodes as self-messages within the service actor
+- Show conditionals as `alt`/`opt` blocks (if/else → alt yes/no)
+- Show loops as `loop` blocks
+- Show error handling (try/catch) as alt blocks
+- Limit diagram to ~50 messages max to prevent overwhelming output
+- Keep external integrations as cross-actor messages
+
+**Non-Goals:**
+- Rendering every single CFG node (500-node CFGs would be unreadable)
+- Showing function-level decomposition (each function as separate lifeline)
+- Replacing the existing cross-actor message rendering
+- CFG-to-UML exact mapping
+
+## Decisions
+
+### Decision 1: Render decision nodes as alt/loop blocks
+
+**Choice**: Map CFG `decision` nodes to Mermaid `alt`/`opt`/`loop` blocks based on edge labels:
+- `yes`/`no` edges → `alt` block (if/else)
+- `loop` edge → `loop` block
+- `case:X` edges → `alt` block with case labels
+- Single `next` edge → `opt` block (try/catch or conditional)
+
+**Rationale**: Mermaid's `alt`/`loop` syntax directly maps to if/else and iteration patterns. No custom rendering needed.
+
+### Decision 2: Depth limiting with truncation
+
+**Choice**: Limit internal logic rendering to max 3 decision depth levels and 50 total messages. If exceeded, emit a single note: "Internal logic too complex — see full CFG at /api/v1/graph/flowchart".
+
+**Rationale**: Deeply nested conditionals produce unreadable diagrams. The flowchart endpoint already provides the complete internal view.
+
+### Decision 3: Use existing CFG data, not re-extract
+
+**Choice**: Load CFG from `function_flowcharts` table (already stored) and render it in the sequence diagram context. Do NOT re-parse source code.
+
+**Rationale**: CFG extraction is already done and stored. The sequence diagram just needs to render it differently.
+
+## Risks / Trade-offs
+
+- **[Risk] Large diagrams** → Mitigation: Hard limit of 50 messages + depth 3. Excess truncated with note.
+- **[Risk] CFG not available for all functions** → Mitigation: Fall back to current behavior (cross-actor only) when CFG is missing.
+- **[Risk] Mermaid rendering issues** → Mitigation: Test with multiple diagram sizes; validate Mermaid syntax.

--- a/openspec/changes/sequence-diagram-internal-logic/proposal.md
+++ b/openspec/changes/sequence-diagram-internal-logic/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The sequence diagram currently only renders cross-actor messages (tradeit-backend → MySQL, tradeit-backend → Steam API). All internal logic is collapsed into a single "tradeit-backend" actor, so the diagram shows WHAT external systems are called but not HOW the code flows internally — no conditionals, no loops, no error handling, no function calls within the service.
+
+This makes the diagram useful for infrastructure overview but useless for understanding business logic. A real sequence diagram should show the flow of control, including branching (if/else), iteration (for-each), and error paths (try/catch).
+
+## What Changes
+
+- Render CFG nodes within the main service actor as self-messages (internal calls)
+- Show branching as `alt`/`opt` blocks in Mermaid (if/else → alt, try/catch → alt try/success/catch)
+- Show loops as `loop` blocks in Mermaid (for-each → loop over items)
+- Collapse sequential internal steps into grouped notes (e.g., "validate balance", "check inventory")
+- Keep external integrations as cross-actor messages
+- Limit total diagram size to prevent overwhelming output (max 50 messages)
+
+## Capabilities
+
+### New Capabilities
+
+- `sequence-diagram-internal-logic`: Sequence diagrams render internal flow logic (conditionals, loops, error handling) within the service actor using Mermaid `alt`/`opt`/`loop` blocks
+
+### Modified Capabilities
+
+_(none — this extends existing sequence diagram rendering)_
+
+## Impact
+
+- **Files**: `internal/flow/sequence.go` (significant rewrite of `RenderSequenceDiagram`)
+- **API**: No contract change — `format=sequence` response improves (shows internal logic)
+- **Breaking**: No — diagrams get richer, no format change
+- **Dependencies**: Requires CFG data (from `function_flowcharts` table) to be populated for the entry function

--- a/openspec/changes/sequence-diagram-internal-logic/specs/sequence-diagram-internal-logic/spec.md
+++ b/openspec/changes/sequence-diagram-internal-logic/specs/sequence-diagram-internal-logic/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Render internal CFG nodes as self-messages
+
+The sequence diagram SHALL render internal function logic within the service actor as self-messages. When a function's CFG is available, step nodes SHALL be rendered as `tradeit-backend->>tradeit-backend: <step label>`.
+
+#### Scenario: Simple function with steps
+- **WHEN** the entry function has CFG nodes `start → validate → process → terminal`
+- **THEN** the sequence diagram SHALL show self-messages for `validate` and `process` within the service actor
+
+#### Scenario: No CFG available
+- **WHEN** the entry function has no CFG in `function_flowcharts`
+- **THEN** the sequence diagram SHALL fall back to current behavior (cross-actor messages only)
+
+### Requirement: Render conditionals as alt/loop blocks
+
+The sequence diagram SHALL render decision nodes as Mermaid `alt`/`opt` blocks. Branch edges with `yes`/`no` labels SHALL map to `alt yes/no` blocks. Single outgoing edges SHALL map to `opt` blocks.
+
+#### Scenario: If/else with yes/no branches
+- **WHEN** a decision node has `yes` and `no` outgoing edges
+- **THEN** the sequence diagram SHALL render `alt yes\n<truthy path>\nelse\n<falsy path>\nend`
+
+#### Scenario: Loop with loop edge
+- **WHEN** a decision node has a `loop` outgoing edge
+- **THEN** the sequence diagram SHALL render `loop condition\n<body>\nend`
+
+### Requirement: Diagram size limits
+
+The sequence diagram SHALL NOT exceed 50 total messages or 3 levels of decision nesting. When exceeded, the diagram SHALL truncate with a note: "Internal logic too complex — see full CFG".
+
+#### Scenario: Deeply nested function
+- **WHEN** the CFG has more than 3 levels of nested decisions
+- **THEN** the sequence diagram SHALL stop rendering internal logic at depth 3 and emit a truncation note
+
+#### Scenario: Exceeds message limit
+- **WHEN** total messages (cross-actor + internal) would exceed 50
+- **THEN** the sequence diagram SHALL emit the first 45 messages and a truncation note

--- a/openspec/changes/sequence-diagram-internal-logic/tasks.md
+++ b/openspec/changes/sequence-diagram-internal-logic/tasks.md
@@ -1,0 +1,29 @@
+## 1. CFG Loading
+
+- [ ] 1.1 Add function to load CFG from `function_flowcharts` table for a given entry point (file + function name)
+- [ ] 1.2 Add function to resolve entry point from flow entry (e.g., `POST /purchase` → `trade.js::purchaseHandler`)
+- [ ] 1.3 Integrate CFG loading into `RenderSequenceDiagram` — load CFG when available, skip when not
+
+## 2. Internal Logic Rendering
+
+- [ ] 2.1 Implement `renderInternalLogic` function that walks CFG nodes and emits self-messages for step nodes
+- [ ] 2.2 Map CFG decision nodes to Mermaid `alt`/`opt` blocks (yes/no → alt, single → opt)
+- [ ] 2.3 Map CFG loop edges to Mermaid `loop` blocks
+- [ ] 2.4 Render terminal nodes as return/self-message
+- [ ] 2.5 Emit middleware guard notes from flow edges (already implemented — verify compatibility)
+
+## 3. Depth & Size Limits
+
+- [ ] 3.1 Add max depth parameter (default 3) to `renderInternalLogic`
+- [ ] 3.2 Add max message count (default 50) with truncation note
+- [ ] 3.3 Emit truncation note: "Internal logic too complex — see full CFG at /api/v1/graph/flowchart"
+
+## 4. Testing & Verification
+
+- [ ] 4.1 Add unit tests for `renderInternalLogic` with simple CFG (start → step → terminal)
+- [ ] 4.2 Add unit test for alt/loop block rendering
+- [ ] 4.3 Add unit test for depth truncation
+- [ ] 4.4 Add unit test for missing CFG (fallback to cross-actor only)
+- [ ] 4.5 Run `go test -race -short ./...`
+- [ ] 4.6 E2E test: `POST /purchase` sequence diagram shows internal logic
+- [ ] 4.7 Run `go test -race -tags=integration ./...`


### PR DESCRIPTION
## Problem

Sequence diagrams only showed cross-actor messages. All internal logic (steps, conditionals, loops) was collapsed into the service actor. Diagram showed WHAT systems are called but not HOW code flows.

## Fix

- Load CFG from function_flowcharts table by HTTP entry point
- Render CFG nodes as self-messages within the service actor
- Decision nodes → alt blocks (yes/no), loop edges → loop blocks
- Depth limit 3, message limit 50 with truncation note
- Fix startID: always find start node by type (cfg.Entry is a full path, not a node ID)

## Verified

- POST /purchase: 100 self-messages showing internal flow (step, decision, terminal nodes)
- Cross-actor messages still work (MySQL, Steam, etc.)
- 8 unit tests pass

Closes #452