### PR TITLE
fix(flow): clean internal logic labels in sequence diagrams

### DIFF
--- a/internal/flow/sequence.go
+++ b/internal/flow/sequence.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/nano-brain/nano-brain/internal/graph"
@@ -363,7 +364,9 @@ func renderInternalLogic(
 
 	switch node.Type {
 	case "step", "merge", "start":
-		selfMsg(node.Label)
+		if cleaned, ok := simplifyStepLabel(node.Label); ok {
+			selfMsg(cleaned)
+		}
 		for _, e := range adj[entryID] {
 			lines = append(lines, renderInternalLogic(e.To, nodes, adj, actor, depth, msgCount, visited)...)
 			if *msgCount >= maxSeqMessages {
@@ -477,6 +480,56 @@ func renderLoopBlock(
 	}
 	lines = append(lines, "    end")
 	return lines
+}
+
+func isLiteral(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return true
+	}
+	if (strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) ||
+		(strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")) ||
+		(strings.HasPrefix(s, "`") && strings.HasSuffix(s, "`")) {
+		return true
+	}
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return true
+	}
+	if s == "true" || s == "false" || s == "null" || s == "nil" || s == "undefined" {
+		return true
+	}
+	if s == "{}" || s == "[]" {
+		return true
+	}
+	return false
+}
+
+func rhsAfterAssignment(s string) string {
+	idx := strings.Index(s, " = ")
+	if idx < 0 {
+		return s
+	}
+	return strings.TrimSpace(s[idx+3:])
+}
+
+func simplifyStepLabel(label string) (string, bool) {
+	for _, prefix := range []string{"const ", "let ", "var "} {
+		if strings.HasPrefix(label, prefix) {
+			rhs := strings.TrimPrefix(rhsAfterAssignment(label[len(prefix):]), "await ")
+			if isLiteral(rhs) {
+				return "", false
+			}
+			return rhs, true
+		}
+	}
+	if idx := strings.Index(label, " = "); idx >= 0 {
+		rhs := strings.TrimSpace(strings.TrimPrefix(label[idx+3:], "await "))
+		if isLiteral(rhs) {
+			return "", false
+		}
+		return rhs, true
+	}
+	return label, true
 }
 
 func RenderSequenceDiagramWithCFG(f Flow, cfgs FlowCFGs) string {

--- a/internal/flow/sequence_test.go
+++ b/internal/flow/sequence_test.go
@@ -459,6 +459,32 @@ func TestRenderSequenceDiagramWithCFG_DepthLimit(t *testing.T) {
 	}
 }
 
+func TestSimplifyStepLabel(t *testing.T) {
+	tests := []struct {
+		input    string
+		want     string
+		wantOK   bool
+	}{
+		{`const redis = Redis.init()`, "Redis.init()", true},
+		{`const redisKey = 'revertTradeScanKey'`, "", false},
+		{`let lastScanId = await redis.get(redisKey)`, "redis.get(redisKey)", true},
+		{`lastScanId = 0`, "", false},
+		{`for loop`, "for loop", true},
+		{`return res.success({})`, "return res.success({})", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := simplifyStepLabel(tt.input)
+			if ok != tt.wantOK {
+				t.Errorf("simplifyStepLabel(%q) ok=%v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("simplifyStepLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRenderInternalLogic_ErrorTerminal(t *testing.T) {
 	cfg := &graph.CFG{
 		Nodes: []graph.CFGNode{

--- a/openspec/changes/clean-sequence-internal-labels/.openspec.yaml
+++ b/openspec/changes/clean-sequence-internal-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20


### PR DESCRIPTION
## Problem

Sequence diagram internal logic rendered raw code labels like:
- `const redis = Redis.init()` (variable declaration)
- `const redisKey = 'revertTradeScanKey'` (string literal)
- `lastScanId = 0` (pure assignment)

## Fix

- Strip `const/let/var X = ` prefix
- Strip `await` from RHS
- Skip pure literal assignments
- Keep only function calls, conditionals, and terminals

Closes #455