### PR TITLE
chore(bench): add LLM quality and debugging benchmark framework

### DIFF
--- a/benchmarks/llm-quality/A_baseline.json
+++ b/benchmarks/llm-quality/A_baseline.json
@@ -1,0 +1,127 @@
+{
+  "run": "baseline",
+  "avg_score": 0.932,
+  "avg_latency_ms": 33.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "avg_score": 4.24,
+      "max_score": 6,
+      "latency_ms": 89
+    },
+    {
+      "query": "how does trade work",
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "latency_ms": 39
+    },
+    {
+      "query": "what is revert trade",
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "latency_ms": 27
+    },
+    {
+      "query": "show me the auth flow",
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "latency_ms": 20
+    },
+    {
+      "query": "how does payment processing work",
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "latency_ms": 17
+    },
+    {
+      "query": "what services does the backend call",
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "latency_ms": 21
+    },
+    {
+      "query": "how is user balance managed",
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "latency_ms": 13
+    },
+    {
+      "query": "what is the tradebot",
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "latency_ms": 38
+    },
+    {
+      "query": "show me the purchase flow",
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "latency_ms": 10
+    },
+    {
+      "query": "how does steam integration work",
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "latency_ms": 25
+    },
+    {
+      "query": "how does hybrid search work",
+      "avg_score": 0.443,
+      "max_score": 0.5,
+      "latency_ms": 68
+    },
+    {
+      "query": "what is the embed queue",
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "latency_ms": 43
+    },
+    {
+      "query": "how does session harvesting work",
+      "avg_score": 0.593,
+      "max_score": 0.8,
+      "latency_ms": 34
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "avg_score": 0.133,
+      "max_score": 0.1,
+      "latency_ms": 37
+    },
+    {
+      "query": "how does code summarization work",
+      "avg_score": 0.428,
+      "max_score": 0.5,
+      "latency_ms": 47
+    },
+    {
+      "query": "what extractors are registered",
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "latency_ms": 29
+    },
+    {
+      "query": "how does the watcher work",
+      "avg_score": 0.426,
+      "max_score": 0.5,
+      "latency_ms": 46
+    },
+    {
+      "query": "what is the MCP server",
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does graph stitching work",
+      "avg_score": 0.409,
+      "max_score": 0.4,
+      "latency_ms": 35
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "avg_score": 0.44,
+      "max_score": 0.6,
+      "latency_ms": 13
+    }
+  ]
+}

--- a/benchmarks/llm-quality/B_hyde.json
+++ b/benchmarks/llm-quality/B_hyde.json
@@ -1,0 +1,127 @@
+{
+  "run": "hyde",
+  "avg_score": 0.933,
+  "avg_latency_ms": 89.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "avg_score": 4.24,
+      "max_score": 6,
+      "latency_ms": 107
+    },
+    {
+      "query": "how does trade work",
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "latency_ms": 49
+    },
+    {
+      "query": "what is revert trade",
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "latency_ms": 24
+    },
+    {
+      "query": "show me the auth flow",
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "latency_ms": 22
+    },
+    {
+      "query": "how does payment processing work",
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "latency_ms": 22
+    },
+    {
+      "query": "what services does the backend call",
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "latency_ms": 27
+    },
+    {
+      "query": "how is user balance managed",
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "latency_ms": 19
+    },
+    {
+      "query": "what is the tradebot",
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "latency_ms": 40
+    },
+    {
+      "query": "show me the purchase flow",
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "latency_ms": 1179
+    },
+    {
+      "query": "how does steam integration work",
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "latency_ms": 27
+    },
+    {
+      "query": "how does hybrid search work",
+      "avg_score": 0.446,
+      "max_score": 0.5,
+      "latency_ms": 59
+    },
+    {
+      "query": "what is the embed queue",
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "latency_ms": 39
+    },
+    {
+      "query": "how does session harvesting work",
+      "avg_score": 0.594,
+      "max_score": 0.8,
+      "latency_ms": 25
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "avg_score": 0.133,
+      "max_score": 0.1,
+      "latency_ms": 22
+    },
+    {
+      "query": "how does code summarization work",
+      "avg_score": 0.43,
+      "max_score": 0.5,
+      "latency_ms": 25
+    },
+    {
+      "query": "what extractors are registered",
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "latency_ms": 20
+    },
+    {
+      "query": "how does the watcher work",
+      "avg_score": 0.428,
+      "max_score": 0.5,
+      "latency_ms": 12
+    },
+    {
+      "query": "what is the MCP server",
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "latency_ms": 19
+    },
+    {
+      "query": "how does graph stitching work",
+      "avg_score": 0.411,
+      "max_score": 0.4,
+      "latency_ms": 21
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "avg_score": 0.44,
+      "max_score": 0.6,
+      "latency_ms": 14
+    }
+  ]
+}

--- a/benchmarks/llm-quality/C_indexed_baseline.json
+++ b/benchmarks/llm-quality/C_indexed_baseline.json
@@ -1,0 +1,147 @@
+{
+  "run": "indexed_baseline",
+  "avg_score": 0.933,
+  "avg_latency_ms": 299.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "avg_score": 4.24,
+      "max_score": 6,
+      "num_results": 5,
+      "latency_ms": 812
+    },
+    {
+      "query": "how does trade work",
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "num_results": 5,
+      "latency_ms": 435
+    },
+    {
+      "query": "what is revert trade",
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "num_results": 5,
+      "latency_ms": 607
+    },
+    {
+      "query": "show me the auth flow",
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 667
+    },
+    {
+      "query": "how does payment processing work",
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 512
+    },
+    {
+      "query": "what services does the backend call",
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 650
+    },
+    {
+      "query": "how is user balance managed",
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "num_results": 5,
+      "latency_ms": 556
+    },
+    {
+      "query": "what is the tradebot",
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "num_results": 5,
+      "latency_ms": 473
+    },
+    {
+      "query": "show me the purchase flow",
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 530
+    },
+    {
+      "query": "how does steam integration work",
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 553
+    },
+    {
+      "query": "how does hybrid search work",
+      "avg_score": 0.449,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 21
+    },
+    {
+      "query": "what is the embed queue",
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 20
+    },
+    {
+      "query": "how does session harvesting work",
+      "avg_score": 0.596,
+      "max_score": 0.8,
+      "num_results": 5,
+      "latency_ms": 22
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "avg_score": 0.133,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 20
+    },
+    {
+      "query": "how does code summarization work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "what extractors are registered",
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does the watcher work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 17
+    },
+    {
+      "query": "what is the MCP server",
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does graph stitching work",
+      "avg_score": 0.412,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 20
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "avg_score": 0.44,
+      "max_score": 0.6,
+      "num_results": 5,
+      "latency_ms": 19
+    }
+  ]
+}

--- a/benchmarks/llm-quality/D_baseline_indexed.json
+++ b/benchmarks/llm-quality/D_baseline_indexed.json
@@ -1,0 +1,147 @@
+{
+  "run": "baseline_indexed",
+  "avg_score": 0.934,
+  "avg_latency_ms": 121.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "avg_score": 4.24,
+      "max_score": 6,
+      "num_results": 5,
+      "latency_ms": 50
+    },
+    {
+      "query": "how does trade work",
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "num_results": 5,
+      "latency_ms": 28
+    },
+    {
+      "query": "what is revert trade",
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "show me the auth flow",
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 19
+    },
+    {
+      "query": "how does payment processing work",
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 19
+    },
+    {
+      "query": "what services does the backend call",
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "how is user balance managed",
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "num_results": 5,
+      "latency_ms": 11
+    },
+    {
+      "query": "what is the tradebot",
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "num_results": 5,
+      "latency_ms": 23
+    },
+    {
+      "query": "show me the purchase flow",
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 14
+    },
+    {
+      "query": "how does steam integration work",
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 1976
+    },
+    {
+      "query": "how does hybrid search work",
+      "avg_score": 0.45,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 62
+    },
+    {
+      "query": "what is the embed queue",
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 11
+    },
+    {
+      "query": "how does session harvesting work",
+      "avg_score": 0.596,
+      "max_score": 0.8,
+      "num_results": 5,
+      "latency_ms": 22
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "avg_score": 0.133,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 24
+    },
+    {
+      "query": "how does code summarization work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 23
+    },
+    {
+      "query": "what extractors are registered",
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "how does the watcher work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 24
+    },
+    {
+      "query": "what is the MCP server",
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does graph stitching work",
+      "avg_score": 0.413,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 28
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "avg_score": 0.44,
+      "max_score": 0.6,
+      "num_results": 5,
+      "latency_ms": 25
+    }
+  ]
+}

--- a/benchmarks/llm-quality/E_hyde_indexed.json
+++ b/benchmarks/llm-quality/E_hyde_indexed.json
@@ -1,0 +1,147 @@
+{
+  "run": "hyde_indexed",
+  "avg_score": 0.934,
+  "avg_latency_ms": 98.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "avg_score": 4.24,
+      "max_score": 6,
+      "num_results": 5,
+      "latency_ms": 89
+    },
+    {
+      "query": "how does trade work",
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "num_results": 5,
+      "latency_ms": 38
+    },
+    {
+      "query": "what is revert trade",
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "num_results": 5,
+      "latency_ms": 39
+    },
+    {
+      "query": "show me the auth flow",
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does payment processing work",
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 10
+    },
+    {
+      "query": "what services does the backend call",
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 20
+    },
+    {
+      "query": "how is user balance managed",
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "num_results": 5,
+      "latency_ms": 12
+    },
+    {
+      "query": "what is the tradebot",
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "num_results": 5,
+      "latency_ms": 21
+    },
+    {
+      "query": "show me the purchase flow",
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 942
+    },
+    {
+      "query": "how does steam integration work",
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 613
+    },
+    {
+      "query": "how does hybrid search work",
+      "avg_score": 0.452,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 30
+    },
+    {
+      "query": "what is the embed queue",
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 21
+    },
+    {
+      "query": "how does session harvesting work",
+      "avg_score": 0.596,
+      "max_score": 0.8,
+      "num_results": 5,
+      "latency_ms": 15
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "avg_score": 0.133,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 13
+    },
+    {
+      "query": "how does code summarization work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 10
+    },
+    {
+      "query": "what extractors are registered",
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "how does the watcher work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 10
+    },
+    {
+      "query": "what is the MCP server",
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does graph stitching work",
+      "avg_score": 0.413,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 12
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "avg_score": 0.44,
+      "max_score": 0.6,
+      "num_results": 5,
+      "latency_ms": 19
+    }
+  ]
+}

--- a/benchmarks/llm-quality/F_codesummary.json
+++ b/benchmarks/llm-quality/F_codesummary.json
@@ -1,0 +1,147 @@
+{
+  "run": "code_summarization",
+  "avg_score": 0.934,
+  "avg_latency_ms": 218.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "avg_score": 4.24,
+      "max_score": 6,
+      "num_results": 5,
+      "latency_ms": 123
+    },
+    {
+      "query": "how does trade work",
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "num_results": 5,
+      "latency_ms": 73
+    },
+    {
+      "query": "what is revert trade",
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "num_results": 5,
+      "latency_ms": 42
+    },
+    {
+      "query": "show me the auth flow",
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 21
+    },
+    {
+      "query": "how does payment processing work",
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "what services does the backend call",
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 1996
+    },
+    {
+      "query": "how is user balance managed",
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "num_results": 5,
+      "latency_ms": 630
+    },
+    {
+      "query": "what is the tradebot",
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "num_results": 5,
+      "latency_ms": 378
+    },
+    {
+      "query": "show me the purchase flow",
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 425
+    },
+    {
+      "query": "how does steam integration work",
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "num_results": 5,
+      "latency_ms": 461
+    },
+    {
+      "query": "how does hybrid search work",
+      "avg_score": 0.452,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 30
+    },
+    {
+      "query": "what is the embed queue",
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "how does session harvesting work",
+      "avg_score": 0.596,
+      "max_score": 0.8,
+      "num_results": 5,
+      "latency_ms": 20
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "avg_score": 0.133,
+      "max_score": 0.1,
+      "num_results": 5,
+      "latency_ms": 20
+    },
+    {
+      "query": "how does code summarization work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 18
+    },
+    {
+      "query": "what extractors are registered",
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does the watcher work",
+      "avg_score": 0.431,
+      "max_score": 0.5,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "what is the MCP server",
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does graph stitching work",
+      "avg_score": 0.413,
+      "max_score": 0.4,
+      "num_results": 5,
+      "latency_ms": 16
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "avg_score": 0.44,
+      "max_score": 0.6,
+      "num_results": 5,
+      "latency_ms": 16
+    }
+  ]
+}

--- a/benchmarks/llm-quality/baseline_3199_scores.json
+++ b/benchmarks/llm-quality/baseline_3199_scores.json
@@ -1,0 +1,307 @@
+{
+  "run": "baseline_3199",
+  "features": "none",
+  "avg_score": 0.921,
+  "avg_latency_ms": 18.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        6,
+        5.200000286102295,
+        3.6000001430511475,
+        3.200000047683716,
+        3.200000047683716
+      ],
+      "avg_score": 4.24,
+      "max_score": 6,
+      "latency_ms": 44
+    },
+    {
+      "query": "how does trade work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.6530303359031677,
+        0.30000001192092896,
+        0.23333333432674408,
+        0.23333333432674408,
+        0.2210526317358017
+      ],
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "latency_ms": 27
+    },
+    {
+      "query": "what is revert trade",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.344876766204834,
+        4.837981700897217,
+        3.573085308074951,
+        3.427359104156494,
+        3.136159896850586
+      ],
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "latency_ms": 22
+    },
+    {
+      "query": "show me the auth flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.0816463977098465,
+        0.07782880961894989,
+        0.07517730444669724,
+        0.03076923079788685,
+        0.03076923079788685
+      ],
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does payment processing work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.41333332657814026,
+        0.41333332657814026,
+        0.11818181723356247,
+        0.08085053414106369,
+        0.08085053414106369
+      ],
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "latency_ms": 19
+    },
+    {
+      "query": "what services does the backend call",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.42222222685813904,
+        0.14666667580604553,
+        0.11081080883741379,
+        0.0948757752776146,
+        0.0823645368218422
+      ],
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "latency_ms": 29
+    },
+    {
+      "query": "how is user balance managed",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.9213675260543823,
+        0.48085901141166687,
+        0.13333334028720856,
+        0.13333334028720856,
+        0.13333334028720856
+      ],
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "latency_ms": 16
+    },
+    {
+      "query": "what is the tradebot",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.200000286102295,
+        5.200000286102295,
+        4.400000095367432,
+        4,
+        3.6000001430511475
+      ],
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "latency_ms": 44
+    },
+    {
+      "query": "show me the purchase flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.02131287381052971,
+        0.01666666753590107,
+        0.01666666753590107,
+        0.004651162773370743,
+        0.004347826354205608
+      ],
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "latency_ms": 9
+    },
+    {
+      "query": "how does steam integration work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.024331796914339066,
+        0.014635658822953701,
+        0.013333333656191826,
+        0.011111111380159855,
+        0.010810811072587967
+      ],
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "latency_ms": 11
+    },
+    {
+      "query": "how does hybrid search work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.5487179756164551,
+        0.4166666865348816,
+        0.4166666865348816,
+        0.4000000059604645,
+        0.004938271827995777
+      ],
+      "avg_score": 0.357,
+      "max_score": 0.5,
+      "latency_ms": 27
+    },
+    {
+      "query": "what is the embed queue",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        1.2285714149475098,
+        0.8666666746139526,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645
+      ],
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does session harvesting work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.82833331823349,
+        0.8266666531562805,
+        0.4943847060203552,
+        0.40799999237060547,
+        0.40799999237060547
+      ],
+      "avg_score": 0.593,
+      "max_score": 0.8,
+      "latency_ms": 11
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.13333334028720856,
+        0.13333334028720856,
+        0.13333334028720856,
+        0.13333334028720856,
+        0.0024691359139978886
+      ],
+      "avg_score": 0.107,
+      "max_score": 0.1,
+      "latency_ms": 10
+    },
+    {
+      "query": "how does code summarization work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.4958333373069763,
+        0.4191148579120636,
+        0.40784314274787903,
+        0.40784314274787903,
+        0.004444444552063942
+      ],
+      "avg_score": 0.347,
+      "max_score": 0.5,
+      "latency_ms": 11
+    },
+    {
+      "query": "what extractors are registered",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.30000001192092896,
+        0.24444444477558136,
+        0.2235294133424759,
+        0.2235294133424759,
+        0.20153845846652985
+      ],
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "latency_ms": 13
+    },
+    {
+      "query": "how does the watcher work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.49666666984558105,
+        0.40799999237060547,
+        0.40799999237060547,
+        0.40360361337661743,
+        0.15833333134651184
+      ],
+      "avg_score": 0.375,
+      "max_score": 0.5,
+      "latency_ms": 17
+    },
+    {
+      "query": "what is the MCP server",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        1.2457143068313599,
+        0.9575970768928528,
+        0.9108108282089233,
+        0.8190476298332214,
+        0.699999988079071
+      ],
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does graph stitching work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.41428571939468384,
+        0.40799999237060547,
+        0.40799999237060547,
+        0.40392157435417175,
+        0.4000000059604645
+      ],
+      "avg_score": 0.407,
+      "max_score": 0.4,
+      "latency_ms": 10
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "workspace": "7f443561795a",
+      "num_results": 4,
+      "scores": [
+        0.6000000238418579,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645
+      ],
+      "avg_score": 0.45,
+      "max_score": 0.6,
+      "latency_ms": 9
+    }
+  ]
+}

--- a/benchmarks/llm-quality/baseline_scores.json
+++ b/benchmarks/llm-quality/baseline_scores.json
@@ -1,0 +1,307 @@
+{
+  "run": "baseline",
+  "features": "none",
+  "avg_score": 1.02,
+  "avg_latency_ms": 24.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        4.800000190734863,
+        3.6000001430511475,
+        3.200000047683716,
+        2.799999952316284,
+        2.4000000953674316
+      ],
+      "avg_score": 3.36,
+      "max_score": 4.8,
+      "latency_ms": 60
+    },
+    {
+      "query": "how does trade work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.6530303359031677,
+        0.30000001192092896,
+        0.23333333432674408,
+        0.23333333432674408,
+        0.2210526317358017
+      ],
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "latency_ms": 17
+    },
+    {
+      "query": "what is revert trade",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.344876766204834,
+        4.837981700897217,
+        3.573085308074951,
+        3.427359104156494,
+        3.136159896850586
+      ],
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "latency_ms": 17
+    },
+    {
+      "query": "show me the auth flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.0816463977098465,
+        0.07782880961894989,
+        0.07517730444669724,
+        0.03076923079788685,
+        0.03076923079788685
+      ],
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "latency_ms": 43
+    },
+    {
+      "query": "how does payment processing work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.41333332657814026,
+        0.41333332657814026,
+        0.11818181723356247,
+        0.06666667014360428,
+        0.06666667014360428
+      ],
+      "avg_score": 0.216,
+      "max_score": 0.4,
+      "latency_ms": 17
+    },
+    {
+      "query": "what services does the backend call",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.42222222685813904,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645
+      ],
+      "avg_score": 0.404,
+      "max_score": 0.4,
+      "latency_ms": 49
+    },
+    {
+      "query": "how is user balance managed",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.9213675260543823,
+        0.7408359050750732,
+        0.6790841221809387,
+        0.616460382938385,
+        0.48085901141166687
+      ],
+      "avg_score": 0.688,
+      "max_score": 0.9,
+      "latency_ms": 46
+    },
+    {
+      "query": "what is the tradebot",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.200000286102295,
+        5.200000286102295,
+        4.400000095367432,
+        4,
+        3.6000001430511475
+      ],
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "latency_ms": 47
+    },
+    {
+      "query": "show me the purchase flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.017391305416822433,
+        0.01666666753590107,
+        0.01666666753590107,
+        0.009643527679145336,
+        0.004651162773370743
+      ],
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "latency_ms": 13
+    },
+    {
+      "query": "how does steam integration work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.024331796914339066,
+        0.014635658822953701,
+        0.013333333656191826,
+        0.011111111380159855,
+        0.010810811072587967
+      ],
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "latency_ms": 18
+    },
+    {
+      "query": "how does hybrid search work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.20000000298023224,
+        0.1269230842590332,
+        0.09410251677036285,
+        0.04873449355363846,
+        0.04457142949104309
+      ],
+      "avg_score": 0.103,
+      "max_score": 0.2,
+      "latency_ms": 12
+    },
+    {
+      "query": "what is the embed queue",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        3.119966983795166,
+        2.1491315364837646,
+        2.004714012145996,
+        1.9653539657592773,
+        1.9380263090133667
+      ],
+      "avg_score": 2.235,
+      "max_score": 3.1,
+      "latency_ms": 27
+    },
+    {
+      "query": "how does session harvesting work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.4886956512928009,
+        0.4810897409915924,
+        0.48000001907348633,
+        0.4048192799091339,
+        0.13344332575798035
+      ],
+      "avg_score": 0.398,
+      "max_score": 0.5,
+      "latency_ms": 9
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.011328976601362228,
+        0.008216960355639458,
+        0.0024691359139978886,
+        0.001612903201021254,
+        0.0013651876943185925
+      ],
+      "avg_score": 0.005,
+      "max_score": 0.0,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does code summarization work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.5,
+        0.20000000298023224,
+        0.16414815187454224,
+        0.13593073189258575,
+        0.12603729963302612
+      ],
+      "avg_score": 0.225,
+      "max_score": 0.5,
+      "latency_ms": 12
+    },
+    {
+      "query": "what extractors are registered",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.8046512007713318,
+        0.5954762101173401,
+        0.5465071797370911,
+        0.5465071797370911,
+        0.5465071797370911
+      ],
+      "avg_score": 0.608,
+      "max_score": 0.8,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does the watcher work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.4000000059604645,
+        0.1961904764175415,
+        0.1961904764175415,
+        0.15833333134651184,
+        0.10000000149011612
+      ],
+      "avg_score": 0.21,
+      "max_score": 0.4,
+      "latency_ms": 20
+    },
+    {
+      "query": "what is the MCP server",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        3.2911651134490967,
+        3.22263765335083,
+        2.853496551513672,
+        2.8474371433258057,
+        2.5582711696624756
+      ],
+      "avg_score": 2.955,
+      "max_score": 3.3,
+      "latency_ms": 23
+    },
+    {
+      "query": "how does graph stitching work",
+      "workspace": "7f443561795a",
+      "num_results": 4,
+      "scores": [
+        0.028282828629016876,
+        0.02222222276031971,
+        0.001932367216795683,
+        0.0019047618843615055
+      ],
+      "avg_score": 0.014,
+      "max_score": 0.0,
+      "latency_ms": 11
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.054700855165719986,
+        0.04444444552063942,
+        0.0062500000931322575,
+        0.005263158120214939,
+        0.0014084507711231709
+      ],
+      "avg_score": 0.022,
+      "max_score": 0.1,
+      "latency_ms": 10
+    }
+  ]
+}

--- a/benchmarks/llm-quality/hyde_3199_scores.json
+++ b/benchmarks/llm-quality/hyde_3199_scores.json
@@ -1,0 +1,307 @@
+{
+  "run": "hyde_3199",
+  "features": "hyde",
+  "avg_score": 0.921,
+  "avg_latency_ms": 28.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        6,
+        5.200000286102295,
+        3.6000001430511475,
+        3.200000047683716,
+        3.200000047683716
+      ],
+      "avg_score": 4.24,
+      "max_score": 6,
+      "latency_ms": 70
+    },
+    {
+      "query": "how does trade work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.6530303359031677,
+        0.30000001192092896,
+        0.23333333432674408,
+        0.23333333432674408,
+        0.2210526317358017
+      ],
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "latency_ms": 26
+    },
+    {
+      "query": "what is revert trade",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.344876766204834,
+        4.837981700897217,
+        3.573085308074951,
+        3.427359104156494,
+        3.136159896850586
+      ],
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "latency_ms": 21
+    },
+    {
+      "query": "show me the auth flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.0816463977098465,
+        0.07782880961894989,
+        0.07517730444669724,
+        0.03076923079788685,
+        0.03076923079788685
+      ],
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "latency_ms": 14
+    },
+    {
+      "query": "how does payment processing work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.41333332657814026,
+        0.41333332657814026,
+        0.11818181723356247,
+        0.08085053414106369,
+        0.08085053414106369
+      ],
+      "avg_score": 0.221,
+      "max_score": 0.4,
+      "latency_ms": 11
+    },
+    {
+      "query": "what services does the backend call",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.42222222685813904,
+        0.14666667580604553,
+        0.11081080883741379,
+        0.0948757752776146,
+        0.0823645368218422
+      ],
+      "avg_score": 0.171,
+      "max_score": 0.4,
+      "latency_ms": 52
+    },
+    {
+      "query": "how is user balance managed",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.9213675260543823,
+        0.48085901141166687,
+        0.13333334028720856,
+        0.13333334028720856,
+        0.13333334028720856
+      ],
+      "avg_score": 0.36,
+      "max_score": 0.9,
+      "latency_ms": 56
+    },
+    {
+      "query": "what is the tradebot",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.200000286102295,
+        5.200000286102295,
+        4.400000095367432,
+        4,
+        3.6000001430511475
+      ],
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "latency_ms": 184
+    },
+    {
+      "query": "show me the purchase flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.02131287381052971,
+        0.01666666753590107,
+        0.01666666753590107,
+        0.004651162773370743,
+        0.004347826354205608
+      ],
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "latency_ms": 14
+    },
+    {
+      "query": "how does steam integration work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.024331796914339066,
+        0.014635658822953701,
+        0.013333333656191826,
+        0.011111111380159855,
+        0.010810811072587967
+      ],
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "latency_ms": 19
+    },
+    {
+      "query": "how does hybrid search work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.5487179756164551,
+        0.4166666865348816,
+        0.4166666865348816,
+        0.4000000059604645,
+        0.004938271827995777
+      ],
+      "avg_score": 0.357,
+      "max_score": 0.5,
+      "latency_ms": 11
+    },
+    {
+      "query": "what is the embed queue",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        1.2285714149475098,
+        0.8666666746139526,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645
+      ],
+      "avg_score": 0.659,
+      "max_score": 1.2,
+      "latency_ms": 10
+    },
+    {
+      "query": "how does session harvesting work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.82833331823349,
+        0.8266666531562805,
+        0.4943847060203552,
+        0.40799999237060547,
+        0.40799999237060547
+      ],
+      "avg_score": 0.593,
+      "max_score": 0.8,
+      "latency_ms": 10
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.13333334028720856,
+        0.13333334028720856,
+        0.13333334028720856,
+        0.13333334028720856,
+        0.0024691359139978886
+      ],
+      "avg_score": 0.107,
+      "max_score": 0.1,
+      "latency_ms": 9
+    },
+    {
+      "query": "how does code summarization work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.4958333373069763,
+        0.4191148579120636,
+        0.40784314274787903,
+        0.40784314274787903,
+        0.004444444552063942
+      ],
+      "avg_score": 0.347,
+      "max_score": 0.5,
+      "latency_ms": 9
+    },
+    {
+      "query": "what extractors are registered",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.30000001192092896,
+        0.24444444477558136,
+        0.2235294133424759,
+        0.2235294133424759,
+        0.20153845846652985
+      ],
+      "avg_score": 0.239,
+      "max_score": 0.3,
+      "latency_ms": 9
+    },
+    {
+      "query": "how does the watcher work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.49666666984558105,
+        0.40799999237060547,
+        0.40799999237060547,
+        0.40360361337661743,
+        0.15833333134651184
+      ],
+      "avg_score": 0.375,
+      "max_score": 0.5,
+      "latency_ms": 9
+    },
+    {
+      "query": "what is the MCP server",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        1.2457143068313599,
+        0.9575970768928528,
+        0.9108108282089233,
+        0.8190476298332214,
+        0.699999988079071
+      ],
+      "avg_score": 0.927,
+      "max_score": 1.2,
+      "latency_ms": 12
+    },
+    {
+      "query": "how does graph stitching work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.41428571939468384,
+        0.40799999237060547,
+        0.40799999237060547,
+        0.40392157435417175,
+        0.4000000059604645
+      ],
+      "avg_score": 0.407,
+      "max_score": 0.4,
+      "latency_ms": 13
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "workspace": "7f443561795a",
+      "num_results": 4,
+      "scores": [
+        0.6000000238418579,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645
+      ],
+      "avg_score": 0.45,
+      "max_score": 0.6,
+      "latency_ms": 9
+    }
+  ]
+}

--- a/benchmarks/llm-quality/hyde_scores.json
+++ b/benchmarks/llm-quality/hyde_scores.json
@@ -1,0 +1,307 @@
+{
+  "run": "hyde",
+  "features": "hyde",
+  "avg_score": 1.02,
+  "avg_latency_ms": 23.0,
+  "queries": [
+    {
+      "query": "what is topup",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        4.800000190734863,
+        3.6000001430511475,
+        3.200000047683716,
+        2.799999952316284,
+        2.4000000953674316
+      ],
+      "avg_score": 3.36,
+      "max_score": 4.8,
+      "latency_ms": 85
+    },
+    {
+      "query": "how does trade work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.6530303359031677,
+        0.30000001192092896,
+        0.23333333432674408,
+        0.23333333432674408,
+        0.2210526317358017
+      ],
+      "avg_score": 0.328,
+      "max_score": 0.7,
+      "latency_ms": 32
+    },
+    {
+      "query": "what is revert trade",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.344876766204834,
+        4.837981700897217,
+        3.573085308074951,
+        3.427359104156494,
+        3.136159896850586
+      ],
+      "avg_score": 4.064,
+      "max_score": 5.3,
+      "latency_ms": 26
+    },
+    {
+      "query": "show me the auth flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.0816463977098465,
+        0.07782880961894989,
+        0.07517730444669724,
+        0.03076923079788685,
+        0.03076923079788685
+      ],
+      "avg_score": 0.059,
+      "max_score": 0.1,
+      "latency_ms": 21
+    },
+    {
+      "query": "how does payment processing work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.41333332657814026,
+        0.41333332657814026,
+        0.11818181723356247,
+        0.06666667014360428,
+        0.06666667014360428
+      ],
+      "avg_score": 0.216,
+      "max_score": 0.4,
+      "latency_ms": 17
+    },
+    {
+      "query": "what services does the backend call",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.42222222685813904,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645,
+        0.4000000059604645
+      ],
+      "avg_score": 0.404,
+      "max_score": 0.4,
+      "latency_ms": 20
+    },
+    {
+      "query": "how is user balance managed",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.9213675260543823,
+        0.7408359050750732,
+        0.6790841221809387,
+        0.616460382938385,
+        0.48085901141166687
+      ],
+      "avg_score": 0.688,
+      "max_score": 0.9,
+      "latency_ms": 40
+    },
+    {
+      "query": "what is the tradebot",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        5.200000286102295,
+        5.200000286102295,
+        4.400000095367432,
+        4,
+        3.6000001430511475
+      ],
+      "avg_score": 4.48,
+      "max_score": 5.2,
+      "latency_ms": 27
+    },
+    {
+      "query": "show me the purchase flow",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.017391305416822433,
+        0.01666666753590107,
+        0.01666666753590107,
+        0.009643527679145336,
+        0.004651162773370743
+      ],
+      "avg_score": 0.013,
+      "max_score": 0.0,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does steam integration work",
+      "workspace": "d1915ee19311",
+      "num_results": 5,
+      "scores": [
+        0.024331796914339066,
+        0.014635658822953701,
+        0.013333333656191826,
+        0.011111111380159855,
+        0.010810811072587967
+      ],
+      "avg_score": 0.015,
+      "max_score": 0.0,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does hybrid search work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.20000000298023224,
+        0.1269230842590332,
+        0.09410251677036285,
+        0.04873449355363846,
+        0.04457142949104309
+      ],
+      "avg_score": 0.103,
+      "max_score": 0.2,
+      "latency_ms": 16
+    },
+    {
+      "query": "what is the embed queue",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        3.119966983795166,
+        2.1491315364837646,
+        2.004714012145996,
+        1.9653539657592773,
+        1.9380263090133667
+      ],
+      "avg_score": 2.235,
+      "max_score": 3.1,
+      "latency_ms": 16
+    },
+    {
+      "query": "how does session harvesting work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.4886956512928009,
+        0.4810897409915924,
+        0.48000001907348633,
+        0.4048192799091339,
+        0.13344332575798035
+      ],
+      "avg_score": 0.398,
+      "max_score": 0.5,
+      "latency_ms": 14
+    },
+    {
+      "query": "show me the memory flow pipeline",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.011328976601362228,
+        0.008216960355639458,
+        0.0024691359139978886,
+        0.001612903201021254,
+        0.0013651876943185925
+      ],
+      "avg_score": 0.005,
+      "max_score": 0.0,
+      "latency_ms": 14
+    },
+    {
+      "query": "how does code summarization work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.5,
+        0.20000000298023224,
+        0.16414815187454224,
+        0.13593073189258575,
+        0.12603729963302612
+      ],
+      "avg_score": 0.225,
+      "max_score": 0.5,
+      "latency_ms": 14
+    },
+    {
+      "query": "what extractors are registered",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.8046512007713318,
+        0.5954762101173401,
+        0.5465071797370911,
+        0.5465071797370911,
+        0.5465071797370911
+      ],
+      "avg_score": 0.608,
+      "max_score": 0.8,
+      "latency_ms": 14
+    },
+    {
+      "query": "how does the watcher work",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.4000000059604645,
+        0.1961904764175415,
+        0.1961904764175415,
+        0.15833333134651184,
+        0.10000000149011612
+      ],
+      "avg_score": 0.21,
+      "max_score": 0.4,
+      "latency_ms": 26
+    },
+    {
+      "query": "what is the MCP server",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        3.2911651134490967,
+        3.22263765335083,
+        2.853496551513672,
+        2.8474371433258057,
+        2.5582711696624756
+      ],
+      "avg_score": 2.955,
+      "max_score": 3.3,
+      "latency_ms": 19
+    },
+    {
+      "query": "how does graph stitching work",
+      "workspace": "7f443561795a",
+      "num_results": 4,
+      "scores": [
+        0.028282828629016876,
+        0.02222222276031971,
+        0.001932367216795683,
+        0.0019047618843615055
+      ],
+      "avg_score": 0.014,
+      "max_score": 0.0,
+      "latency_ms": 12
+    },
+    {
+      "query": "what is the RRF merge algorithm",
+      "workspace": "7f443561795a",
+      "num_results": 5,
+      "scores": [
+        0.054700855165719986,
+        0.04444444552063942,
+        0.0062500000931322575,
+        0.005263158120214939,
+        0.0014084507711231709
+      ],
+      "avg_score": 0.022,
+      "max_score": 0.1,
+      "latency_ms": 14
+    }
+  ]
+}

--- a/benchmarks/llm-quality/queries.json
+++ b/benchmarks/llm-quality/queries.json
@@ -1,0 +1,65 @@
+{
+  "workspace": "d1915ee19311546a064576fc5df565da7ab20fe1c4a81c97e3ba6e9059d977b7",
+  "queries": [
+    {
+      "id": "q1",
+      "query": "what is topup",
+      "category": "feature-understanding",
+      "expect": ["topup", "balance", "payment"]
+    },
+    {
+      "id": "q2",
+      "query": "how does trade work",
+      "category": "feature-understanding",
+      "expect": ["trade", "purchase", "sell"]
+    },
+    {
+      "id": "q3",
+      "query": "what is revert trade",
+      "category": "feature-understanding",
+      "expect": ["revert", "rollback", "cancel"]
+    },
+    {
+      "id": "q4",
+      "query": "show me the auth flow",
+      "category": "flow-understanding",
+      "expect": ["auth", "login", "session", "token"]
+    },
+    {
+      "id": "q5",
+      "query": "how does payment processing work",
+      "category": "feature-understanding",
+      "expect": ["payment", "stripe", "paypal", "charge"]
+    },
+    {
+      "id": "q6",
+      "query": "what services does the backend call",
+      "category": "architecture",
+      "expect": ["service", "redis", "database", "api"]
+    },
+    {
+      "id": "q7",
+      "query": "how is user balance managed",
+      "category": "feature-understanding",
+      "expect": ["balance", "user", "update", "change"]
+    },
+    {
+      "id": "q8",
+      "query": "what is the tradebot",
+      "category": "architecture",
+      "expect": ["tradebot", "bot", "automation"]
+    },
+    {
+      "id": "q9",
+      "query": "show me the purchase flow",
+      "category": "flow-understanding",
+      "expect": ["purchase", "buy", "checkout"]
+    },
+    {
+      "id": "q10",
+      "query": "how does steam integration work",
+      "category": "integration",
+      "expect": ["steam", "inventory", "trade"]
+    }
+  ]
+}

--- a/benchmarks/llm-quality/queries_debug.json
+++ b/benchmarks/llm-quality/queries_debug.json
@@ -1,0 +1,69 @@
+{
+  "workspace": "d1915ee19311546a064576fc5df565da7ab20fe1c4a81c97e3ba6e9059d977b7",
+  "queries": [
+    {
+      "id": "dbg1",
+      "query": "stripe payment has wrong tax",
+      "category": "payment-bug",
+      "expect_code": ["tax", "stripe", "payment"],
+      "expect_sessions": ["tax", "stripe", "payment", "bug"],
+      "expect_config": ["tax_rate", "stripe"]
+    },
+    {
+      "id": "dbg2",
+      "query": "tradebot goes weird status",
+      "category": "trade-bug",
+      "expect_code": ["status", "tradebot", "trade"],
+      "expect_sessions": ["tradebot", "status", "trade"],
+      "expect_config": ["status", "trade"]
+    },
+    {
+      "id": "dbg3",
+      "query": "user balance not updated after topup",
+      "category": "balance-bug",
+      "expect_code": ["balance", "topup", "update"],
+      "expect_sessions": ["balance", "topup", "update"],
+      "expect_config": ["balance"]
+    },
+    {
+      "id": "dbg4",
+      "query": "steam trade stuck in pending",
+      "category": "integration-bug",
+      "expect_code": ["steam", "trade", "pending"],
+      "expect_sessions": ["steam", "trade", "pending"],
+      "expect_config": ["steam", "trade"]
+    },
+    {
+      "id": "dbg5",
+      "query": "revert trade not triggering",
+      "category": "trade-bug",
+      "expect_code": ["revert", "trade", "trigger"],
+      "expect_sessions": ["revert", "trade"],
+      "expect_config": ["revert", "threshold"]
+    },
+    {
+      "id": "dbg6",
+      "query": "duplicate topup transaction",
+      "category": "concurrency-bug",
+      "expect_code": ["topup", "transaction", "duplicate"],
+      "expect_sessions": ["topup", "transaction", "duplicate"],
+      "expect_config": ["idempotent", "transaction"]
+    },
+    {
+      "id": "dbg7",
+      "query": "notification not sent after trade",
+      "category": "integration-bug",
+      "expect_code": ["notification", "trade", "send"],
+      "expect_sessions": ["notification", "trade"],
+      "expect_config": ["notification", "trade"]
+    },
+    {
+      "id": "dbg8",
+      "query": "search returning wrong results",
+      "category": "search-bug",
+      "expect_code": ["search", "query", "result"],
+      "expect_sessions": ["search", "result"],
+      "expect_config": ["search", "rrf", "bm25"]
+    }
+  ]
+}

--- a/benchmarks/llm-quality/queries_nanobrain.json
+++ b/benchmarks/llm-quality/queries_nanobrain.json
@@ -1,0 +1,65 @@
+{
+  "workspace": "7f443561795a6fea64b6e8d35a9b06ed4d216b8a27af5e10e7137b261ade061f",
+  "queries": [
+    {
+      "id": "q1",
+      "query": "how does hybrid search work",
+      "category": "feature-understanding",
+      "expect": ["hybrid", "search", "bm25", "vector"]
+    },
+    {
+      "id": "q2",
+      "query": "what is the embed queue",
+      "category": "feature-understanding",
+      "expect": ["embed", "queue", "chunk"]
+    },
+    {
+      "id": "q3",
+      "query": "how does session harvesting work",
+      "category": "feature-understanding",
+      "expect": ["harvest", "session", "opencode"]
+    },
+    {
+      "id": "q4",
+      "query": "show me the memory flow pipeline",
+      "category": "flow-understanding",
+      "expect": ["flow", "graph", "edge", "node"]
+    },
+    {
+      "id": "q5",
+      "query": "how does code summarization work",
+      "category": "feature-understanding",
+      "expect": ["summarize", "code", "symbol", "llm"]
+    },
+    {
+      "id": "q6",
+      "query": "what extractors are registered",
+      "category": "architecture",
+      "expect": ["extractor", "express", "echo", "gin"]
+    },
+    {
+      "id": "q7",
+      "query": "how does the watcher work",
+      "category": "feature-understanding",
+      "expect": ["watcher", "fsnotify", "index"]
+    },
+    {
+      "id": "q8",
+      "query": "what is the MCP server",
+      "category": "architecture",
+      "expect": ["mcp", "tool", "server"]
+    },
+    {
+      "id": "q9",
+      "query": "how does graph stitching work",
+      "category": "feature-understanding",
+      "expect": ["stitch", "cross", "workspace"]
+    },
+    {
+      "id": "q10",
+      "query": "what is the RRF merge algorithm",
+      "category": "architecture",
+      "expect": ["rrf", "merge", "rank", "fusion"]
+    }
+  ]
+}

--- a/benchmarks/llm-quality/results_20260620_085630.json
+++ b/benchmarks/llm-quality/results_20260620_085630.json
@@ -1,0 +1,140 @@
+{
+  "runs": [
+    {
+      "id": "q1",
+      "query": "what is topup",
+      "category": "feature-understanding",
+      "latency_ms": 94,
+      "results_count": 5,
+      "relevance_score": 1.0,
+      "snippets": [
+        "\u2026ange));\n\t\tSystem.out.println(\"current_balance: $\"+toDollar(current_balance));\n\t\tSystem.out.println(\"topup_crypto: $\"+toDollar(topup_amount_crypto[1])+\"  $\"+toDollar(topup_amount_crypto[0]));\n\t\tSyste\u2026",
+        "class TopupTransactionRepo {\n  async get(id) {\n    const result = await getConnection().execute('SELECT * FROM topup_transactions WHERE tx_id=:id', { id })\n\n    return pathOr(null, [0, 0], result)\n  \u2026",
+        "\u202600)-blackHoled-reserved;\r\n\t\tdouble result2 = bot_profit+sell_amount_crypto[0]+sell_amount_money[0]-(topup_amount_crypto[0]+topup_amount_money[0])+(depr*100)-blackHoled+balance_change;\r\n\t\tdouble bcha\u2026"
+      ]
+    },
+    {
+      "id": "q2",
+      "query": "how does trade work",
+      "category": "feature-understanding",
+      "latency_ms": 50,
+      "results_count": 5,
+      "relevance_score": 0.3333333333333333,
+      "snippets": [
+        "\u2026everses? |\n|---|---|\n| **Skinport** | B **cannot buy** \u2014 listing is hidden during A\u2192bot's 7-day Trade Protection window |\n| **DMarket** | B can buy but B's funds are locked; if Steam reverses \u2192 B ge\u2026",
+        "      title9: 'How our CSGO Trading Bots Function',\n      text9: `Our CSGO trading bots work efficiently to execute trades, ensuring a smooth and secure experience for our users.\n      By employing s\u2026",
+        "\u2026\n  landing_page: {\n    hero: {\n      trustpilot_value: '4.9 of 13,200 reviews',\n      description: 'Tradeit.gg is the highest rated CS2 (CSGO) skin trading site and the best trading bot for instant \u2026"
+      ]
+    },
+    {
+      "id": "q3",
+      "query": "what is revert trade",
+      "category": "feature-understanding",
+      "latency_ms": 34,
+      "results_count": 5,
+      "relevance_score": 0.3333333333333333,
+      "snippets": [
+        "  - Slack API\nlast_updated: 2026-03-27\nupdated_by: Claude\n---\n\n# Trade Revert Detection System\n\n## Overview\n\nThe **Trade Revert Detection System** identifies and responds to cases where users revert \u2026",
+        "ban list |\\n| `items` | old-tradeit | Item prices, metadata |\\n| `bot_balance` | old-tradeit | Bot value tracking |\\n| `configurations` | old-tradeit | Runtime config flags |\\n\\n## External Services\\\u2026",
+        "### Alert Trigger\n\nIf total missing value in 2 hours exceeds threshold:\n```sql\nSELECT SUM(price) as total\nFROM trade_revert_item_missings\nWHERE created_at > CURRENT_DATE - INTERVAL 2 HOUR\n```\n\n**Acti\u2026"
+      ]
+    },
+    {
+      "id": "q4",
+      "query": "show me the auth flow",
+      "category": "flow-understanding",
+      "latency_ms": 21,
+      "results_count": 5,
+      "relevance_score": 0.5,
+      "snippets": [
+        "---\nlast_updated: 2026-03-27\nupdated_by: agent\nflow_type: user-facing\nservices: [tradeit, tradeit-oauth2-server, tradeit-backend]\n---\n\n# OAuth2 Authorization Flow\n\n## Overview\n\nOAuth2 authorization p\u2026",
+        "The flow generates authorization codes that partners exchange for access tokens.\\n\\n## Diagrams\\n\\n### Sequence Diagram: OAuth2 Consent Flow\\n```mermaid\\nsequenceDiagram\\n  participant Partner as Par\u2026",
+        "\u2026\nComprehensive catalog of `tradeit-backend` API endpoints (base `/api/v2/`) grouped by domain \u2014 auth, trading, inventory, sell, payments, store, investment, giveaway, guess game, challenges, market \u2026"
+      ]
+    },
+    {
+      "id": "q5",
+      "query": "how does payment processing work",
+      "category": "feature-understanding",
+      "latency_ms": 12,
+      "results_count": 5,
+      "relevance_score": 0.25,
+      "snippets": [
+        "\u2026hi code v\u00e0 update status cho management. \u0110i\u1ec1u n\u00e0y gi\u00fap tr\u00e1nh rework v\u00e0 gi\u1eef alignment t\u1ed1t h\u01a1n.\n\n### 3/ Ghi ch\u00fa kh\u00e1c:\n\n- Tom c\u00f3 th\u00e1i \u0111\u1ed9 c\u1ea7u th\u1ecb t\u1ed1t \u2014 ti\u1ebfp thu feedback, kh\u00f4ng defensive. \u0110\u00e2y l\u00e0 quality\u2026",
+        "\u2026hi code v\u00e0 update status cho management. \u0110i\u1ec1u n\u00e0y gi\u00fap tr\u00e1nh rework v\u00e0 gi\u1eef alignment t\u1ed1t h\u01a1n.\n\n### 3/ Ghi ch\u00fa kh\u00e1c:\n\n- Tom c\u00f3 th\u00e1i \u0111\u1ed9 c\u1ea7u th\u1ecb t\u1ed1t \u2014 ti\u1ebfp thu feedback, kh\u00f4ng defensive. \u0110\u00e2y l\u00e0 quality\u2026",
+        "\u2026 7.2 Update any related database procedures or triggers\n- [ ] 7.3 Verify database constraints still work properly\n\n## 8. Update Payment Processing\n\n- [ ] 8.1 Update monnectPaymentService.js to remov\u2026"
+      ]
+    },
+    {
+      "id": "q6",
+      "query": "what services does the backend call",
+      "category": "architecture",
+      "latency_ms": 27,
+      "results_count": 5,
+      "relevance_score": 0.75,
+      "snippets": [
+        "\u2026 [ops-log, weekly, 2026-W16]\n---\n\nWeekly operations log for 2026-W16 (Apr 6 \u2013 Apr 12) feeding the all-hands slideshow.\n\n### 2026-04-06 \u2014 Item Details Caching on 10x Marketplace\n- **Category:** Archi\u2026",
+        "\u2026/server/controllers/cron.js:1496      \u2502\n\u2502 Action: Calls validateTradeSurge()                         \u2502\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n               \u2502\n              \u2026",
+        "\u2026backend | Calls `/api/v2/internal/validate-csgo-items`, `/api/v2/internal/checkTradeLimit` |\n| Redis (main) | Bot status, inventory cache, sessions |\n| Redis (LootBear) | External partner integratio\u2026"
+      ]
+    },
+    {
+      "id": "q7",
+      "query": "how is user balance managed",
+      "category": "feature-understanding",
+      "latency_ms": 16,
+      "results_count": 5,
+      "relevance_score": 0.5,
+      "snippets": [
+        "| `userLastSell_{steamId}` | 60s | Rate limit cooldown |\n| `reserved-assets_{appId}` | Variable | Items being processed |\n\n## Error Handling\n\n| Error | Cause | Resolution |\n|-------|-------|---------\u2026",
+        "\u2026| \\\"No available bots\\\" | All bots full | Wait for bot inventory space |\\n\\n## Performance Characteristics\\n\\n- **Trade time:** 2-10 minutes (Steam processing)\\n- **Balance credit:** 1-2 minutes aft\u2026",
+        "You saved ${{ (discountAmount / 100).toFixed(2) }}\\n    </div>\\n  </div>\\n</template>\\n\\n<script>\\nexport default {\\n  methods: {\\n    async validateAndApply() {\\n      const token = await executeRec\u2026"
+      ]
+    },
+    {
+      "id": "q8",
+      "query": "what is the tradebot",
+      "category": "architecture",
+      "latency_ms": 44,
+      "results_count": 5,
+      "relevance_score": 0.6666666666666666,
+      "snippets": [
+        "\u2026ce, bonus, tradeHash\\n  - Every validation failure has a unique stage number for debugging\\n\\n## Redis Keys (Complete)\\n| Key | Type | TTL | Owner | Purpose |\\n|---|---|---|---|---|\\n| `tradeDisable\u2026",
+        "\u2026e: internal\nservices: [tradeit-inventory-server, tradeit-inventory-parser, tradeit-service, tradeit-tradebot-server]\nchanges: DEV-4745 \u2014 added GET /sinv-merged/:gameId (ctx 2+16), vars.sinv_games st\u2026",
+        "| `containers:{botId}` | String | - | tradebot-server | Container status |\n| `invsize730:{botId}` | String | - | tradebot-server | CSGO inv size |\n| `invsize440:{botId}` | String | - | tradebot-serve\u2026"
+      ]
+    },
+    {
+      "id": "q9",
+      "query": "show me the purchase flow",
+      "category": "flow-understanding",
+      "latency_ms": 21,
+      "results_count": 5,
+      "relevance_score": 0.3333333333333333,
+      "snippets": [
+        "\u2026in `startTrade` \u2014 p2p prices excluded from total comparison; acceptable since Halo validates at purchase \u2705\n\n**Filter pattern follows existing codebase convention** (`TradeMain.vue:274`):\n```js\nconst\u2026",
+        "\u2026 at 2.58M (+137% vs baseline); 7 new error signatures including purchase-flow failures. Style: dark-mode SaaS dashboard, neon accents (red for critical, amber for warning, green for healthy), monosp\u2026",
+        "\u2026eline); WAF blocks at 2.58M (+137% vs baseline); 7 new error signatures including purchase-flow failures. Style: dark-mode SaaS dashboard, neon accents (red for critical, amber for warning, green fo\u2026"
+      ]
+    },
+    {
+      "id": "q10",
+      "query": "how does steam integration work",
+      "category": "integration",
+      "latency_ms": 1202,
+      "results_count": 5,
+      "relevance_score": 1.0,
+      "snippets": [
+        "\u2026hot, documented download procedure\n---\n\n# sih-extension\n\nLocal snapshot/extraction folder for the **Steam Inventory Helper (SIH)** Chrome extension. Not a git repo. Not a buildable project \u2014 packed \u2026",
+        "---\ntitle: tradeit-tradebot-server \u2014 Steam trade bot fleet compute layer (~400 instances)\ntype: entity\nscope: org\nconfidence: 0.95\nsources:\n  - ~/Projects/tradeit-tradebot-server/CLAUDE.md\n  - wikijs\u2026",
+        "\u2026rity: medium\n- special instructions:\n  - MUST run codebase_search first to find socket handlers and integration code.\n  - Save sample client snippets and any load-test commands in the same docs fold\u2026"
+      ]
+    }
+  ],
+  "summary": {
+    "total_queries": 10,
+    "avg_latency_ms": 152.1,
+    "avg_relevance": 0.567,
+    "total_results": 50
+  }
+}

--- a/benchmarks/llm-quality/results_debug_20260620_121529.json
+++ b/benchmarks/llm-quality/results_debug_20260620_121529.json
@@ -1,0 +1,107 @@
+{
+  "run": "debugging",
+  "workspace": "d1915ee19311546a064576fc5df565da7ab20fe1c4a81c97e3ba6e9059d977b7",
+  "avg_code_score": 0.625,
+  "avg_session_score": 0.667,
+  "avg_combined_score": 0.88,
+  "avg_latency_ms": 546.0,
+  "total_summaries_found": 8,
+  "queries": [
+    {
+      "id": "dbg1",
+      "query": "stripe payment has wrong tax",
+      "category": "payment-bug",
+      "code_results": 0,
+      "session_results": 5,
+      "code_score": 0.0,
+      "session_score": 0.5,
+      "combined_score": 0.571,
+      "summaries_found": 1,
+      "latency_ms": 352
+    },
+    {
+      "id": "dbg2",
+      "query": "tradebot goes weird status",
+      "category": "trade-bug",
+      "code_results": 0,
+      "session_results": 5,
+      "code_score": 0.0,
+      "session_score": 0.667,
+      "combined_score": 0.667,
+      "summaries_found": 0,
+      "latency_ms": 101
+    },
+    {
+      "id": "dbg3",
+      "query": "user balance not updated after topup",
+      "category": "balance-bug",
+      "code_results": 5,
+      "session_results": 5,
+      "code_score": 1.0,
+      "session_score": 1.0,
+      "combined_score": 1.0,
+      "summaries_found": 1,
+      "latency_ms": 1394
+    },
+    {
+      "id": "dbg4",
+      "query": "steam trade stuck in pending",
+      "category": "integration-bug",
+      "code_results": 5,
+      "session_results": 5,
+      "code_score": 0.667,
+      "session_score": 1.0,
+      "combined_score": 1.0,
+      "summaries_found": 1,
+      "latency_ms": 693
+    },
+    {
+      "id": "dbg5",
+      "query": "revert trade not triggering",
+      "category": "trade-bug",
+      "code_results": 5,
+      "session_results": 5,
+      "code_score": 0.667,
+      "session_score": 1.0,
+      "combined_score": 1.0,
+      "summaries_found": 1,
+      "latency_ms": 602
+    },
+    {
+      "id": "dbg6",
+      "query": "duplicate topup transaction",
+      "category": "concurrency-bug",
+      "code_results": 5,
+      "session_results": 5,
+      "code_score": 1.0,
+      "session_score": 0.667,
+      "combined_score": 1.0,
+      "summaries_found": 2,
+      "latency_ms": 507
+    },
+    {
+      "id": "dbg7",
+      "query": "notification not sent after trade",
+      "category": "integration-bug",
+      "code_results": 5,
+      "session_results": 5,
+      "code_score": 0.667,
+      "session_score": 0.5,
+      "combined_score": 0.8,
+      "summaries_found": 2,
+      "latency_ms": 73
+    },
+    {
+      "id": "dbg8",
+      "query": "search returning wrong results",
+      "category": "search-bug",
+      "code_results": 5,
+      "session_results": 5,
+      "code_score": 1.0,
+      "session_score": 0.0,
+      "combined_score": 1.0,
+      "summaries_found": 0,
+      "latency_ms": 645
+    }
+  ]
+}

--- a/benchmarks/llm-quality/results_nanobrain.json
+++ b/benchmarks/llm-quality/results_nanobrain.json
@@ -1,0 +1,140 @@
+{
+  "runs": [
+    {
+      "id": "q1",
+      "query": "how does hybrid search work",
+      "category": "feature-understanding",
+      "latency_ms": 73,
+      "results_count": 5,
+      "relevance_score": 0.75,
+      "snippets": [
+        "## Search Benchmark Baseline \u2014 2026-06-07\n\n### What we did\nExtended `testdata/search_benchmarks.json` from 62 queries to 110 across 7 categories:\n- Added 15 session queries (decisions, discussions)\n-\u2026",
+        "\u2026enchmark Regression \u2014 Root Cause Analysis\n\n## Date: 2026-06-14\n\n## Problem\n\nCapability benchmark shows regression: `base=0.813 now=0.750 delta=-0.063`\n\n3 tasks failing:\n| Task | Query | Expected fil\u2026",
+        "# Executive Summary: RAG Search Quality 2026\n\n## THE RESEARCH QUESTION\n\nWhat are production-tested techniques for improving natural language search quality in RAG systems, specifically for:\n1. Query \u2026"
+      ]
+    },
+    {
+      "id": "q2",
+      "query": "what is the embed queue",
+      "category": "feature-understanding",
+      "latency_ms": 42,
+      "results_count": 5,
+      "relevance_score": 1.0,
+      "snippets": [
+        "# Session: Trace embed-queue scan triggers (@explore subagent)\n\n- Date: 2026-06-02\n- Source: opencode\n- Session ID: ses_176b06cc0ffeixFtUdiCEOaDaT\n\n\n## Goal\nInvestigate a suspected bug in the nano-br\u2026",
+        "\u2026urce: opencode\n- Session ID: ses_155766c76ffeYRfVgg8ehPDBJu\n\n\n## Goal\nPerform a comprehensive analysis of the `nano\u2011brain.log` file to locate errors, warnings, and any issues related to the embed\u2011qu\u2026",
+        "# Session: Explore embed queue code in detail (@explore subagent)\n\n- Date: 2026-06-09\n- Source: opencode\n- Session ID: ses_1557681aeffeMI5s6VpexwE07d\n\n\n## Goal\nPerform a comprehensive review of the n\u2026"
+      ]
+    },
+    {
+      "id": "q3",
+      "query": "how does session harvesting work",
+      "category": "feature-understanding",
+      "latency_ms": 29,
+      "results_count": 5,
+      "relevance_score": 0.6666666666666666,
+      "snippets": [
+        "\u2026should explain embedding queue mechanism\", \"triggered after document write\"]\n  },\n  {\n    \"query\": \"How does session harvesting work?\",\n    \"category\": \"behavioral\",\n    \"expected_keywords\": [\"harve\u2026",
+        "\u2026ts\": [\"should find the reranking package with Cohere cross-encoder adapter\"]\n  },\n  {\n    \"query\": \"how does workspace isolation work\",\n    \"category\": \"natural_language\",\n    \"expected_keywords\": [\u2026",
+        "\u2026k\",\n    \"category\": \"symbol_lookup\",\n    \"expected_keywords\": [\"LoadScores\", \"pagerank\", \"scores\", \"workspace\"],\n    \"expected_symbols\": [\"LoadScores\"],\n    \"relevance_hints\": [\"should reference pag\u2026"
+      ]
+    },
+    {
+      "id": "q4",
+      "query": "show me the memory flow pipeline",
+      "category": "flow-understanding",
+      "latency_ms": 20,
+      "results_count": 5,
+      "relevance_score": 0.5,
+      "snippets": [
+        "---\nsession_id: ses_11c24957dffexrP1RiFzTQfwaD\nsource: opencode\nmessage_count: 16\ncreated_at: 2026-06-20T07:07:48Z\ntitle: \"Find summarization and code understanding features (@explore subagent)\"\n---\n\u2026",
+        "---\nsession_id: ses_11c24d6b8ffeoUgAnLUZeqEp1l\nsource: opencode\nmessage_count: 7\ncreated_at: 2026-06-20T07:07:31Z\ntitle: \"Find current flow and search response quality (@explore subagent)\"\n---\n\n## us\u2026",
+        "4. **Remove `/ui`:** see the literal checklist in \u00a713 (it's larger than first stated \u2014 committed `dist/`, `vite.config.ts` outDir, `scripts/smoke-ui.sh`, orphaned `SecurityHeaders()`). Note: **CI has\u2026"
+      ]
+    },
+    {
+      "id": "q5",
+      "query": "how does code summarization work",
+      "category": "feature-understanding",
+      "latency_ms": 23,
+      "results_count": 5,
+      "relevance_score": 0.25,
+      "snippets": [
+        "---\nsession_id: ses_11c24957dffexrP1RiFzTQfwaD\nsource: opencode\nmessage_count: 16\ncreated_at: 2026-06-20T07:07:48Z\ntitle: \"Find summarization and code understanding features (@explore subagent)\"\n---\n\u2026",
+        "\u2026ns structured findings for each numbered point before treating the task as done.\n- For multi-area codebase scans, prefer running all targeted searches in a single batched tool call once paths are co\u2026",
+        "# Session: Investigate code summarization config issues (@explore subagent)\n\n- Date: 2026-06-08\n- Source: opencode\n- Session ID: ses_15a7aded4ffedQCrQf4Pgqo69w\n\n\n\n\n## Goal\nInvestigate why code summar\u2026"
+      ]
+    },
+    {
+      "id": "q6",
+      "query": "what extractors are registered",
+      "category": "architecture",
+      "latency_ms": 26,
+      "results_count": 5,
+      "relevance_score": 0.5,
+      "snippets": [
+        "- [ ] 2.8 Enclosing function detection: walk `function_declaration`, `arrow_function`, `method_definition` to map call-site to containing function for `SourceNode`\n- [ ] 2.9 Detect JS/TS consumer patt",
+        "\u2026e.\n    *   *Key Learnings:* Python's tree-sitter AST differs from Go/JS; specifically, method calls are handled via `call_expression` with `attribute`, and keyword arguments use `keyword_argument`.#\u2026",
+        "The system SHALL extract middleware from `app.use()` and `router.use()` call expressions as `EdgeMiddleware` edges.\n\n#### Scenario: Named middleware\n- **WHEN** a file contains `app.use(auth)`\n- **THE\u2026"
+      ]
+    },
+    {
+      "id": "q7",
+      "query": "how does the watcher work",
+      "category": "feature-understanding",
+      "latency_ms": 28,
+      "results_count": 5,
+      "relevance_score": 0.3333333333333333,
+      "snippets": [
+        "\u2026ents\n\n### Requirement: Query preprocessing translates non-English queries to English before search\n\nThe search pipeline SHALL detect non-English queries and translate them to English via an LLM call\u2026",
+        "\u2026gent)\n\n- Date: 2026-06-09\n- Source: opencode\n- Session ID: ses_152c024deffeGSqVkXFVYaFiyy\n\n\n## Goal\nThe overall objective of the session was to address a bug where the `embed_status` of a chunk was \u2026",
+        "* The proposed fix using a SQL `CASE` expression in `UpsertChunk` does not address the root cause of the issue, which is the watcher deleting and recreating chunks.\n* The watcher workflow is not full\u2026"
+      ]
+    },
+    {
+      "id": "q8",
+      "query": "what is the MCP server",
+      "category": "architecture",
+      "latency_ms": 36,
+      "results_count": 5,
+      "relevance_score": 0.6666666666666666,
+      "snippets": [
+        "\u2026h` -> `getBySourcePath` -> `QueryRowContext` (database interaction) -> ... (complex logic involving MCP server, extractor, preprocessor, and various utilities) -> `Bind`.\n    *   Key actions: Summar\u2026",
+        "# Session: Analyze Graphify MCP server (@explore subagent)\n\n- Date: 2026-06-11\n- Source: opencode\n- Session ID: ses_149f53af9ffer1Knp5udORzcNW\n\n\n## Goal\nAnalyze the **Graphify** repository to underst\u2026",
+        "\u2026ntry: `DELETE /api/v1/documents/:id`\n    *   Chain: A long sequence of function calls starting from the API endpoint, going through document deletion logic (`DeleteDocument`, `DeleteDocumentByIDAndW\u2026"
+      ]
+    },
+    {
+      "id": "q9",
+      "query": "how does graph stitching work",
+      "category": "feature-understanding",
+      "latency_ms": 15,
+      "results_count": 4,
+      "relevance_score": 0.6666666666666666,
+      "snippets": [
+        "\u2026 from \u201cpast MVP\u201d to a fully shipped, production\u2011ready state.\n\n## Decisions Made\n- **Add a worker\u2011pool (errgroup) for LLM summarization** \u2013 eliminates the 500\u202f\u00d7\u202f\u2248\u202f500\u202fms sequential bottleneck in `Mat\u2026",
+        "\u2026protocol\u2011aware parsing** \u2013 lower effort, sufficient for current needs.  \n- **Retain the `FrameworkAwareExtractor` interface and per\u2011collection framework detection** \u2013 preserves extensibility.  \n- **\u2026",
+        "\u2026d.\n\n## assistant (2026-06-17T07:56:41Z)\n\nLet me check a few more files for completeness \u2014 the graph edge types and the materializer that powers the API.\n\n## assistant (2026-06-17T07:57:01Z)\n\nNow I h\u2026"
+      ]
+    },
+    {
+      "id": "q10",
+      "query": "what is the RRF merge algorithm",
+      "category": "architecture",
+      "latency_ms": 16,
+      "results_count": 5,
+      "relevance_score": 0.5,
+      "snippets": [
+        "    \"relevance_hints\": [\"should identify sqlc.Queries as the implementation\"]\n  },\n  {\n    \"query\": \"What reads config.yml?\",\n    \"category\": \"entity_centric\",\n    \"expected_keywords\": [\"config\", \"ko\u2026",
+        "\u2026, \"index\", \"process\"],\n    \"expected_symbols\": [\"ExtractSymbols\"],\n    \"relevance_hints\": [\"should list functions that invoke ExtractSymbols\"]\n  },\n  {\n    \"query\": \"What depends on the SearchServic\u2026",
+        "\u2026ols/nano-brain/internal/server/handlers/query.go`\n\n## Problems Encountered\n* *(None reported during the planning and analysis phase)*\n\n## Key Learnings\n* **Search Flow:** The existing hybrid search \u2026"
+      ]
+    }
+  ],
+  "summary": {
+    "total_queries": 10,
+    "avg_latency_ms": 30.8,
+    "avg_relevance": 0.583,
+    "total_results": 49
+  }
+}

--- a/benchmarks/llm-quality/run.sh
+++ b/benchmarks/llm-quality/run.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -e
+
+SERVER_URL="${NANO_BRAIN_URL:-http://localhost:3199}"
+QUERIES_FILE="${1:-benchmarks/llm-quality/queries.json}"
+RESULTS_FILE="${2:-benchmarks/llm-quality/results_$(date +%Y%m%d_%H%M%S).json}"
+export RESULTS_FILE
+
+WORKSPACE=$(python3 -c "import json; print(json.load(open('$QUERIES_FILE'))['workspace'])")
+
+mkdir -p "$(dirname "$RESULTS_FILE")"
+echo '{"runs":[' > "$RESULTS_FILE"
+
+FIRST=true
+TOTAL_QUERIES=$(python3 -c "import json; print(len(json.load(open('$QUERIES_FILE'))['queries']))")
+
+for i in $(seq 0 $((TOTAL_QUERIES - 1))); do
+  QUERY=$(python3 -c "import json; print(json.load(open('$QUERIES_FILE'))['queries'][$i]['query'])")
+  ID=$(python3 -c "import json; print(json.load(open('$QUERIES_FILE'))['queries'][$i]['id'])")
+  CATEGORY=$(python3 -c "import json; print(json.load(open('$QUERIES_FILE'))['queries'][$i]['category'])")
+  EXPECT=$(python3 -c "import json; print(json.dumps(json.load(open('$QUERIES_FILE'))['queries'][$i]['expect']))")
+  
+  echo "[$((i+1))/$TOTAL_QUERIES] $QUERY"
+  echo "  EXPECT: $EXPECT"
+  
+  START=$(date +%s%N)
+  
+  SEARCH_RESULT=$(curl -s -X POST "$SERVER_URL/mcp" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "tools/call",
+      "params": {
+        "name": "memory_search",
+        "arguments": {
+          "workspace": "'$WORKSPACE'",
+          "query": "'"$QUERY"'",
+          "max_results": 5
+        }
+      }
+    }' 2>/dev/null | grep '^data:' | sed 's/^data: //' || echo '{"error": "request failed"}')
+  
+  END=$(date +%s%N)
+  LATENCY_MS=$(( (END - START) / 1000000 ))
+  
+  RESULTS_COUNT=$(echo "$SEARCH_RESULT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    content = d.get('result', {}).get('content', [{}])[0].get('text', '{}')
+    r = json.loads(content)
+    print(len(r.get('results', [])))
+except:
+    print(0)" 2>/dev/null || echo "0")
+  
+  SNIPPETS=$(echo "$SEARCH_RESULT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    content = d.get('result', {}).get('content', [{}])[0].get('text', '{}')
+    r = json.loads(content)
+    snippets = [item.get('snippet', '')[:200] for item in r.get('results', [])[:3]]
+    print(json.dumps(snippets))
+except:
+    print('[]')" 2>/dev/null || echo "[]")
+  
+  RELEVANCE=$(echo "$SEARCH_RESULT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    content = d.get('result', {}).get('content', [{}])[0].get('text', '{}')
+    r = json.loads(content)
+    all_text = ' '.join([item.get('snippet', '') + ' ' + item.get('title', '') for item in r.get('results', [])]).lower()
+    expect = json.loads(sys.argv[1])
+    matches = sum(1 for term in expect if term.lower() in all_text)
+    result = matches / len(expect) if expect else 0
+    print(result)
+except Exception as e:
+    import traceback
+    traceback.print_exc(file=sys.stderr)
+    print(0)" "$EXPECT" 2>/dev/null || echo "0")
+  
+  if [ "$FIRST" = true ]; then
+    FIRST=false
+  else
+    echo "," >> "$RESULTS_FILE"
+  fi
+  
+  python3 -c "
+import json
+result = {
+    'id': '$ID',
+    'query': '$QUERY',
+    'category': '$CATEGORY',
+    'latency_ms': $LATENCY_MS,
+    'results_count': $RESULTS_COUNT,
+    'relevance_score': $RELEVANCE,
+    'snippets': $SNIPPETS
+}
+print(json.dumps(result, indent=2))" >> "$RESULTS_FILE"
+  
+  echo "  Results: $RESULTS_COUNT | Relevance: $RELEVANCE | Latency: ${LATENCY_MS}ms"
+done
+
+echo ']}' >> "$RESULTS_FILE"
+
+python3 -c "
+import json, os
+
+results_file = os.environ.get('RESULTS_FILE', 'benchmarks/llm-quality/results.json')
+with open(results_file) as f:
+    data = json.load(f)
+
+runs = data['runs']
+
+avg_latency = sum(r['latency_ms'] for r in runs) / len(runs)
+avg_relevance = sum(r['relevance_score'] for r in runs) / len(runs)
+total_results = sum(r['results_count'] for r in runs)
+
+data['summary'] = {
+    'total_queries': len(runs),
+    'avg_latency_ms': round(avg_latency, 2),
+    'avg_relevance': round(avg_relevance, 3),
+    'total_results': total_results
+}
+
+with open(results_file, 'w') as f:
+    json.dump(data, f, indent=2)
+
+print()
+print('=== Summary ===')
+print(f'Queries: {len(runs)}')
+print(f'Avg Latency: {avg_latency:.0f}ms')
+print(f'Avg Relevance: {avg_relevance:.3f}')
+print(f'Total Results: {total_results}')
+"
+
+echo
+echo "Results saved to: $RESULTS_FILE"

--- a/benchmarks/llm-quality/run_debug.sh
+++ b/benchmarks/llm-quality/run_debug.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -e
+
+SERVER_URL="${NANO_BRAIN_URL:-http://localhost:3199}"
+QUERIES_FILE="${1:-benchmarks/llm-quality/queries_debug.json}"
+RESULTS_FILE="${2:-benchmarks/llm-quality/results_debug_$(date +%Y%m%d_%H%M%S).json}"
+export RESULTS_FILE
+
+WORKSPACE=$(python3 -c "import json; print(json.load(open('$QUERIES_FILE'))['workspace'])")
+
+python3 << PYEOF
+import json, subprocess, time, sys
+
+url = "$SERVER_URL"
+workspace = "$WORKSPACE"
+queries_file = "$QUERIES_FILE"
+results_file = "$RESULTS_FILE"
+
+with open(queries_file) as f:
+    queries_data = json.load(f)
+queries = queries_data["queries"]
+
+def search(ws, query, max_results=5):
+    payload = json.dumps({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"memory_search","arguments":{"workspace":ws,"query":query,"max_results":max_results}}})
+    start = time.time()
+    r = subprocess.run(["curl","-s","-X","POST",f"{url}/mcp","-H","Content-Type: application/json","-d",payload], capture_output=True, text=True, timeout=10)
+    latency_ms = int((time.time() - start) * 1000)
+    for line in r.stdout.split("\n"):
+        if line.startswith("data: "):
+            data = json.loads(line[6:])
+            content = data["result"]["content"][0]["text"]
+            result = json.loads(content)
+            return result.get("results", []), latency_ms
+    return [], latency_ms
+
+def hybrid_search(ws, query, max_results=5):
+    payload = json.dumps({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"memory_query","arguments":{"workspace":ws,"query":query,"max_results":max_results}}})
+    start = time.time()
+    r = subprocess.run(["curl","-s","-X","POST",f"{url}/mcp","-H","Content-Type: application/json","-d",payload], capture_output=True, text=True, timeout=10)
+    latency_ms = int((time.time() - start) * 1000)
+    for line in r.stdout.split("\n"):
+        if line.startswith("data: "):
+            data = json.loads(line[6:])
+            content = data["result"]["content"][0]["text"]
+            result = json.loads(content)
+            return result.get("results", []), latency_ms
+    return [], latency_ms
+
+def score_terms(results, terms):
+    all_text = " ".join([r.get("snippet","") + " " + r.get("title","") for r in results]).lower()
+    matches = sum(1 for t in terms if t.lower() in all_text)
+    return matches / len(terms) if terms else 0
+
+def count_tags(results, tag):
+    return sum(1 for r in results if tag in r.get("tags", []))
+
+all_results = []
+for q in queries:
+    query = q["query"]
+    print(f"  {query[:50]:50s}", end="", flush=True)
+
+    code_results, t1 = search(workspace, query, 5)
+    session_results, t2 = hybrid_search(workspace, query + " debug session", 5)
+    latency = max(t1, t2)
+
+    code_score = score_terms(code_results, q["expect_code"])
+    session_score = score_terms(session_results, q["expect_sessions"])
+
+    all_code = code_results + session_results
+    combined_score = score_terms(all_code, q["expect_code"] + q["expect_sessions"])
+
+    summaries_found = count_tags(all_code, "symbol-summary")
+
+    result = {
+        "id": q["id"], "query": query, "category": q["category"],
+        "code_results": len(code_results), "session_results": len(session_results),
+        "code_score": round(code_score, 3), "session_score": round(session_score, 3),
+        "combined_score": round(combined_score, 3),
+        "summaries_found": summaries_found,
+        "latency_ms": latency
+    }
+    all_results.append(result)
+    print(f" | code={code_score:.2f} session={session_score:.2f} combined={combined_score:.2f} summaries={summaries_found} {latency}ms")
+
+avg_code = sum(r["code_score"] for r in all_results) / len(all_results)
+avg_session = sum(r["session_score"] for r in all_results) / len(all_results)
+avg_combined = sum(r["combined_score"] for r in all_results) / len(all_results)
+avg_latency = sum(r["latency_ms"] for r in all_results) / len(all_results)
+total_summaries = sum(r["summaries_found"] for r in all_results)
+
+print(f"\nDEBUGGING BENCHMARK: code={avg_code:.3f} session={avg_session:.3f} combined={avg_combined:.3f} latency={avg_latency:.0f}ms summaries={total_summaries}")
+
+output = {
+    "run": "debugging", "workspace": workspace,
+    "avg_code_score": round(avg_code, 3), "avg_session_score": round(avg_session, 3),
+    "avg_combined_score": round(avg_combined, 3), "avg_latency_ms": round(avg_latency, 0),
+    "total_summaries_found": total_summaries, "queries": all_results
+}
+
+with open(results_file, "w") as f:
+    json.dump(output, f, indent=2)
+print(f"\nResults: {results_file}")
+PYEOF

--- a/config.test.yml
+++ b/config.test.yml
@@ -10,5 +10,15 @@ embedding:
   url: "http://host.docker.internal:11434"
   model: "nomic-embed-text"
 
+code_summarization:
+  enabled: true
+  provider_url: "https://ai-proxy.thnkandgrow.com/v1"
+  api_key: "sk-3311e2b466e8b372-wftr7k-6f873ed9"
+  model: "nano-brain"
+  batch_size: 20
+  concurrency: 2
+  max_symbol_lines: 500
+  request_timeout: 600
+
 flow:
   enabled: true


### PR DESCRIPTION
## Summary

Add benchmark framework for measuring LLM feature quality and debugging search effectiveness.

## Deliverables

- `benchmarks/llm-quality/` — benchmark queries, runners, results
- `config.test.yml` — add code_summarization for testing

## Benchmark Results

### Feature Understanding (10 queries)
- BM25 score: 0.934 (already excellent)
- HyDE: no improvement for keyword queries
- code_summarization: adds summaries but doesn't change BM25 score

### Debugging (8 queries)
- Code search: 0.625 (misses tax calculation, tradebot status)
- Session search: 0.667 (finds related sessions)
- Combined: 0.880 (sessions add real debugging context)
- 8 summary documents found (after #460 fix)

Closes #457