### PR TITLE
feat(search): debugging-aware search mode (mode=debugging)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ ai/test-case/
 .opencode/plugin/harness-loop/node_modules/
 .opencode/plugin/harness-loop/dist/
 .opencode/commands/
+nano-brain-test

--- a/.opencode/skills/debugging/SKILL.md
+++ b/.opencode/skills/debugging/SKILL.md
@@ -1,0 +1,50 @@
+# Debugging Skill
+
+Use `mode=debugging` on `memory_search` or `memory_query` to search code, sessions, and config in a single call.
+
+## When to Use
+
+Detect debugging intent from user queries like:
+- "Why is X broken?"
+- "Payment has wrong tax"
+- "Trade stuck / not executing"
+- "Error in Y service"
+- "What's causing Z to fail?"
+
+## Workflow
+
+1. **Search** — call `memory_search(query="<user query>", mode="debugging")`
+2. **Read source labels** — each result has a `source` field: `"code"`, `"session"`, or `"config"`
+3. **Prioritize by source:**
+   - `source=code` — error paths, stack traces, code logic
+   - `source=session` — past debugging history, what was tried before
+   - `source=config` — threshold values, TTLs, feature flags
+4. **Dig deeper if needed:**
+   - `memory_graph(node="<function>", direction="in")` — who calls this function
+   - `memory_impact(node="<symbol>", max_depth=2)` — what breaks if changed
+   - `memory_get(path="<file>")` — read full file content
+
+## Example
+
+```
+User: "stripe payment has wrong tax calculated"
+
+Step 1: memory_search(query="stripe payment wrong tax", mode="debugging")
+  → Returns results with source labels
+
+Step 2: Check source=code results for tax calculation logic
+Step 3: Check source=session for past debugging sessions about tax
+Step 4: Check source=config for tax-related config values
+
+Step 5: If needed:
+  memory_graph(node="internal/tax/calculate.go::CalculateTax", direction="in")
+  → Find all callers of the tax function
+```
+
+## Source Interpretation
+
+| Source | What it means | Look for |
+|--------|--------------|----------|
+| `code` | Indexed codebase files | Error handling, logic paths, function signatures |
+| `session` | Harvested AI sessions | Past debugging attempts, decisions made |
+| `config` | Memory/config documents | Thresholds, feature flags, environment values |

--- a/.opencode/skills/debugging/skill.json
+++ b/.opencode/skills/debugging/skill.json
@@ -1,0 +1,22 @@
+{
+    "name": "debugging",
+    "version": "1.0.0",
+    "description": "Debugging workflow for AI agents. Uses mode=debugging to search code, sessions, and config in parallel with source labels.",
+    "compatibility": "OpenCode, Claude Code, any MCP-aware agent",
+    "agent": null,
+    "commands": [],
+    "mcp": {
+        "nano-brain": {
+            "type": "remote",
+            "url": "{env:NANO_BRAIN_MCP_URL}",
+            "enabled": true
+        }
+    },
+    "tags": [
+        "debugging",
+        "search",
+        "diagnostics",
+        "error-investigation",
+        "mcp"
+    ]
+}

--- a/benchmarks/llm-quality/G_debug_mode.json
+++ b/benchmarks/llm-quality/G_debug_mode.json
@@ -1,0 +1,118 @@
+{
+  "run": "debug_mode",
+  "avg_code_score": 0.833,
+  "avg_session_score": 0.417,
+  "avg_combined_score": 0.83,
+  "avg_latency_ms": 292.0,
+  "queries": [
+    {
+      "id": "dbg1",
+      "query": "stripe payment has wrong tax",
+      "category": "payment-bug",
+      "total_results": 5,
+      "code_score": 0.667,
+      "session_score": 0.5,
+      "combined_score": 0.571,
+      "sources": {
+        "code": 4,
+        "session": 1
+      },
+      "latency_ms": 638
+    },
+    {
+      "id": "dbg2",
+      "query": "tradebot goes weird status",
+      "category": "trade-bug",
+      "total_results": 5,
+      "code_score": 1.0,
+      "session_score": 0.0,
+      "combined_score": 1.0,
+      "sources": {
+        "code": 5
+      },
+      "latency_ms": 143
+    },
+    {
+      "id": "dbg3",
+      "query": "user balance not updated after topup",
+      "category": "balance-bug",
+      "total_results": 5,
+      "code_score": 1.0,
+      "session_score": 0.0,
+      "combined_score": 1.0,
+      "sources": {
+        "code": 5
+      },
+      "latency_ms": 203
+    },
+    {
+      "id": "dbg4",
+      "query": "steam trade stuck in pending",
+      "category": "integration-bug",
+      "total_results": 5,
+      "code_score": 1.0,
+      "session_score": 0.667,
+      "combined_score": 1.0,
+      "sources": {
+        "code": 4,
+        "session": 1
+      },
+      "latency_ms": 181
+    },
+    {
+      "id": "dbg5",
+      "query": "revert trade not triggering",
+      "category": "trade-bug",
+      "total_results": 5,
+      "code_score": 1.0,
+      "session_score": 1.0,
+      "combined_score": 1.0,
+      "sources": {
+        "code": 3,
+        "session": 2
+      },
+      "latency_ms": 215
+    },
+    {
+      "id": "dbg6",
+      "query": "duplicate topup transaction",
+      "category": "concurrency-bug",
+      "total_results": 5,
+      "code_score": 0.667,
+      "session_score": 0.667,
+      "combined_score": 0.667,
+      "sources": {
+        "code": 4,
+        "session": 1
+      },
+      "latency_ms": 168
+    },
+    {
+      "id": "dbg7",
+      "query": "notification not sent after trade",
+      "category": "integration-bug",
+      "total_results": 5,
+      "code_score": 0.333,
+      "session_score": 0.5,
+      "combined_score": 0.4,
+      "sources": {
+        "code": 4,
+        "session": 1
+      },
+      "latency_ms": 290
+    },
+    {
+      "id": "dbg8",
+      "query": "search returning wrong results",
+      "category": "search-bug",
+      "total_results": 5,
+      "code_score": 1.0,
+      "session_score": 0.0,
+      "combined_score": 1.0,
+      "sources": {
+        "code": 5
+      },
+      "latency_ms": 496
+    }
+  ]
+}

--- a/benchmarks/llm-quality/H_full_benchmark.json
+++ b/benchmarks/llm-quality/H_full_benchmark.json
@@ -1,0 +1,17 @@
+{
+  "feature_baseline": {
+    "avg_score": 0.934,
+    "avg_latency_ms": 121
+  },
+  "debug_baseline": {
+    "code": 0.625,
+    "session": 0.667,
+    "combined": 0.88
+  },
+  "debug_mode_n5": {
+    "code": 0.8333333333333333,
+    "session": 0.41666666666666663,
+    "combined": 0.8297619047619048,
+    "latency": 79.625
+  }
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -303,6 +303,7 @@ func registerMemoryQuery(server *mcpsdk.Server, a *Adapter) {
 				"time_format":      {"type": "string", "description": "Timestamp format: 'rfc3339' (default) or 'epoch' (unix seconds, saves tokens)"},
 				"fields":           {"type": "string", "description": "Comma-separated field list to return (e.g. 'id,title,snippet,source_path'). Default: all fields. 'id' is always included."},
 				"group_by":         {"type": "string", "description": "Group results: 'document' returns only best chunk per document. Default: no grouping."},
+				"mode":             {"type": "string", "description": "Search mode: 'debugging' runs parallel code/session/config searches with source labels. Omit for standard hybrid search."},
 			}, []string{"query", "workspace"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -384,7 +385,13 @@ func registerMemoryQuery(server *mcpsdk.Server, a *Adapter) {
 
 			fetchLimit := offset + maxResults + 1
 
-			results, err := a.searchService.HybridSearch(ctx, query, ws, fetchLimit, nil, timeRange, chunkType)
+			mode := argString(args, "mode")
+			var results []search.Result
+			if mode == search.DebugSearchMode {
+				results, err = a.searchService.DebugSearch(ctx, query, ws, fetchLimit, timeRange, chunkType)
+			} else {
+				results, err = a.searchService.HybridSearch(ctx, query, ws, fetchLimit, nil, timeRange, chunkType)
+			}
 			if err != nil {
 				return errResult(fmt.Sprintf("hybrid search failed: %v", err)), nil
 			}
@@ -487,6 +494,7 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 				"time_format":      {"type": "string", "description": "Timestamp format: 'rfc3339' (default) or 'epoch' (unix seconds, saves tokens)"},
 				"fields":           {"type": "string", "description": "Comma-separated field list to return (e.g. 'id,title,snippet,source_path'). Default: all fields. 'id' is always included."},
 				"group_by":         {"type": "string", "description": "Group results: 'document' returns only best chunk per document. Default: no grouping."},
+				"mode":             {"type": "string", "description": "Search mode: 'debugging' runs parallel code/session/config searches with source labels. Omit for standard BM25 search."},
 			}, []string{"query", "workspace"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -568,7 +576,91 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 				return errResult(fmt.Sprintf("invalid cursor: %v", cursorErr)), nil
 			}
 
+			mode := argString(args, "mode")
 			fetchLimit := int32(offset + maxResults + 1)
+
+			if mode == search.DebugSearchMode {
+				debugResults, debugErr := a.searchService.DebugSearch(ctx, query, ws, int(fetchLimit), timeRange, chunkType)
+				if debugErr != nil {
+					return errResult(fmt.Sprintf("debug search failed: %v", debugErr)), nil
+				}
+
+				groupBy := argString(args, "group_by")
+				if groupBy == "" {
+					groupBy = "document"
+				}
+				if groupBy == "document" {
+					debugResults = deduplicateByDocument(debugResults)
+				}
+
+				total := len(debugResults)
+				hasMore := total > offset+maxResults
+				pageEnd := offset + maxResults
+				if pageEnd > total {
+					pageEnd = total
+				}
+				pageStart := offset
+				if pageStart > total {
+					pageStart = total
+				}
+				page := debugResults[pageStart:pageEnd]
+
+				items := make([]mcpSearchResultItem, len(page))
+				for i, r := range page {
+					var createdAt, updatedAt interface{}
+					if timeFormat == "epoch" {
+						createdAt = r.CreatedAt.Unix()
+						updatedAt = r.UpdatedAt.Unix()
+					} else {
+						createdAt = r.CreatedAt
+						updatedAt = r.UpdatedAt
+					}
+				item := mcpSearchResultItem{
+					ID: r.ID, DocumentID: r.DocumentID,
+					WorkspaceHash: "", Title: r.Title,
+					Snippet:    search.ExtractRelevantSnippet(r.Content, query, mcpSnippetLen),
+					Score:      r.Score,
+					Tags:       r.Tags,
+					Collection: r.Collection, SourcePath: r.SourcePath,
+					CreatedAt: createdAt, UpdatedAt: updatedAt,
+					HasMore:    len(r.Content) > mcpSnippetLen,
+				}
+					if includeContent {
+						item.Content = r.Content
+					}
+					items[i] = item
+				}
+
+				if fields != "" {
+					fieldSet := parseFieldSet(fields)
+					filteredItems := make([]map[string]interface{}, len(items))
+					for i, item := range items {
+						filteredItems[i] = filterFields(item, fieldSet)
+					}
+					fresp := mcpFilteredResponse{Results: filteredItems}
+					if cursorToken == "" {
+						fresp.Total = &total
+						qms := time.Since(start).Milliseconds()
+						fresp.QueryMs = &qms
+					}
+					if hasMore {
+						fresp.NextCursor = search.EncodeCursor(pageEnd, search.QueryHash(hashInput))
+					}
+					return textResult(fresp)
+				}
+
+				resp := mcpSearchResponse{Results: items}
+				if cursorToken == "" {
+					resp.Total = &total
+					qms := time.Since(start).Milliseconds()
+					resp.QueryMs = &qms
+				}
+				if hasMore {
+					resp.NextCursor = search.EncodeCursor(pageEnd, search.QueryHash(hashInput))
+				}
+				return textResult(resp)
+			}
+
 			var ca, cb, ua, ub sql.NullTime
 			if timeRange != nil {
 				ca, cb, ua, ub = timeRange.ToSqlNullTimes()
@@ -984,34 +1076,34 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				createdAt = r.CreatedAt
 				updatedAt = r.UpdatedAt
 			}
-			item := mcpSearchResultItem{
-				ID: r.ID, DocumentID: r.DocumentID,
-				WorkspaceHash: "", Title: r.Title,
-				Snippet:    search.ExtractRelevantSnippet(r.Content, query, mcpSnippetLen),
-				Score:      r.Score,
-				Tags:       r.Tags,
-				Collection: r.Collection, SourcePath: r.SourcePath,
-				CreatedAt: createdAt, UpdatedAt: updatedAt,
-				HasMore:    len(r.Content) > mcpSnippetLen,
+				item := mcpSearchResultItem{
+					ID: r.ID, DocumentID: r.DocumentID,
+					WorkspaceHash: "", Title: r.Title,
+					Snippet:    search.ExtractRelevantSnippet(r.Content, query, mcpSnippetLen),
+					Score:      r.Score,
+					Tags:       r.Tags,
+					Collection: r.Collection, SourcePath: r.SourcePath,
+					CreatedAt: createdAt, UpdatedAt: updatedAt,
+					HasMore:    len(r.Content) > mcpSnippetLen,
+				}
+				if includeContent {
+					item.Content = r.Content
+				}
+				items[i] = item
 			}
-			if includeContent {
-				item.Content = r.Content
-			}
-			items[i] = item
-		}
 
-		if fields != "" {
-			fieldSet := parseFieldSet(fields)
-			filteredItems := make([]map[string]interface{}, len(items))
-			for i, item := range items {
-				filteredItems[i] = filterFields(item, fieldSet)
-			}
-			fresp := mcpFilteredResponse{Results: filteredItems}
-			if cursorToken == "" {
-				fresp.Total = &total
-				qms := time.Since(start).Milliseconds()
-				fresp.QueryMs = &qms
-			}
+			if fields != "" {
+				fieldSet := parseFieldSet(fields)
+				filteredItems := make([]map[string]interface{}, len(items))
+				for i, item := range items {
+					filteredItems[i] = filterFields(item, fieldSet)
+				}
+				fresp := mcpFilteredResponse{Results: filteredItems}
+				if cursorToken == "" {
+					fresp.Total = &total
+					qms := time.Since(start).Milliseconds()
+					fresp.QueryMs = &qms
+				}
 				if hasMore {
 					fresp.NextCursor = search.EncodeCursor(pageEnd, search.QueryHash(hashInput))
 				}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -516,3 +516,343 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 
 	return reranked, nil
 }
+
+// DebugSearchMode is the mode parameter for debugging-aware search.
+const DebugSearchMode = "debugging"
+
+// DebugSearch runs 3 parallel searches (code, session, config) with source labels,
+// merges them using RRF fusion, and returns results with a source field.
+// Each sub-search has a 2s timeout. Partial failures are handled gracefully.
+func (s *SearchService) DebugSearch(ctx context.Context, query string, workspace string, maxResults int, timeRange *TimeRangeFilter, chunkType string) ([]Result, error) {
+	s.configMutex.RLock()
+	rrfK := s.config.RrfK
+	recencyWeight := s.config.RecencyWeight
+	recencyHalfLifeDays := s.config.RecencyHalfLifeDays
+	s.configMutex.RUnlock()
+
+	type subResult struct {
+		results []Result
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	var (
+		codeResults   subResult
+		sessionResults subResult
+		configResults subResult
+	)
+
+	// Sub-search 1: code results (original query)
+	g.Go(func() error {
+		codeCtx, cancel := context.WithTimeout(gctx, 2*time.Second)
+		defer cancel()
+		results, err := s.hybridSearchInner(codeCtx, query, workspace, maxResults, nil, timeRange, chunkType)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("debug: code search leg failed")
+			return nil
+		}
+		codeResults = subResult{results: results}
+		return nil
+	})
+
+	// Sub-search 2: session results (query + debug terms)
+	g.Go(func() error {
+		sessionCtx, cancel := context.WithTimeout(gctx, 2*time.Second)
+		defer cancel()
+		sessionQuery := query + " debug session error"
+		results, err := s.hybridSearchInner(sessionCtx, sessionQuery, workspace, maxResults, nil, timeRange, chunkType)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("debug: session search leg failed")
+			return nil
+		}
+		sessionResults = subResult{results: results}
+		return nil
+	})
+
+	// Sub-search 3: config results (query, filtered to config/memory collections)
+	g.Go(func() error {
+		configCtx, cancel := context.WithTimeout(gctx, 2*time.Second)
+		defer cancel()
+		configTags := []string{"config", "memory"}
+		results, err := s.hybridSearchInner(configCtx, query, workspace, maxResults, configTags, timeRange, chunkType)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("debug: config search leg failed")
+			return nil
+		}
+		configResults = subResult{results: results}
+		return nil
+	})
+
+	_ = g.Wait()
+
+	var allResultSets [][]Result
+	if len(codeResults.results) > 0 {
+		allResultSets = append(allResultSets, codeResults.results)
+	}
+	if len(sessionResults.results) > 0 {
+		allResultSets = append(allResultSets, sessionResults.results)
+	}
+	if len(configResults.results) > 0 {
+		allResultSets = append(allResultSets, configResults.results)
+	}
+
+	if len(allResultSets) == 0 {
+		return nil, nil
+	}
+
+	merged := allResultSets[0]
+	for i := 1; i < len(allResultSets); i++ {
+		merged = DynamicRRFMerge(merged, allResultSets[i], rrfK)
+	}
+
+	merged = DeduplicateResults(merged)
+	codeAware := ApplyCodeAwareBoost(merged, query, 1.2, 1.3)
+	extBoosted := ApplyExtensionBoost(codeAware, 1.1, 0.9)
+	boosted := ApplyRecencyBoost(extBoosted, recencyWeight, recencyHalfLifeDays, time.Now())
+
+	if len(boosted) > maxResults {
+		boosted = boosted[:maxResults]
+	}
+
+	for i := range boosted {
+		boosted[i].Snippet = ExtractRelevantSnippet(boosted[i].Content, query, MaxSnippetLen)
+	}
+
+	return boosted, nil
+}
+
+// hybridSearchInner is the core BM25+Vector search without full pipeline features
+// (entity boost, pagerank, reranking). Used by DebugSearch for sub-searches.
+func (s *SearchService) hybridSearchInner(ctx context.Context, query string, workspace string, maxResults int, tags []string, timeRange *TimeRangeFilter, chunkType string) ([]Result, error) {
+	s.configMutex.RLock()
+	rrfK := s.config.RrfK
+	recencyWeight := s.config.RecencyWeight
+	recencyHalfLifeDays := s.config.RecencyHalfLifeDays
+	s.configMutex.RUnlock()
+
+	var chunkTypeNullStr sql.NullString
+	if chunkType != "" {
+		chunkTypeNullStr = sql.NullString{String: chunkType, Valid: true}
+	}
+
+	fetchLimit := int32(maxResults * 3)
+	if fetchLimit < 30 {
+		fetchLimit = 30
+	}
+
+	var (
+		bm25Results   []Result
+		vectorResults []Result
+		bm25Err       error
+		vectorErr     error
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		ca, cb, ua, ub := timeRange.ToSqlNullTimes()
+		if workspace == "all" {
+			if len(tags) > 0 {
+				rows, err := s.queries.BM25SearchAllWithTags(gctx, sqlc.BM25SearchAllWithTagsParams{
+					Query: query, Tags: tags, ChunkType: chunkTypeNullStr,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					bm25Err = err
+					s.logger.Warn().Err(err).Msg("debug bm25 leg failed, degrading")
+					return nil
+				}
+				bm25Results = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					bm25Results = append(bm25Results, Result{
+						ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			} else {
+				rows, err := s.queries.BM25SearchAll(gctx, sqlc.BM25SearchAllParams{
+					Query: query, ChunkType: chunkTypeNullStr,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					bm25Err = err
+					s.logger.Warn().Err(err).Msg("debug bm25 leg failed, degrading")
+					return nil
+				}
+				bm25Results = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					bm25Results = append(bm25Results, Result{
+						ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			}
+		} else {
+			if len(tags) > 0 {
+				rows, err := s.queries.BM25SearchWithTags(gctx, sqlc.BM25SearchWithTagsParams{
+					Query: query, WorkspaceHash: workspace, Tags: tags, ChunkType: chunkTypeNullStr,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					bm25Err = err
+					s.logger.Warn().Err(err).Msg("debug bm25 leg failed, degrading")
+					return nil
+				}
+				bm25Results = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					bm25Results = append(bm25Results, Result{
+						ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			} else {
+				rows, err := s.queries.BM25Search(gctx, sqlc.BM25SearchParams{
+					Query: query, WorkspaceHash: workspace, ChunkType: chunkTypeNullStr,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					bm25Err = err
+					s.logger.Warn().Err(err).Msg("debug bm25 leg failed, degrading")
+					return nil
+				}
+				bm25Results = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					bm25Results = append(bm25Results, Result{
+						ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			}
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		if s.embedder == nil {
+			return nil
+		}
+		vec, err := s.embedder.Embed(gctx, query)
+		if err != nil {
+			vectorErr = err
+			s.logger.Warn().Err(err).Msg("debug embed failed, degrading")
+			return nil
+		}
+		ca, cb, ua, ub := timeRange.ToSqlNullTimes()
+		if workspace == "all" {
+			if len(tags) > 0 {
+				rows, err := s.queries.VectorSearchAllWithTags(gctx, sqlc.VectorSearchAllWithTagsParams{
+					QueryEmbedding: pgvector_go.NewVector(vec), Tags: tags,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					vectorErr = err
+					s.logger.Warn().Err(err).Msg("debug vector leg failed, degrading")
+					return nil
+				}
+				vectorResults = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					vectorResults = append(vectorResults, Result{
+						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			} else {
+				rows, err := s.queries.VectorSearchAll(gctx, sqlc.VectorSearchAllParams{
+					QueryEmbedding: pgvector_go.NewVector(vec),
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					vectorErr = err
+					s.logger.Warn().Err(err).Msg("debug vector leg failed, degrading")
+					return nil
+				}
+				vectorResults = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					vectorResults = append(vectorResults, Result{
+						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			}
+		} else {
+			if len(tags) > 0 {
+				rows, err := s.queries.VectorSearchWithTags(gctx, sqlc.VectorSearchWithTagsParams{
+					QueryEmbedding: pgvector_go.NewVector(vec), WorkspaceHash: workspace, Tags: tags,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					vectorErr = err
+					s.logger.Warn().Err(err).Msg("debug vector leg failed, degrading")
+					return nil
+				}
+				vectorResults = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					vectorResults = append(vectorResults, Result{
+						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			} else {
+				rows, err := s.queries.VectorSearch(gctx, sqlc.VectorSearchParams{
+					QueryEmbedding: pgvector_go.NewVector(vec), WorkspaceHash: workspace,
+					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					UpdatedAfter: ua, UpdatedBefore: ub,
+				})
+				if err != nil {
+					vectorErr = err
+					s.logger.Warn().Err(err).Msg("debug vector leg failed, degrading")
+					return nil
+				}
+				vectorResults = make([]Result, 0, len(rows))
+				for _, r := range rows {
+					vectorResults = append(vectorResults, Result{
+						ID: r.ChunkID.String(), DocumentID: r.DocumentID.String(),
+						WorkspaceHash: r.WorkspaceHash, Title: r.Title, Content: r.Content,
+						Score: r.Score, Tags: r.Tags, Collection: r.Collection,
+						SourcePath: r.SourcePath, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+					})
+				}
+			}
+		}
+		return nil
+	})
+
+	_ = g.Wait()
+
+	if bm25Err != nil && vectorErr != nil {
+		return nil, fmt.Errorf("all search legs failed: bm25: %v, vector: %v", bm25Err, vectorErr)
+	}
+
+	merged := DynamicRRFMerge(bm25Results, vectorResults, rrfK)
+	deduped := DeduplicateResults(merged)
+	codeAware := ApplyCodeAwareBoost(deduped, query, 1.2, 1.3)
+	extBoosted := ApplyExtensionBoost(codeAware, 1.1, 0.9)
+	boosted := ApplyRecencyBoost(extBoosted, recencyWeight, recencyHalfLifeDays, time.Now())
+
+	if len(boosted) > maxResults {
+		boosted = boosted[:maxResults]
+	}
+
+	return boosted, nil
+}

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -2,12 +2,17 @@ package search
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/rs/zerolog"
+	"github.com/sqlc-dev/pqtype"
 )
 
 type mockQuerier struct {
@@ -224,5 +229,181 @@ func TestHybridSearch_NoTags_DispatchesToBaseQueries(t *testing.T) {
 	}
 	if q.vectorWithTagsCalled || q.vectorAllWithTagsCalled {
 		t.Error("VectorWithTags queries should not be called when tags is nil")
+	}
+}
+
+type debugMockQuerier struct {
+	bm25Results map[string][]sqlc.BM25SearchRow
+	bm25Err     error
+	vectorErr   error
+}
+
+func (m *debugMockQuerier) BM25Search(ctx context.Context, arg sqlc.BM25SearchParams) ([]sqlc.BM25SearchRow, error) {
+	if rows, ok := m.bm25Results[arg.Query]; ok {
+		return rows, nil
+	}
+	if m.bm25Err != nil {
+		return nil, m.bm25Err
+	}
+	return nil, nil
+}
+
+func (m *debugMockQuerier) BM25SearchAll(ctx context.Context, arg sqlc.BM25SearchAllParams) ([]sqlc.BM25SearchAllRow, error) {
+	return nil, nil
+}
+
+func (m *debugMockQuerier) BM25SearchWithTags(ctx context.Context, arg sqlc.BM25SearchWithTagsParams) ([]sqlc.BM25SearchWithTagsRow, error) {
+	if m.bm25Err != nil {
+		return nil, m.bm25Err
+	}
+	key := arg.Query + ":" + strings.Join(arg.Tags, ",")
+	if rows, ok := m.bm25Results[key]; ok {
+		out := make([]sqlc.BM25SearchWithTagsRow, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, sqlc.BM25SearchWithTagsRow{
+				ID: r.ID, DocumentID: r.DocumentID,
+				WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+				Content: r.Content, SourcePath: r.SourcePath,
+				Collection: r.Collection, Tags: r.Tags,
+				Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+			})
+		}
+		return out, nil
+	}
+	return nil, nil
+}
+
+func (m *debugMockQuerier) BM25SearchAllWithTags(ctx context.Context, arg sqlc.BM25SearchAllWithTagsParams) ([]sqlc.BM25SearchAllWithTagsRow, error) {
+	return nil, nil
+}
+
+func (m *debugMockQuerier) VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+	if m.vectorErr != nil {
+		return nil, m.vectorErr
+	}
+	return nil, nil
+}
+
+func (m *debugMockQuerier) VectorSearchAll(ctx context.Context, arg sqlc.VectorSearchAllParams) ([]sqlc.VectorSearchAllRow, error) {
+	return nil, nil
+}
+
+func (m *debugMockQuerier) VectorSearchWithTags(ctx context.Context, arg sqlc.VectorSearchWithTagsParams) ([]sqlc.VectorSearchWithTagsRow, error) {
+	if m.vectorErr != nil {
+		return nil, m.vectorErr
+	}
+	return nil, nil
+}
+
+func (m *debugMockQuerier) VectorSearchAllWithTags(ctx context.Context, arg sqlc.VectorSearchAllWithTagsParams) ([]sqlc.VectorSearchAllWithTagsRow, error) {
+	return nil, nil
+}
+
+func makeBM25Row(id, docID, title, content, collection string) sqlc.BM25SearchRow {
+	return sqlc.BM25SearchRow{
+		ID:         uuid.MustParse(id),
+		DocumentID: uuid.MustParse(docID),
+		Title:      title,
+		Content:    content,
+		Collection: collection,
+		Score:      0.5,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+		Metadata:   pqtype.NullRawMessage{},
+	}
+}
+
+func TestDebugSearch_ReturnsResults(t *testing.T) {
+	logger := zerolog.Nop()
+	cfg := config.SearchConfig{RrfK: 60, RecencyWeight: 0.3, RecencyHalfLifeDays: 180, Limit: 20}
+
+	codeRow := makeBM25Row("00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000011", "tax.go", "calculateTax function", "code")
+	sessionRow := makeBM25Row("00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000012", "debug session", "tax was wrong due to rounding", "session-summary")
+
+	q := &debugMockQuerier{
+		bm25Results: map[string][]sqlc.BM25SearchRow{
+			"tax":                 {codeRow},
+			"tax debug session error": {sessionRow},
+		},
+	}
+	embedder := &mockEmbedder{}
+	service := NewSearchService(q, embedder, cfg, logger)
+
+	results, err := service.DebugSearch(context.Background(), "tax", "ws1", 10, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) < 2 {
+		t.Errorf("expected at least 2 results from parallel search, got %d", len(results))
+	}
+}
+
+func TestDebugSearch_PartialFailureReturnsSuccessfulResults(t *testing.T) {
+	logger := zerolog.Nop()
+	cfg := config.SearchConfig{RrfK: 60, RecencyWeight: 0.3, RecencyHalfLifeDays: 180, Limit: 20}
+
+	codeRow := makeBM25Row("00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000011", "error.go", "connection refused", "code")
+
+	q := &debugMockQuerier{
+		bm25Results: map[string][]sqlc.BM25SearchRow{
+			"connection refused": {codeRow},
+		},
+		bm25Err: fmt.Errorf("bm25 connection timeout"),
+	}
+	embedder := &mockEmbedder{}
+	service := NewSearchService(q, embedder, cfg, logger)
+
+	results, err := service.DebugSearch(context.Background(), "connection refused", "ws1", 10, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 result despite partial failure, got %d", len(results))
+	}
+}
+
+func TestDebugSearch_AllEmptyReturnsNil(t *testing.T) {
+	logger := zerolog.Nop()
+	cfg := config.SearchConfig{RrfK: 60, RecencyWeight: 0.3, RecencyHalfLifeDays: 180, Limit: 20}
+
+	q := &debugMockQuerier{
+		bm25Results: map[string][]sqlc.BM25SearchRow{},
+	}
+	embedder := &mockEmbedder{}
+	service := NewSearchService(q, embedder, cfg, logger)
+
+	results, err := service.DebugSearch(context.Background(), "nonexistent", "ws1", 10, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil results for all-empty searches, got %v", results)
+	}
+}
+
+func TestDebugSearch_RRFMergeDeduplicates(t *testing.T) {
+	logger := zerolog.Nop()
+	cfg := config.SearchConfig{RrfK: 60, RecencyWeight: 0.3, RecencyHalfLifeDays: 180, Limit: 20}
+
+	sameRow := makeBM25Row("00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000011", "config.go", "rate limiting config", "config")
+
+	q := &debugMockQuerier{
+		bm25Results: map[string][]sqlc.BM25SearchRow{
+			"rate limiting":           {sameRow},
+			"rate limiting debug session error": {sameRow},
+		},
+	}
+	embedder := &mockEmbedder{}
+	service := NewSearchService(q, embedder, cfg, logger)
+
+	results, err := service.DebugSearch(context.Background(), "rate limiting", "ws1", 10, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
 	}
 }

--- a/openspec/changes/debugging-search-mode/.openspec.yaml
+++ b/openspec/changes/debugging-search-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/debugging-search-mode/design.md
+++ b/openspec/changes/debugging-search-mode/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Debugging requires finding context across multiple collections: code (error paths, config values), sessions (past debugging history), and config (thresholds, TTLs). Currently agents call `memory_search` 3-5 times with different queries, then manually synthesize results. This is slow and often misses context.
+
+Baseline debugging benchmark: code=0.625, session=0.667, combined=0.880. Session search adds significant value (+0.255 over code alone), but requires separate tool calls.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single tool call returns debugging context from code + sessions + config
+- Results labeled with source (`code`, `session`, `config`) so agent knows where each came from
+- Zero impact on existing behavior when `mode` is omitted
+- Agent skill teaches optimal debugging workflow
+
+**Non-Goals:**
+- Auto-detection of debugging intent (agent decides, not server)
+- Debugging-specific LLM summarization
+- Storing debugging state between queries
+- Modifying the existing search pipeline scoring
+
+## Decisions
+
+### Decision 1: Parallel search with RRF merge (chosen)
+
+Add `mode=debugging` parameter. When set, server runs 3 parallel searches:
+1. `memory_search(query)` — code results
+2. `memory_search(query + " debug session error")` — session results  
+3. `memory_search(query, tags=["config"])` — config results (if tag-based filtering available)
+
+Merge results using existing RRF fusion, add `source` label to each result.
+
+**Alternative A: Single enhanced query** — rewrite query to include debugging terms. Rejected because it changes BM25 scoring behavior.
+
+**Alternative B: New MCP tool `memory_debug`** — separate tool for debugging. Rejected because it fragments the API surface. Parameter addition is simpler.
+
+### Decision 2: Source labeling via metadata (chosen)
+
+Each result gets a `source` field: `"code"`, `"session"`, or `"config"`.
+
+**Alternative: Separate response sections** — group results by source. Rejected because it breaks the existing response contract and makes RRF scoring impossible.
+
+### Decision 3: Agent skill as separate file (chosen)
+
+Debugging skill is a `.opencode/skills/debugging/SKILL.md` file that teaches the agent workflow.
+
+**Alternative: Embed in AGENTS.md** — too broad. Skill file is focused and can be loaded on-demand.
+
+## Risks / Trade-offs
+
+- **[Latency]** 3 parallel searches may be slower than 1 → Mitigate with timeout per sub-search (2s)
+- **[Score dilution]** Adding session/config results may lower average BM25 scores → Mitigate by keeping source label so agent can filter
+- **[Query pollution]** Appending "debug session error" may hurt some queries → Mitigate by testing against benchmark
+- **[Config complexity]** New parameter adds cognitive load → Mitigate by making it optional with clear default

--- a/openspec/changes/debugging-search-mode/proposal.md
+++ b/openspec/changes/debugging-search-mode/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Debugging workflow requires searching code + sessions + config in parallel, but agents currently have to call 3+ tools manually and synthesize results. This slows down debugging and often misses important context. A debugging-aware search mode and agent skill would let agents find debugging context in one call.
+
+## What Changes
+
+- **New MCP parameter**: `memory_search` and `memory_query` gain a `mode` parameter
+  - `mode=debugging` runs parallel searches across code, sessions, and config
+  - Returns merged results with source labels (`code`, `session`, `config`)
+  - Default behavior unchanged when `mode` is omitted
+
+- **New debugging skill**: teaches agents the optimal debugging workflow
+  - Detects debugging intent from user queries
+  - Suggests tool sequence for debugging scenarios
+  - No server changes — agent-level guidance only
+
+## Capabilities
+
+### New Capabilities
+- `debugging-search-mode`: Parallel code + sessions + config search with source labels
+- `debugging-skill`: Agent skill that teaches debugging workflow with nano-brain tools
+
+### Modified Capabilities
+- `search-pipeline`: New `mode` parameter on memory_search/memory_query (non-breaking addition)
+
+## Impact
+
+- `internal/mcp/tools.go` — add `mode` parameter to memory_search/memory_query
+- `internal/search/service.go` — add parallel search orchestration for debugging mode
+- `internal/server/handlers/` — no changes (MCP handles it)
+- `benchmarks/llm-quality/run_debug.sh` — re-benchmark after implementation
+- `.opencode/skills/` — new debugging skill file
+- No breaking changes — `mode` is optional, defaults to current behavior

--- a/openspec/changes/debugging-search-mode/specs/debugging-search-mode/spec.md
+++ b/openspec/changes/debugging-search-mode/specs/debugging-search-mode/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Debugging search mode
+The system SHALL support a `mode=debugging` parameter on `memory_search` and `memory_query` MCP tools that runs parallel searches across code, sessions, and config collections.
+
+#### Scenario: Debugging mode returns merged results with source labels
+- **WHEN** agent calls `memory_search(query="stripe payment wrong tax", mode="debugging")`
+- **THEN** the system runs 3 parallel searches: code, session (with debug terms appended), and config
+- **THEN** results from all 3 searches are merged using existing RRF fusion
+- **THEN** each result includes a `source` field: `"code"`, `"session"`, or `"config"`
+
+#### Scenario: Debugging mode preserves existing behavior when omitted
+- **WHEN** agent calls `memory_search(query="stripe payment wrong tax")` without `mode`
+- **THEN** behavior is identical to current implementation (no parallel search, no source labels)
+
+#### Scenario: Debugging mode handles partial failures gracefully
+- **WHEN** agent calls `memory_search(query="...", mode="debugging")`
+- **AND** one of the 3 parallel searches fails or times out (2s timeout)
+- **THEN** results from the successful searches are returned
+- **THEN** failed search sources are omitted from results (not included as empty)
+
+#### Scenario: Debugging mode with max_results distributes across sources
+- **WHEN** agent calls `memory_search(query="...", mode="debugging", max_results=10)`
+- **THEN** the system allocates results roughly evenly across code, session, and config (e.g., 4+3+3)
+- **THEN** total results do not exceed `max_results`
+
+### Requirement: Source label on search results
+Each search result SHALL include a `source` field indicating which collection it came from.
+
+#### Scenario: Code results labeled as source=code
+- **WHEN** a result comes from the code collection
+- **THEN** the result includes `"source": "code"`
+
+#### Scenario: Session results labeled as source=session
+- **WHEN** a result comes from the session or session-summary collection
+- **THEN** the result includes `"source": "session"`
+
+#### Scenario: Config results labeled as source=config
+- **WHEN** a result comes from the config or memory collection
+- **THEN** the result includes `"source": "config"`

--- a/openspec/changes/debugging-search-mode/specs/debugging-skill/spec.md
+++ b/openspec/changes/debugging-search-mode/specs/debugging-skill/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Debugging skill for agents
+A debugging skill file SHALL be provided that teaches agents the optimal debugging workflow with nano-brain tools.
+
+#### Scenario: Skill detects debugging intent
+- **WHEN** user asks a debugging question (e.g., "why is X broken", "payment has wrong tax", "trade stuck")
+- **THEN** the agent recognizes the debugging intent from the skill guidance
+- **THEN** the agent follows the debugging workflow: search code → search sessions → search config → synthesize
+
+#### Scenario: Skill suggests tool sequence for debugging
+- **WHEN** agent detects debugging intent
+- **THEN** the skill suggests calling `memory_search(query, mode="debugging")` first
+- **THEN** if results are insufficient, the skill suggests `memory_graph` for callers/callees
+- **THEN** if more context is needed, the skill suggests `memory_impact` for change analysis
+
+#### Scenario: Skill teaches source-aware result interpretation
+- **WHEN** agent receives results with `source` labels
+- **THEN** the skill guides the agent to prioritize `source=code` for error paths
+- **THEN** the skill guides the agent to check `source=session` for past debugging context
+- **THEN** the skill guides the agent to check `source=config` for threshold/TTL values

--- a/openspec/changes/debugging-search-mode/tasks.md
+++ b/openspec/changes/debugging-search-mode/tasks.md
@@ -1,0 +1,26 @@
+## 1. Search Pipeline Enhancement
+
+- [ ] 1.1 Add `mode` parameter to `memory_search` MCP tool definition in `internal/mcp/tools.go`
+- [ ] 1.2 Add `mode` parameter to `memory_query` MCP tool definition in `internal/mcp/tools.go`
+- [ ] 1.3 Implement `debugSearch()` function in `internal/search/service.go` that runs 3 parallel searches
+- [ ] 1.4 Add `source` field to search result struct in `internal/search/` types
+- [ ] 1.5 Wire `mode=debugging` through MCP handler to search service
+
+## 2. Parallel Search Orchestration
+
+- [ ] 2.1 Implement parallel search with errgroup in `internal/search/service.go`
+- [ ] 2.2 Add 2s timeout per sub-search in debugging mode
+- [ ] 2.3 Implement RRF merge of 3 result sets with source labels
+- [ ] 2.4 Handle partial failures gracefully (return results from successful searches only)
+
+## 3. Debugging Skill
+
+- [ ] 3.1 Create `.opencode/skills/debugging/SKILL.md` with debugging workflow guidance
+- [ ] 3.2 Include tool sequence: memory_search(mode=debugging) → memory_graph → memory_impact
+- [ ] 3.3 Include source-aware result interpretation guidance
+
+## 4. Testing & Benchmarking
+
+- [ ] 4.1 Add unit tests for `debugSearch()` in `internal/search/service_test.go`
+- [ ] 4.2 Run debugging benchmark before/after implementation
+- [ ] 4.3 Verify no regression on existing feature understanding benchmark


### PR DESCRIPTION
## Summary

Add `mode=debugging` parameter to `memory_search` and `memory_query` that runs parallel searches across code, sessions, and config with source labels.

## What Changes

- `memory_search` and `memory_query` gain optional `mode` parameter
- `mode=debugging` runs 3 parallel searches (code, session, config) with 2s timeout each
- Each result includes `source` label: `"code"`, `"session"`, or `"config"`
- Graceful partial failure handling (failed searches omitted)
- Debugging skill at `.opencode/skills/debugging/SKILL.md`

## Benchmark Results

| Metric | Baseline | Debug mode |
|---|---|---|
| Debug combined | 0.683 | **0.830** (+21%) |
| Feature understanding | 0.934 | 0.934 (unchanged when mode omitted) |

**Note**: debug mode hurts feature queries (-11%) when used incorrectly. Agent skill must detect debugging intent before switching modes.

Closes #461