### PR TITLE
fix(graph): emit unresolved call edges for cross-file method invocations

### DIFF
--- a/internal/bench/testdata/results_current.json
+++ b/internal/bench/testdata/results_current.json
@@ -2,7 +2,7 @@
   "dataset_version": "v1",
   "scale": 20,
   "workspace_hash": "7f443561795a6fea64b6e8d35a9b06ed4d216b8a27af5e10e7137b261ade061f",
-  "timestamp": "2026-06-21T09:57:14Z",
+  "timestamp": "2026-06-21T12:58:22Z",
   "version": "v0.3.0-dedup+ranking",
   "precision_at_5": 0,
   "recall_at_10": 0,
@@ -10,7 +10,7 @@
   "precision_at_5_paths": 0,
   "recall_at_10_paths": 0,
   "mrr_paths": 0,
-  "query_p50_ms": 7.770209,
-  "query_p95_ms": 63.582375,
+  "query_p50_ms": 7.395459,
+  "query_p95_ms": 27.654166,
   "query_count": 20
 }

--- a/internal/graph/ruby_extractor.go
+++ b/internal/graph/ruby_extractor.go
@@ -183,10 +183,6 @@ func (e *RubyGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotr
 			}
 			callByte := calleeNode.StartByte()
 
-			if !methodNames[callee] {
-				continue
-			}
-
 			enclosing := enclosingFunc(funcs, callByte)
 			if enclosing == "" {
 				continue

--- a/internal/graph/ruby_extractor_test.go
+++ b/internal/graph/ruby_extractor_test.go
@@ -578,7 +578,7 @@ end
 	}
 }
 
-func TestRubyGraphExtractor_NoCrossFileCalls(t *testing.T) {
+func TestRubyGraphExtractor_CrossFileCalls(t *testing.T) {
 	ex := newRubyExtractor(t)
 	src := []byte(`class MyService
   def run
@@ -591,17 +591,18 @@ end
 		t.Fatal(err)
 	}
 
-	var calls []graph.Edge
+	var callees map[string]bool
 	for _, e := range edges {
 		if e.Kind == graph.EdgeCalls {
-			calls = append(calls, e)
+			if callees == nil {
+				callees = make(map[string]bool)
+			}
+			callees[e.TargetNode] = true
 		}
 	}
 
-	for _, e := range calls {
-		if e.TargetNode == "OtherService" || e.TargetNode == "process" {
-			t.Errorf("should not produce cross-file call edge: %+v", e)
-		}
+	if !callees["process"] {
+		t.Error("expected cross-file call edge to 'process'")
 	}
 }
 

--- a/openspec/changes/ruby-extractor-unresolved-calls/.openspec.yaml
+++ b/openspec/changes/ruby-extractor-unresolved-calls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/ruby-extractor-unresolved-calls/design.md
+++ b/openspec/changes/ruby-extractor-unresolved-calls/design.md
@@ -1,0 +1,26 @@
+## Context
+
+The Ruby call graph extractor (`ruby_extractor.go`) drops method calls where the target is not defined in the same file (line 186-188). Controller files produce 0 call edges because all their calls go to models/services in other files. The cross-file resolver passes through all input edges unchanged, so it has nothing to work with for controller files.
+
+## Decisions
+
+### Decision 1: Remove the methodNames guard
+
+**Choice**: Remove the `if !methodNames[callee] { continue }` block entirely.
+
+**Rationale**: Same-file calls already get resolved edges through the existing path (methodNames check is true → emit edge). Cross-file calls get emitted as additional edges (methodNames check is false → now emit edge instead of dropping). The two paths are mutually exclusive.
+
+**Alternatives considered**:
+- Emit with unresolved metadata: Rejected — adds complexity for no benefit. The resolver passes through all edges unchanged. Metadata isn't needed.
+- Selective filtering: Rejected — too complex. Emit all, let resolver handle.
+
+### Decision 2: Invert test assertion
+
+**Choice**: Invert `TestRubyGraphExtractor_NoCrossFileCalls` to assert cross-file calls DO appear.
+
+**Rationale**: The test currently asserts zero cross-file call edges. After the fix, cross-file calls produce edges. The test must match the new behavior.
+
+## Risks / Trade-offs
+
+- **Edge count increase**: Controller files go from 0 to N call edges. Acceptable — they were silently dropping useful information.
+- **Bare method calls**: `render`, `redirect_to`, `params` will have unresolved edges. Acceptable — they capture the call relationship.

--- a/openspec/changes/ruby-extractor-unresolved-calls/proposal.md
+++ b/openspec/changes/ruby-extractor-unresolved-calls/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+The Ruby call graph extractor (`ruby_extractor.go`) drops method calls where the target is not defined in the same file. This means controller files produce 0 call edges — all their calls go to models/services in other files. The cross-file resolver has nothing to rewrite → flows stop at 3 nodes (entry → handler → func).
+
+The cross-file resolver (PR #469) was designed to resolve bare call targets to qualified cross-file paths. But it can only rewrite edges that exist. The extractor must emit the edges first.
+
+## What Changes
+
+- Emit unresolved call edges for ALL method invocations (not just same-file ones)
+- The resolver rewrites bare targets to qualified cross-file targets
+- Controller files will produce call edges → resolver resolves them → flows reach 5+ nodes
+
+## Impact
+
+- **Code affected**: `internal/graph/ruby_extractor.go` — `extractCalls` method (~5 lines changed)
+- **Risk**: Low — existing same-file behavior preserved; new edges are additional
+- **Verification**: Phil-timeshel flows should show controller→service→model chains (5+ nodes)

--- a/openspec/changes/ruby-extractor-unresolved-calls/specs/unresolved-call-edges/spec.md
+++ b/openspec/changes/ruby-extractor-unresolved-calls/specs/unresolved-call-edges/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Ruby extractor emits call edges for all method invocations
+The Ruby call graph extractor SHALL emit call edges for ALL method invocations found in the source code, not just those defined in the same file.
+
+#### Scenario: Cross-file call in controller
+- **WHEN** a controller file calls `User.create(params)` and `User` is defined in a different file
+- **THEN** the extractor SHALL emit a call edge with TargetNode=`create` (bare name) from the enclosing controller method
+
+#### Scenario: Bare method call (Rails framework)
+- **WHEN** a controller file calls `render json: data` (inherited from ApplicationController)
+- **THEN** the extractor SHALL emit a call edge with TargetNode=`render` from the enclosing controller method
+
+#### Scenario: Same-file call preserved
+- **WHEN** a controller file calls a method defined in the same file
+- **THEN** the extractor SHALL emit the call edge exactly as before (no change to same-file behavior)
+
+#### Scenario: Deduplication
+- **WHEN** the same cross-file call appears multiple times in the same method
+- **THEN** the extractor SHALL emit only one edge (deduplication by enclosing+->+callee)

--- a/openspec/changes/ruby-extractor-unresolved-calls/tasks.md
+++ b/openspec/changes/ruby-extractor-unresolved-calls/tasks.md
@@ -1,0 +1,17 @@
+## 1. Extractor Fix
+
+- [ ] 1.1 Remove the `if !methodNames[callee] { continue }` guard in `extractCalls` (ruby_extractor.go ~line 186-188)
+- [ ] 1.2 Run `go test -race -short ./internal/graph/...` — expect 1 test to fail (NoCrossFileCalls)
+
+## 2. Test Updates
+
+- [ ] 2.1 Invert `TestRubyGraphExtractor_NoCrossFileCalls` to assert cross-file calls DO appear
+- [ ] 2.2 Verify all other existing tests still pass
+- [ ] 2.3 Run full test suite: `go test -race -short ./...`
+
+## 3. Verification
+
+- [ ] 3.1 Rebuild binary, restart test server, reindex Phil workspace
+- [ ] 3.2 Verify controller files now have outgoing call edges via `memory_graph`
+- [ ] 3.3 Verify Phil-timeshel flows show 5+ nodes per controller action
+- [ ] 3.4 Commit, push, create PR, run harness check, merge


### PR DESCRIPTION
## Summary

Remove the `methodNames[callee]` guard that dropped cross-file calls. Controller files now produce call edges (previously 0), enabling the resolver to resolve them cross-file.

Closes #472

## What Changed
- Removed `if !methodNames[callee] { continue }` from `extractCalls` in ruby_extractor.go
- Inverted test: `NoCrossFileCalls` → `CrossFileCalls` (asserts cross-file calls ARE emitted)

## Verification
- [x] `go build ./...` passes
- [x] `go test -race -short ./internal/graph/...` passes
