### PR TITLE
fix(watcher): real-time cleanup for deleted/renamed files

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -372,10 +372,7 @@ func (w *Watcher) handleFSEvent(event fsnotify.Event, debounce *time.Timer) {
 		w.fileCacheMu.Lock()
 		delete(w.fileCache, event.Name)
 		w.fileCacheMu.Unlock()
-		// TODO(story-2.x): Implement stale document cleanup. When a file is deleted,
-		// its document+chunks remain in the DB. Consider diffing globbed files against
-		// DB documents in scanCollection to purge orphans.
-		w.logger.Info().Str("file", event.Name).Msg("file removed (deletion not handled, skipping)")
+		w.cleanupDeletedDocument(event.Name)
 	}
 
 	if !debounce.Stop() {
@@ -533,6 +530,57 @@ func (w *Watcher) cleanupIgnoredDocument(ctx context.Context, col watchedCollect
 	w.fileCacheMu.Unlock()
 
 	w.logger.Debug().Str("file", filePath).Str("doc_id", doc.ID.String()).Msg("cleaned up document matching ignore pattern")
+}
+
+// cleanupDeletedDocument deletes the document + chunks for a file that was
+// removed or renamed on disk. Called from handleFSEvent on Remove/Rename ops.
+// Finds the owning collection by matching the file path prefix against
+// registered collections. No-op if the document doesn't exist.
+func (w *Watcher) cleanupDeletedDocument(filePath string) {
+	w.mu.Lock()
+	var cols []watchedCollection
+	for _, col := range w.collections {
+		if strings.HasPrefix(filePath, col.dirPath+string(os.PathSeparator)) || filePath == col.dirPath {
+			cols = append(cols, col)
+		}
+	}
+	w.mu.Unlock()
+
+	if len(cols) == 0 {
+		return
+	}
+
+	ctx := context.Background()
+	for _, col := range cols {
+		doc, err := w.queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
+			SourcePath:    filePath,
+			WorkspaceHash: col.workspaceHash,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return
+			}
+			w.logger.Warn().Err(err).Str("file", filePath).Msg("cleanupDeletedDocument: get document failed")
+			return
+		}
+
+		if err := w.queries.DeleteChunksByDocumentID(ctx, sqlc.DeleteChunksByDocumentIDParams{
+			DocumentID:    doc.ID,
+			WorkspaceHash: col.workspaceHash,
+		}); err != nil {
+			w.logger.Warn().Err(err).Str("file", filePath).Msg("cleanupDeletedDocument: delete chunks failed")
+		}
+
+		if _, err := w.queries.DeleteDocumentByIDAndWorkspace(ctx, sqlc.DeleteDocumentByIDAndWorkspaceParams{
+			ID:            doc.ID,
+			WorkspaceHash: col.workspaceHash,
+		}); err != nil {
+			w.logger.Warn().Err(err).Str("file", filePath).Msg("cleanupDeletedDocument: delete document failed")
+		}
+
+		w.logger.Info().Str("file", filePath).Str("doc_id", doc.ID.String()).Msg("cleaned up deleted document")
+		return
+	}
 }
 
 // cleanupPathPrefix deletes all documents+chunks whose source_path starts

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -22,12 +22,12 @@ import (
 )
 
 type mockQuerier struct {
-	upsertDocCalls   atomic.Int64
-	upsertChunkCalls atomic.Int64
-	deleteChunkCalls atomic.Int64
-	// sourcePathHash is not synchronized — safe only in sequential test paths.
-	// Add sync.Mutex if tests evolve to exercise concurrent watcher+mock.
-	sourcePathHash map[string]string
+	upsertDocCalls        atomic.Int64
+	upsertChunkCalls      atomic.Int64
+	deleteChunkCalls      atomic.Int64
+	deleteDocCalls        atomic.Int64
+	getDocBySourcePathCalls atomic.Int64
+	sourcePathHash        map[string]string
 }
 
 func newMockQuerier() *mockQuerier {
@@ -61,6 +61,7 @@ func (m *mockQuerier) UpsertChunk(_ context.Context, _ sqlc.UpsertChunkParams) (
 }
 
 func (m *mockQuerier) GetDocumentBySourcePath(_ context.Context, arg sqlc.GetDocumentBySourcePathParams) (sqlc.Document, error) {
+	m.getDocBySourcePathCalls.Add(1)
 	hash, ok := m.sourcePathHash[arg.SourcePath]
 	if !ok {
 		return sqlc.Document{}, sql.ErrNoRows
@@ -72,6 +73,7 @@ func (m *mockQuerier) GetDocumentBySourcePath(_ context.Context, arg sqlc.GetDoc
 }
 
 func (m *mockQuerier) DeleteDocumentByIDAndWorkspace(_ context.Context, _ sqlc.DeleteDocumentByIDAndWorkspaceParams) (int64, error) {
+	m.deleteDocCalls.Add(1)
 	return 1, nil
 }
 
@@ -660,5 +662,82 @@ func TestBuildEdgeMetadata_DoesNotMutateInput(t *testing.T) {
 	}
 	if _, ok := original["line"]; ok {
 		t.Error("buildEdgeMetadata must not inject 'line' into e.Metadata")
+	}
+}
+
+func TestCleanupDeletedDocument_DeletesDocAndChunks(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 50, 60)
+
+	dir := t.TempDir()
+	workspaceHash := "test-ws-hash"
+	filePath := filepath.Join(dir, "main.go")
+
+	mq.sourcePathHash[filePath] = "abc123"
+
+	err := w.Watch("code", dir, workspaceHash, "**/*.go")
+	if err != nil {
+		t.Fatalf("watch: %v", err)
+	}
+
+	w.cleanupDeletedDocument(filePath)
+
+	if mq.getDocBySourcePathCalls.Load() != 1 {
+		t.Errorf("expected 1 GetDocumentBySourcePath call, got %d", mq.getDocBySourcePathCalls.Load())
+	}
+	if mq.deleteChunkCalls.Load() != 1 {
+		t.Errorf("expected 1 DeleteChunksByDocumentID call, got %d", mq.deleteChunkCalls.Load())
+	}
+	if mq.deleteDocCalls.Load() != 1 {
+		t.Errorf("expected 1 DeleteDocumentByIDAndWorkspace call, got %d", mq.deleteDocCalls.Load())
+	}
+}
+
+func TestCleanupDeletedDocument_NoOpWhenDocNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 50, 60)
+
+	dir := t.TempDir()
+	workspaceHash := "test-ws-hash"
+	filePath := filepath.Join(dir, "nonexistent.go")
+
+	err := w.Watch("code", dir, workspaceHash, "**/*.go")
+	if err != nil {
+		t.Fatalf("watch: %v", err)
+	}
+
+	w.cleanupDeletedDocument(filePath)
+
+	if mq.getDocBySourcePathCalls.Load() != 1 {
+		t.Errorf("expected 1 GetDocumentBySourcePath call, got %d", mq.getDocBySourcePathCalls.Load())
+	}
+	if mq.deleteChunkCalls.Load() != 0 {
+		t.Errorf("expected 0 DeleteChunksByDocumentID calls, got %d", mq.deleteChunkCalls.Load())
+	}
+	if mq.deleteDocCalls.Load() != 0 {
+		t.Errorf("expected 0 DeleteDocumentByIDAndWorkspace calls, got %d", mq.deleteDocCalls.Load())
+	}
+}
+
+func TestCleanupDeletedDocument_NoOpWhenNoMatchingCollection(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 50, 60)
+
+	w.cleanupDeletedDocument("/some/random/path.go")
+
+	if mq.getDocBySourcePathCalls.Load() != 0 {
+		t.Errorf("expected 0 GetDocumentBySourcePath calls, got %d", mq.getDocBySourcePathCalls.Load())
 	}
 }


### PR DESCRIPTION
## Summary

When a file is deleted or renamed on disk, the watcher now immediately cleans up the corresponding document + chunks from the database.

Previously, orphaned data persisted until a manual `POST /api/v1/reindex` was triggered.

Closes #478

## Changes

- **`internal/watcher/watcher.go`**: Added `cleanupDeletedDocument` method that looks up the owning collection by file path prefix, deletes associated chunks and document from DB
- **`internal/watcher/watcher.go`**: Wired Remove/Rename events in `handleFSEvent` to call cleanup (replaces the old TODO skip)
- **`internal/watcher/watcher_test.go`**: Added 3 tests — happy path (doc+chunks deleted), no-op when doc not found, no-op when no matching collection

## Verification

- [x] `go build ./...` passes
- [x] `go test -race -short ./...` passes (all packages)
- [x] New tests cover delete, not-found, and no-collection scenarios