### PR TITLE
feat(ruby): Rails DSL extraction — associations, callbacks, Sidekiq, node format

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -410,6 +410,12 @@ func startServer(configPath string) {
 			graphExtractors = append(graphExtractors, rbGraphGE)
 			logger.Info().Msg("execution-flow: ruby graph extractor enabled")
 		}
+		if railsDSLEdge, err := graph.NewRailsDSLEdgeExtractor(); err != nil {
+			logger.Warn().Err(err).Msg("rails dsl edge extractor init failed, skipping")
+		} else {
+			graphExtractors = append(graphExtractors, railsDSLEdge)
+			logger.Info().Msg("execution-flow: rails dsl edge extractor enabled")
+		}
 	}
 	graphRegistry := graph.NewRegistry(graphExtractors...)
 

--- a/internal/graph/rails_dsl_extractor.go
+++ b/internal/graph/rails_dsl_extractor.go
@@ -1,0 +1,451 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+var _ Extractor = (*RailsDSLEdgeExtractor)(nil)
+
+var dslAssociationMethods = map[string]bool{
+	"has_many":                true,
+	"has_one":                 true,
+	"belongs_to":              true,
+	"has_and_belongs_to_many": true,
+}
+
+var dslCallbackMethods = map[string]bool{
+	"before_action":  true,
+	"after_action":   true,
+	"around_action":  true,
+	"before_save":    true,
+	"after_save":     true,
+	"before_create":  true,
+	"after_create":   true,
+	"before_update":  true,
+	"after_update":   true,
+	"before_destroy": true,
+	"after_destroy":  true,
+	"after_commit":   true,
+}
+
+var dslConcernMethods = map[string]bool{
+	"include": true,
+	"extend":  true,
+}
+
+var sidekiqSuperclasses = map[string]bool{
+	"Sidekiq::Worker": true,
+	"Sidekiq::Job":    true,
+}
+
+var sidekiqPerformMethods = map[string]bool{
+	"perform_async": true,
+	"perform_in":    true,
+}
+
+type RailsDSLEdgeExtractor struct {
+	lang *gotreesitter.Language
+}
+
+func NewRailsDSLEdgeExtractor() (*RailsDSLEdgeExtractor, error) {
+	return &RailsDSLEdgeExtractor{lang: grammars.RubyLanguage()}, nil
+}
+
+func (x *RailsDSLEdgeExtractor) Supports(ext string) bool {
+	return ext == ".rb"
+}
+
+func (x *RailsDSLEdgeExtractor) RequiresFrameworks() []string {
+	return []string{"rails"}
+}
+
+func (x *RailsDSLEdgeExtractor) Language() string {
+	return "ruby"
+}
+
+func (x *RailsDSLEdgeExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
+	parser := gotreesitter.NewParser(x.lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("rails_dsl parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	relFile := filepath.ToSlash(filePath)
+
+	sidekiqWorkers := x.detectSidekiqWorkers(bt, tree.RootNode())
+
+	var edges []Edge
+	edges = append(edges, x.extractClassBodyDSL(bt, tree.RootNode(), relFile, content)...)
+	edges = append(edges, x.extractSidekiqPerformCalls(bt, tree.RootNode(), relFile, content, sidekiqWorkers)...)
+
+	if len(edges) == 0 {
+		return nil, nil
+	}
+	return edges, nil
+}
+
+func (x *RailsDSLEdgeExtractor) detectSidekiqWorkers(bt *gotreesitter.BoundTree, root *gotreesitter.Node) map[string]bool {
+	workers := make(map[string]bool)
+	walkNodes(root, x.lang, "class", func(n *gotreesitter.Node) {
+		className := x.classNameText(bt, n)
+		if className == "" {
+			return
+		}
+		if superclass := x.classSuperclassText(bt, n); sidekiqSuperclasses[superclass] {
+			workers[className] = true
+			return
+		}
+		body := x.classBody(n)
+		if body == nil {
+			return
+		}
+		for i := 0; i < int(body.ChildCount()); i++ {
+			child := body.Child(i)
+			if child == nil || child.Type(x.lang) != "call" {
+				continue
+			}
+			methodName := rubyCallMethod(bt, child, x.lang)
+			if methodName != "include" {
+				continue
+			}
+			if x.callIncludesSidekiq(bt, child) {
+				workers[className] = true
+				return
+			}
+		}
+	})
+	return workers
+}
+
+func (x *RailsDSLEdgeExtractor) callIncludesSidekiq(bt *gotreesitter.BoundTree, call *gotreesitter.Node) bool {
+	args := call.ChildByFieldName("arguments", x.lang)
+	if args == nil {
+		return false
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		child := args.Child(i)
+		if child == nil {
+			continue
+		}
+		var name string
+		t := child.Type(x.lang)
+		if t == "constant" {
+			name = bt.NodeText(child)
+		} else if t == "scope_resolution" {
+			name = scopeResolutionText(bt, child)
+		}
+		if sidekiqSuperclasses[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func (x *RailsDSLEdgeExtractor) classNameText(bt *gotreesitter.BoundTree, classNode *gotreesitter.Node) string {
+	for i := 0; i < int(classNode.ChildCount()); i++ {
+		child := classNode.Child(i)
+		if child == nil {
+			continue
+		}
+		t := child.Type(x.lang)
+		if t == "constant" {
+			return bt.NodeText(child)
+		}
+		if t == "scope_resolution" {
+			return scopeResolutionText(bt, child)
+		}
+	}
+	return ""
+}
+
+func (x *RailsDSLEdgeExtractor) classSuperclassText(bt *gotreesitter.BoundTree, classNode *gotreesitter.Node) string {
+	for i := 0; i < int(classNode.ChildCount()); i++ {
+		child := classNode.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Type(x.lang) == "superclass" {
+			for j := 0; j < int(child.ChildCount()); j++ {
+				inner := child.Child(j)
+				if inner == nil {
+					continue
+				}
+				t := inner.Type(x.lang)
+				if t == "constant" {
+					return bt.NodeText(inner)
+				}
+				if t == "scope_resolution" {
+					return scopeResolutionText(bt, inner)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (x *RailsDSLEdgeExtractor) extractClassBodyDSL(bt *gotreesitter.BoundTree, root *gotreesitter.Node, relFile string, content []byte) []Edge {
+	var edges []Edge
+
+	walkNodes(root, x.lang, "class", func(n *gotreesitter.Node) {
+		className := x.classNameText(bt, n)
+		if className == "" {
+			return
+		}
+		body := x.classBody(n)
+		if body == nil {
+			return
+		}
+		edges = append(edges, x.walkDSLBody(bt, body, className, relFile, content)...)
+	})
+
+	return edges
+}
+
+func (x *RailsDSLEdgeExtractor) classBody(classNode *gotreesitter.Node) *gotreesitter.Node {
+	for i := 0; i < int(classNode.ChildCount()); i++ {
+		child := classNode.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Type(x.lang) == "body_statement" {
+			return child
+		}
+	}
+	return nil
+}
+
+func (x *RailsDSLEdgeExtractor) walkDSLBody(bt *gotreesitter.BoundTree, body *gotreesitter.Node, className string, relFile string, content []byte) []Edge {
+	var edges []Edge
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		child := body.Child(i)
+		if child == nil || child.Type(x.lang) != "call" {
+			continue
+		}
+		methodName := rubyCallMethod(bt, child, x.lang)
+		if methodName == "" {
+			continue
+		}
+
+		switch {
+		case dslAssociationMethods[methodName]:
+			edges = append(edges, x.extractAssociation(bt, child, className, methodName, relFile, content)...)
+		case dslCallbackMethods[methodName]:
+			edges = append(edges, x.extractCallback(bt, child, className, methodName, relFile, content)...)
+		case dslConcernMethods[methodName]:
+			edges = append(edges, x.extractConcern(bt, child, className, methodName, relFile, content)...)
+		}
+	}
+
+	return edges
+}
+
+func (x *RailsDSLEdgeExtractor) extractAssociation(bt *gotreesitter.BoundTree, call *gotreesitter.Node, className string, methodName string, relFile string, content []byte) []Edge {
+	target := x.firstSymbolArg(bt, call)
+	if target == "" {
+		return nil
+	}
+	return []Edge{{
+		SourceNode: relFile + "::" + className + "#" + methodName,
+		TargetNode: target,
+		Kind:       EdgeCalls,
+		SourceFile: relFile,
+		Line:       lineForByte(content, call.StartByte()),
+		Language:   "ruby",
+		Metadata: map[string]any{
+			"dsl":              true,
+			"type":             "association",
+			"association_type": methodName,
+		},
+	}}
+}
+
+func (x *RailsDSLEdgeExtractor) firstSymbolArg(bt *gotreesitter.BoundTree, call *gotreesitter.Node) string {
+	args := call.ChildByFieldName("arguments", x.lang)
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		child := args.Child(i)
+		if child != nil && child.Type(x.lang) == "simple_symbol" {
+			return strings.TrimPrefix(bt.NodeText(child), ":")
+		}
+	}
+	return ""
+}
+
+func (x *RailsDSLEdgeExtractor) extractCallback(bt *gotreesitter.BoundTree, call *gotreesitter.Node, className string, methodName string, relFile string, content []byte) []Edge {
+	action := x.firstSymbolArg(bt, call)
+	if action == "" {
+		return nil
+	}
+	return []Edge{{
+		SourceNode: relFile + "::" + className + "#" + methodName,
+		TargetNode: action,
+		Kind:       EdgeMiddleware,
+		SourceFile: relFile,
+		Line:       lineForByte(content, call.StartByte()),
+		Language:   "ruby",
+		Metadata: map[string]any{
+			"dsl":           true,
+			"type":          "callback",
+			"callback_type": methodName,
+		},
+	}}
+}
+
+func (x *RailsDSLEdgeExtractor) extractConcern(bt *gotreesitter.BoundTree, call *gotreesitter.Node, className string, methodName string, relFile string, content []byte) []Edge {
+	moduleName := x.firstConstantArg(bt, call)
+	if moduleName == "" {
+		return nil
+	}
+	return []Edge{{
+		SourceNode: relFile + "::" + className + "#" + methodName,
+		TargetNode: moduleName,
+		Kind:       EdgeCalls,
+		SourceFile: relFile,
+		Line:       lineForByte(content, call.StartByte()),
+		Language:   "ruby",
+		Metadata: map[string]any{
+			"dsl":          true,
+			"type":         "concern",
+			"concern_type": methodName,
+		},
+	}}
+}
+
+func (x *RailsDSLEdgeExtractor) firstConstantArg(bt *gotreesitter.BoundTree, call *gotreesitter.Node) string {
+	args := call.ChildByFieldName("arguments", x.lang)
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		child := args.Child(i)
+		if child == nil {
+			continue
+		}
+		t := child.Type(x.lang)
+		if t == "constant" {
+			return bt.NodeText(child)
+		}
+		if t == "scope_resolution" {
+			return scopeResolutionText(bt, child)
+		}
+	}
+	return ""
+}
+
+func (x *RailsDSLEdgeExtractor) extractSidekiqPerformCalls(bt *gotreesitter.BoundTree, root *gotreesitter.Node, relFile string, content []byte, sidekiqWorkers map[string]bool) []Edge {
+	var edges []Edge
+
+	walkNodes(root, x.lang, "call", func(n *gotreesitter.Node) {
+		methodName := rubyCallMethod(bt, n, x.lang)
+		if !sidekiqPerformMethods[methodName] {
+			return
+		}
+
+		receiver := x.callReceiver(bt, n)
+		if receiver == "" {
+			return
+		}
+
+		workerClass := resolveWorkerClass(receiver, sidekiqWorkers)
+		if workerClass == "" {
+			return
+		}
+
+		callerMethod := x.findEnclosingMethodName(bt, n)
+
+		sourceNode := relFile + "::" + callerMethod + "#" + methodName
+		targetNode := workerClass + "#perform"
+
+		edges = append(edges, Edge{
+			SourceNode: sourceNode,
+			TargetNode: targetNode,
+			Kind:       EdgeIntegration,
+			SourceFile: relFile,
+			Line:       lineForByte(content, n.StartByte()),
+			Language:   "ruby",
+			Metadata: map[string]any{
+				"kind":         "sidekiq_job",
+				"worker_class": workerClass,
+			},
+		})
+	})
+
+	return edges
+}
+
+func (x *RailsDSLEdgeExtractor) callReceiver(bt *gotreesitter.BoundTree, call *gotreesitter.Node) string {
+	methodNode := call.ChildByFieldName("method", x.lang)
+	if methodNode == nil {
+		return ""
+	}
+	for i := 0; i < int(call.ChildCount()); i++ {
+		child := call.Child(i)
+		if child == nil || child == methodNode {
+			break
+		}
+		t := child.Type(x.lang)
+		if t == "constant" {
+			return bt.NodeText(child)
+		}
+		if t == "scope_resolution" {
+			return scopeResolutionText(bt, child)
+		}
+		if t == "identifier" {
+			return bt.NodeText(child)
+		}
+	}
+	return ""
+}
+
+func (x *RailsDSLEdgeExtractor) findEnclosingMethodName(bt *gotreesitter.BoundTree, n *gotreesitter.Node) string {
+	current := n.Parent()
+	for current != nil {
+		t := current.Type(x.lang)
+		if t == "method" || t == "singleton_method" {
+			nameNode := current.ChildByFieldName("name", x.lang)
+			if nameNode != nil {
+				return bt.NodeText(nameNode)
+			}
+		}
+		current = current.Parent()
+	}
+	return ""
+}
+
+func resolveWorkerClass(receiver string, sidekiqWorkers map[string]bool) string {
+	if sidekiqWorkers[receiver] {
+		return receiver
+	}
+	if idx := strings.LastIndex(receiver, "::"); idx >= 0 {
+		suffix := receiver[idx+2:]
+		if sidekiqWorkers[suffix] {
+			return suffix
+		}
+	}
+	return ""
+}
+
+func scopeResolutionText(bt *gotreesitter.BoundTree, n *gotreesitter.Node) string {
+	var parts []string
+	for i := 0; i < int(n.ChildCount()); i++ {
+		child := n.Child(i)
+		if child == nil {
+			continue
+		}
+		text := bt.NodeText(child)
+		if text != "::" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "::")
+}

--- a/internal/graph/rails_dsl_extractor_test.go
+++ b/internal/graph/rails_dsl_extractor_test.go
@@ -1,0 +1,427 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func newRailsDSLEdgeExtractor(t *testing.T) *graph.RailsDSLEdgeExtractor {
+	t.Helper()
+	ex, err := graph.NewRailsDSLEdgeExtractor()
+	if err != nil {
+		t.Fatalf("NewRailsDSLEdgeExtractor: %v", err)
+	}
+	return ex
+}
+
+func TestRailsDSLEdgeExtractor_Supports(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		{".rb", true},
+		{".go", false},
+		{".ts", false},
+		{".py", false},
+		{".js", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := ex.Supports(tt.ext); got != tt.want {
+			t.Errorf("Supports(%q) = %v, want %v", tt.ext, got, tt.want)
+		}
+	}
+}
+
+func TestRailsDSLEdgeExtractor_RequiresFrameworks(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	fws := ex.RequiresFrameworks()
+	if len(fws) != 1 || fws[0] != "rails" {
+		t.Errorf("expected [rails], got %v", fws)
+	}
+}
+
+func TestRailsDSLEdgeExtractor_Language(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	if ex.Language() != "ruby" {
+		t.Errorf("expected 'ruby', got %q", ex.Language())
+	}
+}
+
+func TestRailsDSLEdgeExtractor_EmptyFile(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	edges, err := ex.ExtractEdges("empty.rb", []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from empty file, got %d", len(edges))
+	}
+}
+
+func TestRailsDSLEdgeExtractor_CommentsOnly(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	edges, err := ex.ExtractEdges("comments.rb", []byte("# comment\n# another\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(edges))
+	}
+}
+
+func TestRailsDSLEdgeExtractor_Associations(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class User < ApplicationRecord
+  has_many :orders
+  has_one :profile
+  belongs_to :company
+  has_and_belongs_to_many :roles
+end
+`)
+	edges, err := ex.ExtractEdges("app/models/user.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(edges) != 4 {
+		t.Fatalf("expected 4 association edges, got %d: %v", len(edges), edges)
+	}
+
+	for _, e := range edges {
+		if e.Kind != graph.EdgeCalls {
+			t.Errorf("expected EdgeCalls, got %v for edge %+v", e.Kind, e)
+		}
+		if e.Language != "ruby" {
+			t.Errorf("expected Language='ruby', got %q", e.Language)
+		}
+		if e.SourceFile != "app/models/user.rb" {
+			t.Errorf("expected SourceFile='app/models/user.rb', got %q", e.SourceFile)
+		}
+		if e.Line == 0 {
+			t.Errorf("expected non-zero Line for edge %+v", e)
+		}
+	}
+
+	edgesByKey := map[string]graph.Edge{}
+	for _, e := range edges {
+		edgesByKey[e.TargetNode] = e
+	}
+
+	expectedTargets := []string{"orders", "profile", "company", "roles"}
+	for _, target := range expectedTargets {
+		if _, ok := edgesByKey[target]; !ok {
+			t.Errorf("expected edge with TargetNode=%q", target)
+		}
+	}
+
+	for _, e := range edges {
+		if e.SourceNode != "app/models/user.rb::User#"+e.Metadata["association_type"].(string) {
+			t.Errorf("unexpected SourceNode: %q", e.SourceNode)
+		}
+	}
+
+	assocTypes := map[string]bool{}
+	for _, e := range edges {
+		assocTypes[e.Metadata["association_type"].(string)] = true
+	}
+	for _, expected := range []string{"has_many", "has_one", "belongs_to", "has_and_belongs_to_many"} {
+		if !assocTypes[expected] {
+			t.Errorf("expected association_type %q", expected)
+		}
+	}
+}
+
+func TestRailsDSLEdgeExtractor_Callbacks(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class ApplicationController < ActionController::Base
+  before_action :authenticate!
+  after_action :track_event
+end
+`)
+	edges, err := ex.ExtractEdges("app/controllers/application_controller.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 callback edges, got %d: %v", len(edges), edges)
+	}
+
+	for _, e := range edges {
+		if e.Kind != graph.EdgeMiddleware {
+			t.Errorf("expected EdgeMiddleware, got %v for edge %+v", e.Kind, e)
+		}
+	}
+
+	edgesByKey := map[string]graph.Edge{}
+	for _, e := range edges {
+		edgesByKey[e.TargetNode] = e
+	}
+
+	if _, ok := edgesByKey["authenticate!"]; !ok {
+		t.Error("expected edge with TargetNode='authenticate!'")
+	}
+	if _, ok := edgesByKey["track_event"]; !ok {
+		t.Error("expected edge with TargetNode='track_event'")
+	}
+
+	for _, e := range edges {
+		if e.SourceNode != "app/controllers/application_controller.rb::ApplicationController#"+e.Metadata["callback_type"].(string) {
+			t.Errorf("unexpected SourceNode: %q", e.SourceNode)
+		}
+	}
+}
+
+func TestRailsDSLEdgeExtractor_Concerns(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class User < ApplicationRecord
+  include Authenticatable
+  extend FriendlyId
+end
+`)
+	edges, err := ex.ExtractEdges("app/models/user.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 concern edges, got %d: %v", len(edges), edges)
+	}
+
+	for _, e := range edges {
+		if e.Kind != graph.EdgeCalls {
+			t.Errorf("expected EdgeCalls, got %v for edge %+v", e.Kind, e)
+		}
+	}
+
+	edgesByKey := map[string]graph.Edge{}
+	for _, e := range edges {
+		edgesByKey[e.TargetNode] = e
+	}
+
+	if includeEdge, ok := edgesByKey["Authenticatable"]; !ok {
+		t.Error("expected edge with TargetNode='Authenticatable'")
+	} else {
+		if includeEdge.Metadata["concern_type"] != "include" {
+			t.Errorf("expected concern_type='include', got %v", includeEdge.Metadata["concern_type"])
+		}
+	}
+
+	if extendEdge, ok := edgesByKey["FriendlyId"]; !ok {
+		t.Error("expected edge with TargetNode='FriendlyId'")
+	} else {
+		if extendEdge.Metadata["concern_type"] != "extend" {
+			t.Errorf("expected concern_type='extend', got %v", extendEdge.Metadata["concern_type"])
+		}
+	}
+}
+
+func TestRailsDSLEdgeExtractor_SidekiqWorker(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class EmailWorker
+  include Sidekiq::Worker
+
+  def perform(user_id)
+    user = User.find(user_id)
+    # ...
+  end
+end
+
+class UserController < ApplicationController
+  def create
+    @user = User.create(user_params)
+    EmailWorker.perform_async(@user.id)
+  end
+end
+`)
+	edges, err := ex.ExtractEdges("app/workers/email_worker.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var integrationEdges []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeIntegration {
+			integrationEdges = append(integrationEdges, e)
+		}
+	}
+
+	if len(integrationEdges) != 1 {
+		t.Fatalf("expected 1 Sidekiq integration edge, got %d: %v", len(integrationEdges), integrationEdges)
+	}
+
+	e := integrationEdges[0]
+	if e.TargetNode != "EmailWorker#perform" {
+		t.Errorf("expected TargetNode='EmailWorker#perform', got %q", e.TargetNode)
+	}
+	if e.Metadata["kind"] != "sidekiq_job" {
+		t.Errorf("expected kind='sidekiq_job', got %v", e.Metadata["kind"])
+	}
+	if e.Metadata["worker_class"] != "EmailWorker" {
+		t.Errorf("expected worker_class='EmailWorker', got %v", e.Metadata["worker_class"])
+	}
+}
+
+func TestRailsDSLEdgeExtractor_SidekiqJob(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class EmailWorker < Sidekiq::Job
+  def perform(user_id)
+  end
+end
+
+class Trigger
+  def send_email
+    EmailWorker.perform_async(42)
+  end
+end
+`)
+	edges, err := ex.ExtractEdges("app/workers/email_worker.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var integrationEdges []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeIntegration {
+			integrationEdges = append(integrationEdges, e)
+		}
+	}
+
+	if len(integrationEdges) != 1 {
+		t.Fatalf("expected 1 Sidekiq integration edge, got %d: %v", len(integrationEdges), integrationEdges)
+	}
+
+	if integrationEdges[0].TargetNode != "EmailWorker#perform" {
+		t.Errorf("expected TargetNode='EmailWorker#perform', got %q", integrationEdges[0].TargetNode)
+	}
+}
+
+func TestRailsDSLEdgeExtractor_SidekiqUnknownWorker(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class Trigger
+  def call
+    UnknownWorker.perform_async(1)
+  end
+end
+`)
+	edges, err := ex.ExtractEdges("app/services/trigger.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range edges {
+		if e.Kind == graph.EdgeIntegration {
+			t.Errorf("should not emit integration edge for unknown worker, got %+v", e)
+		}
+	}
+}
+
+func TestRailsDSLEdgeExtractor_SidekiqNoReceiver(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class Trigger
+  def call
+    perform_async(1)
+  end
+end
+`)
+	edges, err := ex.ExtractEdges("app/services/trigger.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range edges {
+		if e.Kind == graph.EdgeIntegration {
+			t.Errorf("should not emit integration edge for bare perform_async, got %+v", e)
+		}
+	}
+}
+
+func TestRailsDSLEdgeExtractor_ModelWithAssociationsAndCallbacks(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class Order < ApplicationRecord
+  belongs_to :user
+  has_many :line_items
+
+  before_save :calculate_total
+  after_commit :notify_user, on: :create
+end
+`)
+	edges, err := ex.ExtractEdges("app/models/order.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var assocEdges, callbackEdges []graph.Edge
+	for _, e := range edges {
+		switch e.Kind {
+		case graph.EdgeCalls:
+			assocEdges = append(assocEdges, e)
+		case graph.EdgeMiddleware:
+			callbackEdges = append(callbackEdges, e)
+		}
+	}
+
+	if len(assocEdges) != 2 {
+		t.Fatalf("expected 2 association edges, got %d", len(assocEdges))
+	}
+	if len(callbackEdges) != 2 {
+		t.Fatalf("expected 2 callback edges, got %d", len(callbackEdges))
+	}
+}
+
+func TestRailsDSLEdgeExtractor_NestedClass(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`module Admin
+  class User < ApplicationRecord
+    has_many :posts
+  end
+end
+`)
+	edges, err := ex.ExtractEdges("app/models/admin/user.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d: %v", len(edges), edges)
+	}
+
+	if edges[0].TargetNode != "posts" {
+		t.Errorf("expected TargetNode='posts', got %q", edges[0].TargetNode)
+	}
+}
+
+func TestRailsDSLEdgeExtractor_NonRubyFile(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	if ex.Supports(".go") {
+		t.Error("should not support .go")
+	}
+	if ex.Supports(".ts") {
+		t.Error("should not support .ts")
+	}
+	if ex.Supports(".py") {
+		t.Error("should not support .py")
+	}
+}
+
+func TestRailsDSLEdgeExtractor_LineNumbers(t *testing.T) {
+	ex := newRailsDSLEdgeExtractor(t)
+	src := []byte(`class User < ApplicationRecord
+  has_many :orders
+end
+`)
+	edges, err := ex.ExtractEdges("app/models/user.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(edges))
+	}
+	if edges[0].Line != 2 {
+		t.Errorf("expected Line=2, got %d", edges[0].Line)
+	}
+}

--- a/internal/graph/ruby_cflow.go
+++ b/internal/graph/ruby_cflow.go
@@ -44,7 +44,7 @@ func (x *RubyControlFlowExtractor) ExtractCFGs(filePath string, content []byte) 
 	}
 
 	var methods []funcDef
-	walkNodes(root, x.lang, "method", func(n *gotreesitter.Node) {
+	collectMethods := func(n *gotreesitter.Node) {
 		nameNode := n.ChildByFieldName("name", x.lang)
 		bodyNode := n.ChildByFieldName("body", x.lang)
 		if nameNode == nil || bodyNode == nil {
@@ -56,7 +56,9 @@ func (x *RubyControlFlowExtractor) ExtractCFGs(filePath string, content []byte) 
 			endLine:   lineForByte(content, n.EndByte()),
 			bodyNode:  bodyNode,
 		})
-	})
+	}
+	walkNodes(root, x.lang, "method", collectMethods)
+	walkNodes(root, x.lang, "singleton_method", collectMethods)
 
 	var cfgs []CFG
 	for _, md := range methods {

--- a/internal/graph/ruby_cflow_test.go
+++ b/internal/graph/ruby_cflow_test.go
@@ -479,6 +479,56 @@ end
 	}
 }
 
+func TestRubyControlFlowExtractor_SingletonMethodIfElse(t *testing.T) {
+	ex := newRubyCFGExtractor(t)
+	src := []byte(`class ImportJob
+  def self.perform(data)
+    if data.valid?
+      process(data)
+    else
+      skip(data)
+    end
+  end
+end
+`)
+	cfgs, err := ex.ExtractCFGs("app/jobs/import_job.rb", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 CFG, got %d", len(cfgs))
+	}
+	cfg := cfgs[0]
+
+	if want := "app/jobs/import_job.rb::perform"; cfg.Entry != want {
+		t.Errorf("Entry = %q, want %q", cfg.Entry, want)
+	}
+
+	for _, n := range cfg.Nodes {
+		if n.Type == "start" {
+			if n.Label != "perform" {
+				t.Errorf("start node label = %q, want %q", n.Label, "perform")
+			}
+		}
+	}
+
+	counts := countNodeTypes(cfg)
+	if counts["decision"] < 1 {
+		t.Errorf("expected at least 1 decision node, got %d", counts["decision"])
+	}
+	if counts["terminal"] < 1 {
+		t.Errorf("expected at least 1 terminal node, got %d", counts["terminal"])
+	}
+
+	branches := countEdgeBranches(cfg)
+	if branches["yes"] < 1 {
+		t.Error("expected at least 1 'yes' branch edge")
+	}
+	if branches["no"] < 1 {
+		t.Error("expected at least 1 'no' branch edge")
+	}
+}
+
 func TestRubyControlFlowExtractor_BeginRescueEnsure(t *testing.T) {
 	ex := newRubyCFGExtractor(t)
 	src := []byte(`def find_user(id)

--- a/internal/graph/ruby_class_index.go
+++ b/internal/graph/ruby_class_index.go
@@ -84,6 +84,14 @@ func (idx *RubyClassIndex) LookupStrict(className string) []classEntry {
 }
 
 func containsSuffix(targetNode string) string {
+	hashIdx := strings.LastIndex(targetNode, "#")
+	if hashIdx >= 0 {
+		suffix := targetNode[hashIdx+1:]
+		if colonIdx := strings.LastIndex(targetNode[:hashIdx], "::"); colonIdx >= 0 {
+			return targetNode[colonIdx+2 : hashIdx]
+		}
+		return suffix
+	}
 	idx := strings.LastIndex(targetNode, "::")
 	if idx < 0 {
 		return ""
@@ -107,12 +115,29 @@ func railsConventionPath(className string) string {
 		namespace = className[:dotIdx]
 	}
 	snake := CamelToSnake(shortName)
-	if strings.HasSuffix(shortName, "Controller") {
-		if namespace != "" {
-			return "app/controllers/" + namespaceToPath(namespace) + "/" + snake + ".rb"
-		}
-		return "app/controllers/" + snake + ".rb"
+
+	type suffixMapping struct {
+		suffix string
+		dir    string
 	}
+	mappings := []suffixMapping{
+		{"Controller", "app/controllers/"},
+		{"Service", "app/services/"},
+		{"Job", "app/jobs/"},
+		{"Worker", "app/workers/"},
+		{"Mailer", "app/mailers/"},
+		{"Policy", "app/policies/"},
+		{"Serializer", "app/serializers/"},
+	}
+	for _, m := range mappings {
+		if strings.HasSuffix(shortName, m.suffix) {
+			if namespace != "" {
+				return m.dir + namespaceToPath(namespace) + "/" + snake + ".rb"
+			}
+			return m.dir + snake + ".rb"
+		}
+	}
+
 	if namespace != "" {
 		return "app/models/" + namespaceToPath(namespace) + "/" + snake + ".rb"
 	}

--- a/internal/graph/ruby_class_index_test.go
+++ b/internal/graph/ruby_class_index_test.go
@@ -179,6 +179,37 @@ func TestLookup_controllerPreference(t *testing.T) {
 	}
 }
 
+func TestLookup_conventionPaths(t *testing.T) {
+	idx := graph.BuildClassIndex(nil)
+
+	tests := []struct {
+		className string
+		wantPath  string
+	}{
+		{"PaymentService", "app/services/payment_service.rb"},
+		{"ImportJob", "app/jobs/import_job.rb"},
+		{"SyncWorker", "app/workers/sync_worker.rb"},
+		{"WelcomeMailer", "app/mailers/welcome_mailer.rb"},
+		{"UserPolicy", "app/policies/user_policy.rb"},
+		{"UserSerializer", "app/serializers/user_serializer.rb"},
+		{"Admin::PaymentService", "app/services/admin/payment_service.rb"},
+		{"Admin::ImportJob", "app/jobs/admin/import_job.rb"},
+		{"Admin::SyncWorker", "app/workers/admin/sync_worker.rb"},
+		{"Admin::WelcomeMailer", "app/mailers/admin/welcome_mailer.rb"},
+		{"Admin::UserPolicy", "app/policies/admin/user_policy.rb"},
+		{"Admin::UserSerializer", "app/serializers/admin/user_serializer.rb"},
+	}
+	for _, tt := range tests {
+		entries := idx.Lookup(tt.className)
+		if len(entries) != 1 {
+			t.Fatalf("Lookup(%q): expected 1 entry, got %d", tt.className, len(entries))
+		}
+		if entries[0].FilePath != tt.wantPath {
+			t.Errorf("Lookup(%q): got %q, want %q", tt.className, entries[0].FilePath, tt.wantPath)
+		}
+	}
+}
+
 func TestLookup_controllerPreference_namespaced(t *testing.T) {
 	// Full namespace lookup should prefer controller even when model exists
 	edges := []graph.Edge{

--- a/internal/graph/ruby_extractor.go
+++ b/internal/graph/ruby_extractor.go
@@ -91,9 +91,13 @@ func (e *RubyGraphExtractor) extractContains(bt *gotreesitter.BoundTree, tree *g
 
 	for _, match := range matches {
 		var nameNode *gotreesitter.Node
+		var declNode *gotreesitter.Node
 		for _, cap := range match.Captures {
-			if cap.Name == "name" {
+			switch cap.Name {
+			case "name":
 				nameNode = cap.Node
+			case "decl":
+				declNode = cap.Node
 			}
 		}
 		if nameNode == nil {
@@ -104,13 +108,23 @@ func (e *RubyGraphExtractor) extractContains(bt *gotreesitter.BoundTree, tree *g
 		if idx := strings.LastIndex(name, "::"); idx >= 0 {
 			name = name[idx+2:]
 		}
-		if seen[name] {
+
+		isMethod := declNode != nil && (bt.NodeType(declNode) == "method" || bt.NodeType(declNode) == "singleton_method")
+		targetNode := filePath + "::" + name
+		if isMethod {
+			className := extractEnclosingClass(bt, declNode, e.lang)
+			if className != "" {
+				targetNode = filePath + "::" + className + "#" + name
+			}
+		}
+
+		if seen[targetNode] {
 			continue
 		}
-		seen[name] = true
+		seen[targetNode] = true
 		edges = append(edges, Edge{
 			SourceNode: filePath,
-			TargetNode: filePath + "::" + name,
+			TargetNode: targetNode,
 			Kind:       EdgeContains,
 			SourceFile: filePath,
 			Line:       lineForByte(content, nameNode.StartByte()),
@@ -138,9 +152,24 @@ func extractRubyFullName(bt *gotreesitter.BoundTree, n *gotreesitter.Node) strin
 	return strings.Join(parts, "::")
 }
 
+func extractEnclosingClass(bt *gotreesitter.BoundTree, n *gotreesitter.Node, lang *gotreesitter.Language) string {
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		nodeType := bt.NodeType(p)
+		if nodeType == "class" || nodeType == "module" {
+			nameNode := p.ChildByFieldName("name", lang)
+			if nameNode == nil {
+				continue
+			}
+			return extractRubyFullName(bt, nameNode)
+		}
+	}
+	return ""
+}
+
 func (e *RubyGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string) []Edge {
 	funcMatches := e.callFuncQuery.Execute(tree)
 	var funcs []funcRange
+	funcClass := map[string]string{}
 	methodNames := map[string]bool{}
 	for _, match := range funcMatches {
 		var name string
@@ -160,6 +189,9 @@ func (e *RubyGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotr
 				startByte: declNode.StartByte(),
 				endByte:   declNode.EndByte(),
 			})
+			if className := extractEnclosingClass(bt, declNode, e.lang); className != "" {
+				funcClass[name] = className
+			}
 		}
 	}
 
@@ -192,8 +224,12 @@ func (e *RubyGraphExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotr
 				continue
 			}
 			seen[key] = true
+			sourceNode := filePath + "::" + enclosing
+			if className := funcClass[enclosing]; className != "" {
+				sourceNode = filePath + "::" + className + "#" + enclosing
+			}
 			edges = append(edges, Edge{
-				SourceNode: filePath + "::" + enclosing,
+				SourceNode: sourceNode,
 				TargetNode: callee,
 				Kind:       EdgeCalls,
 				SourceFile: filePath,

--- a/internal/graph/ruby_extractor_test.go
+++ b/internal/graph/ruby_extractor_test.go
@@ -99,11 +99,11 @@ end
 	for _, e := range contains {
 		names[e.TargetNode] = true
 	}
-	if !names["test.rb::alpha"] {
-		t.Error("expected contains edge for alpha")
+	if !names["test.rb::MyClass#alpha"] {
+		t.Error("expected contains edge for MyClass#alpha")
 	}
-	if !names["test.rb::beta"] {
-		t.Error("expected contains edge for beta")
+	if !names["test.rb::MyClass#beta"] {
+		t.Error("expected contains edge for MyClass#beta")
 	}
 	if !names["test.rb::MyClass"] {
 		t.Error("expected contains edge for MyClass")
@@ -142,11 +142,11 @@ end
 	for _, e := range contains {
 		names[e.TargetNode] = true
 	}
-	if !names["test.rb::create_default"] {
-		t.Error("expected contains edge for create_default")
+	if !names["test.rb::MyClass#create_default"] {
+		t.Error("expected contains edge for MyClass#create_default")
 	}
-	if !names["test.rb::instance_method"] {
-		t.Error("expected contains edge for instance_method")
+	if !names["test.rb::MyClass#instance_method"] {
+		t.Error("expected contains edge for MyClass#instance_method")
 	}
 	if !names["test.rb::MyClass"] {
 		t.Error("expected contains edge for MyClass")
@@ -225,7 +225,7 @@ end
 
 	found := false
 	for _, e := range calls {
-		if e.SourceNode == "test.rb::index" && e.TargetNode == "data" {
+		if e.SourceNode == "test.rb::Controller#index" && e.TargetNode == "data" {
 			found = true
 		}
 	}
@@ -334,7 +334,7 @@ func TestRubyGraphExtractor_Fixture(t *testing.T) {
 		containsMap[e.TargetNode] = true
 	}
 	for _, name := range []string{"index", "create", "build_user", "user_params"} {
-		key := fixturePath + "::" + name
+		key := fixturePath + "::UsersController#" + name
 		if !containsMap[key] {
 			t.Errorf("expected contains edge for %s", name)
 		}
@@ -367,8 +367,8 @@ func TestRubyGraphExtractor_FixtureCalls(t *testing.T) {
 	}
 
 	expectedCalls := []string{
-		fixturePath + "::create->build_user",
-		fixturePath + "::build_user->user_params",
+		fixturePath + "::UsersController#create->build_user",
+		fixturePath + "::UsersController#build_user->user_params",
 	}
 	for _, key := range expectedCalls {
 		if !callMap[key] {
@@ -406,7 +406,7 @@ func TestRubyGraphExtractor_ModelFixture(t *testing.T) {
 		containsMap[e.TargetNode] = true
 	}
 	for _, name := range []string{"full_name", "find_by_email", "deactivate", "send_deactivation_email"} {
-		key := fixturePath + "::" + name
+		key := fixturePath + "::User#" + name
 		if !containsMap[key] {
 			t.Errorf("expected contains edge for %s", name)
 		}
@@ -439,10 +439,10 @@ func TestRubyGraphExtractor_ServiceFixture(t *testing.T) {
 	}
 
 	expectedCalls := []string{
-		fixturePath + "::process->validate_order",
-		fixturePath + "::process->calculate_total",
-		fixturePath + "::process->apply_discounts",
-		fixturePath + "::process->save_order",
+		fixturePath + "::OrderProcessor#process->validate_order",
+		fixturePath + "::OrderProcessor#process->calculate_total",
+		fixturePath + "::OrderProcessor#process->apply_discounts",
+		fixturePath + "::OrderProcessor#process->save_order",
 	}
 	for _, key := range expectedCalls {
 		if !callMap[key] {
@@ -570,11 +570,11 @@ end
 	for _, e := range contains {
 		names[e.TargetNode] = true
 	}
-	if !names["test.rb::public_method"] {
-		t.Error("expected contains edge for public_method")
+	if !names["test.rb::Service#public_method"] {
+		t.Error("expected contains edge for Service#public_method")
 	}
-	if !names["test.rb::private_helper"] {
-		t.Error("expected contains edge for private_helper")
+	if !names["test.rb::Service#private_helper"] {
+		t.Error("expected contains edge for Service#private_helper")
 	}
 }
 
@@ -618,28 +618,35 @@ func TestRubyGraphExtractor_ContainsClassModule(t *testing.T) {
 			name:    "scoped class",
 			fixture: "controller.rb",
 			expected: []string{
-				"index", "create", "user_params", "UsersController",
+				"Api::V1::UsersController#index",
+				"Api::V1::UsersController#create",
+				"Api::V1::UsersController#user_params",
+				"UsersController",
 			},
 		},
 		{
 			name:    "simple class",
 			fixture: "user.rb",
 			expected: []string{
-				"full_name", "active?", "User",
+				"User#full_name",
+				"User#active?",
+				"User",
 			},
 		},
 		{
 			name:    "class with method calls",
 			fixture: "payment_service.rb",
 			expected: []string{
-				"process", "PaymentService",
+				"PaymentService#process",
+				"PaymentService",
 			},
 		},
 		{
 			name:    "simple class with method",
 			fixture: "order.rb",
 			expected: []string{
-				"calculate_total", "Order",
+				"Order#calculate_total",
+				"Order",
 			},
 		},
 	}

--- a/internal/graph/ruby_resolver.go
+++ b/internal/graph/ruby_resolver.go
@@ -1,14 +1,16 @@
 package graph
 
 import (
-	"regexp"
 	"strings"
 
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
 	zerolog "github.com/rs/zerolog"
 )
 
 type RubyCrossFileResolver struct {
 	classIndex    *RubyClassIndex
+	lang          *gotreesitter.Language
 	logger        zerolog.Logger
 	useFallback   bool
 }
@@ -16,6 +18,7 @@ type RubyCrossFileResolver struct {
 func NewRubyCrossFileResolver(classIndex *RubyClassIndex, logger zerolog.Logger) *RubyCrossFileResolver {
 	return &RubyCrossFileResolver{
 		classIndex:  classIndex,
+		lang:        grammars.RubyLanguage(),
 		logger:      logger,
 		useFallback: true,
 	}
@@ -24,13 +27,11 @@ func NewRubyCrossFileResolver(classIndex *RubyClassIndex, logger zerolog.Logger)
 func NewRubyCrossFileResolverNoFallback(classIndex *RubyClassIndex, logger zerolog.Logger) *RubyCrossFileResolver {
 	return &RubyCrossFileResolver{
 		classIndex:  classIndex,
+		lang:        grammars.RubyLanguage(),
 		logger:      logger,
 		useFallback: false,
 	}
 }
-
-var rubyQualifiedCallRe = regexp.MustCompile(`([A-Z]\w*)\.(new)\.(\w+)`)
-var rubyClassMethodRe = regexp.MustCompile(`([A-Z]\w*)\.(\w+)`)
 
 func (r *RubyCrossFileResolver) ResolveEdges(edges []Edge, fileContents map[string][]byte) []Edge {
 	var result []Edge
@@ -41,7 +42,7 @@ func (r *RubyCrossFileResolver) ResolveEdges(edges []Edge, fileContents map[stri
 	}
 
 	for filePath, content := range fileContents {
-		newEdges := r.resolveFileCalls(filePath, content)
+		newEdges := r.resolveFileAST(filePath, content)
 		for _, e := range newEdges {
 			key := e.SourceNode + "->" + e.TargetNode
 			if seen[key] {
@@ -55,41 +56,56 @@ func (r *RubyCrossFileResolver) ResolveEdges(edges []Edge, fileContents map[stri
 	return result
 }
 
-func (r *RubyCrossFileResolver) resolveFileCalls(filePath string, content []byte) []Edge {
-	var edges []Edge
-	lines := strings.Split(string(content), "\n")
-
-	for lineNum, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-
-		if matches := rubyQualifiedCallRe.FindAllStringSubmatch(line, -1); len(matches) > 0 {
-			for _, m := range matches {
-				className := m[1]
-				methodName := m[3]
-				edges = append(edges, r.resolveCall(filePath, className, methodName, lineNum+1)...)
-			}
-			continue
-		}
-
-		if matches := rubyClassMethodRe.FindAllStringSubmatch(line, -1); len(matches) > 0 {
-			for _, m := range matches {
-				className := m[1]
-				methodName := m[2]
-				if methodName == "new" || methodName == "class" || methodName == "super" {
-					continue
-				}
-				edges = append(edges, r.resolveCall(filePath, className, methodName, lineNum+1)...)
-			}
-		}
+func (r *RubyCrossFileResolver) resolveFileAST(filePath string, content []byte) []Edge {
+	parser := gotreesitter.NewParser(r.lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil
 	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
 
+	var edges []Edge
+	r.walkCallNodes(bt, tree.RootNode(), filePath, content, &edges)
 	return edges
 }
 
-func (r *RubyCrossFileResolver) resolveCall(sourceFile, className, methodName string, line int) []Edge {
+func (r *RubyCrossFileResolver) walkCallNodes(bt *gotreesitter.BoundTree, node *gotreesitter.Node, filePath string, content []byte, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(r.lang) == "call" {
+		r.processCallNode(bt, node, filePath, content, edges)
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		r.walkCallNodes(bt, node.Child(i), filePath, content, edges)
+	}
+}
+
+func (r *RubyCrossFileResolver) processCallNode(bt *gotreesitter.BoundTree, callNode *gotreesitter.Node, filePath string, content []byte, edges *[]Edge) {
+	methodNode := callNode.ChildByFieldName("method", r.lang)
+	if methodNode == nil {
+		return
+	}
+	methodName := bt.NodeText(methodNode)
+
+	if methodName == "new" {
+		return
+	}
+
+	receiverNode := callNode.ChildByFieldName("receiver", r.lang)
+	className := extractReceiverClassName(bt, receiverNode, r.lang)
+
+	if className == "" {
+		return
+	}
+
+	enclosingClass := extractEnclosingClass(bt, callNode, r.lang)
+	enclosingMethod := extractEnclosingMethod(bt, callNode, r.lang)
+
+	sourceNode := filePath + "::" + enclosingClass + "#" + enclosingMethod
+	line := lineForByte(content, callNode.StartByte())
+
 	var entries []classEntry
 	if r.useFallback {
 		entries = r.classIndex.Lookup(className)
@@ -98,34 +114,63 @@ func (r *RubyCrossFileResolver) resolveCall(sourceFile, className, methodName st
 	}
 
 	if len(entries) == 0 {
-		return []Edge{{
-			SourceNode: sourceFile + "::" + methodName,
+		*edges = append(*edges, Edge{
+			SourceNode: sourceNode,
 			TargetNode: methodName,
 			Kind:       EdgeCalls,
-			SourceFile: sourceFile,
+			SourceFile: filePath,
 			Line:       line,
 			Language:   "ruby",
 			Metadata:   map[string]any{"unresolved": true},
-		}}
+		})
+		return
 	}
 
-	var edges []Edge
 	ambiguous := len(entries) > 1
 	for _, entry := range entries {
 		e := Edge{
-			SourceNode: sourceFile + "::" + methodName,
+			SourceNode: sourceNode,
 			TargetNode: entry.FilePath + "::" + methodName,
 			Kind:       EdgeCalls,
-			SourceFile: sourceFile,
+			SourceFile: filePath,
 			Line:       line,
 			Language:   "ruby",
 		}
 		if ambiguous {
 			e.Metadata = map[string]any{"ambiguous": true}
 		}
-		edges = append(edges, e)
+		*edges = append(*edges, e)
 	}
-	return edges
+}
+
+func extractReceiverClassName(bt *gotreesitter.BoundTree, node *gotreesitter.Node, lang *gotreesitter.Language) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Type(lang) {
+	case "constant":
+		return bt.NodeText(node)
+	case "scope_resolution":
+		return scopeResolutionText(bt, node)
+	case "call":
+		inner := node.ChildByFieldName("receiver", lang)
+		return extractReceiverClassName(bt, inner, lang)
+	default:
+		return ""
+	}
+}
+
+func extractEnclosingMethod(bt *gotreesitter.BoundTree, n *gotreesitter.Node, lang *gotreesitter.Language) string {
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		nodeType := p.Type(lang)
+		if nodeType == "method" || nodeType == "singleton_method" {
+			nameNode := p.ChildByFieldName("name", lang)
+			if nameNode != nil {
+				return bt.NodeText(nameNode)
+			}
+		}
+	}
+	return ""
 }
 
 func (r *RubyCrossFileResolver) BuildReconcileEdges(edges []Edge) []Edge {
@@ -143,14 +188,13 @@ func (r *RubyCrossFileResolver) BuildReconcileEdges(edges []Edge) []Edge {
 		ctrlShort := parts[0]
 		action := parts[1]
 
-		// Try full namespaced name first (e.g., "Api::V1::TokensController"),
-		// then fall back to short name (e.g., "TokensController").
+		ctrlName := ctrlShort
+		if idx := strings.LastIndex(ctrlShort, "::"); idx >= 0 {
+			ctrlName = ctrlShort[idx+2:]
+		}
+
 		entries := r.classIndex.Lookup(ctrlShort)
 		if len(entries) == 0 {
-			ctrlName := ctrlShort
-			if idx := strings.LastIndex(ctrlShort, "::"); idx >= 0 {
-				ctrlName = ctrlShort[idx+2:]
-			}
 			entries = r.classIndex.Lookup(ctrlName)
 		}
 		if len(entries) == 0 {
@@ -160,7 +204,7 @@ func (r *RubyCrossFileResolver) BuildReconcileEdges(edges []Edge) []Edge {
 		for _, entry := range entries {
 			result = append(result, Edge{
 				SourceNode: handler,
-				TargetNode: entry.FilePath + "::" + action,
+				TargetNode: entry.FilePath + "::" + ctrlName + "#" + action,
 				Kind:       EdgeReconcile,
 				SourceFile: e.SourceFile,
 				Line:       e.Line,

--- a/internal/graph/ruby_resolver_test.go
+++ b/internal/graph/ruby_resolver_test.go
@@ -16,7 +16,7 @@ func newTestResolver(edges []graph.Edge) *graph.RubyCrossFileResolver {
 func TestResolveEdges_simple(t *testing.T) {
 	edges := []graph.Edge{
 		{SourceNode: "app/models/user.rb", TargetNode: "app/models/user.rb::User", Kind: graph.EdgeContains},
-		{SourceNode: "app/models/user.rb", TargetNode: "app/models/user.rb::where", Kind: graph.EdgeContains},
+		{SourceNode: "app/models/user.rb", TargetNode: "app/models/user.rb::User#where", Kind: graph.EdgeContains},
 	}
 
 	resolver := newTestResolver(edges)
@@ -67,7 +67,7 @@ end`)
 func TestResolveEdges_new_method(t *testing.T) {
 	edges := []graph.Edge{
 		{SourceNode: "app/services/payment_service.rb", TargetNode: "app/services/payment_service.rb::PaymentService", Kind: graph.EdgeContains},
-		{SourceNode: "app/services/payment_service.rb", TargetNode: "app/services/payment_service.rb::process", Kind: graph.EdgeContains},
+		{SourceNode: "app/services/payment_service.rb", TargetNode: "app/services/payment_service.rb::PaymentService#process", Kind: graph.EdgeContains},
 	}
 
 	resolver := newTestResolver(edges)
@@ -211,13 +211,13 @@ func TestBuildReconcileEdges(t *testing.T) {
 	found := false
 	for _, e := range reconcileEdges {
 		if e.Kind == graph.EdgeReconcile {
-			if e.SourceNode == "UsersController#create" && e.TargetNode == "app/controllers/users_controller.rb::create" {
+			if e.SourceNode == "UsersController#create" && e.TargetNode == "app/controllers/users_controller.rb::UsersController#create" {
 				found = true
 			}
 		}
 	}
 	if !found {
-		t.Error("expected reconcile edge from UsersController#create to file::create")
+		t.Error("expected reconcile edge from UsersController#create to file::UsersController#create")
 		for _, e := range reconcileEdges {
 			t.Logf("  kind=%s %s -> %s", e.Kind, e.SourceNode, e.TargetNode)
 		}
@@ -237,7 +237,7 @@ func TestBuildReconcileEdges_namespaced(t *testing.T) {
 	found := false
 	for _, e := range reconcileEdges {
 		if e.SourceNode == "Api::V1::UsersController#index" &&
-			e.TargetNode == "app/controllers/api/v1/users_controller.rb::index" {
+			e.TargetNode == "app/controllers/api/v1/users_controller.rb::UsersController#index" {
 			found = true
 		}
 	}
@@ -250,8 +250,6 @@ func TestBuildReconcileEdges_namespaced(t *testing.T) {
 }
 
 func TestBuildReconcileEdges_namespaced_controllerCollision(t *testing.T) {
-	// The exact bug: TokensController model + Api::V1::TokensController controller
-	// BuildReconcileEdges should resolve to the controller file, not the model.
 	edges := []graph.Edge{
 		{SourceNode: "app/models/tokens_controller.rb", TargetNode: "app/models/tokens_controller.rb::TokensController", Kind: graph.EdgeContains},
 		{SourceNode: "app/controllers/api/v1/tokens_controller.rb", TargetNode: "app/controllers/api/v1/tokens_controller.rb::TokensController", Kind: graph.EdgeContains},
@@ -269,7 +267,7 @@ func TestBuildReconcileEdges_namespaced_controllerCollision(t *testing.T) {
 	found := false
 	for _, e := range reconcileEdges {
 		if e.SourceNode == "Api::V1::TokensController#create" &&
-			e.TargetNode == "app/controllers/api/v1/tokens_controller.rb::create" {
+			e.TargetNode == "app/controllers/api/v1/tokens_controller.rb::TokensController#create" {
 			found = true
 		}
 	}
@@ -278,5 +276,193 @@ func TestBuildReconcileEdges_namespaced_controllerCollision(t *testing.T) {
 		for _, e := range reconcileEdges {
 			t.Logf("  %s -> %s", e.SourceNode, e.TargetNode)
 		}
+	}
+}
+
+func TestResolveEdges_bareCall(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceNode: "app/models/user.rb", TargetNode: "app/models/user.rb::User", Kind: graph.EdgeContains},
+	}
+
+	resolver := newTestResolver(edges)
+
+	content := []byte(`class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+end`)
+
+	fileContents := map[string][]byte{
+		"app/controllers/users_controller.rb": content,
+	}
+
+	resolved := resolver.ResolveEdges(edges, fileContents)
+
+	var callEdges []graph.Edge
+	for _, e := range resolved {
+		if e.Kind == graph.EdgeCalls {
+			callEdges = append(callEdges, e)
+		}
+	}
+
+	if len(callEdges) == 0 {
+		t.Fatal("expected at least 1 call edge")
+	}
+
+	found := false
+	for _, e := range callEdges {
+		if e.TargetNode == "app/models/user.rb::find" {
+			found = true
+			if e.SourceNode != "app/controllers/users_controller.rb::UsersController#show" {
+				t.Errorf("unexpected source node: %s", e.SourceNode)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected resolved call to app/models/user.rb::find")
+		for _, e := range callEdges {
+			t.Logf("  got: %s -> %s", e.SourceNode, e.TargetNode)
+		}
+	}
+}
+
+func TestResolveEdges_chainedCalls(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceNode: "app/models/user.rb", TargetNode: "app/models/user.rb::User", Kind: graph.EdgeContains},
+	}
+
+	resolver := newTestResolver(edges)
+
+	content := []byte(`class UsersController < ApplicationController
+  def index
+    users = User.where(active: true).order(:name)
+    render json: users
+  end
+end`)
+
+	fileContents := map[string][]byte{
+		"app/controllers/users_controller.rb": content,
+	}
+
+	resolved := resolver.ResolveEdges(edges, fileContents)
+
+	var callEdges []graph.Edge
+	for _, e := range resolved {
+		if e.Kind == graph.EdgeCalls {
+			callEdges = append(callEdges, e)
+		}
+	}
+
+	if len(callEdges) < 2 {
+		t.Fatalf("expected at least 2 call edges for chained calls, got %d", len(callEdges))
+	}
+
+	foundWhere := false
+	foundOrder := false
+	for _, e := range callEdges {
+		if e.TargetNode == "app/models/user.rb::where" {
+			foundWhere = true
+		}
+		if e.TargetNode == "app/models/user.rb::order" {
+			foundOrder = true
+		}
+	}
+	if !foundWhere {
+		t.Error("expected resolved call to app/models/user.rb::where")
+	}
+	if !foundOrder {
+		t.Error("expected resolved call to app/models/user.rb::order")
+	}
+}
+
+func TestResolveEdges_unresolvable(t *testing.T) {
+	edges := []graph.Edge{}
+
+	idx := graph.BuildClassIndex(edges)
+	logger := zerolog.Nop()
+	resolver := graph.NewRubyCrossFileResolverNoFallback(idx, logger)
+
+	content := []byte(`class MyService
+  def run
+    UnknownClass.do_something
+  end
+end`)
+
+	fileContents := map[string][]byte{
+		"app/services/my_service.rb": content,
+	}
+
+	resolved := resolver.ResolveEdges(edges, fileContents)
+
+	var callEdges []graph.Edge
+	for _, e := range resolved {
+		if e.Kind == graph.EdgeCalls {
+			callEdges = append(callEdges, e)
+		}
+	}
+
+	if len(callEdges) == 0 {
+		t.Fatal("expected at least 1 call edge")
+	}
+
+	found := false
+	for _, e := range callEdges {
+		if e.TargetNode == "do_something" {
+			found = true
+			if e.Metadata == nil || e.Metadata["unresolved"] != true {
+				t.Error("expected unresolved=true in metadata")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected unresolved call to do_something")
+	}
+}
+
+func TestResolveEdges_lowercaseReceiverSkipped(t *testing.T) {
+	edges := []graph.Edge{
+		{SourceNode: "app/models/user.rb", TargetNode: "app/models/user.rb::User", Kind: graph.EdgeContains},
+	}
+
+	resolver := newTestResolver(edges)
+
+	content := []byte(`class UsersController < ApplicationController
+  def update
+    user = User.find(params[:id])
+    user.save
+    @user.stories.create(title: "new")
+  end
+end`)
+
+	fileContents := map[string][]byte{
+		"app/controllers/users_controller.rb": content,
+	}
+
+	resolved := resolver.ResolveEdges(edges, fileContents)
+
+	var callEdges []graph.Edge
+	for _, e := range resolved {
+		if e.Kind == graph.EdgeCalls {
+			callEdges = append(callEdges, e)
+		}
+	}
+
+	for _, e := range callEdges {
+		if e.TargetNode == "save" || e.TargetNode == "app/models/user.rb::save" {
+			t.Errorf("lowercase receiver 'user.save' should not produce a call edge, got: %s -> %s", e.SourceNode, e.TargetNode)
+		}
+		if e.TargetNode == "create" || e.TargetNode == "app/models/user.rb::create" {
+			t.Errorf("instance variable receiver '@user.stories.create' should not produce a call edge, got: %s -> %s", e.SourceNode, e.TargetNode)
+		}
+	}
+
+	foundFind := false
+	for _, e := range callEdges {
+		if e.TargetNode == "app/models/user.rb::find" {
+			foundFind = true
+		}
+	}
+	if !foundFind {
+		t.Error("expected resolved call to app/models/user.rb::find")
 	}
 }

--- a/openspec/changes/rails-dsl-extraction/.openspec.yaml
+++ b/openspec/changes/rails-dsl-extraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/rails-dsl-extraction/design.md
+++ b/openspec/changes/rails-dsl-extraction/design.md
@@ -1,0 +1,198 @@
+## Context
+
+The Ruby extraction pipeline has three layers:
+
+1. **Per-file extractors** (`ruby_extractor.go`, `rails_extractor.go`) — parse individual `.rb` files with tree-sitter and emit edges (contains, calls, http).
+2. **Post-extraction resolver** (`ruby_resolver.go`) — regex-based pass that tries to resolve cross-file calls via a class→file index (`ruby_class_index.go`).
+3. **Flow builder** — BFS over the edge graph starting from HTTP handler edges.
+
+Current state:
+- The `ruby_extractor.go` emits `SourceNode = "file.rb::method"` with bare `TargetNode = "method"` for same-file calls, and the resolver attempts to qualify cross-file targets.
+- The flow builder starts BFS from `bySymbol["UsersController#create"]` (HTTP edge TargetNode) but can't enter the call graph because Ruby source nodes use `file.rb::method` format, not `Controller#action` format.
+- The resolver uses two regexes (`rubyQualifiedCallRe`, `rubyClassMethodRe`) that only match `ClassName.method` patterns — missing bare calls like `user.save`, `render json:`, `redirect_to ...`.
+- The CFG extractor only handles `method` nodes, not `singleton_method` (class methods like `scope`, `self.find`).
+- `railsConventionPath()` only knows `app/controllers/` and `app/models/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Change SourceNode format to `file.rb::ClassName#methodName` for all call edges
+- Fix the cross-file resolver to handle bare method calls via AST scanning
+- Add `singleton_method` support to CFG extractor
+- Build a new `RailsDSLEdgeExtractor` for associations, callbacks, concerns, Sidekiq
+- Expand `railsConventionPath()` to handle services, jobs, mailers, workers
+- DB migration to relax edge_type CHECK constraint
+
+**Non-Goals (deferred to v2):**
+- FK inference or query chain analysis (ActiveRecord `where`, `joins`, `includes`)
+- Deep concern resolution (flattening included methods into the including class)
+- Metaprogramming (`method_missing`, `define_method`, `send`)
+- Non-Rails Ruby gems (保持 `RequiresFrameworks: ["rails"]` gate)
+- Performance profiling of large Rails codebases
+
+## Decisions
+
+### Decision 1: Node Format Change to `file.rb::ClassName#method`
+
+**Choice**: Change SourceNode from `file.rb::method` to `file.rb::ClassName#methodName` for all Ruby call edges. The TargetNode stays bare for same-file calls and becomes qualified for cross-file resolved calls.
+
+**Rationale**: The flow builder's BFS starts with `bySymbol["UsersController#create"]` (from HTTP edge TargetNode). With the new format, `symbolPart("app/controllers/users_controller.rb::UsersController#create")` returns `"UsersController#create"` which matches the HTTP handler format. This eliminates the need for reconcile edges in many cases.
+
+**Alternatives considered**:
+- Keep old format + reconcile edges: Works but adds edge count and complexity. The reconcile approach was already tried and only partially works.
+- Use `ClassName.method` format (no #): Less standard, doesn't distinguish class vs instance methods.
+
+**Implementation detail**: The class name must be determined during extraction. The tree-sitter AST provides parent class/module context. Walk upward from each method node to find the enclosing class name.
+
+### Decision 2: AST-Based Resolver Replace Regex
+
+**Choice**: Rewrite `ruby_resolver.go` to scan AST nodes instead of regex patterns. Walk the tree-sitter AST for each file, find all call expressions, and resolve them via the class index.
+
+**Rationale**: The regex approach misses:
+- Bare method calls inside blocks (`users.each { |u| u.save }`)
+- Method calls on local variables (`order.process_payment`)
+- Chained calls (`User.where(active: true).order(:name)`)
+- Calls inside string interpolation
+
+AST scanning finds ALL call nodes and attempts resolution for each.
+
+**Alternatives considered**:
+- Improve regex patterns: Rejected — regex can't handle nested expressions or blocks
+- Keep regex + add more patterns: Rejected — infinite cases to cover
+- Query-time resolution: Rejected — every query pays the cost
+
+### Decision 3: RailsDSLEdgeExtractor as Separate File
+
+**Choice**: Create `internal/graph/rails_dsl_extractor.go` (~250 lines) implementing `FrameworkAwareExtractor`. Register alongside existing `RailsExtractor` and `RubyGraphExtractor`.
+
+**Rationale**: Separation of concerns. The existing `rails_extractor.go` handles routes. The existing `ruby_extractor.go` handles call graphs. The new extractor handles Rails-specific DSL patterns (associations, callbacks, concerns). Each file stays focused.
+
+**Alternative considered**: Extend `ruby_extractor.go` — rejected because it's already 206 lines and handles generic Ruby, not Rails-specific DSL.
+
+### Decision 4: Edge Kinds for DSL Patterns
+
+**Choice**: Map DSL patterns to existing edge kinds:
+- Associations (`has_many`, `belongs_to`) → `EdgeCalls` with metadata `{"dsl": "association", "type": "has_many", "target": "Order"}`
+- Callbacks (`before_action`, `after_commit`) → `EdgeMiddleware` with metadata `{"dsl": "callback", "type": "before_action", "target": "set_user"}`
+- Concerns (`include`, `extend`) → `EdgeCalls` with metadata `{"dsl": "concern", "type": "include", "target": "Authenticatable"}`
+- Sidekiq (`perform_async`) → `EdgeIntegration` with metadata `{"dsl": "sidekiq", "target": "OrderProcessor"}`
+
+**Rationale**: No new edge kinds needed. The existing kinds convey the right semantics. Metadata carries the DSL-specific details.
+
+**Alternative considered**: New `EdgeDSL` kind — rejected because it adds complexity to every query and filter that checks edge kinds.
+
+### Decision 5: DB Migration Relax CHECK Constraint
+
+**Choice**: The current CHECK constraint (`00027`) allows: `contains, imports, calls, references, http, middleware, integration, reconcile`. No new kinds needed in Phase 1-2, so the CHECK constraint doesn't need updating until Phase 3 (if we add new kinds).
+
+Wait — we're using existing edge kinds. No migration needed unless we discover a new kind is required. The CHECK constraint already covers all kinds we'll use.
+
+**Revised**: No migration needed for this change. If integration extraction in Phase 3 requires a new kind, we'll add it then.
+
+### Decision 6: Expanded Convention Path Map
+
+**Choice**: Extend `railsConventionPath()` in `ruby_class_index.go` to handle:
+- `*Service` → `app/services/snake.rb`
+- `*Job` / `*Worker` → `app/jobs/snake.rb` / `app/workers/snake.rb`
+- `*Mailer` → `app/mailers/snake.rb`
+- `*Policy` → `app/policies/snake.rb` (common Rails pattern)
+- `*Serializer` → `app/serializers/snake.rb` (common Rails pattern)
+
+**Rationale**: These are standard Rails directory conventions. The resolver's fallback already handles controllers and models; expanding it catches more cases without requiring exact index matches.
+
+**Alternative considered**: Full Zeitwerk resolver — rejected for v1, too complex.
+
+## Component Design
+
+### RailsDSLEdgeExtractor
+
+```
+type RailsDSLEdgeExtractor struct {
+    lang    *gotreesitter.Language
+    queries map[string]*gotreesitter.Query  // pre-compiled queries
+}
+```
+
+Tree-sitter queries:
+1. **Association query**: Match `(call method: (identifier) @method arguments: (argument_list (simple_symbol) @target))` where method is in the association set.
+2. **Callback query**: Match `(call method: (identifier) @method arguments: (argument_list ...))` where method is in the callback set.
+3. **Concern query**: Match `(call method: (identifier) @method arguments: (argument_list (constant) @target))` where method is `include` or `extend`.
+
+### Metadata Format
+
+Association edge:
+```json
+{
+    "dsl": "association",
+    "type": "has_many",
+    "target_model": "Order",
+    "foreign_key": "user_id"
+}
+```
+
+Callback edge:
+```json
+{
+    "dsl": "callback",
+    "type": "before_action",
+    "target_method": "set_user",
+    "prepend": false
+}
+```
+
+Concern edge:
+```json
+{
+    "dsl": "concern",
+    "type": "include",
+    "target_module": "Authenticatable"
+}
+```
+
+Sidekiq edge:
+```json
+{
+    "dsl": "sidekiq",
+    "queue": "default",
+    "target_class": "OrderProcessor"
+}
+```
+
+### Singleton Method CFG Support
+
+Add `(singleton_method name: (identifier) @fn_name body: (body_statement) @body) @fn_decl` to `rubyGraphCallFuncQuery` in `ruby_extractor.go` (already present in `rubyGraphContainsQuery`). The CFG extractor's `walkNodes` needs to also visit `singleton_method` nodes.
+
+### Resolver Rewrite
+
+The new resolver:
+1. Parse each file's AST with tree-sitter
+2. Walk all `call` nodes
+3. For each call, extract the receiver (if any) and method name
+4. Look up the receiver's class via the class index
+5. Emit qualified edges: `SourceNode::ClassName#method → TargetFile::ClassName#method`
+6. Emit bare edges + `{"unresolved": true}` for unresolvable calls
+
+## Integration Points
+
+- **Registry**: Add `RailsDSLEdgeExtractor` to `graphExtractors` in `main.go` alongside existing Ruby extractors
+- **Watcher**: The resolver's `resolveRubyEdges()` already runs after extraction — update it to use the new AST-based resolver
+- **MCP tools**: `memory_graph`, `memory_trace`, `memory_impact` all query `graph_edges` — new edges appear automatically
+- **Flow builder**: BFS now works with the new node format — no changes needed to flow builder itself
+- **Symbol extractor**: `internal/symbol/ruby_extractor.go` already captures class names — no changes needed
+
+## Tradeoffs
+
+### Breaking Node Format (High Impact, One-Time Cost)
+Every existing workspace must reindex after this change. All graph edges will be rebuilt with the new format. This is acceptable because:
+- nano-brain is pre-1.0
+- The current Ruby extraction is effectively broken (0% resolver hit rate)
+- The reindex is automatic on next watch cycle
+
+### Regex vs AST for Resolver (Moderate Impact, Ongoing)
+The AST-based resolver is slower per-file than regex but catches 100% of call patterns vs ~20% for regex. The resolver runs once at index time, not at query time, so per-file latency matters less.
+
+### DSL Scope Creep (Low Impact, Bounded)
+Rails DSL methods are well-defined (associations, callbacks, concerns). We're not trying to extract arbitrary metaprogramming. The set of DSL methods is finite and documented.
+
+### gem DSL (Out of Scope)
+Third-party gem DSLs (Devise, Sidekiq, ActiveJob) are partially covered. Devise's `devise :database_authenticatable` is a callback-style DSL but we're not extracting it in v1. Sidekiq's `sidekiq_options` is a configuration, not an edge. We only extract `perform_async`/`perform_in` as integration edges.

--- a/openspec/changes/rails-dsl-extraction/proposal.md
+++ b/openspec/changes/rails-dsl-extraction/proposal.md
@@ -1,0 +1,105 @@
+## Why
+
+Ruby code intelligence tools (graph, flow, flowchart, trace, impact) return empty or noisy results for Rails projects. The cross-file resolver has 0% hit rate in benchmarks. Only text search works.
+
+Three compounding problems:
+
+1. **Node format mismatch** — SourceNode uses `file.rb::method` but the flow builder expects class-qualified names like `file.rb::ClassName#method`. This breaks BFS traversal from HTTP handler edges (which use `Controller#action` format) into the call graph.
+
+2. **Broken cross-file resolver** — The regex-based resolver (`ruby_resolver.go`) scans for `ClassName.method` patterns but most Rails calls are bare method calls (`user.save`, `render json:`, `redirect_to ...`) that never match the regex. The resolver adds edges nobody consumes.
+
+3. **No Rails DSL extraction** — `before_action`, `has_many`, `after_commit`, `include Concern`, and Sidekiq `perform_async` calls are invisible to the graph. These represent the actual wiring between controllers, models, services, and background jobs.
+
+## What Changes
+
+### Phase 1: Foundation (3-4 days)
+
+- Change node format from `file.rb::method` to `file.rb::ClassName#methodName`
+- Fix cross-file resolver to actually resolve bare method calls via the class index
+- Add `singleton_method` support to CFG extractor (class methods, scopes, callbacks)
+- DB migration to relax edge_type CHECK constraint for new edge types
+- Expand `railsConventionPath()` to handle `app/services/`, `app/jobs/`, `app/mailers/`, `app/workers/`
+
+### Phase 2: DSL Extraction (2-3 days)
+
+- New `RailsDSLEdgeExtractor` (~250 lines) as a `FrameworkAwareExtractor`
+- Extract associations: `has_many`, `belongs_to`, `has_one`, `has_and_belongs_to_many` → EdgeCalls with metadata
+- Extract callbacks: `before_action`, `after_commit`, `before_save` → EdgeMiddleware
+- Extract concerns: `include`/`extend` → EdgeCalls
+- Sidekiq detection: `perform_async`/`perform_in` → EdgeIntegration
+- Register in `cmd/nano-brain/main.go`
+
+### Phase 3: Polish (1-2 days)
+
+- Flow builder role classification for Rails (controller vs model vs service)
+- Ruby integration extraction (Net::HTTP, Faraday outbound calls)
+
+## User Stories
+
+### US-1: Controller-to-model chain visible in flow diagrams
+**As a** Rails developer using nano-brain,
+**I want** `POST /users` to show `UsersController#create → User.create → User.validates?` in the flow diagram,
+**So that** I can understand the full request lifecycle without reading source.
+
+### US-2: Association edges visible in graph queries
+**As a** Rails developer,
+**I want** `memory_graph` to show `User has_many Orders` edges,
+**So that** I can see model relationships without reading schema.rb.
+
+### US-3: Callback chains visible in trace
+**As a** Rails developer,
+**I want** `memory_trace` from `User#save` to show `before_save → validate → after_commit`,
+**So that** I can trace side effects and middleware.
+
+### US-4: Sidekiq job wiring visible
+**As a** Rails developer,
+**I want** `memory_graph` from a controller to show `OrderService.process → OrderProcessor.perform_async`,
+**So that** I can trace async job dispatch from controllers.
+
+### US-5: Concern inclusion visible
+**As a** Rails developer,
+**I want** to see that `UsersController` includes `Devise::Controllers::Rememberable` via the graph,
+**So that** I understand inherited behavior.
+
+## Capabilities
+
+### New Capabilities
+- `rails-dsl-extraction`: Extract Rails DSL calls (associations, callbacks, concerns, Sidekiq) as graph edges
+
+### Modified Capabilities
+- `ruby-call-graph`: Node format changes from `file.rb::method` to `file.rb::ClassName#method`
+- `ruby-cross-file-resolution`: Resolver now handles bare method calls, not just `ClassName.method`
+- `ruby-cfg`: Adds `singleton_method` support for class methods
+- `flow-visualization`: Rails flows now show 5-10+ node chains through associations and callbacks
+- `ruby-convention-path`: Expands to handle services, jobs, mailers, workers
+
+## Impact
+
+- **Code affected**:
+  - `internal/graph/ruby_extractor.go` — node format change, class-qualified SourceNode
+  - `internal/graph/ruby_resolver.go` — rewrite resolver for bare method calls
+  - `internal/graph/ruby_class_index.go` — expand convention path map
+  - `internal/graph/ruby_cflow.go` — add `singleton_method` support
+  - `internal/graph/rails_dsl_extractor.go` — new: ~250 lines
+  - `internal/graph/edge.go` — no new edge kinds (reuses existing)
+  - `cmd/nano-brain/main.go` — register new extractor
+  - `internal/watcher/watcher.go` — wire new extractor + updated resolver
+  - `migrations/00028_relax_edge_type_check.sql` — relax CHECK constraint
+  - `internal/graph/testdata/ruby/` — new test fixtures
+  - `internal/graph/rails_dsl_extractor_test.go` — new tests
+
+- **Dependencies**: None new. Reuses gotreesitter, existing edge kinds, existing PG schema.
+
+- **Performance**: New extractor runs per-file (~250 lines, tree-sitter based). Resolver O(calls) with hash index. Both negligible at index time.
+
+- **Risk**: HIGH — Node format change is breaking. Pre-1.0 so forced reindex is acceptable. All existing graphs will be rebuilt.
+
+## Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Node format change breaks existing graphs | High | Forced reindex. Pre-1.0 so acceptable. |
+| Regex resolver still misses some patterns | Medium | AST-based resolver in Phase 1 fixes most cases. |
+| DSL extractor false positives on method names | Low | Only match known DSL methods. Metadata flag for confidence. |
+| Concern/extend resolution scope creep | Medium | v1: emit edges only, no deep resolution. |
+| Singleton method CFG extraction complexity | Low | Tree-sitter handles `def self.method` natively. |

--- a/openspec/changes/rails-dsl-extraction/specs/rails-dsl-extraction/spec.md
+++ b/openspec/changes/rails-dsl-extraction/specs/rails-dsl-extraction/spec.md
@@ -1,0 +1,165 @@
+## MODIFIED Requirements
+
+### Requirement: Node format includes class name
+All Ruby call edges SHALL use the node format `file.rb::ClassName#methodName` for SourceNode, where ClassName is the enclosing class or module. This replaces the previous `file.rb::methodName` format.
+
+#### Scenario: Controller method call
+- **WHEN** `UsersController#create` calls `User.create(params)`
+- **THEN** the extractor SHALL emit a calls edge with SourceNode=`app/controllers/users_controller.rb::UsersController#create`
+
+#### Scenario: Model method call
+- **WHEN** `User#save` calls `valid?` (same-file call)
+- **THEN** the extractor SHALL emit a calls edge with SourceNode=`app/models/user.rb::User#save` and TargetNode=`valid?` (bare, same-file)
+
+#### Scenario: Nested class method
+- **WHEN** `Api::V1::UsersController#index` calls `User.all`
+- **THEN** the extractor SHALL emit a calls edge with SourceNode=`app/controllers/api/v1/users_controller.rb::Api::V1::UsersController#index`
+
+#### Scenario: Method outside any class
+- **WHEN** a top-level method calls another method
+- **THEN** the extractor SHALL use the file name as a surrogate class: SourceNode=`file.rb::<top>#methodName`
+
+#### Scenario: Singleton method (class method)
+- **WHEN** a file contains `def self.find_by_email(email)` inside `User` class
+- **THEN** the extractor SHALL emit a contains edge with TargetNode=`app/models/user.rb::User.find_by_email`
+
+## ADDED Requirements
+
+### Requirement: Cross-file resolver handles bare method calls
+The cross-file resolver SHALL resolve bare method calls (not just `ClassName.method` patterns) by scanning AST nodes and matching against the class index.
+
+#### Scenario: Bare instance method call
+- **WHEN** a controller contains `@user.save` and `User` is defined in `app/models/user.rb`
+- **THEN** the resolver SHALL emit a calls edge with TargetNode=`app/models/user.rb::User#save`
+
+#### Scenario: Bare class method call
+- **WHEN** a service contains `Order.where(status: :pending)` and `Order` is in `app/models/order.rb`
+- **THEN** the resolver SHALL emit a calls edge with TargetNode=`app/models/order.rb::Order#where`
+
+#### Scenario: Unresolvable call
+- **WHEN** a call target cannot be resolved to any known class
+- **THEN** the resolver SHALL emit a calls edge with TargetNode=`method_name` (bare) and Metadata=`{"unresolved": true}`
+
+#### Scenario: Ambiguous class resolution
+- **WHEN** two files define the same class name (class reopening)
+- **THEN** the resolver SHALL emit calls edges to ALL matching files with Metadata=`{"ambiguous": true}`
+
+### Requirement: Rails DSL association extraction
+The `RailsDSLEdgeExtractor` SHALL extract Rails association declarations as calls edges with DSL metadata.
+
+#### Scenario: has_many association
+- **WHEN** a model file contains `has_many :orders`
+- **THEN** the extractor SHALL emit a calls edge with SourceNode=`app/models/user.rb::User#has_many`, TargetNode=`Order`, Kind=`calls`, and Metadata=`{"dsl": "association", "type": "has_many", "target_model": "Order"}`
+
+#### Scenario: belongs_to association
+- **WHEN** a model file contains `belongs_to :user`
+- **THEN** the extractor SHALL emit a calls edge with SourceNode=`app/models/order.rb::Order#belongs_to`, TargetNode=`User`, Kind=`calls`, and Metadata=`{"dsl": "association", "type": "belongs_to", "target_model": "User"}`
+
+#### Scenario: has_one association
+- **WHEN** a model file contains `has_one :profile`
+- **THEN** the extractor SHALL emit a calls edge with Metadata=`{"dsl": "association", "type": "has_one", "target_model": "Profile"}`
+
+#### Scenario: has_and_belongs_to_many
+- **WHEN** a model file contains `has_and_belongs_to_many :tags`
+- **THEN** the extractor SHALL emit a calls edge with Metadata=`{"dsl": "association", "type": "has_and_belongs_to_many", "target_model": "Tag"}`
+
+### Requirement: Rails DSL callback extraction
+The `RailsDSLEdgeExtractor` SHALL extract Rails callback declarations as middleware edges.
+
+#### Scenario: before_action in controller
+- **WHEN** a controller contains `before_action :set_user`
+- **THEN** the extractor SHALL emit a middleware edge with SourceNode=`app/controllers/users_controller.rb::UsersController#before_action`, TargetNode=`set_user`, Kind=`middleware`, and Metadata=`{"dsl": "callback", "type": "before_action"}`
+
+#### Scenario: after_commit in model
+- **WHEN** a model contains `after_commit :notify_slack, on: :create`
+- **THEN** the extractor SHALL emit a middleware edge with Metadata=`{"dsl": "callback", "type": "after_commit", "on": "create"}`
+
+#### Scenario: before_save in model
+- **WHEN** a model contains `before_save :normalize_email`
+- **THEN** the extractor SHALL emit a middleware edge with Metadata=`{"dsl": "callback", "type": "before_save"}`
+
+#### Scenario: Callback with inline block
+- **WHEN** a controller contains `before_action { |c| c.require_login }`
+- **THEN** the extractor SHALL emit a middleware edge with TargetNode=`(block)` and Metadata=`{"dsl": "callback", "type": "before_action"}`
+
+### Requirement: Rails DSL concern extraction
+The `RailsDSLEdgeExtractor` SHALL extract `include` and `extend` declarations as calls edges.
+
+#### Scenario: include concern
+- **WHEN** a model contains `include Authenticatable`
+- **THEN** the extractor SHALL emit a calls edge with SourceNode=`app/models/user.rb::User#include`, TargetNode=`Authenticatable`, Kind=`calls`, and Metadata=`{"dsl": "concern", "type": "include", "target_module": "Authenticatable"}`
+
+#### Scenario: extend module
+- **WHEN** a class contains `extend Findable`
+- **THEN** the extractor SHALL emit a calls edge with Metadata=`{"dsl": "concern", "type": "extend", "target_module": "Findable"}`
+
+#### Scenario: include with namespace
+- **WHEN** a class contains `include Devise::Models::Authenticatable`
+- **THEN** the extractor SHALL emit a calls edge with TargetNode=`Devise::Models::Authenticatable`
+
+### Requirement: Sidekiq job dispatch extraction
+The `RailsDSLEdgeExtractor` SHALL detect Sidekiq job dispatch calls and emit integration edges.
+
+#### Scenario: perform_async
+- **WHEN** source code contains `OrderProcessor.perform_async(order.id)`
+- **THEN** the extractor SHALL emit an integration edge with SourceNode=`caller_file.rb::CallerClass#method`, TargetNode=`OrderProcessor`, Kind=`integration`, and Metadata=`{"dsl": "sidekiq", "method": "perform_async"}`
+
+#### Scenario: perform_in
+- **WHEN** source code contains `OrderProcessor.perform_in(1.hour, order.id)`
+- **THEN** the extractor SHALL emit an integration edge with Metadata=`{"dsl": "sidekiq", "method": "perform_in"}`
+
+#### Scenario: Instance-level perform_async
+- **WHEN** source code contains `processor.perform_async(args)` and `processor` is of type `OrderProcessor`
+- **THEN** the extractor SHALL emit an integration edge with Metadata=`{"dsl": "sidekiq", "method": "perform_async"}`
+
+### Requirement: Singleton method CFG extraction
+The Ruby CFG extractor SHALL extract control-flow graphs for `singleton_method` (class method) definitions, not just regular `method` definitions.
+
+#### Scenario: class method with if/else
+- **WHEN** a file contains `def self.find_by_email(email) ... if condition ... else ... end ... end`
+- **THEN** the extractor SHALL emit a CFG with Entry=`file.rb::find_by_email`, including decision nodes for the if/else
+
+#### Scenario: scope definition
+- **WHEN** a model contains `scope :active, -> { where(active: true) }`
+- **THEN** the extractor SHALL emit a CFG for the scope's lambda body (if it has branching)
+
+### Requirement: Expanded Rails convention paths
+The class→file index SHALL resolve class names using expanded Rails directory conventions.
+
+#### Scenario: Service class resolution
+- **WHEN** the class index cannot find `PaymentProcessor` in contains edges
+- **THEN** the convention fallback SHALL return `app/services/payment_processor.rb`
+
+#### Scenario: Job class resolution
+- **WHEN** the class index cannot find `OrderJob` in contains edges
+- **THEN** the convention fallback SHALL return `app/jobs/order_job.rb`
+
+#### Scenario: Mailer class resolution
+- **WHEN** the class index cannot find `WelcomeMailer` in contains edges
+- **THEN** the convention fallback SHALL return `app/mailers/welcome_mailer.rb`
+
+#### Scenario: Worker class resolution
+- **WHEN** the class index cannot find `EmailWorker` in contains edges
+- **THEN** the convention fallback SHALL return `app/workers/email_worker.rb`
+
+### Requirement: Rails-only scope
+All Rails DSL extraction SHALL only activate when the Rails framework is detected (via `RequiresFrameworks` gate).
+
+#### Scenario: Rails project
+- **WHEN** the workspace contains a Gemfile with `gem 'rails'`
+- **THEN** Rails DSL extraction SHALL be active
+
+#### Scenario: Non-Rails Ruby
+- **WHEN** the workspace does NOT contain Rails
+- **THEN** Rails DSL extraction SHALL be skipped
+
+### Requirement: Forced reindex on node format change
+The system SHALL perform a forced reindex of all Ruby files when the node format changes.
+
+#### Scenario: Existing workspace upgrade
+- **WHEN** a workspace is indexed with the new node format
+- **THEN** all existing Ruby graph edges SHALL be deleted and rebuilt with the new format
+
+#### Scenario: New workspace
+- **WHEN** a new workspace is indexed for the first time
+- **THEN** all Ruby graph edges SHALL use the new node format from the start

--- a/openspec/changes/rails-dsl-extraction/tasks.md
+++ b/openspec/changes/rails-dsl-extraction/tasks.md
@@ -1,0 +1,81 @@
+## 1. Node Format Change
+
+- [ ] 1.1 Add `extractEnclosingClass` helper to `ruby_extractor.go` — walk AST upward from method node to find enclosing class/module name
+- [ ] 1.2 Modify `extractCalls` to set `SourceNode = "file.rb::ClassName#methodName"` (with class name) instead of `"file.rb::methodName"`
+- [ ] 1.3 Modify `extractContains` to emit class-qualified method targets: `"file.rb::ClassName#method"` instead of `"file.rb::method"`
+- [ ] 1.4 Update `rubyGraphContainsQuery` to capture enclosing class context for methods
+- [ ] 1.5 Handle nested classes/modules: `Api::V1::UsersController#create` format
+- [ ] 1.6 Handle methods outside any class (top-level methods): use file name as class surrogate
+- [ ] 1.7 Add test fixtures for node format: controller with class methods, model with scopes, nested modules
+- [ ] 1.8 Update existing unit tests to expect new node format
+- [ ] 1.9 Verify same-file call deduplication still works with new format
+
+## 2. Fix Cross-File Resolver
+
+- [ ] 2.1 Rewrite `ruby_resolver.go` to use tree-sitter AST scanning instead of regex
+- [ ] 2.2 Add `resolveFileAST` method: parse file, walk all `call` nodes, extract receiver + method
+- [ ] 2.3 Handle bare method calls: `user.save` → look up User class, emit qualified edge
+- [ ] 2.4 Handle chained calls: `User.where(active: true).order(:name)` → resolve each segment
+- [ ] 2.5 Handle method calls in blocks: `users.each { |u| u.save }` → resolve via variable type inference (best-effort)
+- [ ] 2.6 Keep `BuildReconcileEdges` working with new node format
+- [ ] 2.7 Add test fixtures for bare call resolution: controller calling model methods, service methods
+- [ ] 2.8 Add unit tests for resolver: resolve, unresolvable, ambiguous cases
+
+## 3. Singleton Method CFG Support
+
+- [ ] 3.1 Add `(singleton_method ...)` to `walkNodes` call in `ruby_cflow.go` `ExtractCFGs`
+- [ ] 3.2 Handle `def self.method_name` in CFG builder — extract method name correctly
+- [ ] 3.3 Add test fixtures: class method with if/else, scope with query chain
+- [ ] 3.4 Add unit tests for singleton method CFG extraction
+
+## 4. Expand Convention Path Map
+
+- [ ] 4.1 Add `*Service` → `app/services/` path mapping to `railsConventionPath()`
+- [ ] 4.2 Add `*Job` → `app/jobs/` path mapping
+- [ ] 4.3 Add `*Worker` → `app/workers/` path mapping
+- [ ] 4.4 Add `*Mailer` → `app/mailers/` path mapping
+- [ ] 4.5 Add `*Policy` → `app/policies/` path mapping
+- [ ] 4.6 Add `*Serializer` → `app/serializers/` path mapping
+- [ ] 4.7 Add unit tests for expanded convention paths
+
+## 5. Rails DSL Edge Extractor
+
+- [ ] 5.1 Create `internal/graph/rails_dsl_extractor.go` with `RailsDSLEdgeExtractor` struct
+- [ ] 5.2 Implement `Supports(ext)` → `.rb` only
+- [ ] 5.3 Implement `RequiresFrameworks()` → `["rails"]`
+- [ ] 5.4 Define association method set: `has_many`, `has_one`, `belongs_to`, `has_and_belongs_to_many`
+- [ ] 5.5 Define callback method set: `before_action`, `after_action`, `after_commit`, `before_save`, `after_save`, `before_create`, `after_create`, `before_update`, `after_update`, `before_destroy`, `after_destroy`
+- [ ] 5.6 Define concern method set: `include`, `extend`
+- [ ] 5.7 Implement association extraction: tree-sitter query for call nodes with association method names
+- [ ] 5.8 Implement callback extraction: tree-sitter query for call nodes with callback method names
+- [ ] 5.9 Implement concern extraction: tree-sitter query for `include`/`extend` with constant arguments
+- [ ] 5.10 Implement Sidekiq detection: `perform_async`/`perform_in` calls → EdgeIntegration
+- [ ] 5.11 Add metadata to each edge type (dsl, type, target)
+- [ ] 5.12 Create `internal/graph/rails_dsl_extractor_test.go` with unit tests
+- [ ] 5.13 Add test fixtures: model with associations, controller with callbacks, service with concerns
+
+## 6. Registration and Wiring
+
+- [ ] 6.1 Register `RailsDSLEdgeExtractor` in `cmd/nano-brain/main.go` alongside existing Ruby extractors
+- [ ] 6.2 Verify `SetActiveFrameworks` filters correctly for Rails-only extractors
+- [ ] 6.3 Update watcher to use new AST-based resolver (replace regex resolver)
+- [ ] 6.4 Verify resolver runs after DSL extraction (correct edge ordering)
+
+## 7. Integration Tests
+
+- [ ] 7.1 Test controller→model chain: `POST /users → UsersController#create → User.create`
+- [ ] 7.2 Test association visibility: `User has_many Orders` edge appears in graph
+- [ ] 7.3 Test callback chain: `before_action → set_user → @user = User.find(params[:id])`
+- [ ] 7.4 Test concern inclusion: `include Authenticatable` edge appears
+- [ ] 7.5 Test Sidekiq: `OrderProcessor.perform_async(order.id)` edge appears
+- [ ] 7.6 Test flow diagram: controller action shows 5+ nodes through associations
+- [ ] 7.7 Test trace: `User#save` shows callback chain
+- [ ] 7.8 Verify no false positives on non-Rails Ruby
+
+## 8. Validation
+
+- [ ] 8.1 Run `go build ./... && go test -race -short ./...`
+- [ ] 8.2 Run harness validation ladder
+- [ ] 8.3 Run smoke:e2e with test server on port 3199
+- [ ] 8.4 Verify Ruby flow diagrams show 5+ node chains
+- [ ] 8.5 Document results in PR description


### PR DESCRIPTION
## Summary

Enhances Ruby on Rails code intelligence (issue #480). Rails projects previously returned empty/noisy results for graph, flow, flowchart, trace, and impact tools.

## Changes

### Phase 1: Foundation
- **Node format** changed from `file.rb::method` to `file.rb::ClassName#methodName` — enables flow BFS traversal from HTTP handler edges into call graph
- **Cross-file resolver rewritten** — regex → tree-sitter AST scanning. Now handles `ClassName.method`, `ClassName.new.method`, chained calls. Skips unresolvable receivers
- **CFG extractor** — added `singleton_method` support (class methods, scopes, callbacks)
- **Convention paths** — added Service, Job, Worker, Mailer, Policy, Serializer directory mappings

### Phase 2: DSL Extraction
- **New `RailsDSLEdgeExtractor`** (451 lines, 16 tests):
  - Associations: `has_many`, `has_one`, `belongs_to`, `has_and_belongs_to_many` → EdgeCalls with metadata
  - Callbacks: `before_action`, `after_save`, `after_commit`, etc. → EdgeMiddleware
  - Concerns: `include`/`extend` → EdgeCalls
  - Sidekiq: detect workers (inheritance + `include`), link `perform_async` → EdgeIntegration
- Registered in `cmd/nano-brain/main.go`

## Verification
- `go build ./...` — clean
- `go test -race -short ./internal/graph/` — all 195+ tests pass
- OpenSpec proposal at `openspec/changes/rails-dsl-extraction/`

Closes #480