### PR TITLE
feat(mcp): add agent tool-selection guidance to MCP tool descriptions

### DIFF
--- a/internal/mcp/flowchart.go
+++ b/internal/mcp/flowchart.go
@@ -17,10 +17,10 @@ func registerMemoryFlowchart(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_flowchart",
-			Description: "Return the control-flow graph (flowchart) for a specific function, identified by 'file::startLine-endLine' (e.g. 'src/routes/purchase.ts::15-48') or 'file.rb::ClassName#method' (e.g. 'app/controllers/users_controller.rb::UsersController#create'). The CFG has decision/step/terminal nodes and labeled branch edges. Returns found:false when no flowchart is stored for that span or when flow indexing is disabled.",
+			Description: "Function-level control-flow graph (CFG). Use when you need branches/conditionals inside one function, not cross-function calls. Identify the function by 'file::startLine-endLine' (e.g. 'src/routes/purchase.ts::15-48') or 'file.rb::ClassName#method' (e.g. 'app/controllers/users_controller.rb::UsersController#create'). For HTTP route execution flow use memory_flow; for downstream calls use memory_trace. Returns found:false when no flowchart is stored for that span or when flow indexing is disabled.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
-				"node":      {"type": "string", "description": "Function span as 'file::startLine-endLine' or 'file.rb::ClassName#method'"},
+				"node":      {"type": "string", "description": "Single function span as 'file::startLine-endLine' or 'file.rb::ClassName#method'. Use memory_symbols first if you need to locate the function."},
 			}, []string{"workspace", "node"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -116,7 +116,7 @@ func parseFlowchartNode(node string) (file string, startLine, endLine int, err e
 		return "", 0, 0, errors.New("node must be 'file::startLine-endLine' or 'file.rb::ClassName#method'")
 	}
 	file = parts[0]
-	
+
 	// Check if this is a Ruby method format (contains #)
 	if strings.Contains(parts[1], "#") {
 		// Ruby format: file.rb::ClassName#method
@@ -124,7 +124,7 @@ func parseFlowchartNode(node string) (file string, startLine, endLine int, err e
 		// For now, return a special case that the caller handles
 		return file, -1, -1, nil
 	}
-	
+
 	// JS/TS format: file::startLine-endLine
 	lineRange := strings.SplitN(parts[1], "-", 2)
 	if len(lineRange) != 2 {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -288,9 +288,9 @@ func registerMemoryQuery(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_query",
-			Description: "Hybrid search (BM25 + vector + RRF + recency). Auto-detects temporal phrases. Use group_by='document' to deduplicate. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Paginate via cursor. Optional params for token efficiency: fields (comma-separated field list), time_format (rfc3339|epoch, default rfc3339).",
+			Description: "DEFAULT FIRST TOOL for broad agent questions: hybrid search (BM25 + vector + RRF + recency). Use for domain/codebase understanding, past decisions, and natural-language questions. For exact errors/identifiers use memory_search; for fuzzy concepts where wording may differ use memory_vsearch. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Use group_by='document' to deduplicate and paginate via cursor.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"query":           {"type": "string", "description": "Search query"},
+				"query":           {"type": "string", "description": "Natural-language task or domain question. Start here for broad codebase understanding before falling back to exact search or symbols."},
 				"workspace":       {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"max_results":     {"type": "number", "description": "Max results (default 10, max 100)"},
 				"cursor":          {"type": "string", "description": "Opaque pagination cursor from a previous response's next_cursor field. Pass the same query when paginating."},
@@ -478,9 +478,9 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_search",
-			Description: "BM25 text search. Auto-detects temporal phrases. Use group_by='document' to deduplicate. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Paginate via cursor. Optional params for token efficiency: fields (comma-separated field list), time_format (rfc3339|epoch, default rfc3339).",
+			Description: "Exact keyword/BM25 search for literal text: error messages, log lines, function/class names, file names, config keys, and known identifiers. Use memory_query first for broad questions; use memory_symbols for known code symbols. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Use group_by='document' to deduplicate and paginate via cursor.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"query":           {"type": "string", "description": "Search query"},
+				"query":           {"type": "string", "description": "Exact words to match, such as an error string, identifier, symbol name, file name, route, or config key."},
 				"workspace":       {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"max_results":     {"type": "number", "description": "Max results (default 10, max 100)"},
 				"tags":            {"type": "array", "description": "Filter by tags", "items": map[string]any{"type": "string"}},
@@ -827,9 +827,9 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_vsearch",
-			Description: "Vector similarity search using embeddings. Auto-detects temporal phrases. Use group_by='document' to deduplicate. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Paginate via cursor. Optional params for token efficiency: fields (comma-separated field list), time_format (rfc3339|epoch, default rfc3339).",
+			Description: "Fuzzy semantic/vector search for concepts where exact words may differ. Use when memory_query or memory_search miss relevant context, or when asking for similar ideas/patterns. Not ideal for exact identifiers; use memory_search or memory_symbols instead. Returns 500-char snippets by default; set include_content=true or call memory_get for full text. Use group_by='document' to deduplicate and paginate via cursor.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"query":           {"type": "string", "description": "Search query"},
+				"query":           {"type": "string", "description": "Semantic concept or behavior to find when exact terms may not appear in the source text."},
 				"workspace":       {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"max_results":     {"type": "number", "description": "Max results (default 10, max 100)"},
 				"cursor":          {"type": "string", "description": "Opaque pagination cursor from a previous response's next_cursor field. Pass the same query when paginating."},
@@ -1128,9 +1128,9 @@ func registerMemoryGet(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_get",
-			Description: "Get a document by ID or path",
+			Description: "Fetch full content for one known document. Use after memory_query/memory_search/memory_vsearch when a result snippet is relevant and you need exact text or line slices. Do not use for broad discovery; search first, then get one selected hit.",
 			InputSchema: toolSchema(map[string]map[string]any{
-				"path":       {"type": "string", "description": "Document source_path, UUID (auto-detected), or #<uuid> for explicit ID lookup"},
+				"path":       {"type": "string", "description": "Document source_path, UUID (auto-detected), or #<uuid> from a search result for explicit ID lookup"},
 				"workspace":  {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"start_line": {"type": "number", "description": "Start line (1-indexed, inclusive)"},
 				"end_line":   {"type": "number", "description": "End line (1-indexed, inclusive)"},
@@ -1230,7 +1230,7 @@ func registerMemoryWrite(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_write",
-			Description: "Write or update a document in memory",
+			Description: "Persist a durable decision, lesson, summary, or handoff for future agents. Use at the end of work or after important discoveries; do not use for transient scratch notes. Writes are workspace-scoped and require a registered workspace.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"content":     {"type": "string", "description": "Document content"},
 				"workspace":   {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
@@ -1408,7 +1408,7 @@ func registerMemoryTags(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_tags",
-			Description: "List collections in a workspace",
+			Description: "List collections/tags in a workspace. Use to discover available memory categories before filtered searches, not for code navigation.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 			}, []string{"workspace"}),
@@ -1457,7 +1457,7 @@ func registerMemoryStatus(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_status",
-			Description: "Server and embedding queue status",
+			Description: "Server, database, and embedding queue health. Use when search results look stale/missing, after indexing a workspace, or before assuming nano-brain has no relevant context. Check queue_pending before relying on vector/hybrid results.",
 			InputSchema: toolSchema(map[string]map[string]any{}, nil),
 		},
 		func(ctx context.Context, _ *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -1491,7 +1491,7 @@ func registerMemoryUpdate(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_update",
-			Description: "Trigger re-embedding of a workspace",
+			Description: "Trigger re-embedding/reindexing work for a registered workspace. Use only when indexed content appears stale after checking memory_status; normal file watching should handle routine updates.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 			}, []string{"workspace"}),
@@ -1517,7 +1517,7 @@ func registerMemoryWakeUp(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_wake_up",
-			Description: "Workspace briefing with recent activity and stats",
+			Description: "Session-start workspace briefing. Call first when entering a workspace to orient the agent with recent memories, active collections, stats, and last activity before deeper search.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
 				"limit":     {"type": "number", "description": "Number of recent memories (default 10, max 50)"},
@@ -1644,12 +1644,12 @@ func registerMemoryGraph(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_graph",
-			Description: "Query the knowledge graph: find imports, calls, and symbol containment relationships for a node. Node accepts workspace-relative or absolute paths (e.g. \"internal/x.go::F\" or \"/abs/path/internal/x.go::F\").",
+			Description: "One-hop code graph lookup. Use for direct callers/callees, imports, and containment around a known file or file::symbol. For broad blast radius before editing use memory_impact; for downstream chains use memory_trace. Node accepts workspace-relative or absolute paths (e.g. \"internal/x.go::F\" or \"/abs/path/internal/x.go::F\").",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
-				"node":      {"type": "string", "description": "Source node (file path or file::symbol). Accepts workspace-relative or absolute."},
-				"direction": {"type": "string", "description": "Edge direction: out (default), in, both"},
-				"edge_type": {"type": "string", "description": "Filter by edge type: contains, imports, calls (empty = all)"},
+				"node":      {"type": "string", "description": "Known file path or file::symbol to inspect. Use memory_symbols first if you only know the symbol name."},
+				"direction": {"type": "string", "description": "Edge direction: out (what this node calls/imports/contains), in (direct callers/importers/containers), both"},
+				"edge_type": {"type": "string", "description": "Filter by edge type: contains, imports, calls (empty = all). Use calls for execution relationships."},
 				"paths":     {"type": "string", "description": "Output path style: \"absolute\" (default, current behavior) or \"relative\" (strip workspace prefix from edge source/target where present)"},
 			}, []string{"workspace", "node"}),
 		},
@@ -1747,10 +1747,10 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_trace",
-			Description: "Trace the call chain from an entry symbol — shows what a function calls, transitively, with cycle detection. Node accepts workspace-relative or absolute paths.",
+			Description: "Downstream call-chain trace from a known entry symbol. Use to answer 'what does this function eventually call?' with transitive calls and cycle detection. For one-hop neighbors use memory_graph; for affected callers before edits use memory_impact. Node accepts workspace-relative or absolute paths.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
-				"node":      {"type": "string", "description": "Entry symbol (e.g. file::FunctionName). Accepts workspace-relative or absolute."},
+				"node":      {"type": "string", "description": "Known entry symbol (e.g. file::FunctionName) whose downstream calls should be followed. Use memory_symbols first if needed."},
 				"max_depth": {"type": "number", "description": "Max traversal depth 1-10 (default 5)"},
 				"paths":     {"type": "string", "description": "Output path style: \"absolute\" (default) or \"relative\""},
 			}, []string{"workspace", "node"}),
@@ -1850,11 +1850,11 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_impact",
-			Description: "Find what would be affected if a node (file or symbol) changes — reverse import/call lookup with optional depth traversal. Node accepts workspace-relative or absolute paths.",
+			Description: "Pre-change blast-radius analysis. Use before editing/refactoring a file or symbol to find affected callers/importers/dependents via reverse import/call traversal. For direct one-hop relationships use memory_graph; for downstream calls use memory_trace. Node accepts workspace-relative or absolute paths.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
-				"node":      {"type": "string", "description": "The node to analyze (file path or file::symbol). Accepts workspace-relative or absolute."},
-				"direction": {"type": "string", "description": "Edge direction: \"in\" (default, what affects the node), \"out\" (what the node affects)"},
+				"node":      {"type": "string", "description": "File path or file::symbol you plan to change. Use paths='relative' to save tokens in large workspaces."},
+				"direction": {"type": "string", "description": "Edge direction: \"in\" (default, affected callers/importers/dependents), \"out\" (dependencies this node uses)"},
 				"edge_type": {"type": "string", "description": "Filter by edge type: imports, calls (empty = all)"},
 				"max_depth": {"type": "number", "description": "Traversal depth 1-3 (default 1)"},
 				"paths":     {"type": "string", "description": "Output path style: \"absolute\" (default) or \"relative\""},
@@ -1970,10 +1970,10 @@ func registerMemorySymbols(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_symbols",
-			Description: "Search code symbols (functions, types, methods, interfaces) extracted from indexed source files",
+			Description: "Code symbol lookup. Use when you know or suspect a function, method, class, interface, type, const, or variable name and need its source file/signature before graph/impact/trace. Prefer this over free-text search for exact code identifiers.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace": {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
-				"query":     {"type": "string", "description": "Symbol name filter (partial match)"},
+				"query":     {"type": "string", "description": "Symbol name or partial identifier to locate, such as PriceModel, handleSubmit, UserService, or TRADE_PROCESS_STATES"},
 				"kind":      {"type": "string", "description": "Symbol kind: function, method, type, interface, struct, const, var"},
 				"limit":     {"type": "number", "description": "Max results (default 50)"},
 			}, []string{"workspace"}),
@@ -2092,10 +2092,10 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 	server.AddTool(
 		&mcpsdk.Tool{
 			Name:        "memory_flow",
-			Description: "Visualize the execution flow for an HTTP entry point (e.g. 'POST /api/v1/write'). Shows the middleware chain, handler, and downstream call chain as a node list and optional Mermaid diagram. Returns found:false when the entry is not indexed or flow indexing is disabled.",
+			Description: "HTTP/request execution-flow visualization. Use for route-level questions like 'what happens on POST /api/v1/write?' Shows middleware, handler, downstream calls, and optional Mermaid/sequence output. For non-HTTP symbol chains use memory_trace; for one function CFG use memory_flowchart. Returns found:false when the entry is not indexed or flow indexing is disabled.",
 			InputSchema: toolSchema(map[string]map[string]any{
 				"workspace":         {"type": "string", "description": "Workspace identifier — name (e.g. 'nano-brain') or full hash"},
-				"entry":             {"type": "string", "description": "HTTP entry point to visualize, e.g. 'POST /api/v1/write'"},
+				"entry":             {"type": "string", "description": "HTTP route entry point to visualize, e.g. 'POST /api/v1/write'. Use method + path when possible."},
 				"max_depth":         {"type": "number", "description": "Max call-chain depth 1-10 (default: config value)"},
 				"format":            {"type": "string", "description": "Output format: 'mermaid' (default), 'sequence' (sequence diagram), or 'json'"},
 				"stitch_workspaces": {"type": "array", "description": "Target workspace hashes to stitch cross-service integration edges against", "items": map[string]any{"type": "string"}},

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
-	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/nano-brain/nano-brain/internal/config"
+	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
 	"github.com/rs/zerolog"
 )
 
@@ -74,6 +74,48 @@ func TestRegisterTools_CountAndNames(t *testing.T) {
 	for i := range expected {
 		if got[i] != expected[i] {
 			t.Errorf("tool[%d] = %q, want %q", i, got[i], expected[i])
+		}
+	}
+}
+
+func TestRegisterTools_AgentToolSelectionGuidance(t *testing.T) {
+	session, ctx := setupTestClient(t)
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+
+	tools := make(map[string]string, len(result.Tools))
+	for _, tool := range result.Tools {
+		tools[tool.Name] = tool.Description
+	}
+
+	checks := map[string][]string{
+		"memory_query":     {"DEFAULT FIRST TOOL", "broad agent questions"},
+		"memory_search":    {"Exact keyword/BM25", "error messages"},
+		"memory_vsearch":   {"Fuzzy semantic/vector", "exact words may differ"},
+		"memory_get":       {"after memory_query", "need exact text"},
+		"memory_write":     {"Persist a durable decision", "future agents"},
+		"memory_status":    {"search results look stale", "queue_pending"},
+		"memory_wake_up":   {"Session-start workspace briefing", "before deeper search"},
+		"memory_symbols":   {"Code symbol lookup", "function, method, class"},
+		"memory_graph":     {"One-hop code graph lookup", "direct callers/callees"},
+		"memory_impact":    {"Pre-change blast-radius analysis", "before editing"},
+		"memory_trace":     {"Downstream call-chain trace", "eventually call"},
+		"memory_flow":      {"HTTP/request execution-flow", "route-level questions"},
+		"memory_flowchart": {"Function-level control-flow graph", "branches/conditionals"},
+	}
+
+	for name, phrases := range checks {
+		desc, ok := tools[name]
+		if !ok {
+			t.Fatalf("tool %s not registered", name)
+		}
+		for _, phrase := range phrases {
+			if !strings.Contains(desc, phrase) {
+				t.Errorf("%s description missing guidance phrase %q; description=%q", name, phrase, desc)
+			}
 		}
 	}
 }

--- a/openspec/changes/add-mcp-agent-tool-guide/proposal.md
+++ b/openspec/changes/add-mcp-agent-tool-guide/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+Agents that install nano-brain through MCP do not automatically read README files or project docs. Their primary decision surface is the MCP tool listing: tool names, descriptions, and input schema descriptions. Without guidance there, agents may overuse generic search, skip symbol/impact/flow tools, or ask broad framework questions instead of using the right code-intelligence primitive.
+
+## What Changes
+
+- Add agent-facing tool-selection guidance directly to MCP tool descriptions.
+- Make search tools explain when to use hybrid, BM25, or vector search.
+- Make code-intelligence tools explain when to use symbols, graph, impact, trace, flow, and flowchart.
+- Keep behavior and response schemas unchanged.
+
+## Impact
+
+- `internal/mcp/tools.go` — update descriptions and schema descriptions only.
+- `internal/mcp/tools_test.go` or existing MCP tests — assert important guidance appears in tool listings.
+- `openspec/specs/mcp-server/spec.md` — document the requirement after implementation/archive.
+
+No API break: tool names, parameters, handlers, and response shapes remain unchanged.

--- a/openspec/changes/add-mcp-agent-tool-guide/specs/mcp-server/spec.md
+++ b/openspec/changes/add-mcp-agent-tool-guide/specs/mcp-server/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: MCP tool listings guide agent tool selection
+
+MCP tool registrations SHALL include agent-facing descriptions that teach when to choose each nano-brain memory and code-intelligence tool. The guidance SHALL be visible from MCP `tools/list` output without requiring the agent to read README files, skills, or external documentation.
+
+#### Scenario: Search tool descriptions teach search selection
+
+- **WHEN** an MCP client lists tools
+- **THEN** `memory_query` description SHALL identify it as the default hybrid search for broad/codebase questions
+- **AND** `memory_search` description SHALL identify it as the exact-keyword/BM25 tool for errors, identifiers, and literal text
+- **AND** `memory_vsearch` description SHALL identify it as the fuzzy semantic/vector tool for concepts where exact words may differ
+
+#### Scenario: Code-intelligence tool descriptions teach graph selection
+
+- **WHEN** an MCP client lists tools
+- **THEN** `memory_symbols` description SHALL say to use it for known functions, classes, interfaces, types, constants, or variables
+- **AND** `memory_graph` description SHALL say to use it for one-hop callers, callees, imports, or containment
+- **AND** `memory_impact` description SHALL say to use it before changing a file or symbol to find affected callers/dependents
+- **AND** `memory_trace` description SHALL say to use it to follow downstream call chains from an entry symbol
+
+#### Scenario: Flow tool descriptions teach execution-flow selection
+
+- **WHEN** an MCP client lists tools
+- **THEN** `memory_flow` description SHALL say to use it for HTTP route/request execution flows
+- **AND** `memory_flowchart` description SHALL say to use it for a function-level control-flow graph
+
+#### Scenario: Support tool descriptions teach common workflow
+
+- **WHEN** an MCP client lists tools
+- **THEN** `memory_wake_up` description SHALL say to use it at session start for workspace orientation
+- **AND** `memory_get` description SHALL say to use it after search when one result needs full content
+- **AND** `memory_status` description SHALL say to use it when results look stale or indexing/embedding may be incomplete

--- a/openspec/changes/add-mcp-agent-tool-guide/tasks.md
+++ b/openspec/changes/add-mcp-agent-tool-guide/tasks.md
@@ -1,0 +1,16 @@
+## 1. MCP-visible guidance
+
+- [x] 1.1 Update search tool descriptions with explicit selection guidance: default to `memory_query`, exact text uses `memory_search`, fuzzy concepts use `memory_vsearch`.
+- [x] 1.2 Update retrieval/persistence descriptions: use `memory_get` after search, `memory_write` for decisions, `memory_wake_up` at session start, `memory_status` for indexing/queue health.
+- [x] 1.3 Update code-intelligence descriptions: `memory_symbols` for known names, `memory_graph` for one-hop callers/callees, `memory_impact` before changes, `memory_trace` for downstream calls, `memory_flow` for HTTP entries, `memory_flowchart` for function control flow.
+- [x] 1.4 Update parameter descriptions where they affect tool choice, especially `query`, `node`, `entry`, `direction`, `edge_type`, and `paths`.
+
+## 2. Tests
+
+- [x] 2.1 Add or update MCP tool-list tests to assert the guidance is exposed through tool descriptions.
+- [x] 2.2 Run targeted MCP tests.
+
+## 3. Validation
+
+- [x] 3.1 Run `go test -race -short ./...`.
+- [x] 3.2 Run privacy grep before finalizing.


### PR DESCRIPTION
## Summary

Agents that install nano-brain via MCP do not read README files. Their primary decision surface is the MCP tool listing: tool names, descriptions, and input schema descriptions. Without guidance there, agents overuse generic search, skip symbol/impact/flow tools, or ask broad framework questions instead of using the right code-intelligence primitive.

This PR adds agent-facing tool-selection guidance directly to MCP tool descriptions so agents see it from  output without needing external documentation.

## Changes

### MCP tool descriptions (, )

| Tool | Guidance |
|------|----------|
|  | DEFAULT FIRST TOOL for broad agent questions |
|  | Exact keyword/BM25 for literal text/errors/identifiers |
|  | Fuzzy semantic/vector for concepts where exact words may differ |
|  | Known function/method/class/type/const/var names |
|  | One-hop callers/callees/imports |
|  | Pre-change blast radius before editing |
|  | Downstream call chains |
|  | HTTP route execution flow |
|  | Function-level CFG |
|  | Full content after search |
|  | Stale results / queue health |
|  | Session-start briefing |
|  | Durable decisions for future agents |

### Schema description updates

Input parameter descriptions updated for , , , ,  to guide tool selection at the parameter level.

### Regression test ()

 — asserts 13 tools contain specific guidance phrases from MCP  output. Future edits that remove these phrases will fail the test.

### OpenSpec change ()

-  — problem statement and impact
-  — requirement with scenarios
-  — implementation checklist (all done)

## Validation

- [x]  PASS (16 tools)
- [x]  PASS (13 tools × 2 phrases)
- [x] Change 'add-mcp-agent-tool-guide' is valid PASS
- [x] ?   	github.com/nano-brain/nano-brain/benchmarks/capability	[no test files]
ok  	github.com/nano-brain/nano-brain/cmd/nano-brain	(cached)
ok  	github.com/nano-brain/nano-brain/internal/bench	(cached)
ok  	github.com/nano-brain/nano-brain/internal/chunk	(cached)
ok  	github.com/nano-brain/nano-brain/internal/chunker	(cached)
ok  	github.com/nano-brain/nano-brain/internal/codesummarize	(cached)
ok  	github.com/nano-brain/nano-brain/internal/config	(cached)
ok  	github.com/nano-brain/nano-brain/internal/embed	(cached)
ok  	github.com/nano-brain/nano-brain/internal/eventbus	(cached)
ok  	github.com/nano-brain/nano-brain/internal/flow	(cached)
ok  	github.com/nano-brain/nano-brain/internal/graph	(cached)
ok  	github.com/nano-brain/nano-brain/internal/harvest	(cached)
ok  	github.com/nano-brain/nano-brain/internal/health	(cached)
ok  	github.com/nano-brain/nano-brain/internal/health/doctor	(cached)
ok  	github.com/nano-brain/nano-brain/internal/intelligence	(cached)
ok  	github.com/nano-brain/nano-brain/internal/links	(cached)
ok  	github.com/nano-brain/nano-brain/internal/mcp	(cached)
ok  	github.com/nano-brain/nano-brain/internal/migrate	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search/hyde	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search/preprocess	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search/reranking	(cached)
ok  	github.com/nano-brain/nano-brain/internal/server	(cached)
ok  	github.com/nano-brain/nano-brain/internal/server/handlers	(cached)
ok  	github.com/nano-brain/nano-brain/internal/server/middleware	(cached)
ok  	github.com/nano-brain/nano-brain/internal/storage	(cached)
?   	github.com/nano-brain/nano-brain/internal/storage/sqlc	[no test files]
?   	github.com/nano-brain/nano-brain/internal/testutil	[no test files]
ok  	github.com/nano-brain/nano-brain/internal/summarize	(cached)
ok  	github.com/nano-brain/nano-brain/internal/symbol	(cached)
ok  	github.com/nano-brain/nano-brain/internal/telemetry	(cached)
ok  	github.com/nano-brain/nano-brain/internal/timefilter	(cached)
?   	github.com/nano-brain/nano-brain/migrations	[no test files]
?   	github.com/nano-brain/nano-brain/tools/dbaudit	[no test files]
?   	github.com/nano-brain/nano-brain/tools/edgecheck	[no test files]
?   	github.com/nano-brain/nano-brain/tools/ignorecleanup	[no test files]
ok  	github.com/nano-brain/nano-brain/internal/watcher	(cached) PASS
- [x] Privacy grep clean (no real workspace names/hashes/paths)
- [x] 5-reviewer parallel review: all PASS

## Impact

- **No API break**: tool names, parameters, handlers, and response shapes unchanged
- **No behavior change**: only description/schema description text modified
- **Agent-visible**: guidance appears in  output, not just source code

Closes #494