### PR TITLE
bench(typescript): add agent-oriented capability benchmark profile

### DIFF
--- a/benchmarks/typescript/capability/.gitignore
+++ b/benchmarks/typescript/capability/.gitignore
@@ -1,0 +1,1 @@
+results_current.json

--- a/benchmarks/typescript/capability/README.md
+++ b/benchmarks/typescript/capability/README.md
@@ -1,0 +1,23 @@
+# TypeScript Capability Benchmark
+
+Agent-oriented benchmark profile for a TypeScript/JavaScript CS2 item-trading workspace. The committed dataset uses privacy-safe placeholders; local runs provide the real workspace hash through `NANO_BRAIN_WORKSPACE`.
+
+## Running
+
+```bash
+NANO_BRAIN_URL=http://host.docker.internal:3100 \
+NANO_BRAIN_WORKSPACE=<runtime-workspace-hash> \
+go test -v -tags=capbench -run TestCapabilityBenchmark ./benchmarks/typescript/capability/
+```
+
+The benchmark writes `results_current.json`, which is ignored by git.
+
+## Scoring
+
+Each task has a fixed tool layer plus deterministic agent-style retrieval:
+
+- `fixed_recall` — direct tools listed on the task.
+- `agent_recall` — fixed layer plus query/question/input and identifier-driven symbol lookups.
+- `recall` — final score used for category and overall metrics.
+
+The dataset intentionally checks project-domain concepts: CS2 item pricing, inventory reads, trade offer status/recheck flows, item/product models, SteamID conversion, and trading workflow documentation. Do not commit real workspace names, hashes, absolute paths, or private project names.

--- a/benchmarks/typescript/capability/baseline_v1.json
+++ b/benchmarks/typescript/capability/baseline_v1.json
@@ -1,0 +1,134 @@
+{
+  "version": "1",
+  "overall": 0.85,
+  "by_category": {
+    "multi-tool": 1,
+    "search-qa": 0.76,
+    "symbol-lookup": 1
+  },
+  "tasks": [
+    {
+      "id": "ts-cs2-pricing",
+      "category": "search-qa",
+      "recall": 1,
+      "fixed_recall": 1,
+      "agent_recall": 1,
+      "matched": [
+        "PriceModel",
+        "PriceModel.ts",
+        "instruction-pricing-manager.md"
+      ],
+      "missed": null
+    },
+    {
+      "id": "ts-inventory-read",
+      "category": "symbol-lookup",
+      "recall": 1,
+      "fixed_recall": 0.833,
+      "agent_recall": 1,
+      "matched": [
+        "InventoryOS",
+        "getInv",
+        "getUserInventory",
+        "getCSGOAssetProperties",
+        "InventoryOS.ts",
+        "index.ts"
+      ],
+      "missed": null
+    },
+    {
+      "id": "ts-trade-status",
+      "category": "search-qa",
+      "recall": 0.7142857142857143,
+      "fixed_recall": 0.714,
+      "agent_recall": 0.714,
+      "matched": [
+        "checkOffer",
+        "recheckTradeStatus",
+        "checkRevertOffer",
+        "index.ts",
+        "cron.js"
+      ],
+      "missed": [
+        "TRADE_PROCESS_STATES",
+        "enums.js"
+      ]
+    },
+    {
+      "id": "ts-item-models",
+      "category": "search-qa",
+      "recall": 0.75,
+      "fixed_recall": 0.75,
+      "agent_recall": 0.75,
+      "matched": [
+        "ProductModel",
+        "ItemInfo",
+        "ProductModel.ts"
+      ],
+      "missed": [
+        "ItemsMetaItems.ts"
+      ]
+    },
+    {
+      "id": "ts-steam-id",
+      "category": "search-qa",
+      "recall": 1,
+      "fixed_recall": 1,
+      "agent_recall": 1,
+      "matched": [
+        "CONTEXT_IDS",
+        "partnerIdToSteamId64",
+        "steamOffset",
+        "matchedSteamAssetIds",
+        "helper.ts",
+        "helpers.js"
+      ],
+      "missed": null
+    },
+    {
+      "id": "ts-trading-workflow",
+      "category": "search-qa",
+      "recall": 0.3333333333333333,
+      "fixed_recall": 0.333,
+      "agent_recall": 0.333,
+      "matched": [
+        "csfloat-workflow.md"
+      ],
+      "missed": [
+        "itemSchemas.ts",
+        "itemRepo.js"
+      ]
+    },
+    {
+      "id": "ts-price-to-inventory-multi-tool",
+      "category": "multi-tool",
+      "recall": 1,
+      "fixed_recall": 0.333,
+      "agent_recall": 1,
+      "matched": [
+        "PriceModel",
+        "InventoryOS",
+        "getCSGOAssetProperties",
+        "PriceModel.ts",
+        "InventoryOS.ts",
+        "index.ts"
+      ],
+      "missed": null
+    },
+    {
+      "id": "ts-trade-state-multi-tool",
+      "category": "multi-tool",
+      "recall": 1,
+      "fixed_recall": 0.8,
+      "agent_recall": 1,
+      "matched": [
+        "TRADE_PROCESS_STATES",
+        "checkOffer",
+        "recheckTradeStatus",
+        "enums.js",
+        "index.ts"
+      ],
+      "missed": null
+    }
+  ]
+}

--- a/benchmarks/typescript/capability/capability_test.go
+++ b/benchmarks/typescript/capability/capability_test.go
@@ -1,0 +1,191 @@
+//go:build capbench
+
+package capability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	datasetPath  = "dataset.json"
+	baselinePath = "baseline_v1.json"
+	resultsPath  = "results_current.json"
+)
+
+func TestCapabilityBenchmark(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if err := CheckReachable(cfg.ServerURL); err != nil {
+		t.Skipf("nano-brain server unreachable at %s: %v", cfg.ServerURL, err)
+	}
+
+	raw, err := os.ReadFile(datasetPath)
+	if err != nil {
+		t.Fatalf("read dataset: %v", err)
+	}
+	var dataset Dataset
+	if err := json.Unmarshal(raw, &dataset); err != nil {
+		t.Fatalf("parse dataset: %v", err)
+	}
+	if len(dataset.Tasks) == 0 {
+		t.Fatal("dataset contains no tasks")
+	}
+
+	client := newHTTPClient()
+	ctx := context.Background()
+
+	taskResults := make([]TaskResult, 0, len(dataset.Tasks))
+	for _, task := range dataset.Tasks {
+		r := RunTask(ctx, client, cfg, dataset.Agent, task)
+		taskResults = append(taskResults, r)
+	}
+
+	results := Aggregate(taskResults)
+
+	printScorecard(t, results)
+
+	writeJSON(t, resultsPath, results)
+
+	if cfg.Freeze {
+		writeJSON(t, baselinePath, results)
+		t.Log("baseline frozen to", baselinePath)
+		return
+	}
+
+	baselineRaw, err := os.ReadFile(baselinePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Log("no baseline found; run with CAPBENCH_FREEZE=1 to freeze one")
+			return
+		}
+		t.Fatalf("read baseline: %v", err)
+	}
+	var baseline BenchResults
+	if err := json.Unmarshal(baselineRaw, &baseline); err != nil {
+		t.Fatalf("parse baseline: %v", err)
+	}
+
+	printDelta(t, baseline, results)
+
+	const regressionThreshold = 0.001
+	if results.Overall < baseline.Overall-regressionThreshold {
+		t.Errorf("REGRESSION: overall recall %.3f < baseline %.3f (delta %.3f)",
+			results.Overall, baseline.Overall, results.Overall-baseline.Overall)
+	}
+}
+
+func newHTTPClient() *http.Client {
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+func printScorecard(t *testing.T, r BenchResults) {
+	t.Helper()
+	var sb strings.Builder
+
+	sb.WriteString("\n=== CAPABILITY BENCHMARK SCORECARD ===\n")
+	sb.WriteString(fmt.Sprintf("%-40s %-14s %-8s %-8s %s\n", "TASK ID", "CATEGORY", "FIXED", "AGENT", "RECALL"))
+	sb.WriteString(strings.Repeat("-", 70) + "\n")
+
+	for _, task := range r.Tasks {
+		sb.WriteString(fmt.Sprintf("%-40s %-14s %.3f    %.3f    %.3f", task.ID, task.Category, task.FixedRecall, task.AgentRecall, task.Recall))
+		if len(task.Missed) > 0 {
+			sb.WriteString(fmt.Sprintf("  missed: %s", strings.Join(task.Missed, ", ")))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(strings.Repeat("-", 70) + "\n")
+	sb.WriteString("BY CATEGORY:\n")
+
+	cats := make([]string, 0, len(r.ByCategory))
+	for c := range r.ByCategory {
+		cats = append(cats, c)
+	}
+	sort.Strings(cats)
+	for _, cat := range cats {
+		sb.WriteString(fmt.Sprintf("  %-20s %.3f\n", cat, r.ByCategory[cat]))
+	}
+
+	sb.WriteString(fmt.Sprintf("\nOVERALL: %.3f\n", r.Overall))
+	sb.WriteString("=====================================\n")
+
+	t.Log(sb.String())
+}
+
+func printDelta(t *testing.T, baseline, current BenchResults) {
+	t.Helper()
+	var sb strings.Builder
+
+	sb.WriteString("\n=== DELTA vs BASELINE ===\n")
+	sb.WriteString(fmt.Sprintf("%-40s %-8s %-8s %s\n", "TASK ID", "BASE", "NOW", "DELTA"))
+	sb.WriteString(strings.Repeat("-", 70) + "\n")
+
+	baseMap := make(map[string]float64, len(baseline.Tasks))
+	for _, bt := range baseline.Tasks {
+		baseMap[bt.ID] = bt.Recall
+	}
+
+	for _, task := range current.Tasks {
+		baseRecall := baseMap[task.ID]
+		delta := task.Recall - baseRecall
+		marker := ""
+		if delta > 0.001 {
+			marker = " +"
+		} else if delta < -0.001 {
+			marker = " *** REGRESSION"
+		}
+		sb.WriteString(fmt.Sprintf("%-40s %.3f    %.3f    %+.3f%s\n",
+			task.ID, baseRecall, task.Recall, delta, marker))
+	}
+
+	sb.WriteString(strings.Repeat("-", 70) + "\n")
+	sb.WriteString("BY CATEGORY:\n")
+
+	cats := make([]string, 0)
+	seen := make(map[string]bool)
+	for c := range current.ByCategory {
+		if !seen[c] {
+			cats = append(cats, c)
+			seen[c] = true
+		}
+	}
+	sort.Strings(cats)
+	for _, cat := range cats {
+		cur := current.ByCategory[cat]
+		base := baseline.ByCategory[cat]
+		sb.WriteString(fmt.Sprintf("  %-20s base=%.3f now=%.3f delta=%+.3f\n", cat, base, cur, cur-base))
+	}
+
+	overallDelta := current.Overall - baseline.Overall
+	sb.WriteString(fmt.Sprintf("\nOVERALL: base=%.3f now=%.3f delta=%+.3f\n",
+		baseline.Overall, current.Overall, overallDelta))
+	if overallDelta > 0.001 {
+		sb.WriteString("IMPROVEMENT detected.\n")
+	} else if overallDelta < -0.001 {
+		sb.WriteString("REGRESSION detected.\n")
+	} else {
+		sb.WriteString("No significant change.\n")
+	}
+	sb.WriteString("=========================\n")
+
+	t.Log(sb.String())
+}
+
+func writeJSON(t *testing.T, path string, v interface{}) {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, b, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/benchmarks/typescript/capability/dataset.json
+++ b/benchmarks/typescript/capability/dataset.json
@@ -1,0 +1,106 @@
+{
+  "version": 1,
+  "workspace": "typescript-app",
+  "agent": {
+    "enabled": true,
+    "tools": ["query_question", "query_input", "symbols_identifiers"],
+    "max_symbol_queries": 8
+  },
+  "tasks": [
+    {
+      "id": "ts-cs2-pricing",
+      "category": "search-qa",
+      "question": "Find the CS2 item pricing model and pricing manager logic.",
+      "tools": ["query"],
+      "input": {
+        "query": "CS2 item price pricing manager price source exchange rate PriceModel"
+      },
+      "expect_symbols": ["PriceModel"],
+      "expect_files": ["PriceModel.ts", "instruction-pricing-manager.md"]
+    },
+    {
+      "id": "ts-inventory-read",
+      "category": "symbol-lookup",
+      "question": "Locate the inventory code that reads CS2 assets and user inventory.",
+      "tools": ["symbols", "query"],
+      "input": {
+        "query": "CS2 inventory getInv getUserInventory getCSGOAssetProperties InventoryOS",
+        "kind": "",
+        "max_results": 20
+      },
+      "expect_symbols": ["InventoryOS", "getInv", "getUserInventory", "getCSGOAssetProperties"],
+      "expect_files": ["InventoryOS.ts", "index.ts"]
+    },
+    {
+      "id": "ts-trade-status",
+      "category": "search-qa",
+      "question": "Find trade offer status handling and recheck/revert logic.",
+      "tools": ["query"],
+      "input": {
+        "query": "trade offer status lifecycle checkOffer recheckTradeStatus revert trade state"
+      },
+      "expect_symbols": ["TRADE_PROCESS_STATES", "checkOffer", "recheckTradeStatus", "checkRevertOffer"],
+      "expect_files": ["enums.js", "index.ts", "cron.js"]
+    },
+    {
+      "id": "ts-item-models",
+      "category": "search-qa",
+      "question": "Find TypeScript models/interfaces that describe tradable item/product data.",
+      "tools": ["query", "symbols"],
+      "input": {
+        "query": "ProductModel ItemInfo ItemsMetaItems TypeScript interface item model",
+        "kind": "",
+        "max_results": 20
+      },
+      "expect_symbols": ["ProductModel", "ItemInfo"],
+      "expect_files": ["ProductModel.ts", "ItemsMetaItems.ts"]
+    },
+    {
+      "id": "ts-steam-id",
+      "category": "search-qa",
+      "question": "Find SteamID and app context helpers used when matching trade items.",
+      "tools": ["query"],
+      "input": {
+        "query": "SteamID 64 bit partnerIdToSteamId64 steamOffset CONTEXT_IDS matchedSteamAssetIds"
+      },
+      "expect_symbols": ["CONTEXT_IDS", "partnerIdToSteamId64", "steamOffset", "matchedSteamAssetIds"],
+      "expect_files": ["helper.ts", "helpers.js"]
+    },
+    {
+      "id": "ts-trading-workflow",
+      "category": "search-qa",
+      "question": "Find CS2 trading workflow documentation and item schema/repository code.",
+      "tools": ["query"],
+      "input": {
+        "query": "CS2 trading workflow item schema item repository trade offer inventory parser"
+      },
+      "expect_files": ["csfloat-workflow.md", "itemSchemas.ts", "itemRepo.js"]
+    },
+    {
+      "id": "ts-price-to-inventory-multi-tool",
+      "category": "multi-tool",
+      "question": "Use search and symbols to connect pricing data models with inventory asset retrieval.",
+      "tools": ["query", "symbols"],
+      "input": {
+        "query": "PriceModel InventoryOS getCSGOAssetProperties item pricing inventory TypeScript",
+        "kind": "",
+        "max_results": 20
+      },
+      "expect_symbols": ["PriceModel", "InventoryOS", "getCSGOAssetProperties"],
+      "expect_files": ["PriceModel.ts", "InventoryOS.ts", "index.ts"]
+    },
+    {
+      "id": "ts-trade-state-multi-tool",
+      "category": "multi-tool",
+      "question": "Use search and symbols to connect trade state constants with trade recheck handlers.",
+      "tools": ["query", "symbols"],
+      "input": {
+        "query": "TRADE_PROCESS_STATES checkOffer recheckTradeStatus checkRevertOffer trade status",
+        "kind": "",
+        "max_results": 20
+      },
+      "expect_symbols": ["TRADE_PROCESS_STATES", "checkOffer", "recheckTradeStatus"],
+      "expect_files": ["enums.js", "index.ts"]
+    }
+  ]
+}

--- a/benchmarks/typescript/capability/runner.go
+++ b/benchmarks/typescript/capability/runner.go
@@ -1,0 +1,557 @@
+package capability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Config holds runtime configuration derived from environment variables.
+type Config struct {
+	ServerURL string
+	Workspace string
+	Freeze    bool
+}
+
+// DefaultConfig returns configuration with defaults applied.
+func DefaultConfig() Config {
+	// Defaults target the isolated benchmark server (port 3199, nanobrain_test DB),
+	// not the dev server on 3100, so benchmark runs never touch dev data.
+	serverURL := os.Getenv("NANO_BRAIN_URL")
+	if serverURL == "" {
+		serverURL = "http://localhost:3199"
+	}
+	workspace := os.Getenv("NANO_BRAIN_WORKSPACE")
+	if workspace == "" {
+		workspace = "typescript-app"
+	}
+	return Config{
+		ServerURL: serverURL,
+		Workspace: workspace,
+		Freeze:    os.Getenv("CAPBENCH_FREEZE") == "1",
+	}
+}
+
+// --- Dataset types ---
+
+type Task struct {
+	ID            string                 `json:"id"`
+	Category      string                 `json:"category"`
+	Question      string                 `json:"question"`
+	Tools         []string               `json:"tools"`
+	Input         map[string]interface{} `json:"input"`
+	ExpectSymbols []string               `json:"expect_symbols,omitempty"`
+	ExpectFiles   []string               `json:"expect_files,omitempty"`
+}
+
+type AgentPlan struct {
+	Enabled          bool     `json:"enabled"`
+	Tools            []string `json:"tools,omitempty"`
+	MaxSymbolQueries int      `json:"max_symbol_queries,omitempty"`
+}
+
+type Dataset struct {
+	Version   int       `json:"version"`
+	Workspace string    `json:"workspace"`
+	Agent     AgentPlan `json:"agent,omitempty"`
+	Tasks     []Task    `json:"tasks"`
+}
+
+// --- Result types ---
+
+type TaskResult struct {
+	ID          string   `json:"id"`
+	Category    string   `json:"category"`
+	Recall      float64  `json:"recall"`
+	FixedRecall float64  `json:"fixed_recall,omitempty"`
+	AgentRecall float64  `json:"agent_recall,omitempty"`
+	Matched     []string `json:"matched"`
+	Missed      []string `json:"missed"`
+}
+
+type BenchResults struct {
+	Version    string             `json:"version"`
+	Overall    float64            `json:"overall"`
+	ByCategory map[string]float64 `json:"by_category"`
+	Tasks      []TaskResult       `json:"tasks"`
+}
+
+// --- API response types ---
+
+type flowChainEntry struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+type flowResponse struct {
+	Found     bool             `json:"found"`
+	Chain     []flowChainEntry `json:"chain"`
+	Externals []flowChainEntry `json:"externals"`
+}
+
+type impactNode struct {
+	Node string `json:"node"`
+}
+
+type impactResponse struct {
+	Node     string       `json:"node"`
+	Impacted []impactNode `json:"impacted"`
+}
+
+type traceNode struct {
+	Node string `json:"node"`
+}
+
+type traceResponse struct {
+	Entry string      `json:"entry"`
+	Chain []traceNode `json:"chain"`
+}
+
+type symbolEntry struct {
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourcePath string `json:"source_path"`
+}
+
+type symbolsResponse struct {
+	Count   int           `json:"count"`
+	Symbols []symbolEntry `json:"symbols"`
+}
+
+type queryResult struct {
+	Title      string `json:"title"`
+	SourcePath string `json:"source_path"`
+	Snippet    string `json:"snippet"`
+}
+
+type queryResponse struct {
+	Results []queryResult `json:"results"`
+}
+
+// --- HTTP helpers ---
+
+func postJSON(ctx context.Context, client *http.Client, endpoint string, body interface{}, out interface{}) error {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func getJSON(ctx context.Context, client *http.Client, endpoint string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// --- Per-tool callers ---
+
+// Surfaced holds the name-like and path-like strings collected from all tool calls.
+type Surfaced struct {
+	Names []string // symbol names, function names, chain/external names
+	Paths []string // source paths, file parts of node ids
+}
+
+func (s *Surfaced) addName(v string) {
+	if v != "" {
+		s.Names = append(s.Names, v)
+	}
+}
+
+func (s *Surfaced) addPath(v string) {
+	if v != "" {
+		s.Paths = append(s.Paths, v)
+	}
+}
+
+// splitNodeID splits "file::Func" into (file, func). Returns ("", v) if no "::".
+func splitNodeID(v string) (string, string) {
+	idx := strings.LastIndex(v, "::")
+	if idx < 0 {
+		return "", v
+	}
+	return v[:idx], v[idx+2:]
+}
+
+func callFlow(ctx context.Context, client *http.Client, cfg Config, input map[string]interface{}) Surfaced {
+	entry, _ := input["entry"].(string)
+	maxDepth := 8
+	if d, ok := input["max_depth"]; ok {
+		switch v := d.(type) {
+		case float64:
+			maxDepth = int(v)
+		case int:
+			maxDepth = v
+		}
+	}
+	body := map[string]interface{}{
+		"workspace": cfg.Workspace,
+		"entry":     entry,
+		"max_depth": maxDepth,
+		"format":    "json",
+	}
+	var resp flowResponse
+	var s Surfaced
+	if err := postJSON(ctx, client, cfg.ServerURL+"/api/v1/graph/flow", body, &resp); err != nil {
+		return s
+	}
+	for _, c := range resp.Chain {
+		s.addName(c.Name)
+	}
+	for _, e := range resp.Externals {
+		s.addName(e.Name)
+	}
+	return s
+}
+
+func callImpact(ctx context.Context, client *http.Client, cfg Config, input map[string]interface{}) Surfaced {
+	node, _ := input["node"].(string)
+	maxDepth := 4
+	if d, ok := input["max_depth"]; ok {
+		switch v := d.(type) {
+		case float64:
+			maxDepth = int(v)
+		case int:
+			maxDepth = v
+		}
+	}
+	body := map[string]interface{}{
+		"workspace": cfg.Workspace,
+		"node":      node,
+		"max_depth": maxDepth,
+	}
+	var resp impactResponse
+	var s Surfaced
+	if err := postJSON(ctx, client, cfg.ServerURL+"/api/v1/graph/impact", body, &resp); err != nil {
+		return s
+	}
+	for _, n := range resp.Impacted {
+		s.addPath(n.Node)
+		file, bare := splitNodeID(n.Node)
+		s.addName(bare)
+		if file != "" {
+			s.addPath(file)
+		}
+	}
+	return s
+}
+
+func callTrace(ctx context.Context, client *http.Client, cfg Config, input map[string]interface{}) Surfaced {
+	node, _ := input["node"].(string)
+	maxDepth := 4
+	if d, ok := input["max_depth"]; ok {
+		switch v := d.(type) {
+		case float64:
+			maxDepth = int(v)
+		case int:
+			maxDepth = v
+		}
+	}
+	body := map[string]interface{}{
+		"workspace": cfg.Workspace,
+		"node":      node,
+		"max_depth": maxDepth,
+	}
+	var resp traceResponse
+	var s Surfaced
+	if err := postJSON(ctx, client, cfg.ServerURL+"/api/v1/graph/trace", body, &resp); err != nil {
+		return s
+	}
+	for _, n := range resp.Chain {
+		s.addPath(n.Node)
+		file, bare := splitNodeID(n.Node)
+		s.addName(bare)
+		if file != "" {
+			s.addPath(file)
+		}
+	}
+	return s
+}
+
+func callSymbols(ctx context.Context, client *http.Client, cfg Config, input map[string]interface{}) Surfaced {
+	query, _ := input["query"].(string)
+	endpoint := fmt.Sprintf("%s/api/v1/symbols?workspace=%s&query=%s&limit=20",
+		cfg.ServerURL,
+		url.QueryEscape(cfg.Workspace),
+		url.QueryEscape(query),
+	)
+	var resp symbolsResponse
+	var s Surfaced
+	if err := getJSON(ctx, client, endpoint, &resp); err != nil {
+		return s
+	}
+	for _, sym := range resp.Symbols {
+		s.addName(sym.Name)
+		s.addPath(sym.SourcePath)
+	}
+	return s
+}
+
+func callQuery(ctx context.Context, client *http.Client, cfg Config, input map[string]interface{}) Surfaced {
+	query, _ := input["query"].(string)
+	body := map[string]interface{}{
+		"workspace": cfg.Workspace,
+		"query":     query,
+		"limit":     20,
+	}
+	var resp queryResponse
+	var s Surfaced
+	if err := postJSON(ctx, client, cfg.ServerURL+"/api/v1/query", body, &resp); err != nil {
+		return s
+	}
+	for _, r := range resp.Results {
+		s.addPath(r.SourcePath)
+		s.addName(r.Title)
+		s.addName(r.Snippet)
+	}
+	return s
+}
+
+// --- Task runner ---
+
+// RunTask calls every fixed tool listed in the task, then optionally augments
+// that context with deterministic agent-style discovery. Agent discovery never
+// looks at expected answers; it uses the task question and input the same way a
+// real coding agent would start with broad retrieval before specializing.
+func RunTask(ctx context.Context, client *http.Client, cfg Config, agent AgentPlan, task Task) TaskResult {
+	var names []string
+	var paths []string
+
+	for _, tool := range task.Tools {
+		var s Surfaced
+		switch tool {
+		case "flow":
+			s = callFlow(ctx, client, cfg, task.Input)
+		case "impact":
+			s = callImpact(ctx, client, cfg, task.Input)
+		case "trace":
+			s = callTrace(ctx, client, cfg, task.Input)
+		case "symbols":
+			s = callSymbols(ctx, client, cfg, task.Input)
+		case "query":
+			s = callQuery(ctx, client, cfg, task.Input)
+		}
+		names = append(names, s.Names...)
+		paths = append(paths, s.Paths...)
+	}
+
+	fixed := scoreTask(task, names, paths)
+	if !agent.Enabled {
+		return fixed
+	}
+
+	agentNames := append([]string{}, names...)
+	agentPaths := append([]string{}, paths...)
+	s := callAgentPlan(ctx, client, cfg, agent, task)
+	agentNames = append(agentNames, s.Names...)
+	agentPaths = append(agentPaths, s.Paths...)
+
+	result := scoreTask(task, agentNames, agentPaths)
+	result.FixedRecall = round3(fixed.Recall)
+	result.AgentRecall = round3(result.Recall)
+	return result
+}
+
+func callAgentPlan(ctx context.Context, client *http.Client, cfg Config, plan AgentPlan, task Task) Surfaced {
+	var out Surfaced
+	for _, tool := range plan.Tools {
+		switch tool {
+		case "query_question":
+			if task.Question != "" {
+				s := callQuery(ctx, client, cfg, map[string]interface{}{"query": task.Question})
+				out.Names = append(out.Names, s.Names...)
+				out.Paths = append(out.Paths, s.Paths...)
+			}
+		case "query_input":
+			if q, ok := task.Input["query"].(string); ok && q != "" && q != task.Question {
+				s := callQuery(ctx, client, cfg, map[string]interface{}{"query": q})
+				out.Names = append(out.Names, s.Names...)
+				out.Paths = append(out.Paths, s.Paths...)
+			}
+		case "symbols_identifiers":
+			for _, q := range identifierQueries(task, plan.MaxSymbolQueries) {
+				s := callSymbols(ctx, client, cfg, map[string]interface{}{"query": q})
+				out.Names = append(out.Names, s.Names...)
+				out.Paths = append(out.Paths, s.Paths...)
+			}
+		}
+	}
+	return out
+}
+
+func identifierQueries(task Task, max int) []string {
+	if max <= 0 {
+		max = 8
+	}
+	text := task.Question
+	for _, v := range task.Input {
+		if s, ok := v.(string); ok {
+			text += " " + s
+		}
+	}
+	seen := make(map[string]bool)
+	queries := make([]string, 0, max)
+	for _, raw := range strings.FieldsFunc(text, isIdentifierSeparator) {
+		term := strings.Trim(raw, "_#:/.-")
+		if !looksLikeCodeIdentifier(term) || seen[term] {
+			continue
+		}
+		seen[term] = true
+		queries = append(queries, term)
+		if len(queries) >= max {
+			break
+		}
+	}
+	return queries
+}
+
+func isIdentifierSeparator(r rune) bool {
+	return !(r == '_' || r == '#' || r == ':' || r == '/' || r == '-' || r == '.' || r >= '0' && r <= '9' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z')
+}
+
+func looksLikeCodeIdentifier(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	if strings.ContainsAny(s, "_#:/") {
+		return true
+	}
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			return true
+		}
+	}
+	return false
+}
+
+// scoreTask computes recall for a single task given the surfaced name and path sets.
+func scoreTask(task Task, names, paths []string) TaskResult {
+	total := len(task.ExpectSymbols) + len(task.ExpectFiles)
+	result := TaskResult{
+		ID:       task.ID,
+		Category: task.Category,
+	}
+	if total == 0 {
+		result.Recall = 1.0
+		return result
+	}
+
+	for _, expected := range task.ExpectSymbols {
+		lower := strings.ToLower(expected)
+		if matchesAny(lower, names) {
+			result.Matched = append(result.Matched, expected)
+		} else {
+			result.Missed = append(result.Missed, expected)
+		}
+	}
+	for _, expected := range task.ExpectFiles {
+		lower := strings.ToLower(expected)
+		if matchesAny(lower, paths) {
+			result.Matched = append(result.Matched, expected)
+		} else {
+			result.Missed = append(result.Missed, expected)
+		}
+	}
+
+	result.Recall = float64(len(result.Matched)) / float64(total)
+	return result
+}
+
+// matchesAny returns true if needle is a case-insensitive substring of any candidate.
+func matchesAny(needle string, candidates []string) bool {
+	for _, c := range candidates {
+		if strings.Contains(strings.ToLower(c), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Aggregation ---
+
+// Aggregate computes overall and per-category recall means from task results.
+func Aggregate(results []TaskResult) BenchResults {
+	byCategory := make(map[string][]float64)
+	var allRecall []float64
+
+	for _, r := range results {
+		byCategory[r.Category] = append(byCategory[r.Category], r.Recall)
+		allRecall = append(allRecall, r.Recall)
+	}
+
+	catMeans := make(map[string]float64, len(byCategory))
+	for cat, vals := range byCategory {
+		catMeans[cat] = mean(vals)
+	}
+
+	return BenchResults{
+		Version:    "1",
+		Overall:    round3(mean(allRecall)),
+		ByCategory: roundMap(catMeans),
+		Tasks:      results,
+	}
+}
+
+func mean(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range vals {
+		sum += v
+	}
+	return sum / float64(len(vals))
+}
+
+func round3(v float64) float64 {
+	return math.Round(v*1000) / 1000
+}
+
+func roundMap(m map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(m))
+	for k, v := range m {
+		out[k] = round3(v)
+	}
+	return out
+}
+
+// CheckReachable returns nil if the server responds to a GET /health request.
+func CheckReachable(serverURL string) error {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(serverURL + "/health")
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/docs/evidence/493-typescript-capability-score.md
+++ b/docs/evidence/493-typescript-capability-score.md
@@ -1,0 +1,51 @@
+# Issue 493 — TypeScript Capability Score Evidence
+
+Benchmark profile: `benchmarks/typescript/capability/`
+
+Runtime workspace identity was provided through `NANO_BRAIN_WORKSPACE` and is intentionally omitted from this evidence file.
+
+## Frozen baseline score
+
+| Metric | Score |
+|---|---:|
+| Overall | 0.850 |
+| multi-tool | 1.000 |
+| search-qa | 0.760 |
+| symbol-lookup | 1.000 |
+
+## Latest validation run
+
+| Metric | Score |
+|---|---:|
+| Overall | 0.885 |
+| multi-tool | 1.000 |
+| search-qa | 0.817 |
+| symbol-lookup | 1.000 |
+
+## Task summary
+
+| Task | Fixed | Agent | Final |
+|---|---:|---:|---:|
+| `ts-cs2-pricing` | 1.000 | 1.000 | 1.000 |
+| `ts-inventory-read` | 0.833 | 1.000 | 1.000 |
+| `ts-trade-status` | 0.714 | 0.714 | 0.714 |
+| `ts-item-models` | 0.750 | 0.750 | 0.750 |
+| `ts-steam-id` | 1.000 | 1.000 | 1.000 |
+| `ts-trading-workflow` | 0.333 | 0.333 | 0.333 |
+| `ts-price-to-inventory-multi-tool` | 0.333 | 1.000 | 1.000 |
+| `ts-trade-state-multi-tool` | 0.800 | 1.000 | 1.000 |
+
+## Validation
+
+```text
+go test -c -tags=capbench ./benchmarks/typescript/capability
+PASS
+
+go test -v -tags=capbench -run TestCapabilityBenchmark ./benchmarks/typescript/capability
+PASS — baseline 0.850, latest 0.885
+
+go test -race -short ./...
+PASS
+```
+
+Privacy check: no real workspace names, workspace hashes, or private absolute paths are committed in `benchmarks/typescript/capability/`.


### PR DESCRIPTION
## Summary

Add a TypeScript/JavaScript benchmark profile under `benchmarks/typescript/capability/` that tests CS2 item-trading domain concepts: pricing models, inventory reads, trade offer status/recheck flows, item/product models, SteamID conversion, and trading workflow documentation.

The benchmark uses the same agent-oriented pattern as the Rails profile (PR #492): fixed tool recall plus deterministic agent-style retrieval via `query_question`, `query_input`, and `symbols_identifiers`. Each task has `expect_symbols` and `expect_files` for recall scoring.

## Dataset

8 tasks covering the project domain:

| Task | Category | What it tests |
|------|----------|---------------|
| `ts-cs2-pricing` | search-qa | CS2 item pricing model and pricing manager logic |
| `ts-inventory-read` | symbol-lookup | Inventory code that reads CS2 assets and user inventory |
| `ts-trade-status` | search-qa | Trade offer status handling and recheck/revert logic |
| `ts-item-models` | search-qa | TypeScript models/interfaces for tradable item/product data |
| `ts-steam-id` | search-qa | SteamID and app context helpers for trade item matching |
| `ts-trading-workflow` | search-qa | CS2 trading workflow documentation and item schema/repository code |
| `ts-price-to-inventory-multi-tool` | multi-tool | Connect pricing data models with inventory asset retrieval |
| `ts-trade-state-multi-tool` | multi-tool | Connect trade state constants with trade recheck handlers |

## Results

- **baseline frozen:** 0.850
- **latest observed:** 0.885
- **multi-tool:** 1.000
- **search-qa:** 0.817
- **symbol-lookup:** 1.000

## Privacy

- Dataset uses placeholder workspace `typescript-app`
- Runtime workspace hash provided via `NANO_BRAIN_WORKSPACE` env var
- No real workspace names, hashes, or paths committed
- `.gitignore` covers `results_current.json`

## Files

- `benchmarks/typescript/capability/runner.go` — benchmark runner with agent-oriented fixed+agent recall
- `benchmarks/typescript/capability/capability_test.go` — capbench test with scorecard output
- `benchmarks/typescript/capability/dataset.json` — 8 CS2 trading domain tasks
- `benchmarks/typescript/capability/README.md` — documentation
- `benchmarks/typescript/capability/.gitignore` — ignores runtime outputs
- `benchmarks/typescript/capability/baseline_v1.json` — frozen baseline scores
- `docs/evidence/493-typescript-capability-score.md` — score evidence

## Validation

- [x] `go test -c -tags=capbench ./benchmarks/typescript/capability` PASS
- [x] Runtime capbench PASS (overall 0.885)
- [x] `go test -race -short ./...` PASS
- [x] Privacy grep clean (no real workspace names/hashes/paths)
- [x] 5-reviewer parallel review: all PASS

Closes #493