### PR TITLE
fix(watcher): register recursive fsnotify watches for subdirectories

### DIFF
--- a/docs/evidence/review-497.md
+++ b/docs/evidence/review-497.md
@@ -1,0 +1,21 @@
+# Review Gate — Issue #497 (recursive fsnotify watches)
+
+Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (independent pass, separate from authoring context)
+Commit reviewed: `ecc78c1`
+
+## Per-criterion verdicts
+| Criterion | Verdict | Evidence |
+|---|---|---|
+| Correctness (recursive watch + event routing) | PASS | watchDir adds per-dir watch in scanCollection walk; handleFSEvent prefix-matches owning collection root |
+| Concurrency / data races | PASS | watchDir locks w.mu; scanCollection never invoked under w.mu (processDirty/processAll unlock first); fsw/watchedDirs only touched under w.mu |
+| fd exhaustion | PASS | excluded dirs SkipDir'd before watchDir; Add failure logs + degrades to poll |
+| New-subdir gap | PASS | created dir watched on next scan; same WalkDir pass indexes its files — no gap |
+| Regression test validity | PASS | TestSubdirEdit_IndexedWithoutRootActivity exercises real fsnotify + Run loop, asserts indexing with no root activity |
+
+## Findings
+No critical or major issues.
+
+## Recommendation
+Approve for merge.

--- a/docs/evidence/self-review-497.md
+++ b/docs/evidence/self-review-497.md
@@ -1,0 +1,48 @@
+# Self-Review: Issue #497 — recursive fsnotify watches for subdirectories
+
+Change type: **bug-fix** · Lane: code · Scope: `internal/watcher`
+
+## Actions Taken
+- Diagnosed (code + live DB + a live probe test) that the file watcher registered
+  an fsnotify watch only on each collection **root**. fsnotify is non-recursive,
+  so edits in subdirectories fired no event and were indexed only via the
+  periodic poll (gated on `hasNewEvents`) or a restart.
+- Added `watchedDirs` bookkeeping + a `watchDir` helper that idempotently adds a
+  watch per directory during the existing `scanCollection` walk (excluded dirs
+  are `SkipDir`'d before `watchDir`, so the fd cost tracks source dirs only).
+- Routed fsnotify events to the owning collection root by path-prefix in
+  `handleFSEvent` (was: exact `collections[parentDir]`), so the ~2s debounce path
+  picks up subdir edits.
+- Cleaned up watches on dir removal/rename and in `Unwatch` (prefix sweep);
+  reset `watchedDirs` when the fsnotify watcher is recreated in `Run`.
+
+## Files Changed
+- `internal/watcher/watcher.go` — `watchedDirs` field, `watchDir` helper,
+  recursive add in `scanCollection`, prefix event routing in `handleFSEvent`,
+  watch cleanup in `Unwatch`/`Run`/`Watch`.
+- `internal/watcher/watcher_test.go` — `TestScanCollection_WatchesSubdirectories`
+  (unit) and `TestSubdirEdit_IndexedWithoutRootActivity` (E2E regression).
+
+## Findings Summary
+- Concurrency: `watchDir` takes `w.mu`; verified `scanCollection` is never called
+  while `w.mu` is held (`processDirty`/`processAll` unlock before calling). No
+  deadlock. `fsw` and `watchedDirs` are read/written only under `w.mu`.
+- New-subdir gap: a directory created at runtime is walked + watched on the next
+  scan; files created before the watch registers are still indexed by that same
+  `WalkDir` pass. No gap.
+- fd exhaustion: only a logged degrade-to-poll; excluded dirs never reach `watchDir`.
+
+## Resolution Status
+- All findings: **RESOLVED**. No open critical/major issues.
+- Independent review (oh-my-claudecode:code-reviewer): **Review Verdict: PASS** (see `review-497.md`).
+
+## Validation
+- `CGO_ENABLED=0 go build ./...` — PASS
+- `go test -race -short ./...` — PASS (all packages)
+- `go test -race -tags=integration ./internal/watcher/` — PASS (incl. new regression test)
+- Live probe (real running server): subdir file not indexed for 18s with no root
+  activity (old behavior reproduced); after fix's regression test, subdir edit is
+  indexed off its own event with no root activity.
+- Pre-existing/unrelated: `internal/graph` and `internal/bench` integration tests
+  fail identically on clean `origin/master` (verified via worktree) — environmental
+  (workspace registration / seeded benchmark corpus), not caused by this change.

--- a/docs/evidence/self-review-497.md
+++ b/docs/evidence/self-review-497.md
@@ -35,6 +35,11 @@ Change type: **bug-fix** · Lane: code · Scope: `internal/watcher`
 ## Resolution Status
 - All findings: **RESOLVED**. No open critical/major issues.
 - Independent review (oh-my-claudecode:code-reviewer): **Review Verdict: PASS** (see `review-497.md`).
+- PR review (gemini-code-assist) on #498 found a real follow-up bug: `handleFSEvent`
+  deleted only the exact `watchedDirs` entry on dir remove/rename, stranding nested
+  entries so a recreated subtree would be skipped by `watchDir`. **RESOLVED** —
+  extracted `unwatchTreeLocked` (prefix sweep) now used by both `handleFSEvent` and
+  `Unwatch`; covered by `TestUnwatchTree_ClearsNestedAndAllowsRewatch`.
 
 ## Validation
 - `CGO_ENABLED=0 go build ./...` — PASS

--- a/docs/evidence/smoke-e2e-497.md
+++ b/docs/evidence/smoke-e2e-497.md
@@ -1,0 +1,18 @@
+# smoke:e2e — Issue #497 (recursive fsnotify watches)
+
+Status: **N/A — no REST API endpoint added or changed** (R19 applies to endpoint changes).
+
+This bug-fix is internal to `internal/watcher`; it adds no route and changes no
+request/response contract. The equivalent end-to-end verification was done at the
+watcher layer instead:
+
+- `go test -race -tags=integration ./internal/watcher/` — PASS, including
+  `TestSubdirEdit_IndexedWithoutRootActivity`, which boots the real `Run` loop
+  with a real `fsnotify.Watcher`, writes a file in a nested subdirectory with no
+  root-level activity, and asserts it is indexed (upsert) off its own event.
+- Live reproduction against the running server confirmed the pre-fix behavior
+  (subdir file not indexed for 18s without root activity) and that a root-level
+  event triggers a full walk that catches the subdir change.
+
+No REST endpoints to exercise via curl; FAIL conditions in the smoke:e2e gate
+(status codes, response JSON) are not applicable.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -84,6 +84,10 @@ type Watcher struct {
 	mu          sync.Mutex
 	collections map[string]watchedCollection
 	dirty       map[string]bool
+	// watchedDirs tracks every directory currently registered with fsnotify.
+	// fsnotify is non-recursive, so each subdirectory must be added individually
+	// for edits inside it to fire events (issue #497). Guarded by mu.
+	watchedDirs map[string]bool
 	// hotRegisterCh signals Run() that a workspace was registered at runtime so
 	// the dirty map should be processed without waiting for fsnotify events.
 	// Buffered=1 so WatchWithFilter never blocks. See issue #308.
@@ -128,6 +132,7 @@ func New(db *sql.DB, queries WatcherQuerier, logger zerolog.Logger, cfg config.C
 		chunkOverlap:  cfg.Watcher.ChunkOverlap,
 		collections:   make(map[string]watchedCollection),
 		dirty:         make(map[string]bool),
+		watchedDirs:   make(map[string]bool),
 		hotRegisterCh: make(chan struct{}, 1),
 		fileCache:     make(map[string]fileState),
 	}
@@ -222,6 +227,7 @@ func (w *Watcher) WatchWithFilter(collectionName, dirPath, workspaceHash, globPa
 		if err := w.fsw.Add(absPath); err != nil {
 			return fmt.Errorf("watch dir %s: %w", absPath, err)
 		}
+		w.watchedDirs[absPath] = true
 		// Mark dirty + nudge Run() so processDirty runs an immediate scan.
 		// Without this, fsnotify only fires on FUTURE changes — existing files in a
 		// freshly-registered workspace never get queued for embedding until server
@@ -248,8 +254,15 @@ func (w *Watcher) Unwatch(dirPath string) error {
 	delete(w.collections, absPath)
 	delete(w.dirty, absPath)
 
-	if w.fsw != nil {
-		_ = w.fsw.Remove(absPath)
+	// Remove the root watch plus every recursive subdirectory watch under it.
+	prefix := absPath + string(os.PathSeparator)
+	for dir := range w.watchedDirs {
+		if dir == absPath || strings.HasPrefix(dir, prefix) {
+			if w.fsw != nil {
+				_ = w.fsw.Remove(dir)
+			}
+			delete(w.watchedDirs, dir)
+		}
 	}
 	return nil
 }
@@ -292,6 +305,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 	w.mu.Lock()
 	w.fsw = fsw
+	// fsw is brand new here; drop any stale watch bookkeeping from a prior run.
+	// Subdirectory watches are re-added by the initial scanCollection walk.
+	w.watchedDirs = make(map[string]bool)
 	for absPath, col := range w.collections {
 		if _, err := os.Stat(absPath); err != nil {
 			w.logger.Info().Str("dir", absPath).Str("collection", col.name).Msg("collection path not found, skipping watch")
@@ -301,6 +317,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 			w.logger.Warn().Err(err).Str("dir", absPath).Msg("failed to add watch")
 			continue
 		}
+		w.watchedDirs[absPath] = true
 		w.logger.Info().Str("dir", absPath).Str("collection", col.name).Msg("watching directory")
 	}
 	w.mu.Unlock()
@@ -369,11 +386,15 @@ func (w *Watcher) handleFSEvent(event fsnotify.Event, debounce *time.Timer) {
 
 	w.hasNewEvents.Store(true)
 
-	dir := filepath.Dir(event.Name)
-
+	// Mark the owning collection (by path prefix) dirty, not just the exact
+	// parent dir. With recursive watches an event can come from any depth, so
+	// matching only collections[parentDir] would miss every subdirectory edit
+	// (issue #497). The dirty collection is re-walked on the next debounce tick.
 	w.mu.Lock()
-	if _, ok := w.collections[dir]; ok {
-		w.dirty[dir] = true
+	for root, col := range w.collections {
+		if event.Name == root || strings.HasPrefix(event.Name, col.dirPath+string(os.PathSeparator)) {
+			w.dirty[root] = true
+		}
 	}
 	w.mu.Unlock()
 
@@ -381,6 +402,9 @@ func (w *Watcher) handleFSEvent(event fsnotify.Event, debounce *time.Timer) {
 		w.fileCacheMu.Lock()
 		delete(w.fileCache, event.Name)
 		w.fileCacheMu.Unlock()
+		w.mu.Lock()
+		delete(w.watchedDirs, event.Name)
+		w.mu.Unlock()
 		w.cleanupDeletedDocument(event.Name)
 	}
 
@@ -424,6 +448,29 @@ func (w *Watcher) processAll(ctx context.Context) {
 	for _, col := range cols {
 		w.scanCollection(ctx, col)
 	}
+}
+
+// watchDir registers an fsnotify watch on dir unless it is already watched.
+// Idempotent and safe to call on every scan, which is how newly-created
+// subdirectories get picked up. fsnotify is non-recursive, so each directory
+// in the tree must be added individually (issue #497).
+//
+// ponytail: a watch costs one fd; excluded dirs (node_modules, .git, vendor…)
+// are SkipDir'd before this is ever called, so the fd count tracks source
+// dirs only. If Add fails (e.g. fd limit), we log and fall back to the
+// periodic poll for that subtree rather than aborting the scan.
+func (w *Watcher) watchDir(dir string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.fsw == nil || w.watchedDirs[dir] {
+		return
+	}
+	if err := w.fsw.Add(dir); err != nil {
+		w.logger.Warn().Err(err).Str("dir", dir).
+			Msg("failed to add recursive watch; edits here rely on periodic reindex")
+		return
+	}
+	w.watchedDirs[dir] = true
 }
 
 func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
@@ -474,7 +521,9 @@ func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
 			return nil
 		}
 
-		if !d.IsDir() {
+		if d.IsDir() {
+			w.watchDir(path)
+		} else {
 			w.processFile(ctx, col, path)
 		}
 		return nil

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -255,15 +255,7 @@ func (w *Watcher) Unwatch(dirPath string) error {
 	delete(w.dirty, absPath)
 
 	// Remove the root watch plus every recursive subdirectory watch under it.
-	prefix := absPath + string(os.PathSeparator)
-	for dir := range w.watchedDirs {
-		if dir == absPath || strings.HasPrefix(dir, prefix) {
-			if w.fsw != nil {
-				_ = w.fsw.Remove(dir)
-			}
-			delete(w.watchedDirs, dir)
-		}
-	}
+	w.unwatchTreeLocked(absPath)
 	return nil
 }
 
@@ -403,7 +395,7 @@ func (w *Watcher) handleFSEvent(event fsnotify.Event, debounce *time.Timer) {
 		delete(w.fileCache, event.Name)
 		w.fileCacheMu.Unlock()
 		w.mu.Lock()
-		delete(w.watchedDirs, event.Name)
+		w.unwatchTreeLocked(event.Name)
 		w.mu.Unlock()
 		w.cleanupDeletedDocument(event.Name)
 	}
@@ -471,6 +463,23 @@ func (w *Watcher) watchDir(dir string) {
 		return
 	}
 	w.watchedDirs[dir] = true
+}
+
+// unwatchTreeLocked removes the fsnotify watch for path and every watched
+// subdirectory beneath it, clearing them from watchedDirs. Deleting only the
+// exact path would strand nested entries, so a later recreate of a subtree
+// would be skipped by watchDir and never re-watched (#497 review). Caller must
+// hold w.mu.
+func (w *Watcher) unwatchTreeLocked(path string) {
+	prefix := path + string(os.PathSeparator)
+	for dir := range w.watchedDirs {
+		if dir == path || strings.HasPrefix(dir, prefix) {
+			if w.fsw != nil {
+				_ = w.fsw.Remove(dir)
+			}
+			delete(w.watchedDirs, dir)
+		}
+	}
 }
 
 func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -822,3 +822,54 @@ func TestSubdirEdit_IndexedWithoutRootActivity(t *testing.T) {
 		t.Fatalf("expected subdir edit to be indexed (upsert calls > %d), got %d", baseline, got)
 	}
 }
+
+// TestUnwatchTree_ClearsNestedAndAllowsRewatch covers the #497 review finding:
+// removing a directory must clear its nested watch entries (not just the exact
+// path), otherwise watchDir would skip re-watching a recreated subtree.
+func TestUnwatchTree_ClearsNestedAndAllowsRewatch(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(a, "b")
+	if err := os.MkdirAll(b, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 2000, 300)
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fsw.Close()
+	w.fsw = fsw
+
+	col := watchedCollection{name: "c", dirPath: root, workspaceHash: "ws", globPattern: "*.md"}
+	w.scanCollection(context.Background(), col)
+
+	w.mu.Lock()
+	for _, p := range []string{root, a, b} {
+		if !w.watchedDirs[p] {
+			w.mu.Unlock()
+			t.Fatalf("precondition: %s should be watched (watchedDirs=%v)", p, w.watchedDirs)
+		}
+	}
+	// Remove the subtree rooted at a/.
+	w.unwatchTreeLocked(a)
+	if w.watchedDirs[a] || w.watchedDirs[b] {
+		w.mu.Unlock()
+		t.Fatalf("nested watch entries not cleared on remove: %v", w.watchedDirs)
+	}
+	if !w.watchedDirs[root] {
+		w.mu.Unlock()
+		t.Fatal("root watch should survive removal of a nested subtree")
+	}
+	w.mu.Unlock()
+
+	// A recreated subdirectory must be watchable again (no stale entry blocking it).
+	w.watchDir(b)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.watchedDirs[b] {
+		t.Fatal("recreated subdirectory was not re-watched (stale watchedDirs entry)")
+	}
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -741,3 +741,84 @@ func TestCleanupDeletedDocument_NoOpWhenNoMatchingCollection(t *testing.T) {
 		t.Errorf("expected 0 GetDocumentBySourcePath calls, got %d", mq.getDocBySourcePathCalls.Load())
 	}
 }
+
+// TestScanCollection_WatchesSubdirectories verifies that scanning a collection
+// registers an fsnotify watch on every (non-skipped) directory in the tree, not
+// just the root. fsnotify is non-recursive, so without per-dir watches edits in
+// subdirectories never fire events (issue #497).
+func TestScanCollection_WatchesSubdirectories(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "internal", "embed")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "x.md"), []byte("# x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 2000, 300)
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fsw.Close()
+	w.fsw = fsw
+
+	col := watchedCollection{name: "c", dirPath: root, workspaceHash: "ws", globPattern: "*.md"}
+	w.scanCollection(context.Background(), col)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, want := range []string{root, filepath.Join(root, "internal"), sub} {
+		if !w.watchedDirs[want] {
+			t.Errorf("expected dir to be watched: %s (watchedDirs=%v)", want, w.watchedDirs)
+		}
+	}
+}
+
+// TestSubdirEdit_IndexedWithoutRootActivity is the end-to-end regression for
+// issue #497: a file created in a nested subdirectory must be indexed off its
+// own fsnotify event, with no activity at the workspace root.
+func TestSubdirEdit_IndexedWithoutRootActivity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing-sensitive test in short mode")
+	}
+
+	root := t.TempDir()
+	sub := filepath.Join(root, "nested", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 100, 3600)
+
+	if err := w.Watch("c", root, "ws", "*.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Let the initial scan run and register the recursive subdir watch.
+	time.Sleep(300 * time.Millisecond)
+	baseline := mq.upsertDocCalls.Load()
+
+	// Write a new file ONLY in the deep subdir — no root-level activity.
+	if err := os.WriteFile(filepath.Join(sub, "new.md"), []byte("# new\nbody text"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(400 * time.Millisecond) // > debounce (100ms)
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	if got := mq.upsertDocCalls.Load(); got <= baseline {
+		t.Fatalf("expected subdir edit to be indexed (upsert calls > %d), got %d", baseline, got)
+	}
+}


### PR DESCRIPTION
Closes #497

## Problem
The file watcher registered an fsnotify watch only on each collection **root**. fsnotify is non-recursive, so edits to files in subdirectories (`internal/`, `cmd/`, …) fired no event and were indexed only via the periodic poll (gated on `hasNewEvents`) or a server restart. With no root-level activity, a subdir-only edit could go un-indexed until restart/manual reindex.

## Fix
- `watchedDirs` bookkeeping + `watchDir` helper: idempotently add an fsnotify watch per directory during the existing `scanCollection` walk (excluded dirs are `SkipDir`'d before `watchDir`, so the fd cost tracks source dirs only; an `Add` failure logs and degrades to the periodic poll).
- `handleFSEvent` now marks the owning collection dirty by **path-prefix** (was: exact `collections[parentDir]`), so the ~2s debounce path picks up subdir edits.
- Watch cleanup on dir removal/rename and in `Unwatch` (prefix sweep); `watchedDirs` reset when the fsnotify watcher is recreated in `Run`.

## Verification
- `go build ./...` — PASS
- `go test -race -short ./...` — PASS (all packages)
- `go test -race -tags=integration ./internal/watcher/` — PASS
- New tests:
  - `TestScanCollection_WatchesSubdirectories` (unit) — asserts every subdir is watched
  - `TestSubdirEdit_IndexedWithoutRootActivity` (E2E regression) — boots the real `Run` loop + a real `fsnotify.Watcher`, writes a file in a nested subdir with **no root activity**, and asserts it is indexed
- Independent review (code-reviewer): **Review Verdict: PASS**, no critical/major (see `docs/evidence/review-497.md`).

## Note on local harness pre-merge
Two local gates fail for reasons unrelated to this change:
- **integration `./...`** — `internal/graph` + `internal/bench` fail **identically on clean `origin/master`** (verified via worktree): environmental (workspace registration / seeded benchmark corpus). `internal/watcher` integration passes.
- **smoke:e2e** — this change adds/changes no REST endpoint (R19 N/A); verified via the watcher regression test instead (`docs/evidence/smoke-e2e-497.md`).