### PR TITLE
harness: enforce independent code review (R88) — author may not self-review

### DIFF
--- a/.claude/skills/harness-check/SKILL.md
+++ b/.claude/skills/harness-check/SKILL.md
@@ -16,14 +16,16 @@ description: |
   "pre-work check", "pre-merge check", "next-ready", "retro gate",
   "can I start next feature", "are gates green".
 
-compatibility: OpenCode with bash + git + go. Optional: gh CLI, openspec CLI, golangci-lint.
+compatibility: Claude Code with bash + git + go. Optional: gh CLI, openspec CLI, golangci-lint.
 ---
 
 # Harness Check
 
 Enforce the harness gate specification defined in `docs/HARNESS_GATES.md`.
 
-> **Tip:** For autonomous development, use the `/harness-on` slash command — it runs this script automatically and injects fix instructions. See `.opencode/plugin/harness-loop/README.md`.
+> **Note:** The autonomous gate loop (`/harness-on`, `.opencode/plugin/harness-loop/`)
+> is OpenCode-only. On Claude Code this skill runs the gates manually / on trigger;
+> you drive the fix-and-re-run loop yourself based on the script output below.
 
 ## Core Rules
 
@@ -100,7 +102,7 @@ When the retro gate triggers:
 
 ## Automatic Trigger Points
 
-The orchestrator (Sisyphus) MUST invoke this skill at these points:
+The orchestrator MUST invoke this skill at these points:
 
 | Trigger | Gate |
 |---------|------|

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -398,6 +398,19 @@ error/edge path (auth fail, rate limit, malformed input, etc.).
 After user-flow tests pass, a **fresh review agent** verifies the implementation.
 The reviewer **must not be** the implementing agent.
 
+> **R88 (hard rule): the code review pass MUST be performed by a separate,
+> spawned sub-agent. The agent that wrote the code MUST NOT review or approve
+> its own code in the same context.** Self-review (`## Self-Review` evidence) is
+> required but is NOT a substitute for the independent review gate. The review
+> evidence file MUST name an independent `Reviewer:` (e.g. a spawned
+> `code-reviewer`/Oracle sub-agent) that is distinct from the author — gate 3.5
+> fails if the `Reviewer:` is missing or names the author/self/implementer.
+> Rationale: an author's review inherits the author's blind spots; an
+> independent agent reviews cold and catches what the author's mental model
+> assumed away. Gate 3.5 verifies the verdict is *declared* by a named
+> independent reviewer (an honesty guardrail, not tamper-proof); the
+> identity-bound external check is the PR bot review at gate 3.6.
+
 **What the reviewer checks:**
 1. Read `git diff <default-branch>` + the proposal, design, and spec.
 2. For each acceptance criterion, find evidence (test output, screenshot,

--- a/docs/HARNESS_GATES.md
+++ b/docs/HARNESS_GATES.md
@@ -137,7 +137,7 @@ Run before creating or merging a PR. All checks must be green.
 | 3.2 | `go test -race -short ./...` pass | exit code 0 |
 | 3.3 | `go test -race -tags=integration ./...` pass | exit code 0 |
 | 3.4 | `golangci-lint run` clean (if available) | exit code 0 |
-| 3.5 | Review Gate pass (Oracle or review-work) | evidence in PR/issue |
+| 3.5 | Review Gate pass by an **independent** reviewer (R27 verdict + R88 reviewer ≠ author) | `docs/evidence/review-<story>.md` for THIS story: `Review Verdict: PASS` + a `Reviewer:` naming a separate spawned sub-agent (not self/author/implementer) |
 | 3.6 | PR review comments addressed — all critical/high Gemini comments fixed, medium acknowledged | `gh pr view --comments` — no unresolved critical/high comments |
 | 3.7 | CI workflow pass | `gh pr checks` all green |
 | 3.8 | PR linked to GitHub issue | PR body contains `Closes #N` |

--- a/docs/evidence/review-499.md
+++ b/docs/evidence/review-499.md
@@ -1,0 +1,23 @@
+# Review Gate — Issue #499 (enforce independent code review, R88)
+
+Review Verdict: PASS
+
+Reviewer: /code-review skill — independent finder + verify sub-agents (correctness, removed-behavior, conventions), separate from the authoring context
+Date: 2026-06-26
+
+## Per-criterion verdicts
+| Criterion | Verdict | Evidence |
+|---|---|---|
+| Gate enforces reviewer independence (R88) | PASS | gate 3.5 requires a `Reviewer:` not matching self/author/implementer |
+| Story-scoped review resolution | PASS | resolves `review-<sid>.md`/`review-<sid>-*.md`; stale cross-story review no longer satisfies the gate |
+| No prefix false-match | PASS | fixed sid-segment matching; verified sid `36` does not match `review-368.md` |
+| Behavior parity (SKIP/PASS/FAIL three-way) | PASS | removed-behavior audit confirmed parity; SKIP→FAIL on stale review is intentional |
+| `set -euo pipefail` safety | PASS | `story_review=""` init kept; guarded sid; grep-in-condition does not trip `set -e` |
+| Conventions (CLAUDE.md, R88 consistency) | PASS | conventions agent: clean; R88 consistent across docs + both skills |
+
+## Findings
+- CRITICAL (fixed): prefix glob `review-${sid}*.md` false-matched a different story's review. Resolved by whole-segment matching.
+- Minor (accepted, honesty-guardrail not adversarial control): reviewer-name regex word-boundary edge cases; detached-HEAD sid; first-`Reviewer:`-line only.
+
+## Recommendation
+Approve for merge.

--- a/docs/evidence/self-review-499.md
+++ b/docs/evidence/self-review-499.md
@@ -1,0 +1,38 @@
+# Self-Review: Issue #499 — enforce independent code review (R88)
+
+Change type: **infra/process** · Lane: docs+tooling · Scope: harness rule + gate
+
+## Actions Taken
+- Added rule **R88**: the code-review pass MUST be performed by a separate
+  spawned sub-agent; the implementing agent may NOT self-review/self-approve.
+- Made gate 3.5 enforce it: resolve the review file for THIS story
+  (`review-<sid>.md` / `review-<sid>-*.md`), require `Review Verdict: PASS`, and
+  require a `Reviewer:` that is not self/author/implementer. A stale cross-story
+  review no longer satisfies the gate; an unresolvable sid FAILs loudly.
+- Updated docs (`HARNESS.md`, `HARNESS_GATES.md`) and both skill copies
+  (`.claude` + `.opencode` `harness-check/SKILL.md`); installed the harness-check
+  skill for Claude Code.
+
+## Files Changed
+- `scripts/harness-check.sh` — gate 3.5 rewrite (story-scoped review + reviewer independence)
+- `docs/HARNESS.md` — R88 rule + rationale
+- `docs/HARNESS_GATES.md` — gate 3.5 row updated (R27 + R88)
+- `.claude/skills/harness-check/SKILL.md` (new), `.opencode/skills/harness-check/SKILL.md` — R88 in Core Rules + Rule IDs
+
+## Findings Summary
+- `/simplify` (4 agents): consolidated two `find` calls into one; kept the
+  `[[ -n rg_sid ]]` guard (load-bearing) and `story_review=""` init (required
+  under `set -u`).
+- `/code-review` (independent, 3 finder angles + conventions): found **1
+  critical** — prefix glob `review-${sid}*.md` false-matched (sid `49` →
+  `review-497.md`). Fixed by matching the sid as a whole segment
+  (`review-${sid}.md` / `review-${sid}-*.md`). Verified: sid `36` no longer
+  matches `review-368.md`. Minor findings (word-boundary edge cases, detached
+  HEAD, multiple `Reviewer:` lines) triaged as acceptable for an honesty
+  guardrail; conventions clean.
+- Known scope-limit: gates 3.10/3.12 use the same prefix-match style for their
+  evidence globs (pre-existing); not changed here.
+
+## Resolution Status
+- All findings: **RESOLVED** or consciously deferred (noted above). No open critical/major.
+- Independent review verdict recorded in `review-499.md` (Reviewer ≠ author).

--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -441,19 +441,42 @@ phase_pre_merge() {
         add_check "SKIP" "3.4 golangci-lint not installed"
     fi
     
-    # 3.5 Review Gate verdict (R27: must contain literal 'Review Verdict: PASS')
-    review_files=$(find docs/evidence -name "review-*.md" 2>/dev/null || true)
-    if [[ -z "$review_files" ]]; then
-        add_check "SKIP" "3.5 Review gate evidence not yet created"
-    else
-        latest_review=$(echo "$review_files" | head -1)
-        if grep -qE '^Review Verdict: PASS' "$latest_review"; then
-            add_check "PASS" "3.5 Review Verdict: PASS in $latest_review (R27)"
-        elif grep -qE '^Review Verdict: FAIL' "$latest_review"; then
-            add_check "FAIL" "3.5 Review Verdict: FAIL in $latest_review — fix before merge" "R27"
+    # 3.5 Review Gate verdict (R27: literal 'Review Verdict: PASS') +
+    #     reviewer independence (R88: review MUST be done by a separate agent —
+    #     the implementing agent may NOT self-review/self-approve its own code).
+    rg_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    rg_sid=$(echo "$rg_branch" | sed 's|^[^/]*/||' | sed 's/-.*//g' 2>/dev/null || echo "")
+    # Only the review file for THIS story counts — a stale cross-story review must
+    # not satisfy the gate. The [[ -n rg_sid ]] guard is load-bearing: an empty
+    # sid would turn the glob into review-*.md and match every review.
+    # Match the sid as a whole segment (followed by '.md' or '-slug'), never a
+    # prefix: sid '49' must NOT match review-497.md.
+    story_review=""
+    if [[ -n "$rg_sid" ]]; then
+        story_review=$(find docs/evidence -type f \( -name "review-${rg_sid}.md" -o -name "review-${rg_sid}-*.md" \) 2>/dev/null | head -1)
+    fi
+    if [[ -n "$story_review" ]]; then
+        # Note: this checks that an independent reviewer is *declared*; it is an
+        # honesty guardrail, not a tamper-proof control. Identity-bound external
+        # review is enforced separately by the PR bot review (gate 3.6).
+        if grep -qE '^Review Verdict: FAIL' "$story_review"; then
+            add_check "FAIL" "3.5 Review Verdict: FAIL in $story_review — fix before merge" "R27"
+        elif ! grep -qE '^Review Verdict: PASS' "$story_review"; then
+            add_check "FAIL" "3.5 $story_review missing 'Review Verdict: PASS|FAIL' line" "R27"
         else
-            add_check "FAIL" "3.5 $latest_review missing 'Review Verdict: PASS|FAIL' line" "R27"
+            reviewer=$(grep -iE '^Reviewer:' "$story_review" | head -1 | sed 's/^[Rr]eviewer:[[:space:]]*//')
+            if [[ -z "$reviewer" ]]; then
+                add_check "FAIL" "3.5 $story_review has no 'Reviewer:' line (R88: name the independent review agent)" "R88"
+            elif echo "$reviewer" | grep -qiE '\b(self|author|implementer)\b'; then
+                add_check "FAIL" "3.5 $story_review reviewer '$reviewer' is the author — review must be a separate agent (R88)" "R88"
+            else
+                add_check "PASS" "3.5 Review Verdict: PASS by independent reviewer '$reviewer' (R27, R88)"
+            fi
         fi
+    elif find docs/evidence -name "review-*.md" -type f 2>/dev/null | grep -q .; then
+        add_check "FAIL" "3.5 No review-${rg_sid}*.md for this story (R88: independent review required)" "R88"
+    else
+        add_check "SKIP" "3.5 Review gate evidence not yet created"
     fi
     
     # 3.6 Gemini comment triage (R31) + override check (R7)


### PR DESCRIPTION
Closes #499

## Why
On PR #498 the author's self-review + a reviewer scoped by the author's framing both missed a bug that an independent cold reviewer (gemini) caught. The Review Gate prose already said "Reviewer ≠ implementer" but it was **not a numbered rule and gate 3.5 did not enforce it** — the script greped any `review-*.md` (even a stale one from another story) for `Review Verdict: PASS` and never checked who reviewed.

## Change
- **R88 (new hard rule):** the code-review pass MUST be performed by a separate spawned sub-agent; the implementing agent MUST NOT review/approve its own code. Self-review is still required but does not satisfy the review gate.
- **Gate 3.5 now:** (1) resolves the review file for THIS story by **whole-segment** sid match (`review-<sid>.md` / `review-<sid>-*.md`) so a stale cross-story review can't satisfy it and sid `49` can't false-match `review-497.md`; (2) requires a `Reviewer:` line that is not self/author/implementer; (3) FAILs loudly when the sid is unresolvable instead of silently passing.
- Docs: `HARNESS.md` (R88 + rationale), `HARNESS_GATES.md` (gate 3.5 row). Skill: `.claude` + `.opencode` `harness-check/SKILL.md`. Installs the harness-check skill for Claude Code.

## Dogfooding
This PR was put through the new rule: `/simplify` (4 agents) + an **independent** `/code-review` (separate finder + verify sub-agents) which caught a CRITICAL prefix-glob false-match (since fixed). Evidence: `docs/evidence/self-review-499.md` and `docs/evidence/review-499.md` (Reviewer ≠ author).

## Note
Gate 3.5 verifies an independent reviewer is *declared* (honesty guardrail, not tamper-proof); the identity-bound external check remains the PR bot review at gate 3.6. Gates 3.10/3.12 use the same prefix-match style for their evidence globs (pre-existing) — not changed here.