### PR TITLE
feat(mcp): add memory_workspaces_list tool

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,87 @@
+# PROJECT.md — nano-brain
+
+## What This Is
+
+nano-brain is an **agent-oriented memory and code intelligence daemon** for AI coding agents. It provides persistent context, impact analysis, and call-chain tracing via MCP (Model Context Protocol).
+
+**Core thesis:** Agents don't read docs — they call tools. Every capability is exposed as an MCP tool or REST endpoint.
+
+## What This Does
+
+- **Session memory** — Harvest, index, and retrieve context across coding sessions
+- **Code intelligence** — Symbol graph, call chains, impact analysis, flow diagrams
+- **Hybrid search** — BM25 + vector + RRF fusion for high-recall retrieval
+- **Multi-runtime** — Works with OpenCode, Claude Code, Cursor, any MCP client
+
+## Core Value
+
+The ONE thing that must work: **Impact analysis** — "What breaks if I change this?" must return accurate, sub-50ms results for any file in the workspace.
+
+## Constraints
+
+- **Performance** — Sub-50ms latency for code intelligence tools (agents skip slow tools)
+- **Self-hosted** — No cloud dependency, user data stays local
+- **Single binary** — `CGO_ENABLED=0` static build, npm wrapper for distribution
+- **Backward compatible** — No breaking changes to existing MCP tools
+
+## Requirements
+
+### Validated
+
+- ✓ Hybrid search (BM25 + vector + RRF) — existing
+- ✓ Session harvesting (OpenCode, Claude Code) — existing
+- ✓ Go/Ruby/JS/TS code intelligence — existing
+- ✓ MCP protocol support (16 tools) — existing
+- ✓ REST API endpoints — existing
+- ✓ PostgreSQL + pgvector storage — existing
+- ✓ Embedding queue + providers — existing
+- ✓ File system watcher — existing
+
+### Active
+
+- [ ] Vue SFC code intelligence support (proposal ready, OpenSpec created)
+- [ ] Fix import edge target resolution (issue #501, high-risk bug-fix)
+- [ ] Ruby graph/flowchart/impact improvements (issue #486)
+- [ ] Auto-generate HyDE context hints (issue #481)
+- [ ] LLM quality benchmark framework (issue #458)
+- [ ] OpenAI-compatible embedding provider (issue #412)
+
+### Out of Scope
+
+- Multi-tenant SaaS deployment — self-hosted only
+- Real-time collaboration — single-agent focus
+- Browser-based IDE integration — CLI/MCP only
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| MCP over REST for agents | Agents call tools, not HTTP endpoints | — Active |
+| PostgreSQL + pgvector | Mature, reliable, pgvector for semantic search | — Active |
+| Tree-sitter for code parsing | Fast, accurate, multi-language support | — Active |
+| Constructor injection (no DI) | Simplicity, explicit dependencies | — Active |
+| Single binary deployment | Easy installation via npm/npx | — Active |
+
+## Architecture
+
+See `.planning/codebase/ARCHITECTURE.md` for detailed architecture documentation.
+
+**Key patterns:**
+- Service daemon with errgroup goroutine orchestration
+- Registry pattern for pluggable language extractors
+- Event bus for async pub/sub (watcher, embed queue, flow materializer)
+- Pipeline architecture: file → chunk → embed → search
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition:**
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+---
+*Last updated: 2026-06-28 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,80 @@
+# REQUIREMENTS.md — nano-brain
+
+## v1 Requirements (Active)
+
+### Code Intelligence
+
+- [ ] **REQ-CI-01**: Vue SFC code intelligence support — parse .vue files, extract script-level edges, detect component composition via AST
+- [ ] **REQ-CI-02**: Fix import edge target resolution — resolve unresolved specifiers in import edges to improve memory_impact accuracy
+- [ ] **REQ-CI-03**: Ruby graph/flowchart/impact improvements — fix Ruby AST parsing gaps for graph, flowchart, impact, deep flow
+- [ ] **REQ-CI-04**: Auto-generate HyDE context hints from project files — improve search quality with project-specific context
+
+### Search Quality
+
+- [ ] **REQ-SQ-01**: Improve search quality — reduce false positives, improve ranking for domain-specific queries
+- [ ] **REQ-SQ-02**: Debugging search mode — detect debugging intent and adjust search behavior
+
+### Benchmarks
+
+- [ ] **REQ-BENCH-01**: LLM quality benchmark framework — measure LLM-generated summary quality across workspaces
+- [ ] **REQ-BENCH-02**: Ruby benchmark comparison — compare Ruby code intelligence quality against Go/TypeScript
+
+### Infrastructure
+
+- [ ] **REQ-INFRA-01**: OpenAI-compatible embedding provider — support OpenAI API for embeddings
+- [ ] **REQ-INFRA-02**: Dashboard split — separate web dashboard into independent module
+
+### Ruby/Rails
+
+- [ ] **REQ-RUBY-01**: Ruby extractor unresolved calls — fix unresolved call edges in Ruby code intelligence
+- [ ] **REQ-RUBY-02**: Ruby class index fix — improve class indexing accuracy
+- [ ] **REQ-RUBY-03**: Rails cross-file calls — support cross-file method calls in Rails
+- [ ] **REQ-RUBY-04**: Rails DSL extraction — extract Rails-specific DSL patterns (resources, callbacks, etc.)
+
+### Flow Visualization
+
+- [ ] **REQ-FLOW-01**: Execution flow phase 3 — complete execution flow visualization pipeline
+- [ ] **REQ-FLOW-02**: Sequence diagram internal logic — add internal logic to sequence diagrams
+
+### Documentation
+
+- [ ] **REQ-DOC-01**: MCP agent tool guide — document MCP tools for agent developers
+- [ ] **REQ-DOC-02**: Clean sequence internal labels — improve sequence diagram labeling
+
+## v2 Requirements (Deferred)
+
+- [ ] CFG extraction for .vue files
+- [ ] Template-level intelligence (v-if/v-for as CFG nodes)
+- [ ] Props/emits tracking
+- [ ] Composable usage patterns (useXxx)
+- [ ] Store dependency tracking (Pinia/Vuex)
+- [ ] Unified JSX+Vue component detection
+
+## Out of Scope
+
+- Multi-tenant SaaS deployment — self-hosted only
+- Real-time collaboration — single-agent focus
+- Browser-based IDE integration — CLI/MCP only
+
+## Traceability
+
+| Requirement | OpenSpec Change | Harness Story | Status |
+|-------------|-----------------|---------------|--------|
+| REQ-CI-01 | vue-sfc-code-intelligence | — | Active |
+| REQ-CI-02 | fix-import-target-resolution | — | Active |
+| REQ-CI-03 | (issue #486) | — | Pending |
+| REQ-CI-04 | (issue #481) | — | Pending |
+| REQ-SQ-01 | improve-search-quality | — | In-progress |
+| REQ-SQ-02 | debugging-search-mode | — | Pending |
+| REQ-BENCH-01 | benchmark-weaknesses | — | Pending |
+| REQ-BENCH-02 | ruby-benchmark-comparison | — | Pending |
+| REQ-INFRA-01 | (issue #412) | — | Pending |
+| REQ-INFRA-02 | dashboard-split | — | In-progress |
+| REQ-RUBY-01 | ruby-extractor-unresolved-calls | — | Pending |
+| REQ-RUBY-02 | ruby-class-index-fix | — | Pending |
+| REQ-RUBY-03 | rails-cross-file-calls | — | Pending |
+| REQ-RUBY-04 | rails-dsl-extraction | — | Pending |
+| REQ-FLOW-01 | execution-flow-phase3 | — | Pending |
+| REQ-FLOW-02 | sequence-diagram-internal-logic | — | Pending |
+| REQ-DOC-01 | add-mcp-agent-tool-guide | — | Complete |
+| REQ-DOC-02 | clean-sequence-internal-labels | — | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,154 @@
+# ROADMAP.md — nano-brain
+
+## Phase 1: Vue SFC Support (High Priority)
+
+**Goal**: Add Vue Single File Component code intelligence — parse .vue files, extract edges, detect component composition.
+
+**Requirements**: REQ-CI-01
+
+**Success Criteria**:
+- Parse .vue files with script/template/style blocks
+- Extract contains, imports, calls edges from script content
+- Detect component usage via AST tag_name nodes (PascalCase filter)
+- P@5 ≥ 0.75 baseline maintained (no regression)
+
+**Estimated effort**: 3-5 days
+
+---
+
+## Phase 2: Import Edge Fix (High Priority)
+
+**Goal**: Fix import edge target resolution to improve memory_impact accuracy.
+
+**Requirements**: REQ-CI-02
+
+**Success Criteria**:
+- Import edges resolve unresolved specifiers
+- memory_impact returns accurate results for import chains
+- No false negatives in impact analysis
+
+**Estimated effort**: 2-3 days
+
+---
+
+## Phase 3: Search Quality Improvements (Medium Priority)
+
+**Goal**: Improve search quality and add debugging intent detection.
+
+**Requirements**: REQ-SQ-01, REQ-SQ-02
+
+**Success Criteria**:
+- Reduce false positives in search results
+- Detect debugging intent and adjust search behavior
+- Improve ranking for domain-specific queries
+
+**Estimated effort**: 3-4 days
+
+---
+
+## Phase 4: Ruby/Rails Improvements (Medium Priority)
+
+**Goal**: Fix Ruby AST parsing gaps and improve Rails code intelligence.
+
+**Requirements**: REQ-RUBY-01, REQ-RUBY-02, REQ-RUBY-03, REQ-RUBY-04
+
+**Success Criteria**:
+- Fix unresolved call edges in Ruby
+- Improve class indexing accuracy
+- Support cross-file method calls in Rails
+- Extract Rails-specific DSL patterns
+
+**Estimated effort**: 5-7 days
+
+---
+
+## Phase 5: Flow Visualization (Medium Priority)
+
+**Goal**: Complete execution flow visualization pipeline and sequence diagrams.
+
+**Requirements**: REQ-FLOW-01, REQ-FLOW-02
+
+**Success Criteria**:
+- Complete execution flow phase 3
+- Add internal logic to sequence diagrams
+- Clean up internal labels
+
+**Estimated effort**: 4-6 days
+
+---
+
+## Phase 6: Benchmarks & Infrastructure (Low Priority)
+
+**Goal**: Add LLM quality benchmarks, OpenAI embedding provider, and dashboard split.
+
+**Requirements**: REQ-BENCH-01, REQ-BENCH-02, REQ-INFRA-01, REQ-INFRA-02
+
+**Success Criteria**:
+- LLM quality benchmark framework operational
+- Ruby benchmark comparison complete
+- OpenAI-compatible embedding provider working
+- Dashboard split into independent module
+
+**Estimated effort**: 4-6 days
+
+---
+
+## Phase 7: HyDE & Documentation (Low Priority)
+
+**Goal**: Auto-generate HyDE context hints and complete documentation.
+
+**Requirements**: REQ-CI-04, REQ-DOC-01, REQ-DOC-02
+
+**Success Criteria**:
+- Auto-generate HyDE context hints from project files
+- Complete MCP agent tool guide
+- Clean up sequence internal labels
+
+**Estimated effort**: 2-3 days
+
+---
+
+## Parallel Execution Opportunities
+
+```
+Phase 1 (Vue SFC) ─────────┐
+Phase 2 (Import Fix) ───────┤
+                             ├─→ Phase 3 (Search Quality)
+Phase 4 (Ruby/Rails) ───────┤
+                             ├─→ Phase 5 (Flow Visualization)
+Phase 6 (Benchmarks) ───────┤
+                             └─→ Phase 7 (HyDE & Docs)
+```
+
+**Note**: Phases 1-2 can run in parallel. Phases 4-6 can run in parallel. Phase 3 depends on Phases 1-2. Phase 5 depends on Phase 4. Phase 7 depends on Phase 6.
+
+---
+
+## Milestones
+
+### Milestone 1: Vue + Import Fix
+- Phase 1: Vue SFC Support
+- Phase 2: Import Edge Fix
+
+### Milestone 2: Search + Ruby
+- Phase 3: Search Quality
+- Phase 4: Ruby/Rails Improvements
+
+### Milestone 3: Flow + Benchmarks
+- Phase 5: Flow Visualization
+- Phase 6: Benchmarks & Infrastructure
+
+### Milestone 4: Polish
+- Phase 7: HyDE & Documentation
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| P@5 (Vue/Nuxt) | 0.75 | ≥ 0.75 (no regression) |
+| P@5 (Go) | 1.000 | 1.000 (maintain) |
+| P@5 (Ruby) | 0.795 | ≥ 0.85 |
+| memory_impact accuracy | Unknown | ≥ 90% |
+| Latency (code intel) | ~42ms | < 50ms |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,49 @@
+# STATE.md — nano-brain
+
+## Current Phase
+
+**Phase 1: Vue SFC Support** (not started)
+
+## Progress
+
+| Phase | Status | Start | End |
+|-------|--------|-------|-----|
+| Phase 1: Vue SFC Support | Pending | — | — |
+| Phase 2: Import Edge Fix | Pending | — | — |
+| Phase 3: Search Quality | Pending | — | — |
+| Phase 4: Ruby/Rails | Pending | — | — |
+| Phase 5: Flow Visualization | Pending | — | — |
+| Phase 6: Benchmarks | Pending | — | — |
+| Phase 7: HyDE & Docs | Pending | — | — |
+
+## Active Work
+
+- **OpenSpec**: vue-sfc-code-intelligence (0/32 tasks) — design complete, ready for implementation
+- **Harness**: Epic 10 complete, 50 stories done
+- **Branch**: feat/502-memory-workspaces-list (memory_workspaces_list MCP tool)
+
+## Blockers
+
+- None currently
+
+## Key Decisions
+
+| Decision | Date | Rationale |
+|----------|------|-----------|
+| Use GSD Core as phase loop | 2026-06-28 | Harness rules updated, GSD provides structured workflow |
+| Vue SFC: Defer CFG to v2 | 2026-06-28 | Lowest ROI, agents use memory_trace/memory_impact more |
+| Vue SFC: Include template detection | 2026-06-28 | Highest-value missing piece, AST-based detection |
+| Vue SFC: Universal extractor | 2026-06-28 | Runs for all .vue files, not framework-gated |
+
+## Open Questions
+
+- None currently
+
+## Next Actions
+
+1. Start Phase 1: Vue SFC Support
+2. Run `/gsd-plan-phase 1` to create detailed plan
+3. Run `/gsd-execute-phase 1` to implement
+
+---
+*Last updated: 2026-06-28 after initialization*

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,235 @@
+# ARCHITECTURE.md — nano-brain
+
+**Last updated:** 2026-06-28
+
+---
+
+## Overview
+
+nano-brain is an agent-oriented memory and code intelligence daemon. It provides persistent context, impact analysis, and call-chain tracing for AI agents via the MCP (Model Context Protocol). A single Go binary serves HTTP (REST + MCP) backed by PostgreSQL with pgvector.
+
+**Core thesis:** Agents don't read docs — they call tools. Every capability is exposed as an MCP tool or REST endpoint.
+
+---
+
+## Architectural Patterns
+
+| Pattern | Implementation |
+|---------|----------------|
+| **Service daemon** | Single binary, PID-file lifecycle, `errgroup` goroutine orchestration |
+| **Constructor injection** | No DI framework. `config`, `logger`, `*pgxpool.Pool`, `*sqlc.Queries` passed at construction |
+| **Interface-based decoupling** | Small role interfaces (`Embedder`, `Querier`, `Harvester`) defined on consumer side |
+| **Pipeline architecture** | File → chunk → embed → search. Each stage is a queue/work item |
+| **Registry pattern** | `symbol.Registry`, `graph.Registry` — pluggable language extractors |
+| **Event bus** | `eventbus.Bus` — async pub/sub between watcher, embed queue, flow materializer |
+| **Code generation** | sqlc generates type-safe Go from SQL queries (no hand-written DB code) |
+
+---
+
+## System Layers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  AI Agent (OpenCode, Claude Code, Cursor, etc.)         │
+└──────────────┬──────────────────────────────────────────┘
+               │ MCP Protocol (streamable HTTP / SSE)
+               │ REST API (JSON)
+┌──────────────▼──────────────────────────────────────────┐
+│  Transport Layer                                        │
+│  ├── internal/mcp/     — MCP server (16 tools)          │
+│  ├── internal/server/  — Echo v4 HTTP server            │
+│  │   ├── handlers/     — 76 handler files (per-endpoint)│
+│  │   └── middleware/   — auth, workspace, CSRF           │
+│  └── cmd/nano-brain/   — CLI dispatcher + daemon mgmt   │
+├─────────────────────────────────────────────────────────┤
+│  Business Logic                                         │
+│  ├── internal/search/     — Hybrid search (BM25+vector) │
+│  ├── internal/graph/      — Code intelligence extractors│
+│  ├── internal/harvest/    — Session harvesting           │
+│  ├── internal/embed/      — Embedding queue + providers  │
+│  ├── internal/flow/       — Execution flow materializer  │
+│  ├── internal/summarize/  — LLM session summarization    │
+│  ├── internal/codesummarize/ — Batched code summaries    │
+│  ├── internal/intelligence/  — Memory consolidation      │
+│  ├── internal/symbol/     — Code symbol extraction       │
+│  ├── internal/chunker/    — Document chunking strategies │
+│  ├── internal/links/      — Document link resolution     │
+│  └── internal/watcher/    — File system watcher           │
+├─────────────────────────────────────────────────────────┤
+│  Infrastructure                                         │
+│  ├── internal/config/     — YAML + env config (koanf)   │
+│  ├── internal/storage/    — pgxpool, sqlc, goose         │
+│  ├── internal/eventbus/   — Async pub/sub                │
+│  ├── internal/telemetry/  — Query logging + metrics      │
+│  ├── internal/health/     — Health checks, doctor        │
+│  ├── internal/timefilter/ — Time range parsing           │
+│  └── internal/testutil/   — Test DB helpers              │
+├─────────────────────────────────────────────────────────┤
+│  PostgreSQL 17 + pgvector 0.8.2                         │
+│  ├── Documents, Chunks, Embeddings                      │
+│  ├── Graph edges, PageRank scores                        │
+│  ├── Symbol-aware chunks, Flowcharts                     │
+│  └── Telemetry, Code summarization tracking              │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Data Flow
+
+### 1. Document Ingestion
+
+```
+File change (watcher) or API write
+  → Watcher detects / handler receives
+  → chunker.Dispatcher selects strategy (symbol / heading / fixed)
+  → Chunks stored in `chunks` table
+  → EmbedQueue.Enqueue(chunk_ids)
+  → EmbedQueue worker calls Embedder (Ollama / VoyageAI)
+  → Vectors stored in `embeddings` table (pgvector)
+  → BM25 search vectors updated
+```
+
+### 2. Search / Query
+
+```
+Agent calls memory_query (or POST /api/v1/query)
+  → SearchService.Query()
+  ├── BM25 full-text search (tsvector/tsquery)
+  ├── Vector similarity (pgvector HNSW cosine)
+  ├── Reciprocal Rank Fusion (RRF)
+  ├── Recency decay (exponential half-life)
+  ├── PageRank boost (pre-computed)
+  └── Optional: HyDE, reranking, query preprocessing
+  → Ranked results returned as structured JSON
+```
+
+### 3. Code Intelligence
+
+```
+Agent calls memory_impact / memory_trace / memory_graph
+  → MCP handler → sqlc queries
+  ├── graph_edges table (pre-computed by watcher)
+  ├── Reverse BFS for impact analysis
+  ├── Forward BFS for call chain tracing
+  └── One-hop lookup for graph queries
+  → Structured results (<50ms target)
+```
+
+### 4. Session Harvesting
+
+```
+OpenCode / Claude Code session files
+  → Harvester polls (configurable interval)
+  → Deduplication (content hash)
+  → Optional LLM summarization (map-reduce pipeline)
+  → Stored as documents + chunks
+  → Embed queue processes new chunks
+```
+
+### 5. Execution Flow
+
+```
+File change → Watcher
+  → Graph extractors (Echo, Express, Rails, Gin, etc.)
+  → Graph edges stored (http, middleware, calls)
+  → Flow materializer builds call chains
+  → Optional LLM summarization of flow paths
+  → Mermaid / sequence diagrams via memory_flow
+```
+
+---
+
+## Key Abstractions
+
+| Abstraction | Description |
+|-------------|-------------|
+| **Workspace** | SHA-256 hash of absolute root path. Isolates all data. |
+| **Collection** | Named path within a workspace. Groups related documents. |
+| **Document** | Source file metadata + content + tags. Versioned via `supersedes_id`. |
+| **Chunk** | Sub-document unit (symbol-aware, heading-based, or fixed-size). |
+| **Embedding** | Vector representation of a chunk (provider + model tracked). |
+| **GraphEdge** | Directed edge: `source_node → target_node` with type + metadata. |
+| **Symbol** | Code entity (function, type, const) extracted by language-specific extractors. |
+| **FlowChart** | Pre-materialized control-flow graph for a function span. |
+
+---
+
+## Entry Points
+
+### Daemon Startup
+
+```
+cmd/nano-brain/main.go:main()
+  → flag.Parse()
+  → startServer(configPath)
+    → guardBeforeStart()           // single-instance check
+    → config.Load()                // YAML + env
+    → storage.NewPool()            // pgxpool
+    → storage.RunMigrations()      // goose
+    → symbol.NewRegistry()         // language extractors
+    → graph.NewRegistry()          // graph extractors
+    → watcher.New()                // file watcher
+    → embed.NewQueue()             // embedding queue
+    → eventbus.New()               // pub/sub
+    → server.New()                 // HTTP server
+    → errgroup: server.Start() + watcher.Run() + queue.Run() + harvester.Run()
+```
+
+### MCP Tool Registration
+
+```
+internal/mcp/tools.go:RegisterTools(server, adapter)
+  → 16 register*() functions
+  → Each: schema + handler closure → server.AddTool()
+```
+
+### REST Route Registration
+
+```
+internal/server/routes.go:registerRoutes(s)
+  → /health, /api/status, /api/version
+  → /api/v1/ (workspace-scoped group)
+    ├── /init, /workspaces, /collections
+    ├── /query, /search, /vsearch
+    ├── /write, /embed, /reindex
+    ├── /graph/*, /flow/*
+    └── /events (SSE)
+  → /mcp (streamable HTTP + SSE)
+```
+
+---
+
+## Concurrency Model
+
+- **errgroup** manages goroutine lifecycle at startup (server, watcher, embed queue, harvester, code summarizer)
+- **embed.Queue** — bounded worker pool with configurable concurrency
+- **harvest.Runner** — polls harvesters on interval, deduplicates, optionally summarizes
+- **watcher.Watcher** — fsnotify-based, debounced, processes file changes sequentially per collection
+- **flow.Materializer** — async trigger from watcher, builds call chains with configurable depth/fanout
+- **eventbus.Bus** — fan-out pub/sub for cross-component notifications
+
+---
+
+## Error Handling
+
+- `fmt.Errorf("context: %w", err)` — wrapped errors throughout
+- No custom error types; callers use `errors.Is` / `errors.As`
+- Constructor failures → `log.Warn` (optional) or `log.Fatal` (critical)
+- Nil-safe interfaces: optional dependencies checked for nil before use
+- Graceful degradation: failed embedder → skip embeddings, failed summarizer → raw harvest
+
+---
+
+## Testing Strategy
+
+| Layer | Approach |
+|-------|----------|
+| Unit | `package <name>_test`, inline struct mocks, table-driven with `t.Run` |
+| Integration | `//go:build integration`, `testutil.SetupTestDB(t)` creates isolated PG schema |
+| Handler | `httptest.NewServer` + `httptest.NewRecorder`, mock interfaces |
+| MCP | Tool handler unit tests with mock `*Adapter` |
+| Benchmark | `bench/` package with generate/run/compare/stress cycle |
+
+**Quick:** `go build ./... && go test -race -short ./...`
+**Full:** `go test -race -tags=integration ./...`

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,409 @@
+# Codebase Concerns — nano-brain
+
+> Generated: 2026-06-28 | Scope: 5,250 Go files, 211K LOC, 370 internal packages
+
+## Table of Contents
+
+1. [Critical (P0)](#critical-p0)
+2. [High (P1)](#high-p1)
+3. [Medium (P2)](#medium-p2)
+4. [Low (P3)](#low-p3)
+5. [Summary Table](#summary-table)
+
+---
+
+## Critical (P0)
+
+### C1. CVE-2026-34742 — DNS Rebinding in MCP Go SDK
+
+**Package:** `github.com/modelcontextprotocol/go-sdk v0.8.0`
+**Published:** 2026-06-25
+**Impact:** DNS Rebinding Protection Disabled by Default — affects 13 files in `internal/mcp/` and `internal/server/server.go:13`
+
+The MCP Go SDK used by nano-brain has a known CVE that allows DNS rebinding attacks against servers running on localhost. Since nano-brain's primary interface is the MCP endpoint at `POST /mcp`, this directly affects the attack surface.
+
+**Action:** Bump to a fixed version as soon as upstream releases one. Track via `govulncheck ./...`.
+
+---
+
+### C2. Data Race — `Server.SetHarvestStatus` (server.go:214-227)
+
+**File:** `internal/server/server.go:214-227`
+
+`SetHarvestStatus` mutates `s.harvestStatus` **without any lock**. Concurrent reads happen from:
+- `routes.go:24,112` (startup, single-threaded — safe)
+- Health/stats handler goroutines via `s.healthHandler.SetHarvestStatus` / `s.statsHandler.SetHarvestStatus`
+
+Five other fields on `Server` use dedicated `sync.RWMutex` (`harvestMu`, `summarizeMu`, `codeSummarizeMu`, `flowMaterializeMu`, `configMu`). This field is the obvious outlier.
+
+**Action:** Reuse `harvestMu` (already protects `harvestRunner` on L48) or switch to `atomic.Pointer[handlers.HarvestStatusSnapshot]`.
+
+---
+
+## High (P1)
+
+### H1. Swallowed `json.Marshal` Errors — 13 Production Sites
+
+`_, _ := json.Marshal(...)` or `meta, _ := json.Marshal(...)` discards the error. If marshalling fails, metadata is stored as `nil`, silently degrading stored context. No log, no error propagation.
+
+| File | Line | Context |
+|------|------|---------|
+| `internal/links/extract.go` | 140 | Wikilink metadata for `KindID` |
+| `internal/links/extract.go` | 163 | Wikilink metadata for `KindTitle` |
+| `internal/links/extract.go` | 199 | `links_changed` event payload |
+| `internal/summarize/persist.go` | 97 | Summary document metadata |
+| `internal/flow/materializer.go` | 210 | Flow document metadata |
+| `internal/harvest/automemory.go` | 83 | Auto-memory document metadata |
+| `internal/harvest/claudecode.go` | 176 | Session metadata |
+| `internal/harvest/runner.go` | 133 | Harvest event payload |
+| `internal/watcher/watcher.go` | 843 | File event metadata |
+| `internal/watcher/watcher.go` | 1127 | Reindex event payload |
+| `internal/server/handlers/reindex.go` | 358 | Reindex event payload |
+| `internal/server/handlers/events.go` | 74 | SSE hello payload |
+| `internal/mcp/tools.go` | 56 | MCP tool schema |
+
+---
+
+### H2. Partial Writes Without Compensation
+
+**`internal/links/extract.go:179-195`** — Old edges are deleted first (L179), then new edges are upserted one by one (L187). If any `UpsertReferenceEdge` fails mid-loop, the document loses its reference edges for the failed targets. No compensation or rollback.
+
+**`internal/summarize/persist.go:126-146`** — Document is upserted (L112), then chunks are upserted in a loop. Failed chunk upserts are skipped via `continue`. Document exists with fewer chunks than expected — embeddings will be generated for fewer chunks.
+
+**Action:** Wrap in a transaction, or add rollback on partial failure.
+
+---
+
+### H3. Config Hot-Reload Is Broken By Design
+
+**File:** `internal/config/reload.go:14-66`
+
+`Reload()` classifies which fields are "reloaded" vs "require restart" but **does nothing else** — no RWMutex, no atomic pointer, no signal to in-flight goroutines. The HTTP handler that calls it has undefined semantics:
+- If it assigns `cfg = newCfg`, concurrent reads see torn reads
+- If it does nothing, the "Reloaded" fields are never actually reloaded
+- 24 fields are marked `reloadable: false` but change behavior at runtime (e.g., `embedding.concurrency`, `watcher.debounce_ms`)
+
+Additionally, `ApplyPatch` (patch.go:57-89) reads + rewrites the YAML file with no locking against concurrent `Reload` or `Load`.
+
+**Action:** Either wire `Reload` into running subsystems via RWMutex-protected config pointer, or remove the misleading "Reloaded" classification.
+
+---
+
+### H4. Watcher Mutex Held During I/O
+
+**File:** `internal/watcher/watcher.go:84`
+
+`w.mu` is a plain `sync.Mutex` (not `RWMutex`). Every fsnotify `Add`/`Remove` call happens under it (L227, L308, L460, L478), and the recursive subdirectory walk (`watchDir`) acquires it for every directory. Read-heavy paths like `processDirty` (L412) and `CollectionsWatched` (L118) serialize behind these.
+
+**Action:** Promote to `sync.RWMutex` and narrow critical sections — snapshot collections, then call fsnotify outside the lock.
+
+---
+
+### H5. Three Fire-and-Forget Goroutines Use `context.Background()`
+
+| File:Line | Context | Risk |
+|-----------|---------|------|
+| `internal/server/handlers/reindex.go:372` | `TriggerUpdate` HTTP handler | Runs forever after server shutdown; multiple concurrent triggers each spawn unbounded goroutines |
+| `internal/graph/pagerank_service.go:48` | `IncrementEdgeCount` threshold trigger | No cancellation tied to server lifecycle |
+| `internal/telemetry/telemetry.go:24` | Per-request `Record` | Leaks per call on shutdown; bounded to request rate |
+
+**Action:** Plumb the server's shutdown context (or accept it as a parameter). For telemetry, add a `sync.WaitGroup` so `Shutdown` waits for in-flight inserts.
+
+---
+
+### H6. No HTTP Rate Limiting
+
+The server has no request-level rate limiting on any endpoint. The only rate limiting in the codebase is:
+- `internal/watcher/watcher.go:1116-1119` — file re-index rate limiter per workspace (10/sec)
+- `internal/summarize/client.go:55` — LLM API call rate limiter
+
+POST endpoints like `/api/v1/write`, `/api/v1/reindex`, `/api/v1/summarize` are unbounded. A malicious or misconfigured agent could overwhelm the server.
+
+**Action:** Add Echo middleware rate limiter or per-IP token bucket on write endpoints.
+
+---
+
+### H7. Auth Bypass via `BypassPaths` Config
+
+**File:** `internal/server/middleware/auth.go:36-41`
+
+The auth middleware checks `cfg.BypassPaths` for exact path matches. The default config includes `/health` (defaults.go:22). If an operator adds `"/"` or `"/api"` to `BypassPaths`, all endpoints are unprotected. There's no warning log when bypass paths are active.
+
+**Action:** Log a warning at startup when `auth.enabled=true` AND `bypass_paths` is non-default. Consider rejecting `"/"` as a bypass path.
+
+---
+
+### H8. `summarize/pipeline.go:156-181` — Unnecessary Mutex During LLM Calls
+
+A single `mu sync.Mutex` is held for the entire `wg.Wait()`. Each goroutine acquires `mu` before writing to `results[idx]`, but since `idx` is unique per goroutine, the mutex is unnecessary — direct indexed writes to a pre-sized slice are race-free. This serializes all concurrent LLM completion handlers through one lock for the duration of the slowest call.
+
+**Action:** Remove the mutex; pre-allocate `results` slice and write directly to `results[idx]`.
+
+---
+
+## Medium (P2)
+
+### M1. Large Files Needing Decomposition
+
+| File | LOC | Concern |
+|------|----:|---------|
+| `internal/mcp/tools.go` | 2,361 | 16 tool handlers in one file. Split per-tool (one file per MCP tool) like handler files already are |
+| `internal/watcher/watcher.go` | 1,434 | Mixes fsnotify loop, DB upserts, gitignore stack, symbol/graph extraction, notification callbacks. `processFile` (L686-830) does 5 different concerns |
+| `internal/search/service.go` | 991 | `HybridSearch` body (L131-609) is 478 lines. Extract RRF/recency/rerank dispatch to existing `rrf.go`/`recency.go` |
+| `internal/graph/js_cflow.go` | 876 | Complex tree-sitter CFG builder — acceptable for now but worth monitoring |
+
+---
+
+### M2. `watcher.flowNotify` Synchronous Callback
+
+**File:** `internal/watcher/watcher.go:826-828`
+
+`w.flowNotify(col.workspaceHash)` fires synchronously inside `processFile`, on the same goroutine as the file walk. If the notify handler triggers heavy flow materialization, it stalls every subsequent file processing for the collection.
+
+**Action:** Defer to a goroutine or bounded queue.
+
+---
+
+### M3. `fmt.Errorf` with `%v` Instead of `%w` — Error Chain Lost
+
+| File | Line | Code |
+|------|------|------|
+| `internal/mcp/flowchart.go` | 135 | `fmt.Errorf("invalid start line: %v", err)` |
+| `internal/mcp/flowchart.go` | 139 | `fmt.Errorf("invalid end line: %v", err)` |
+| `internal/search/service.go` | 480 | `fmt.Errorf("all search legs failed: bm25: %v, vector: %v", ...)` |
+| `internal/search/service.go` | 927 | `fmt.Errorf("all search legs failed: bm25: %v, vector: %v", ...)` |
+
+The `service.go` cases aggregate two errors (intentional), but `flowchart.go` cases are simple wrapping misses that break `errors.Is()`/`errors.As()`.
+
+---
+
+### M4. Error Handling — Log-and-Continue Data Loss Risks
+
+| File | Lines | Risk |
+|------|-------|------|
+| `internal/server/handlers/embed.go` | 90-122 | Embed loop stops on first error but HTTP response reports success with partial count; `CountPendingChunks` error shows `remaining: 0` |
+| `internal/summarize/persist.go` | 141-143 | Chunk upsert errors logged, `continue` — partial chunks silently lost |
+| `internal/flow/materializer.go` | 237, 261, 283, 289 | Flow doc/chunk upsert errors logged, no return — mermaid diagram may be missing nodes |
+| `internal/graph/pagerank_service.go` | 60 | `logger.Error()` then no return — PageRank scores not stored, downstream boost uses stale data |
+| `internal/server/handlers/stats.go` | 141-166 | Six queries logged on error, all return partial stats with `0` values — caller can't distinguish "zero" from "failed" |
+
+---
+
+### M5. Embed Queue — Fragile Hard-Failure Detection
+
+**File:** `internal/embed/queue.go:464-475`
+
+Hard-failure detection uses string-matching on error messages (`"<provider>: unexpected status <N>:"`). If `ollama.go:64` or `voyageai.go:76` changes the error format, hard-failure detection silently breaks — chunks that should be marked `embed_failed` will retry forever.
+
+**Action:** Use typed errors with `errors.Is()` sentinels instead of string matching.
+
+---
+
+### M6. Test Coverage Gaps
+
+**Overall:** 41,723 test LOC / 41,375 source LOC = 1.01x ratio. Good baseline.
+
+**Packages with low test/source ratio:**
+
+| Package | Source LOC | Test LOC | Ratio | Concern |
+|---------|----------:|---------:|------:|---------|
+| `internal/codesummarize` | 1,318 | 309 | 0.23x | 620-line `service.go` has zero direct tests |
+| `internal/chunker` | 379 | 118 | 0.31x | Low-level chunking logic undertested |
+| `internal/symbol` | 580 | 382 | 0.66x | Symbol registry undertested |
+| `internal/intelligence` | 615 | 482 | 0.78x | Categorization/consolidation undertested |
+| `internal/watcher` | 1,865 | 1,484 | 0.80x | `extractAndUpsertSymbols`, `extractAndUpsertEdges`, `Run()`, `Watch()` untested |
+
+**Large files with limited unit coverage:**
+- `internal/mcp/tools.go` (2,361 lines) — 23 unit tests focus on schema/registration; the 13 `registerMemory*` handler bodies are mostly untested at unit level
+- `internal/watcher/watcher.go` (1,434 lines) — 24 tests cover filtering/debounce; symbol/edge extraction pipeline untested
+- `internal/search/service.go` (991 lines) — `HybridSearch` 478-line body has limited direct unit coverage
+
+---
+
+### M7. Missing Config Validation
+
+**File:** `internal/config/config.go:409-521`
+
+- **No URL format validation** for `Database.URL`, `Embedding.URL`, `Summarization.ProviderURL`, `HyDE.ProviderURL`, `Reranking.ProviderURL` — typos pass silently, fail deep in goroutines
+- **No positive value validation** for `Embedding.MaxChars`, `Watcher.ChunkOverlap`, `Intelligence.Concurrency`, and ~15 other numeric fields — zero/negative accepted
+- **No embedding provider validation at Load time** — `Embedding.Provider` is free-form; error only surfaces at queue construction
+
+---
+
+### M8. Docker Security Concerns
+
+**File:** `Dockerfile`
+
+- **No `USER` directive** — runs as root inside the container. A nano-brain RCE would have root.
+- **No `HEALTHCHECK` directive** — Docker doesn't auto-restart on hang
+- **Build context is entire repo** (`COPY . .`) — wastes bandwidth, includes `.git`, `.opencode/`, `node_modules/`
+- **`alpine:3.21`** is not the latest (3.22 available since 2026-05)
+- **No `mem_limit` / `cpus` / `pids_limit`** in `docker-compose.yml` — runaway embed queue could exhaust resources
+
+---
+
+### M9. Missing `SecretFieldPaths` Entries
+
+**File:** `internal/config/secrets.go`
+
+`code_summarization.api_key` and `intelligence.api_key` are **NOT** in `SecretFieldPaths`. They will be exposed in JSON config dumps via `GET /api/v1/config`.
+
+**Action:** Add both to `SecretFieldPaths`.
+
+---
+
+### M10. No HTTP Server Timeouts
+
+**File:** `internal/server/server.go:178-182`
+
+The server starts with `s.echo.Start(addr)` — no `ReadTimeout`, `WriteTimeout`, `IdleTimeout`, `ReadHeaderTimeout`, or `MaxHeaderBytes` configured. A slow client can hold connections indefinitely, exhausting server resources. Combined with no HTTP rate limiting (H6), this amplifies the DoS surface.
+
+**Action:** Set `ReadTimeout`, `WriteTimeout`, `IdleTimeout` on the Echo server. Consider `MaxHeaderBytes` to bound header parsing.
+
+---
+
+### M11. No TLS Enforcement
+
+**File:** `internal/server/server.go:178-182`
+
+Plaintext HTTP only. All API traffic including `Authorization: Basic` and `Bearer` tokens is sent in cleartext. This is a design choice (assumes loopback or reverse proxy), but the README and config docs do not explicitly mandate TLS termination in production.
+
+**Action:** Document the TLS requirement. Consider adding a startup warning when `server.host` is not `localhost`/`127.0.0.1` and TLS is not configured.
+
+---
+
+### M12. Config Patch Type Safety Gap
+
+**File:** `internal/config/patch.go:57-89`
+
+`PatchConfig` uses `PatchableFieldPaths` allowlist (patch.go:14-38) but does not validate type safety of values. The `setNodeValue` function converts via `json.Marshal(value)` then YAML unmarshal — type-confusion is possible if an attacker sends a `map[string]interface{}` for an int field (e.g., `server.port`). YAML's type coercion could silently produce zero-value results.
+
+---
+
+### M13. Defaults Drift Between Config and Queue
+
+**Files:** `internal/config/defaults.go:33` vs `internal/embed/queue.go:42`
+
+`MaxChars = 3000` is hardcoded in both places. If one changes, the other silently disagrees. The queue constant is the actual fallback when config is unset.
+
+Additionally, `RerankingConfig` and `BenchConfig` are absent from `getDefaults()` — the defaults struct drifts from the actual `Config` struct.
+
+---
+
+## Low (P3)
+
+### L1. `context.Background()` in Internal Code (Acceptable with Caveats)
+
+14 instances in `internal/` production code. Most are acceptable:
+- `internal/health/doctor/doctor.go` — health checks with `WithTimeout` (correct)
+- `internal/graph/pagerank_service.go:48` — fire-and-forget (see H5)
+- `internal/watcher/watcher.go:620` — `cleanupDeletedDocument` (acceptable, short-lived)
+
+The pattern is widespread but not harmful except where noted in H5.
+
+---
+
+### L2. `nolint:errcheck` on Transaction Rollback (Acceptable)
+
+6 instances across `internal/watcher/watcher.go` and `internal/harvest/automemory.go`:
+
+```go
+defer tx.Rollback() //nolint:errcheck
+```
+
+This is the standard Go pattern — `Rollback` after `Commit` is a no-op, and the error is intentionally ignored. Acceptable.
+
+---
+
+### L3. `panic()` in Production Code
+
+**File:** `internal/search/cursor.go:153`
+
+```go
+panic(err)  // JSON marshaling of simple struct should never fail
+```
+
+This is in `EncodeCursor` for a `json.Marshal` of a simple `{Offset, QueryHash}` struct. The comment is accurate — this should never fail. Low risk but worth noting.
+
+---
+
+### L4. Bare `return err` Without Context Wrapping
+
+Several files return errors from sub-calls without adding contextual wrapping:
+
+| File | Lines |
+|------|-------|
+| `internal/links/extract.go` | 135, 146, 175, 183, 194 |
+| `internal/server/middleware.go` | 106 |
+| `internal/config/patch.go` | 108, 112 |
+
+The caller cannot distinguish which sub-call failed. Low severity since the call chains are short.
+
+---
+
+### L5. `expandPaths` Is Dead Code
+
+**File:** `internal/config/config.go:404-406`
+
+```go
+func expandPaths(cfg *Config) error {
+    return nil  // no-op
+}
+```
+
+The comment claims it expands tildes, but the function does nothing. Actual tilde expansion happens inline for `Summarization.OutputDir` only (config.go:386-392).
+
+---
+
+### L6. `lib/pq` Dependency (Legacy)
+
+**File:** `go.mod:16`
+
+`github.com/lib/pq v1.12.3` appears as a transitive dependency of `jackc/pgx/v5/pgconn`. It's not directly used but is a legacy driver. No action needed, but worth noting.
+
+---
+
+### L7. No `govulncheck` in CI
+
+**File:** `.github/workflows/ci.yml`
+
+The CI pipeline runs `go build` + `go test -race -short` but does not run `govulncheck`. Given the go-sdk CVE (C1), this would have caught it.
+
+**Action:** Add `govulncheck ./...` to CI.
+
+---
+
+## Summary Table
+
+| ID | Severity | Category | Title | Status |
+|----|----------|----------|-------|--------|
+| C1 | **P0** | Security | CVE-2026-34742 — DNS Rebinding in MCP Go SDK | **Open** |
+| C2 | **P0** | Concurrency | `Server.SetHarvestStatus` data race | **Open** |
+| H1 | P1 | Correctness | 13 swallowed `json.Marshal` errors | **Open** |
+| H2 | P1 | Correctness | Partial writes without compensation | **Open** |
+| H3 | P1 | Config | Hot-reload is broken by design | **Open** |
+| H4 | P1 | Concurrency | Watcher mutex held during I/O | **Open** |
+| H5 | P1 | Concurrency | 3 fire-and-forget goroutines (no ctx) | **Open** |
+| H6 | P1 | Security | No HTTP rate limiting | **Open** |
+| H7 | P1 | Security | Auth bypass via BypassPaths | **Open** |
+| H8 | P1 | Performance | Unnecessary mutex in summarize/pipeline | **Open** |
+| M1 | P2 | Maintainability | 4 files >876 LOC need decomposition | **Open** |
+| M2 | P2 | Performance | watcher.flowNotify synchronous callback | **Open** |
+| M3 | P2 | Correctness | `fmt.Errorf` uses `%v` not `%w` | **Open** |
+| M4 | P2 | Correctness | Log-and-continue data loss risks | **Open** |
+| M5 | P2 | Maintainability | Fragile string-match error detection | **Open** |
+| M6 | P2 | Testing | Test coverage gaps (5 packages <0.8x) | **Open** |
+| M7 | P2 | Config | Missing URL/numeric validation | **Open** |
+| M8 | P2 | Security | Docker runs as root, no healthcheck | **Open** |
+| M9 | P2 | Security | API keys not in SecretFieldPaths | **Open** |
+| M10 | P2 | Security | No HTTP server timeouts | **Open** |
+| M11 | P2 | Security | No TLS enforcement | **Open** |
+| M12 | P2 | Security | Config patch type safety gap | **Open** |
+| M13 | P2 | Config | Defaults drift between config and queue | **Open** |
+| L1 | P3 | Code Quality | `context.Background()` in internal (14 sites) | **Open** |
+| L2 | P3 | Code Quality | `nolint:errcheck` on tx.Rollback | **Open** |
+| L3 | P3 | Code Quality | `panic()` in cursor.go | **Open** |
+| L4 | P3 | Code Quality | Bare `return err` without wrapping | **Open** |
+| L5 | P3 | Code Quality | `expandPaths` dead code | **Open** |
+| L6 | P3 | Dependencies | Legacy `lib/pq` transitive dep | **Open** |
+| L7 | P3 | CI/CD | No `govulncheck` in CI | **Open** |

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,121 @@
+# Coding Conventions
+
+> Observed patterns from the nano-brain codebase. Last reviewed: 2026-06-28.
+
+## Language & Build
+
+- **Go 1.23**, `CGO_ENABLED=0` static binary, no external DI framework
+- Constructor injection throughout — config, logger, `*pgxpool.Pool` passed at construction
+- `sqlc` for type-safe SQL; generated files in `internal/storage/sqlc/` are **DO NOT EDIT**
+- Migrations via `goose v3`, embedded in `migrations/FS`
+
+## Package Layout
+
+| Convention | Example |
+|---|---|
+| One package per domain concern | `internal/search`, `internal/embed`, `internal/harvest` |
+| `cmd/nano-brain/` — CLI dispatcher + server entry | `main.go`, `commands.go`, `daemon.go` |
+| `internal/server/handlers/` — one file per endpoint group | `query.go`, `health.go`, `graph.go` |
+| `internal/testutil/` — shared test helpers | `testdb.go`, `testutil.go` |
+
+## Naming
+
+- **Files:** `snake_case.go`; test files `snake_case_test.go`
+- **Packages:** short, lowercase, single-word (`search`, `embed`, `graph`, `symbol`)
+- **Exported types:** PascalCase (`HybridSearcher`, `Embedder`, `Harvester`)
+- **Unexported functions:** camelCase (`maskPassword`, `expandTildeForConfig`)
+- **Interfaces:** small, role-based, named after the capability (`HybridSearcher`, `PoolChecker`, `EmbedQueueInfo`). Defined on the consumer side, not the provider
+- **Config structs:** `XxxConfig` with `koanf:"snake_case" json:"snake_case"` tags (both tags always present)
+
+## Error Handling
+
+```go
+// Standard pattern — wrap with context, never bare errors.New in callers
+return nil, fmt.Errorf("failed to create pool: %w", err)
+
+// Errors are always wrapped; custom error types are not used
+// Callers check with errors.Is()
+if errors.Is(err, sql.ErrNoRows) { ... }
+```
+
+- No custom error types anywhere in the codebase
+- No `_ = err` on constructor calls in startup paths — use `log.Warn` (optional) or `log.Fatal` (critical)
+- Errors include context: `fmt.Errorf("parse config: %w", err)`
+
+## Logging
+
+- **zerolog** structured JSON logging throughout
+- Scope per component: `.With().Str("component", "x").Logger()`
+- Per-request logger via middleware, retrieved with `LoggerFromCtx(c, fallback)`
+- CLI logs to stderr (not stdout) to avoid polluting JSON output
+
+## Configuration
+
+- **koanf** YAML + env vars; config path precedence: `--config` flag > `NANO_BRAIN_CONFIG` env > `~/.nano-brain/config.yml`
+- Dynamic reload via `RWMutex`; hot-reload via `POST /api/reload-config`
+- Env var mapping: `NANO_BRAIN_<SECTION>_<FIELD>` → `section.field` (first underscore becomes dot)
+- Special non-prefixed env vars: `DATABASE_URL`, `VOYAGE_API_KEY`, `OPENCODE_STORAGE_DIR`, etc.
+- Config validation accumulates errors into `[]error`, returns combined message
+- Defaults defined in `internal/config/defaults.go`
+
+## Context
+
+- `ctx context.Context` is always the first parameter on all I/O functions
+- `errgroup` (`golang.org/x/sync/errgroup`) for goroutine lifecycle management
+- Signal handling via `signal.NotifyContext` for graceful shutdown
+
+## HTTP Handlers (Echo v4)
+
+- Constructor function returns `echo.HandlerFunc`; dependencies passed as arguments:
+  ```go
+  func Query(searcher HybridSearcher, logger zerolog.Logger) echo.HandlerFunc {
+      return func(c echo.Context) error { ... }
+  }
+  ```
+- Each handler file defines a small interface for its dependency (keeps it testable)
+- Request binding: `c.Bind(&req)` → validate → `c.JSON(http.StatusOK, resp)`
+- Errors: `echo.NewHTTPError(statusCode, "message")` — never `c.JSON(4xx, ...)`
+- Workspace extracted from context: `c.Get("workspace").(string)`, injected by middleware
+
+## Database
+
+- Connection: `storage.NewPool(ctx, cfg, logger)` → `*pgxpool.Pool` (MaxConns=10, HealthCheckPeriod=30s)
+- Queries: `sqlc.New(db)` wraps pool; generated methods on `*sqlc.Queries`
+- DSN passwords masked in logs: `maskPassword(dsn)`
+- Error redaction: `storage.RedactError(err)` / `storage.RedactString(s)` for CLI output
+- Workspace hash: SHA-256 of absolute root path → hex string
+
+## Struct Tag Convention
+
+Config structs always carry both tags:
+```go
+Field string `koanf:"field_name" json:"field_name"`
+```
+JSON output uses snake_case exclusively (no PascalCase keys).
+
+## Builder / Fluent Patterns
+
+Used for optional configuration chains:
+```go
+fw := watcher.New(db, queries, logger, *cfg).
+    WithSymbolRegistry(symRegistry).
+    WithGraphRegistry(graphRegistry, queries).
+    WithFrameworkDetector(frameworkDetector).
+    WithDispatcher(dispatcher)
+```
+
+## File Organization
+
+- One concern per file; small files preferred
+- Package doc comment on the first line of `package.go` files
+- `AGENTS.md` in key directories documents package-level conventions for AI agents
+- No comments unless explaining non-obvious behavior (AGENTS.md convention)
+
+## Forbidden Practices
+
+- No `_ = err` on constructors in startup paths
+- No bare `errors.New` in callers (always wrap with `fmt.Errorf`)
+- No `git push origin <branch>` without verifying current branch
+- No direct commits to `master`
+- No self-review
+- No real workspace names, paths, or hashes in committed files

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,251 @@
+# External Integrations — nano-brain
+
+Last updated: 2026-06-28
+
+## Overview
+
+nano-brain integrates with external services for embeddings, LLM processing, reranking, and data sources. All external calls use standard HTTP REST APIs with configurable timeouts and retry logic.
+
+## Databases
+
+### PostgreSQL 17 + pgvector
+
+| Detail | Value |
+|--------|-------|
+| Default URL | `postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev` |
+| Driver | `jackc/pgx/v5` (connection pool) |
+| Extensions | pgvector 0.8.2 (HNSW vector index), tsvector/tsquery (BM25) |
+| Migrations | 27 goose SQL files in `migrations/` |
+| Codegen | sqlc v2 → `internal/storage/sqlc/` |
+
+Purpose: Primary data store for documents, chunks, embeddings, knowledge graph, code symbols, search telemetry.
+
+### SQLite (read-only)
+
+| Detail | Value |
+|--------|-------|
+| Driver | `modernc.org/sqlite` (pure Go, no CGO) |
+| Source | OpenCode session database |
+| Access | `internal/harvest/opencode_sqlite.go` |
+
+Purpose: Read-only access to OpenCode's per-project SQLite databases for session harvesting.
+
+## Embedding Providers
+
+### Ollama (default)
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `POST {url}/api/embed` |
+| Default URL | `http://localhost:11434` |
+| Default model | `nomic-embed-text` |
+| Dimension | 768 |
+| Timeout | 60s |
+| Auth | None (local) |
+
+Purpose: Generate vector embeddings for semantic search. Runs locally or in Docker.
+
+### Voyage AI
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `POST https://api.voyageai.com/v1/embeddings` |
+| Default model | `voyage-3` |
+| Dimension | 1024 |
+| Timeout | 60s |
+| Auth | `Authorization: Bearer {VOYAGE_API_KEY}` |
+| Config key | `embedding.voyage_api_key` |
+
+Purpose: Cloud-hosted embedding alternative to Ollama. Requires API key.
+
+## LLM Providers (OpenAI-compatible)
+
+All LLM integrations use the OpenAI chat completions API format (`POST /chat/completions`). Any OpenAI-compatible endpoint works.
+
+### Session Summarization
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `{summarization.provider_url}/chat/completions` |
+| Default model | `nano-brain` |
+| Timeout | 120s |
+| Auth | `Authorization: Bearer {summarization.api_key}` |
+| Features | SSE streaming, retry (3 attempts, exponential backoff) |
+
+Purpose: Summarize harvested sessions via map-reduce LLM pipeline.
+
+### Code Symbol Summarization
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `{code_summarization.provider_url}/chat/completions` |
+| Default model | `nano-brain` |
+| Timeout | 600s (configurable) |
+| Auth | `Authorization: Bearer {code_summarization.api_key}` |
+| Features | Batch processing, JSON response format, token budget management |
+
+Purpose: Generate AI summaries for code symbols (functions, types, interfaces). Batched for efficiency.
+
+### HyDE (Hypothetical Document Embedding)
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `{search.hyde.provider_url}/chat/completions` |
+| Default timeout | 500ms |
+| Auth | `Authorization: Bearer {search.hyde.api_key}` |
+
+Purpose: Rewrite search queries as "ideal answer" passages before embedding to improve semantic retrieval.
+
+### Query Preprocessing
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `{search.query_preprocessing.provider_url}/chat/completions` |
+| Default timeout | 500ms |
+| Auth | `Authorization: Bearer {search.query_preprocessing.api_key}` |
+
+Purpose: Classify query intent (keyword/conceptual/temporal), extract time filters, expand queries.
+
+### Intelligence (Categorization + Consolidation)
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `{intelligence.provider_url}/chat/completions` |
+| Default model | `claude-sonnet-4-5` |
+| Auth | `Authorization: Bearer {intelligence.api_key}` |
+
+Purpose: Auto-tag uncategorized documents. Merge semantically similar documents to reduce redundancy.
+
+## Reranking Providers
+
+### Cohere (default)
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `POST https://api.cohere.ai/v1/rerank` |
+| Default model | `rerank-v4.0-pro` |
+| Timeout | 2s |
+| Auth | `Authorization: Bearer {search.reranking.api_key}` |
+| Features | Retry (3 attempts), min score threshold |
+
+Purpose: Cross-encoder reranking of hybrid search results for improved precision.
+
+### Jina AI
+
+| Detail | Value |
+|--------|-------|
+| Endpoint | `POST https://api.jina.ai/v1/rerank` |
+| Default model | `jina-reranker-v2-base-multilingual` |
+| Auth | `Authorization: Bearer {search.reranking.api_key}` |
+
+Purpose: Alternative reranking provider. Selected when `reranking.provider = "jina"`.
+
+## Session Harvesters
+
+### OpenCode Sessions
+
+| Detail | Value |
+|--------|-------|
+| Sources | SQLite DB (per-project), JSON session files |
+| Config | `harvester.opencode.db_root`, `harvester.opencode.db_path`, `harvester.opencode.session_dir` |
+| Resolved paths | DB root (new layout) > DB path (legacy) > session dir (legacy) |
+
+Purpose: Ingest AI coding sessions from OpenCode for persistent memory.
+
+### Claude Code Sessions
+
+| Detail | Value |
+|--------|-------|
+| Source | JSONL session files |
+| Config | `harvester.claudecode.session_dir` |
+| Toggle | `harvester.claudecode.enabled` |
+
+Purpose: Ingest AI coding sessions from Claude Code for persistent memory.
+
+### Git History
+
+| Detail | Value |
+|--------|-------|
+| Toggle | `harvester.git.enabled` |
+| Access | `internal/harvest/git.go` |
+
+Purpose: Harvest commit messages and file changes from local git history.
+
+## File System
+
+### fsnotify Watcher
+
+| Detail | Value |
+|--------|-------|
+| Library | `fsnotify/fsnotify` v1.9.0 |
+| Config | `watcher.debounce_ms` (2000ms default), `watcher.reindex_interval` (300s) |
+| Filters | `watcher.exclude_patterns`, `watcher.allowed_extensions` |
+| Per-workspace | `watcher.workspaces.<path>.exclude_patterns` |
+
+Purpose: Watch workspace files for changes and trigger incremental re-indexing.
+
+## MCP Protocol
+
+| Detail | Value |
+|--------|-------|
+| Library | `modelcontextprotocol/go-sdk` v0.8.0 |
+| Transports | Streamable HTTP (`POST /mcp`), SSE (`GET /sse` + `POST /sse`) |
+| Tools | 16 registered tools |
+| Keep-alive | 30s ping interval |
+
+Purpose: Primary agent interface. All capabilities exposed as MCP tool calls.
+
+## Authentication
+
+| Detail | Value |
+|--------|-------|
+| Method | HTTP Basic Auth or Bearer token |
+| Password | bcrypt hash (configurable) |
+| Config | `server.auth.enabled`, `server.auth.users`, `server.auth.tokens` |
+| Bypass | `server.auth.bypass_paths` (default: `/health`) |
+
+Purpose: Protect HTTP API in VPS/remote deployments. Optional — disabled by default.
+
+## CI/CD
+
+### GitHub Actions
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci.yml` | Push to master, PRs | Build + test with PG service container |
+| `auto-tag.yml` | Push to master | Compute date-based tag (`v{YYYY}.{M}.{DDNN}`) |
+| `release.yml` | `v*` tag push | Cross-build 4 binaries + GH Release + npm publish |
+| `gemini-review.yml` | PR open/sync | Gemini AI code review |
+
+### npm Publishing
+
+| Detail | Value |
+|--------|-------|
+| Registry | `https://registry.npmjs.org` |
+| Package | `@nano-step/nano-brain` + `nano-brain` (unscoped alias) |
+| Auth | `NPM_TOKEN` secret |
+| Tag logic | `latest` (stable) or `beta` (pre-release) |
+
+## Docker Compose Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| `postgres` | `pgvector/pgvector:pg17` | 5432 | Primary database |
+| `ollama` | `ollama/ollama:latest` | 11434 | Local embeddings |
+| `nano-brain` | `./Dockerfile` | 3100 | Application server |
+
+## Webhook / Event Integrations
+
+| System | Mechanism | Purpose |
+|--------|-----------|---------|
+| Internal event bus | `internal/eventbus` | Decouple reindex notifications |
+| fsnotify | File system events | Trigger incremental indexing |
+| OpenCode MCP | Streamable HTTP | Agent ↔ daemon communication |
+
+## External Tool Dependencies
+
+| Tool | Used by | Purpose |
+|------|---------|---------|
+| Tree-sitter | `internal/graph/` | AST parsing for 15+ languages |
+| pgvector HNSW | PostgreSQL extension | Vector similarity search |
+| tsvector/tsquery | PostgreSQL built-in | BM25 full-text search |

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,186 @@
+# Technology Stack — nano-brain
+
+Last updated: 2026-06-28
+
+## Runtime
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| Go | 1.23 | `CGO_ENABLED=0` static binary |
+| PostgreSQL | 17 | Primary data store |
+| pgvector | 0.8.2 | Vector similarity (HNSW indexing) |
+| Node.js | 24 | npm package only (postinstall, CLI shim) |
+| Alpine Linux | 3.21 | Docker base image |
+
+## Languages
+
+- **Go 1.23** — 100% of application logic (cmd/, internal/)
+- **SQL** — 27 goose migrations + sqlc queries
+- **YAML** — Config files, GitHub Actions workflows
+- **JavaScript** — npm shim only (npm/run.js, npm/postinstall.js) — not application code
+
+## Frameworks & Libraries
+
+### HTTP / API
+
+| Library | Purpose |
+|---------|---------|
+| `labstack/echo/v4` | HTTP framework, routing, middleware |
+| `modelcontextprotocol/go-sdk` v0.8.0 | MCP protocol server (streamable HTTP + SSE) |
+
+### Database
+
+| Library | Purpose |
+|---------|---------|
+| `jackc/pgx/v5` v5.7.2 | PostgreSQL driver + connection pool |
+| `pgvector/pgvector-go` v0.2.2 | pgvector type support for Go |
+| `sqlc-dev/pqtype` v0.3.0 | sqlc JSON/array type mappings |
+| `lib/pq` v1.12.3 | PostgreSQL driver (compat) |
+| `pressly/goose/v3` v3.22.1 | Database migrations |
+| `sqlc` v2 | Type-safe SQL code generation |
+
+### Configuration
+
+| Library | Purpose |
+|---------|---------|
+| `knadh/koanf/v2` v2.3.4 | YAML + env config loading |
+| `knadh/koanf/parsers/yaml` | YAML parser for koanf |
+| `knadh/koanf/providers/file` | File-based config provider |
+| `knadh/koanf/providers/structs` | Default struct config provider |
+
+### Logging & Observability
+
+| Library | Purpose |
+|---------|---------|
+| `rs/zerolog` v1.35.1 | Structured JSON logging |
+| `natefinch/lumberjack` v2.0.0 | Log file rotation |
+| `internal/telemetry` | Search telemetry (embedded) |
+
+### Caching & Data Structures
+
+| Library | Purpose |
+|---------|---------|
+| `hashicorp/golang-lru/v2` v2.0.7 | LRU cache (PageRank, search) |
+| `google/uuid` v1.6.0 | UUID generation |
+| `sabhiram/go-gitignore` | .gitignore pattern matching |
+| `odvcencio/gotreesitter` v0.19.1 | Tree-sitter AST parsing |
+
+### Search & AI
+
+| Library | Purpose |
+|---------|---------|
+| `modernc.org/sqlite` v1.38.2 | Pure-Go SQLite (OpenCode session DB) |
+| `golang.org/x/sync` v0.15.0 | errgroup for parallel operations |
+| `golang.org/x/time` v0.9.0 | Rate limiting (LLM calls) |
+| `golang.org/x/crypto` v0.31.0 | bcrypt (auth password hashing) |
+
+### Testing
+
+| Library | Purpose |
+|---------|---------|
+| `stretchr/testify` v1.9.0 | Test assertions + require |
+
+## Code Generation
+
+| Tool | Config | Output |
+|------|--------|--------|
+| `sqlc` | `sqlc.yaml` | `internal/storage/sqlc/` — type-safe query wrappers |
+| `goose` | `migrations/*.sql` | Schema versioning (27 migrations) |
+
+## Build System
+
+| Tool | Purpose |
+|------|---------|
+| `Makefile` | `build`, `lint`, `test`, `test-integration`, `test-e2e` |
+| `golangci-lint` | Static analysis (errcheck, govet, staticcheck, unused) |
+| `Dockerfile` | Multi-stage build (golang:1.23-alpine → alpine:3.21) |
+| `docker-compose.yml` | 3-service stack (postgres + ollama + nano-brain) |
+
+## Configuration
+
+### Config file
+- Default: `~/.nano-brain/config.yml`
+- Override: `--config` flag or `NANO_BRAIN_CONFIG` env var
+
+### Config sections
+
+| Section | Key | Default |
+|---------|-----|---------|
+| `server` | `host:port` | `localhost:3100` |
+| `database` | `url` | `postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev` |
+| `embedding` | `provider,url,model` | `ollama, http://localhost:11434, nomic-embed-text` |
+| `search` | `rrf_k, recency_weight, limit` | `60, 0.3, 20` |
+| `watcher` | `debounce_ms, reindex_interval` | `2000, 300` |
+| `summarization` | `enabled, provider_url, model` | disabled |
+| `code_summarization` | `enabled, provider_url, model` | disabled |
+| `flow` | `enabled, max_depth` | disabled, 10 |
+| `intelligence` | `enabled, model` | disabled, claude-sonnet-4-5 |
+
+### Environment variables
+
+| Variable | Maps to | Notes |
+|----------|---------|-------|
+| `NANO_BRAIN_CONFIG` | config file path | |
+| `NANO_BRAIN_SERVER_PORT` | `server.port` | |
+| `NANO_BRAIN_DATABASE_URL` | `database.url` | |
+| `DATABASE_URL` | `database.url` | Postgres convention |
+| `VOYAGE_API_KEY` | `embedding.voyage_api_key` | |
+| `OPENCODE_STORAGE_DIR` | `harvester.opencode.session_dir` | |
+| `OPENCODE_DB_PATH` | `harvester.opencode.db_path` | |
+| `OPENCODE_DB_ROOT` | `harvester.opencode.db_root` | |
+
+## Docker Stack
+
+```yaml
+services:
+  postgres:   pgvector/pgvector:pg17  (port 5432)
+  ollama:     ollama/ollama:latest    (port 11434)
+  nano-brain: ./Dockerfile            (port 3100)
+```
+
+## npm Package
+
+- Name: `@nano-step/nano-brain`
+- Purpose: Distribute pre-built Go binary via npm
+- Dependencies: `@nano-step/oh-my-harness` (dev workflow only)
+- Binary shim: `npm/run.js` → spawns Go binary
+
+## Database Schema
+
+27 goose migrations covering:
+- Documents + chunks + embeddings (HNSW vector index)
+- BM25 full-text search (tsvector/tsquery)
+- Knowledge graph (nodes, edges, types)
+- Code symbols + call graph
+- Flow charts + execution flows
+- Search telemetry
+- Code summarization usage/failures
+- Auto-summarization
+
+## Internal Packages (17)
+
+| Package | Responsibility |
+|---------|---------------|
+| `cmd/nano-brain` | CLI dispatcher, daemon startup, 53+ command files |
+| `internal/server` | HTTP server, routes, middleware |
+| `internal/storage` | PostgreSQL pool, sqlc, migrations |
+| `internal/search` | Hybrid search pipeline (BM25 + vector + RRF) |
+| `internal/embed` | Embedding queue (Ollama, VoyageAI) |
+| `internal/mcp` | MCP protocol server, 16 tools |
+| `internal/graph` | Code intelligence (15+ language extractors) |
+| `internal/symbol` | Symbol extraction (Go, JS, TS, Python, Ruby) |
+| `internal/flow` | Execution flow visualization |
+| `internal/harvest` | Session harvesting (OpenCode, Claude Code, Git) |
+| `internal/summarize` | LLM session summarization |
+| `internal/codesummarize` | Batched LLM code symbol summarization |
+| `internal/intelligence` | Memory consolidation + categorization |
+| `internal/watcher` | File system watching + incremental indexing |
+| `internal/chunker` | Document chunking |
+| `internal/chunk` | Chunk types |
+| `internal/config` | Configuration management |
+| `internal/eventbus` | Internal event bus |
+| `internal/telemetry` | Search telemetry |
+| `internal/timefilter` | Time range parsing |
+| `internal/links` | Link resolution |
+| `internal/bench` | Benchmark harness |
+| `internal/testutil` | Test utilities |

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,216 @@
+# STRUCTURE.md — nano-brain
+
+**Last updated:** 2026-06-28
+
+---
+
+## Top-Level Layout
+
+```
+nano-brain/
+├── cmd/nano-brain/          # CLI dispatcher + server entry point
+├── internal/                # 24 packages — all application logic
+├── migrations/              # Goose SQL migrations (embedded)
+├── benchmarks/              # Capability benchmarks per workspace
+├── sqlc.yaml                # sqlc code generation config
+├── go.mod / go.sum          # Go 1.23 module
+├── Dockerfile               # Multi-stage build
+├── docker-compose.yml       # Postgres + nano-brain
+├── config.test.yml          # Test config (port 3199)
+├── Makefile                 # Build/test targets
+├── npm/                     # npm package wrapper
+├── scripts/                 # Helper scripts
+├── skills/                  # OpenCode skill definitions
+├── openspec/                # OpenSpec change proposals
+├── docs/                    # User-facing documentation
+├── testdata/                # Test fixtures
+└── test/                    # Additional test resources
+```
+
+---
+
+## `cmd/nano-brain/` — CLI Layer
+
+Custom dispatcher (no cobra). `main.go` switches on `os.Args[1]`.
+
+| File | Purpose |
+|------|---------|
+| `main.go` | Entry point: flag parsing, command dispatch, `startServer()` |
+| `commands.go` | `runWriteCmd`, `runQueryCmd`, `runSearchCmd`, `runVSearchCmd`, `runReindexCmd`, `runHarvestCmd`, `runInitCmd` |
+| `ops.go` | Server-side ops: `runLogsCmd`, `runStatusCmd`, `runVersionCmd`, `runDockerCmd`, `runBenchCmd`, `runDBMigrateCmd` |
+| `daemon.go` | `runServeCmd`, `runServeDaemon`, `runStopCmd`, `runRestartCmd`; PID-file lifecycle |
+| `guard.go` | Single-instance guard, container detection |
+| `client.go` | HTTP client: `doRequest`, `sendRequest`, `getBaseURL` |
+| `collection.go` | `runCollectionCmd` — add/remove/list collections |
+| `workspaces.go` | `runWorkspacesCmd` — list workspaces |
+| `init.go` | `runInteractiveInit` — guided workspace registration wizard |
+| `config_cmd.go` | `runConfigCmd` — show/validate config |
+| `doctor.go` | `runDoctorCmd` — prerequisite checks (PG, pgvector, Ollama) |
+| `detect.go` | Auto-detect OpenCode/Claude Code storage directories |
+| `migrate.go` | `runDBMigrateCmd` — goose migrations + V1 SQLite import |
+| `bench.go` | `runBenchCmd` — generate/run/compare benchmarks |
+
+---
+
+## `internal/` — Application Packages
+
+### Core Infrastructure
+
+| Package | Purpose |
+|---------|---------|
+| `config/` | YAML + env configuration (koanf). `Config` struct with 14 sub-configs. Hot-reload via `POST /api/reload-config`. |
+| `storage/` | PostgreSQL pool (pgxpool), goose migrations, sqlc query generation |
+| `storage/sqlc/` | **Generated** type-safe Go from SQL. Never edit directly. |
+| `storage/queries/` | Raw SQL files (input to sqlc). 17 query files. |
+| `eventbus/` | Async pub/sub bus. Fan-out notifications between components. |
+| `health/` | Health checks, doctor prerequisite validation, logger setup |
+| `telemetry/` | Query logging, latency tracking, retention cleanup |
+| `testutil/` | `SetupTestDB(t)` — isolated PG schema per test |
+
+### Business Logic
+
+| Package | Purpose |
+|---------|---------|
+| `search/` | Hybrid search pipeline: BM25 + vector + RRF + recency + PageRank + entity boost. Optional HyDE, reranking, query preprocessing. |
+| `graph/` | Code intelligence: 15+ language/framework extractors (Go, TS, JS, Python, Ruby, Echo, Express, Gin, Rails, NestJS, Nuxt). PageRank. CFG extraction. |
+| `symbol/` | Code symbol extraction: functions, types, interfaces, constants. 5 language extractors. |
+| `harvest/` | Session harvesting from OpenCode (SQLite/JSON) and Claude Code (JSONL). Dedup, tagging, auto-memory. |
+| `embed/` | Embedding queue + provider adapters (Ollama, VoyageAI). Bounded worker pool. |
+| `flow/` | Execution flow materializer. Builds call chains, Mermaid diagrams, sequence diagrams. |
+| `summarize/` | LLM session summarization. Map-reduce pipeline, disk persistence, harvest adapter. |
+| `codesummarize/` | Batched code symbol summarization. Budget tracking, retry, cascade, graph context. |
+| `intelligence/` | Memory consolidation and LLM-based categorization. |
+| `chunker/` | Document chunking strategies: symbol-aware, heading-based, fixed-size. Dispatcher selects strategy. |
+| `chunk/` | Chunk data model. |
+| `links/` | Document link resolution and extraction (backlinks, forward links). |
+| `watcher/` | File system watcher (fsnotify). Debounced, filtered, triggers re-indexing. |
+| `timefilter/` | Time range parsing for query filtering. |
+
+### Transport
+
+| Package | Purpose |
+|---------|---------|
+| `mcp/` | MCP protocol server. 16 tools. Streamable HTTP + SSE transport. |
+| `server/` | Echo v4 HTTP server. Routes, middleware, handler registration. |
+| `server/handlers/` | 76 handler files. One per endpoint group. Constructor pattern with interface deps. |
+| `server/middleware/` | Auth, workspace resolution, CSRF protection. |
+| `bench/` | Benchmark framework: generate, run, compare, stress test. |
+| `migrate/` | V1 SQLite import (migration from v1 schema). |
+
+---
+
+## Database Schema
+
+### Tables (from migrations)
+
+| Table | Purpose |
+|-------|---------|
+| `workspaces` | Registered project roots (hash, name, path) |
+| `collections` | Named paths within workspaces (glob, exclude, extensions) |
+| `documents` | Source file metadata + content (versioned via `supersedes_id`) |
+| `chunks` | Sub-document units (symbol-aware, heading, or fixed) |
+| `embeddings` | Vector representations (provider, model, vector) |
+| `graph_edges` | Directed edges: `source_node → target_node` with type |
+| `pagerank_scores` | Pre-computed PageRank importance scores |
+| `function_flowcharts` | Pre-materialized control-flow graphs |
+| `chunk_entities` | Entity mentions within chunks |
+| `telemetry_logs` | Query logging and metrics |
+| `code_summarization_usage` | Daily API usage tracking |
+| `code_summarization_failures` | Failed summarization attempts |
+
+### Key Relationships
+
+```
+workspaces 1──* collections 1──* documents 1──* chunks 1──* embeddings
+     │                          │
+     └──* graph_edges           └──* chunk_entities
+     └──* pagerank_scores
+     └──* function_flowcharts
+     └──* telemetry_logs
+```
+
+---
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Go packages | lowercase, single word | `search`, `graph`, `embed` |
+| Go files | snake_case | `opencode_sqlite.go`, `pagerank_loader.go` |
+| Go types | PascalCase | `SearchService`, `GraphEdge`, `EmbedQueue` |
+| Go interfaces | Role-based, small | `Embedder`, `Querier`, `Harvester`, `Publisher` |
+| SQL tables | snake_case, plural | `documents`, `graph_edges`, `embeddings` |
+| SQL queries | PascalCase, descriptive | `GetDocumentByPath`, `ListGraphEdges` |
+| Config keys | snake_case | `session_poll`, `max_depth`, `rrf_k` |
+| HTTP routes | kebab-case | `/api/v1/multi-get`, `/api/v1/reload-config` |
+| MCP tool names | snake_case, prefixed | `memory_query`, `memory_impact`, `memory_trace` |
+| CLI commands | kebab-case | `backfill-summaries`, `detect-changes`, `code-impact` |
+| Env vars | SCREAMING_SNAKE | `NANO_BRAIN_SERVER_PORT`, `DATABASE_URL` |
+| Migrations | Sequential zero-padded | `00001_initial_schema.sql` → `00027_reconcile_edge_type.sql` |
+
+---
+
+## Key File Locations
+
+| What | Where |
+|------|-------|
+| Server startup | `cmd/nano-brain/main.go:229` (`startServer()`) |
+| Route registration | `internal/server/routes.go:14` (`registerRoutes()`) |
+| MCP tool registration | `internal/mcp/tools.go:28` (`RegisterTools()`) |
+| Config loading | `internal/config/config.go:294` (`Load()`) |
+| Pool creation | `internal/storage/pool.go` (`NewPool()`) |
+| Migration runner | `internal/storage/migrate.go` (`RunMigrations()`) |
+| Workspace hash | `internal/storage/workspace.go` (SHA-256 of root path) |
+| Search pipeline | `internal/search/service.go` (`SearchService`) |
+| Graph registry | `internal/graph/registry.go` (`Registry`) |
+| Symbol registry | `internal/symbol/symbol.go` (`Registry`) |
+| Watcher main loop | `internal/watcher/watcher.go` (`Run()`) |
+| Embed queue worker | `internal/embed/queue.go` (`Run()`) |
+| Harvester runner | `internal/harvest/runner.go` (`Run()`) |
+| Flow materializer | `internal/flow/materializer.go` (`Materializer`) |
+| Code summarizer | `internal/codesummarize/service.go` (`Service`) |
+
+---
+
+## Configuration
+
+Default path: `~/.nano-brain/config.yml`
+
+Precedence: `--config` flag > `NANO_BRAIN_CONFIG` env > default path > built-in defaults.
+
+| Section | Key Fields |
+|---------|-----------|
+| `server` | `host`, `port`, `auth.enabled`, `serve_only` |
+| `database` | `url` (PostgreSQL DSN) |
+| `embedding` | `provider`, `url`, `model`, `dimension`, `concurrency`, `max_chars` |
+| `search` | `rrf_k`, `recency_weight`, `limit`, `pagerank_enabled`, `hyde.enabled`, `reranking.enabled` |
+| `harvester` | `opencode.session_dir`, `opencode.db_path`, `opencode.db_root`, `claudecode.session_dir` |
+| `watcher` | `debounce_ms`, `reindex_interval`, `exclude_patterns`, `allowed_extensions` |
+| `summarization` | `enabled`, `provider_url`, `model`, `concurrency`, `write_to_disk` |
+| `code_summarization` | `enabled`, `provider_url`, `model`, `batch_size`, `workers` |
+| `flow` | `enabled`, `max_depth`, `max_fanout`, `summary_enabled` |
+| `intelligence` | `enabled`, `provider_url`, `model`, `consolidation_age` |
+
+---
+
+## Build & Test
+
+```bash
+# Build
+CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain
+
+# Quick test
+go build ./... && go test -race -short ./...
+
+# Integration tests
+go test -race -tags=integration ./...
+
+# Lint
+golangci-lint run
+
+# sqlc codegen
+sqlc generate
+
+# Migrations
+./nano-brain db:migrate
+```

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,220 @@
+# Testing Patterns
+
+> Observed patterns from the nano-brain codebase. Last reviewed: 2026-06-28.
+
+## Framework & Tooling
+
+- **Standard `testing` package** — no testify assertions (testify only used for `require` in a few places)
+- **`t.Run` subtests** for table-driven and scenario tests
+- **`t.Parallel()`** used in pure unit tests
+- **`t.TempDir()`** for filesystem isolation
+- **`t.Setenv()`** for env var manipulation (auto-restored on cleanup)
+- **`t.Cleanup()`** for resource teardown
+- **`t.Helper()`** on all test helper functions
+- **`httptest`** for HTTP server and request simulation
+
+## Test Categories
+
+| Category | Build tag | Command | Database | Purpose |
+|---|---|---|---|---|
+| **Unit** | (none) | `go test -race -short ./...` | None | Pure logic, no external deps |
+| **Integration** | `integration` | `go test -race -tags=integration ./...` | `nanobrain_test` | DB, migrations, full pipeline |
+| **E2E** | `e2e` | `go test -race -tags=e2e ./...` | `nanobrain_test` | Server + curl endpoints |
+| **Capability bench** | `capbench` | `go test -v -tags=capbench -run TestCapabilityBenchmark ./...` | `nanobrain_test` | Agent-oriented search quality |
+
+## Makefile Targets
+
+```bash
+make test              # unit tests (race, short)
+make test-integration  # integration tests (race, build tag)
+make test-e2e          # e2e tests (race, build tag)
+make lint              # golangci-lint run
+```
+
+## Unit Test Patterns
+
+### Table-Driven Tests
+
+```go
+func TestRedactString_ScrubsPasswordInPostgresURL(t *testing.T) {
+    cases := []struct {
+        name string
+        in   string
+        want string
+    }{
+        {"basic password leak", "postgres://user:secret@host/db", "postgres://user:REDACTED@host/db"},
+        {"no password — leave as-is", "postgres://user@host/db", "postgres://user@host/db"},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            got := RedactString(c.in)
+            if got != c.want {
+                t.Errorf("\n  in:   %q\n  got:  %q\n  want: %q", c.in, got, c.want)
+            }
+        })
+    }
+}
+```
+
+### Inline Struct Mocks (No gomock/gomock)
+
+```go
+type mockPool struct{ pingErr error }
+func (m *mockPool) Ping(_ context.Context) error { return m.pingErr }
+
+type mockQueue struct{}
+func (m *mockQueue) Depth() int      { return 0 }
+func (m *mockQueue) Capacity() int   { return 0 }
+func (m *mockQueue) Status() string  { return "idle" }
+```
+
+- Mocks are defined **in the test file**, not in a separate mocks package
+- Each handler defines its own small interface (e.g., `HybridSearcher`, `PoolChecker`)
+- Mocks implement only the methods the handler needs
+- No code generation for mocks — hand-rolled inline structs
+
+### HTTP Handler Tests
+
+```go
+e := echo.New()
+req := httptest.NewRequest(http.MethodPost, "/api/v1/query", strings.NewReader(body))
+req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+rec := httptest.NewRecorder()
+c := e.NewContext(req, rec)
+c.Set("workspace", "test-hash")  // inject workspace middleware value
+
+err := handlers.Query(mock, zerolog.Nop())(c)
+// assert err, rec.Code, parse rec.Body
+```
+
+- Handler tests use `package handlers_test` (external test package)
+- Request/response JSON constructed as string literals
+- Workspace injected via `c.Set("workspace", "test-hash")`
+- Response decoded with `json.NewDecoder(rec.Body).Decode(&result)`
+
+### CLI Command Tests
+
+```go
+ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(response)
+}))
+defer ts.Close()
+
+t.Setenv("NANO_BRAIN_HOST", host)
+t.Setenv("NANO_BRAIN_PORT", port)
+```
+
+- CLI tests mock the HTTP server with `httptest.NewServer`
+- Env vars set via `t.Setenv` for host/port overrides
+- Tests in `package main` (internal test package) for direct function access
+
+## Integration Test Patterns
+
+### Build Tag Guard
+
+```go
+//go:build integration
+
+package storage
+```
+
+All integration test files start with `//go:build integration`.
+
+### Database Setup
+
+```go
+pool := testutil.SetupTestDB(t)
+```
+
+- Connects to `nanobrain_test` (NOT `nanobrain_dev`)
+- Default DSN: `postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable`
+- Override: `NANO_BRAIN_TEST_DATABASE_URL=<dsn>`
+- Creates an **isolated schema** per test: `test_<sha256(name)[:6]>`
+- Runs goose migrations automatically
+- Drops schema on cleanup
+
+### Isolation Model
+
+```
+testutil.SetupTestDB(t)
+  → sha256(t.Name()) → schema "test_<hash>"
+  → CREATE SCHEMA IF NOT EXISTS <schema>
+  → SET search_path TO <schema>, public
+  → goose.UpContext (migrations)
+  → t.Cleanup: DROP SCHEMA IF EXISTS <schema> CASCADE + pool.Close()
+```
+
+- Tests never share state — each gets its own PG schema
+- Parallel-safe because schemas are isolated
+
+### Integration Test Structure
+
+```go
+func TestUpsertChunkPreservesEmbedStatus(t *testing.T) {
+    pool := testutil.SetupTestDB(t)
+    db := stdlib.OpenDBFromPool(pool)
+    defer db.Close()
+
+    q := sqlc.New(db)
+    ctx := context.Background()
+
+    // seed data...
+    workspaceHash := uuid.New().String()[:8]
+    _, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{...})
+
+    t.Run("new chunk gets pending status", func(t *testing.T) {
+        chunkID, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{...})
+        // assert...
+    })
+}
+```
+
+## Test Helpers (`internal/testutil/`)
+
+| Function | Purpose |
+|---|---|
+| `SetupTestDB(t)` | Connect, create isolated schema, migrate, register cleanup |
+| `TestDSN()` | Returns integration test DSN (env override or default) |
+| `NopLogger()` | Returns `zerolog.Nop()` for silent logging in tests |
+| `SeedDocumentWithTimestamps(...)` | Insert test documents with custom timestamps and tags |
+
+## Assertion Style
+
+- **No testify assertions** — standard `t.Errorf` / `t.Fatalf` throughout
+- Format: `t.Errorf("field = %v, want %v", got, want)`
+- Multi-line diffs in error messages when helpful:
+  ```go
+  t.Errorf("\n  in:   %q\n  got:  %q\n  want: %q", in, got, want)
+  ```
+- `t.Fatalf` for setup failures (DB connect, migration)
+- `t.Errorf` for assertion failures (continues test)
+
+## Coverage & Quality
+
+- **Race detector** always on: `-race` flag in all test commands
+- **Short mode** for unit tests: `-short` skips long-running operations
+- **No coverage thresholds enforced** — coverage is informational
+- **golangci-lint** with minimal linters: `errcheck`, `govet`, `staticcheck`, `unused`
+- **Lint timeout:** 5 minutes (`timeout: 5m` in `.golangci.yml`)
+
+## CI Pipeline
+
+```yaml
+# .github/workflows/ci.yml
+go build ./...
+go test -race -short ./...
+# Runs against ephemeral PG service container
+```
+
+## Common Patterns to Follow
+
+1. **Always use `t.Helper()`** in test helper functions
+2. **Always use `t.Parallel()`** in pure unit tests (no DB)
+3. **Always use `t.TempDir()`** for file system tests (auto-cleanup)
+4. **Always use `t.Setenv()`** for env var tests (auto-restore)
+5. **Never hardcode paths** — use `t.TempDir()` or relative paths
+6. **Never share state between tests** — isolated schemas per test
+7. **Test both success and failure paths** — error messages validated with string matching
+8. **Table-driven tests** for functions with multiple input variations
+9. **Mock at interface boundaries** — handler tests mock services, not DB

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,85 @@
+{
+  "model_profile": "adaptive",
+  "commit_docs": true,
+  "parallelization": true,
+  "search_gitignored": false,
+  "brave_search": false,
+  "firecrawl": false,
+  "exa_search": false,
+  "tavily_search": false,
+  "ref_search": false,
+  "perplexity": false,
+  "jina": false,
+  "git": {
+    "branching_strategy": "none",
+    "create_tag": true,
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "quick_branch_template": null
+  },
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": true,
+    "auto_advance": false,
+    "node_repair": true,
+    "node_repair_budget": 2,
+    "ui_phase": true,
+    "ui_safety_gate": true,
+    "ai_integration_phase": true,
+    "human_verify_mode": "end-of-phase",
+    "context_guard_mode": "warn",
+    "text_mode": false,
+    "research_before_questions": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "code_review": true,
+    "code_review_depth": "standard",
+    "code_review_command": null,
+    "pattern_mapper": true,
+    "plan_bounce": false,
+    "plan_bounce_script": null,
+    "plan_bounce_passes": 2,
+    "auto_prune_state": false,
+    "post_planning_gaps": true,
+    "security_enforcement": true,
+    "security_asvs_level": 1,
+    "security_block_on": "high"
+  },
+  "ship": {
+    "pr_body_sections": [
+      {
+        "heading": "User Stories & Acceptance Criteria",
+        "enabled": true,
+        "source": "REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria",
+        "fallback": "- Acceptance criteria are covered by the linked requirements and verification evidence."
+      },
+      {
+        "heading": "Risks & Dependencies",
+        "enabled": true,
+        "source": "PLAN.md ## Risks || PLAN.md ## Dependencies",
+        "fallback": "- No known high-risk rollout dependencies."
+      },
+      {
+        "heading": "Success Metrics & Release Criteria",
+        "enabled": true,
+        "source": "REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria",
+        "fallback": "- Release when automated verification and required manual checks pass."
+      }
+    ]
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "project_code": null,
+  "phase_naming": "sequential",
+  "agent_skills": {},
+  "claude_md_path": "./.claude/CLAUDE.md",
+  "plan_review": {
+    "source_grounding": true,
+    "source_grounding_authority": "grep"
+  },
+  "mode": "yolo",
+  "granularity": "fine"
+}

--- a/.planning/phases/phase-1-vue-sfc/GOAL.md
+++ b/.planning/phases/phase-1-vue-sfc/GOAL.md
@@ -1,0 +1,58 @@
+## Why
+
+nano-brain's code intelligence layer currently has **zero support for Vue Single File Components (.vue)**. This means:
+
+- **No call graph edges** from `.vue` files — agents can't trace component dependencies
+- **No component composition graph** — agents can't see parent→child relationships
+- **No symbol extraction** — `memory_symbols` returns nothing for `.vue` files
+- **Impact analysis fails** — `memory_impact` misses all Vue component edges
+
+Vue/Nuxt workspaces show **P@5 of 0.75** (vs 1.000 for Go). Adding Vue SFC support is the highest-impact improvement for Vue/Nuxt agent workflows.
+
+**Why now**: The gotreesitter v0.19.1 Vue grammar is already available — no new dependencies needed. The two-pass extraction approach has been verified via live parse.
+
+## What Changes
+
+- **New Vue SFC parser** — splits `.vue` files into template/script/style blocks using tree-sitter
+- **Script block re-parsing** — extracts symbols and edges from `<script>` using existing TS/JS extractors
+- **Component detection** — identifies `<MyChild />` references in template via AST `tag_name` nodes (PascalCase filter)
+- **Universal extractor** — runs for ALL `.vue` files (not framework-gated)
+- **Edge types**: `contains`, `imports`, `calls`, `component_usage` (template→child)
+
+**Deferred to v2** (per user decision):
+- CFG extraction for `.vue` files
+- Template-level intelligence (v-if/v-for as CFG nodes)
+- Props/emits tracking
+- Composable usage patterns
+
+## Capabilities
+
+### New Capabilities
+
+- `vue-sfc-parsing`: Vue Single File Component parsing — splits .vue files into blocks, re-parses script content with TS/JS grammars, extracts symbols and edges
+- `vue-component-detection`: Template component detection — identifies child component references via AST tag_name nodes, creates component_usage edges
+
+### Modified Capabilities
+
+- `code-intelligence`: Add .vue support to existing code intelligence pipeline (edges, symbols, impact analysis)
+
+## Impact
+
+**Affected code:**
+- `internal/graph/` — new Vue SFC parser and extractor files
+- `internal/graph/registry.go` — wire new extractors
+- `internal/symbol/` — add .vue symbol extraction
+- `internal/chunker/dispatcher.go` — add .vue case (Phase 2)
+
+**APIs:**
+- `memory_impact` — will now include Vue component edges
+- `memory_trace` — will now follow Vue component call chains
+- `memory_symbols` — will now return Vue component symbols
+- `memory_graph` — will now show Vue import/component edges
+
+**Dependencies:**
+- No new dependencies — uses existing `grammars.VueLanguage()` from gotreesitter v0.19.1
+
+**Systems:**
+- Vue/Nuxt workspaces will see improved search quality (P@5 target: ≥0.75 baseline maintained)
+- Component composition graph becomes visible to agents

--- a/.planning/phases/phase-1-vue-sfc/PLAN.md
+++ b/.planning/phases/phase-1-vue-sfc/PLAN.md
@@ -1,0 +1,145 @@
+## Context
+
+nano-brain's code intelligence layer supports Go, Ruby/Rails, and JS/TS — but has **zero support for Vue Single File Components**. Vue/Nuxt workspaces show P@5 of 0.75 (vs 1.000 for Go), primarily because:
+
+1. No `.vue` parsing — the chunker treats them as plain text
+2. No script extraction — `<script>` blocks are not re-parsed with TS/JS grammars
+3. No component detection — template references to child components are invisible
+
+The gotreesitter v0.19.1 Vue grammar (`grammars.VueLanguage()`) is already available — no new dependencies needed. Live parse verification (2026-06-26) confirmed:
+
+- Vue grammar emits `template_element`, `script_element`, `style_element` nodes
+- Script body is a single `raw_text` child — **no language injection**
+- Two-pass extraction is mandatory (Vue parse → TS/JS re-parse)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse `.vue` files and extract script-level symbols and edges
+- Detect component composition via AST `tag_name` nodes (PascalCase filter)
+- Maintain P@5 ≥ 0.75 baseline (no regression)
+- Universal extractor — runs for all `.vue` files (not framework-gated)
+
+**Non-Goals (deferred to v2):**
+- CFG extraction for `.vue` files
+- Template-level intelligence (v-if/v-for as CFG nodes)
+- Props/emits tracking
+- Composable usage patterns (useXxx)
+- Store dependency tracking (Pinia/Vuex)
+- Unified JSX+Vue component detection
+
+## Decisions
+
+### D1: Two-Phase Parsing (verified)
+
+**Decision**: Parse `.vue` with `VueLanguage()`, extract `raw_text` from `script_element`, re-parse with `TypescriptLanguage()` or `JavascriptLanguage()`.
+
+**Alternatives considered:**
+- Regex SFC splitting — rejected (breaks codebase patterns, false positives)
+- Single-pass with language injection — rejected (Vue grammar has no injection)
+
+**Rationale**: Verified by live parse. The Vue grammar yields opaque `raw_text` for script blocks. Two-pass is the only correct approach.
+
+### D2: Component Detection via AST (not regex)
+
+**Decision**: Use `tag_name` nodes from Vue grammar, filter PascalCase, create `component_usage` edges.
+
+**Alternatives considered:**
+- Regex on raw text — rejected (false positives from comments, HTML elements)
+- Unified JSX+Vue detection — deferred to v2
+
+**Rationale**: Vue grammar already emits `tag_name`="MyChild" inside `element`/`self_closing_tag`. AST-based detection is reliable; regex is fragile.
+
+### D3: Universal Extractor (not framework-gated)
+
+**Decision**: New Vue extractor runs for ALL `.vue` files. No `detectVue` rule in `detector.go`.
+
+**Alternatives considered:**
+- Framework-aware (only when `vue` in package.json) — rejected (plain Vue projects also need support)
+
+**Rationale**: Vue SFC parsing is generic. `NuxtExtractor` stays framework-gated for routes only. They coexist via registry's edge dedup logic.
+
+### D4: Line Number Offset via RootNodeWithOffset
+
+**Decision**: Use `tree.RootNodeWithOffset(scriptStartByte, point)` when re-parsing extracted script blocks. Only add manual `byteOffset` field if insufficient.
+
+**Alternatives considered:**
+- Manual byte offset calculation — more error-prone
+- Adjust all line numbers post-parse — fragile
+
+**Rationale**: `RootNodeWithOffset` exists in gotreesitter (`tree.go:2178`) and handles offset correctly. Test with `offset.vue` fixture (script starts past line 1).
+
+### D5: Multiple Script Blocks
+
+**Decision**: Iterate ALL `script_element` nodes. An SFC may have BOTH `<script setup>` AND `<script>` (Options API).
+
+**Rationale**: Both are valid Vue 3 patterns and can coexist in one file. Missing either block loses symbols/edges.
+
+### D6: Error Handling for Parse Failures
+
+**Decision**: Wrap Phase 2 re-parse in `recover`, return `Status: "parse_error"` for that script block. Don't crash the extractor.
+
+**Rationale**: Malformed `<script>` blocks should not crash the indexer. Graceful degradation is better than failure.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Line number offset bugs with multi-block SFCs | Use `RootNodeWithOffset`; test with `offset.vue` fixture (script starts at line 400+) |
+| NuxtExtractor conflict | New extractor produces ONLY contains/imports/calls — NOT http edges; registry dedup handles coexistence |
+| Multiple script blocks missed | Iterate all `script_element` nodes; test with `dual_script.vue` fixture |
+| Phase 2 parse failure | Wrap in recover, return parse_error status; test with `parse_error.vue` fixture |
+| Chunker gap (Phase 1 limitation) | Defer `.vue` chunker case to Phase 2; search baseline won't improve until then |
+| Symbol extraction gap (Phase 1 limitation) | Defer `.vue` symbol extractor to Phase 2; `memory_symbols` returns nothing for `.vue` until then |
+
+## Implementation Phases
+
+### Phase 1 (MVP): Edges + Component Graph
+
+Parse `.vue` files, extract script-level symbols and component composition edges.
+
+**Key files:**
+- `internal/graph/vue_sfc_parser.go` (new) — Vue SFC block splitter
+- `internal/graph/vue_sfc_extractor.go` (new) — Script re-parsing, edge extraction, component detection
+- `internal/graph/registry.go` — Wire new extractors (universal, no `RequiresFrameworks`)
+
+**Test fixtures:**
+- `script_setup.vue` — `<script setup lang="ts">`
+- `options_api.vue` — plain `<script>` Options API
+- `dual_script.vue` — both `<script>` and `<script setup>`
+- `no_script.vue` — template + style only
+- `parse_error.vue` — malformed script body
+- `offset.vue` — template before script (line number test)
+
+### Phase 2: CFG + Symbols
+
+Add control flow graphs and symbol extraction for `.vue` files.
+
+**Key files:**
+- `internal/graph/vue_sfc_cflow.go` (new) — CFG extraction
+- `internal/symbol/vue_sfc_extractor.go` (new) — Symbol extraction
+- `internal/chunker/dispatcher.go` — Add `.vue` case
+- `internal/server/handlers/reindex_cfg.go` — Add `.vue` to `cfgExts`
+
+### Phase 3 (v2): Template Intelligence
+
+Deep template analysis, props/emits tracking, composable patterns.
+
+**Deferred items:**
+- Props/emits tracking from `<script setup>`
+- `useFetch`/`useAsyncData` patterns
+- Composable tracking (useXxx with package filtering)
+- Store dependency tracking (Pinia/Vuex)
+- Unified JSX+Vue component detection
+
+## Migration Plan
+
+1. **Phase 1**: Add Vue SFC parser + extractor → wire into registry
+2. **Phase 2**: Add CFG + symbol extraction → update chunker
+3. **Verification**: Re-run Vue-workspace benchmark, confirm P@5 ≥ 0.75 baseline
+
+**Rollback**: Remove new extractor files, revert registry changes. No data migration needed.
+
+## Open Questions
+
+None — all decisions resolved via deep-design pipeline (Phase 1-2) and user decisions (Q1-Q3).

--- a/.planning/phases/phase-1-vue-sfc/TASKS.md
+++ b/.planning/phases/phase-1-vue-sfc/TASKS.md
@@ -1,0 +1,49 @@
+## 1. Test Fixtures
+
+- [ ] 1.1 Create `internal/graph/testdata/script_setup.vue` — `<script setup lang="ts">` with imports and function calls
+- [ ] 1.2 Create `internal/graph/testdata/options_api.vue` — plain `<script>` Options API with methods and data
+- [ ] 1.3 Create `internal/graph/testdata/dual_script.vue` — both `<script setup>` and `<script>` in one file
+- [ ] 1.4 Create `internal/graph/testdata/no_script.vue` — template + style only, no script block
+- [ ] 1.5 Create `internal/graph/testdata/parse_error.vue` — malformed script body (syntax errors)
+- [ ] 1.6 Create `internal/graph/testdata/offset.vue` — template before script (script starts at line 400+)
+- [ ] 1.7 Create `internal/graph/testdata/component-usage.vue` — template with `<MyChild />` references
+
+## 2. Vue SFC Parser
+
+- [ ] 2.1 Create `internal/graph/vue_sfc_parser.go` — VueSFCParser struct with Parse method
+- [ ] 2.2 Implement block splitting — iterate `script_element` nodes, extract `raw_text` + `lang` attribute
+- [ ] 2.3 Implement `lang` attribute → grammar matrix (ts→TypescriptLanguage, js→JavascriptLanguage, default→JavascriptLanguage)
+- [ ] 2.4 Implement error handling — wrap re-parse in recover, return parse_error status for malformed scripts
+- [ ] 2.5 Implement line number offset — use `RootNodeWithOffset(scriptStartByte, point)` for correct line numbers
+
+## 3. Vue SFC Extractor
+
+- [ ] 3.1 Add `EdgeComponentUsage EdgeKind = "component_usage"` to `internal/graph/edge.go` (Momus condition)
+- [ ] 3.2 Create `internal/graph/vue_sfc_extractor.go` — VueSFCExtractor struct implementing Extractor interface
+- [ ] 3.3 Implement script edge extraction — extract contains, imports, calls edges from re-parsed script content, set `Language: "vue"` on all edges
+- [ ] 3.4 Implement component detection — walk `tag_name` nodes, filter PascalCase, create component_usage edges
+- [ ] 3.5 Implement component edge deduplication — deduplicate component_usage edges for same child component
+- [ ] 3.6 Add universal wiring — register extractor in `registry.go` without `RequiresFrameworks` (runs for all .vue)
+
+## 4. Registry Integration
+
+- [ ] 4.1 Update `internal/graph/registry.go` — add VueSFCExtractor to extractor list
+- [ ] 4.2 Verify edge dedup — ensure Vue extractor and NuxtExtractor coexist without duplicate edges
+- [ ] 4.3 Verify Vue extractor does NOT produce http edges — only contains, imports, calls, component_usage
+
+## 5. Unit Tests
+
+- [ ] 5.1 Write `TestVueSFCParser` — test block splitting for all fixture files
+- [ ] 5.2 Write `TestVueSFCExtractor` — test edge extraction from script blocks
+- [ ] 5.3 Write `TestVueComponentDetection` — test component_usage edge creation and dedup
+- [ ] 5.4 Write `TestVueLineOffset` — test correct line numbers with offset.vue fixture
+- [ ] 5.5 Write `TestVueParseError` — verify parse_error status for malformed scripts
+- [ ] 5.6 Write `TestVueDualScript` — verify both script blocks are processed
+
+## 6. Integration Verification
+
+- [ ] 6.1 Run `go build ./...` — verify no compilation errors
+- [ ] 6.2 Run `go test -race -short ./internal/graph/ -run TestVue` — all Vue tests pass
+- [ ] 6.3 Run `go test -race -short ./...` — no regression in existing tests
+- [ ] 6.4 Verify `memory_impact` includes Vue component edges — manual verification with test workspace
+- [ ] 6.5 Verify `memory_trace` follows Vue component call chains — manual verification with test workspace

--- a/.planning/phases/phase-1-vue-sfc/specs/code-intelligence/spec.md
+++ b/.planning/phases/phase-1-vue-sfc/specs/code-intelligence/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Code intelligence pipeline support for .vue files
+
+The system SHALL support `.vue` files in the code intelligence pipeline, including edge extraction, symbol extraction, and impact analysis.
+
+#### Scenario: Extract edges from .vue files
+
+- **WHEN** a `.vue` file is indexed
+- **THEN** the system SHALL extract `contains`, `imports`, `calls`, and `component_usage` edges
+
+#### Scenario: Include .vue in impact analysis
+
+- **WHEN** `memory_impact` is called on a `.vue` file
+- **THEN** the system SHALL return all dependent files including other `.vue` files that import or use it as a component
+
+#### Scenario: Include .vue in call chain tracing
+
+- **WHEN** `memory_trace` is called from a `.vue` file
+- **THEN** the system SHALL follow call chains into imported modules and child components
+
+#### Scenario: Include .vue in symbol search
+
+- **WHEN** `memory_symbols` is called with a query matching a Vue component name
+- **THEN** the system SHALL return the `.vue` file as a symbol result
+
+### Requirement: Universal .vue extractor wiring
+
+The system SHALL wire the Vue SFC extractor as a universal extractor (no framework detection required).
+
+#### Scenario: Vue extractor runs for all .vue files
+
+- **WHEN** any `.vue` file is encountered during indexing
+- **THEN** the Vue SFC extractor SHALL run regardless of whether `vue` is in `package.json`
+
+#### Scenario: Nuxt extractor coexists with Vue extractor
+
+- **WHEN** a `.vue` file in a Nuxt project is indexed
+- **THEN** both the Vue SFC extractor and Nuxt extractor SHALL run, with edge dedup logic preventing duplicate edges
+
+#### Scenario: Vue extractor does not produce HTTP edges
+
+- **WHEN** the Vue SFC extractor processes a `.vue` file
+- **THEN** it SHALL NOT create `http` edges (only `contains`, `imports`, `calls`, `component_usage`)

--- a/.planning/phases/phase-1-vue-sfc/specs/vue-component-detection/spec.md
+++ b/.planning/phases/phase-1-vue-sfc/specs/vue-component-detection/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Component detection via AST
+
+The system SHALL detect child component references in Vue templates using AST `tag_name` nodes, filtered by PascalCase naming convention.
+
+#### Scenario: Detect PascalCase component in template
+
+- **WHEN** a `.vue` template contains `<MyChild />` or `<MyChild prop="value">`
+- **THEN** the system SHALL create a `component_usage` edge from the parent `.vue` file to `MyChild`
+
+#### Scenario: Detect PascalCase component with closing tag
+
+- **WHEN** a `.vue` template contains `<MyChild>...</MyChild>`
+- **THEN** the system SHALL create a `component_usage` edge from the parent `.vue` file to `MyChild`
+
+#### Scenario: Ignore lowercase HTML elements
+
+- **WHEN** a `.vue` template contains `<div>`, `<span>`, `<p>`, or other lowercase elements
+- **THEN** the system SHALL NOT create `component_usage` edges for these elements
+
+#### Scenario: Ignore comments
+
+- **WHEN** a `.vue` template contains `<!-- <MyChild /> -->` (comment)
+- **THEN** the system SHALL NOT create `component_usage` edges for commented components
+
+#### Scenario: Ignore PascalCase in text content
+
+- **WHEN** a `.vue` template contains text like "Use MyChild for this"
+- **THEN** the system SHALL NOT create `component_usage` edges for text references
+
+### Requirement: Component edge deduplication
+
+The system SHALL deduplicate component usage edges when the same child component is referenced multiple times.
+
+#### Scenario: Multiple references to same component
+
+- **WHEN** a `.vue` template references `<MyChild>` in 3 different places
+- **THEN** the system SHALL create only ONE `component_usage` edge to `MyChild`
+
+#### Scenario: Component referenced in script and template
+
+- **WHEN** a `.vue` file imports `MyChild` in script AND uses it in template
+- **THEN** the system SHALL create both `imports` and `component_usage` edges (no dedup across edge types)

--- a/.planning/phases/phase-1-vue-sfc/specs/vue-sfc-parsing/spec.md
+++ b/.planning/phases/phase-1-vue-sfc/specs/vue-sfc-parsing/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Vue SFC block splitting
+
+The system SHALL parse `.vue` files using `grammars.VueLanguage()` and extract `template_element`, `script_element`, and `style_element` nodes.
+
+#### Scenario: Parse .vue file with script setup
+
+- **WHEN** a `.vue` file contains `<script setup lang="ts">`
+- **THEN** the parser SHALL extract the script block as a `script_element` node with `lang="ts"` attribute
+
+#### Scenario: Parse .vue file with options API
+
+- **WHEN** a `.vue` file contains `<script>` (no setup)
+- **THEN** the parser SHALL extract the script block as a `script_element` node with default lang (js)
+
+#### Scenario: Parse .vue file with dual script blocks
+
+- **WHEN** a `.vue` file contains BOTH `<script setup>` AND `<script>` (Options API)
+- **THEN** the parser SHALL extract BOTH script blocks as separate `script_element` nodes
+
+#### Scenario: Parse .vue file with no script
+
+- **WHEN** a `.vue` file contains only `<template>` and `<style>` (no script)
+- **THEN** the parser SHALL extract template and style elements, and return empty script list
+
+#### Scenario: Parse .vue file with malformed script
+
+- **WHEN** a `.vue` file contains a `<script>` block with syntax errors
+- **THEN** the parser SHALL return `Status: "parse_error"` for that script block without crashing
+
+### Requirement: Script block re-parsing
+
+The system SHALL re-parse extracted `raw_text` content from `script_element` nodes using the appropriate grammar based on the `lang` attribute.
+
+#### Scenario: Re-parse TypeScript script
+
+- **WHEN** a script block has `lang="ts"` or `lang="typescript"`
+- **THEN** the system SHALL re-parse the content using `grammars.TypescriptLanguage()`
+
+#### Scenario: Re-parse JavaScript script
+
+- **WHEN** a script block has no `lang` attribute or `lang="js"` or `lang="javascript"`
+- **THEN** the system SHALL re-parse the content using `grammars.JavascriptLanguage()`
+
+#### Scenario: Re-parse with unsupported lang
+
+- **WHEN** a script block has an unsupported `lang` attribute (e.g., `lang="coffee"`)
+- **THEN** the system SHALL skip script extraction and emit `parse_error` status
+
+### Requirement: Edge extraction from script
+
+The system SHALL extract `contains`, `imports`, and `calls` edges from re-parsed script content.
+
+#### Scenario: Extract import edges
+
+- **WHEN** a script block contains `import { ref } from 'vue'`
+- **THEN** the system SHALL create an `imports` edge from the `.vue` file to `'vue'`
+
+#### Scenario: Extract call edges
+
+- **WHEN** a script block contains `const data = await useFetch('/api/data')`
+- **THEN** the system SHALL create a `calls` edge from the `.vue` file to `useFetch`
+
+#### Scenario: Extract contains edges
+
+- **WHEN** a script block defines a function or variable
+- **THEN** the system SHALL create `contains` edges from the `.vue` file to those symbols
+
+### Requirement: Line number offset handling
+
+The system SHALL correctly handle line numbers when script blocks start after line 1.
+
+#### Scenario: Script starts at line 1
+
+- **WHEN** a `.vue` file has `<script>` as the first element
+- **THEN** line numbers in the re-parsed script SHALL start at line 1
+
+#### Scenario: Script starts after template
+
+- **WHEN** a `.vue` file has `<template>` before `<script>` (script starts at line 400+)
+- **THEN** line numbers in the re-parsed script SHALL be correctly offset using `RootNodeWithOffset`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,18 @@ git worktree move ../nano-brain-foo .opencode/worktrees/feat-NNN-short-name
 **Entry:** `cmd/nano-brain/` — CLI dispatcher + server startup. `internal/` — 17 packages.
 **Injection pattern:** config, logger, `*pgxpool.Pool` passed at construction; `sqlc.Queries` wraps the pool.
 
+### Agent-Oriented Design Principles
+
+nano-brain is **built for agents, not humans**. Every design decision optimizes for how agents actually work:
+
+1. **MCP is the primary interface.** Agents call tools, not REST APIs. Every capability is a tool call.
+2. **50ms latency target for code intelligence.** Agents skip tools that are slow. `memory_impact`, `memory_trace`, `memory_graph` must be sub-50ms.
+3. **Impact analysis is the #1 use case.** "What breaks if I change this?" — the most common agent query. Pre-computed blast radius via reverse BFS.
+4. **Call chains > control flow.** Agents trace execution across files (inter-procedural), not within functions (intra-procedural). Optimize `memory_trace` and `memory_graph` over `memory_flowchart`.
+5. **Component composition > internal logic.** For frontend frameworks, "who uses this component?" is more valuable than "what does the template do?"
+6. **Session continuity matters.** Agents work across sessions. `memory_write` at end of session, `memory_wake_up` + `memory_query` at start.
+7. **Structured results, not raw bytes.** Agents don't want 500-line file dumps. They want structured data: symbol names, line numbers, edge lists, blast radius counts.
+
 ### Cross-Cutting Conventions
 
 - **Errors:** `fmt.Errorf("<context>: %w", err)` — no custom error types, no bare `errors.New` in callers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,15 +18,22 @@ All operations are MCP tool calls. Every tool takes a `workspace` (SHA-256 hash;
 | Catch up at session start | `memory_wake_up` | `workspace` |
 | Fetch one doc by ID/path | `memory_get` | `workspace`, `path` |
 | Check daemon health | `memory_status` | (none) |
+| List all registered workspaces | `memory_workspaces_list` | (none) |
 
 ### Session Workflow
 
-**Start of session:** Resolve workspace once, then wake up + query the topic.
+**Start of session:** List workspaces first, then resolve and query.
 
 ```
-memory_workspaces_resolve(path="<project root>")  // → workspace hash
+memory_workspaces_list()                    // → list all workspaces with paths
+memory_workspaces_resolve(path="<path>")   // → workspace hash (if you know the path)
 memory_wake_up(workspace=<hash>, limit=8)
 memory_query(workspace=<hash>, query="<task topic>")
+```
+
+**If you don't know the workspace path:**
+```
+memory_workspaces_list()  // → find workspace by name or path
 ```
 
 **End of session:** Save key decisions, patterns discovered, and debugging insights.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,62 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+**All project context lives in [AGENTS.md](AGENTS.md).** Read that file for architecture, conventions, testing, and agent-oriented design principles.
 
-nano-brain — persistent memory and code intelligence server for AI coding agents. Go 1.23, PostgreSQL 17 + pgvector, single static binary (`CGO_ENABLED=0`). Hybrid search (BM25 + vector + RRF fusion + recency decay). 9 MCP tools, REST API, CLI.
-
-## Commands
+## Quick Reference
 
 ```bash
-# Build
-CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain
-
-# Test (unit — fast, no DB required)
-go test -race -short ./...
-
-# Test (integration — requires PostgreSQL + pgvector)
-go test -race -tags=integration ./...
-
-# Run tests for a single package
-go test -race -short ./internal/search/...
-
-# Start server
-DATABASE_URL="postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev" ./nano-brain
-
-# SQL codegen (after editing queries/*.sql)
-sqlc generate
-
-# Database migrations
-go run ./cmd/nano-brain db:migrate
+CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain   # Build
+go test -race -short ./...                                 # Unit tests
+go test -race -tags=integration ./...                      # Integration tests
+sqlc generate                                              # SQL codegen
 ```
-
-## Architecture
-
-- `cmd/nano-brain/` — CLI entry + server startup. Custom dispatcher (no cobra). See `cmd/nano-brain/AGENTS.md`
-- `internal/server/` — Echo v4 HTTP server, middleware (request logging, version header, workspace extraction)
-- `internal/server/handlers/` — 34 handler files, one per endpoint group. See `handlers/AGENTS.md`
-- `internal/storage/` — PostgreSQL pool + sqlc-generated queries (DO NOT EDIT `sqlc/` files). See `storage/AGENTS.md`
-- `internal/search/` — Hybrid search: BM25 + vector + RRF fusion + recency decay. See `search/AGENTS.md`
-- `internal/embed/` — Embedding queue worker, Ollama/Voyage providers. See `embed/AGENTS.md`
-- `internal/harvest/` — Session harvesting from OpenCode/Claude Code SQLite DBs. See `harvest/AGENTS.md`
-- `internal/mcp/` — MCP protocol server, 9 tools. Largest file: `tools.go` (1206 lines). See `mcp/AGENTS.md`
-- `internal/config/` — koanf YAML + env config with hot-reload
-- `internal/watcher/` — fsnotify file watching with debounce
-- `internal/summarize/` — LLM-powered session summarization (map-reduce)
-
-## Key Conventions
-
-- **DI pattern**: constructor injection — config, logger, DB pool passed as params. No globals, no DI framework.
-- **Errors**: `fmt.Errorf("<context>: %w", err)` — no custom error types. Always wrap.
-- **Logging**: zerolog structured. Scoped: `logger.With().Str("component","x").Logger()` at construction.
-- **Context**: `ctx context.Context` first param on all I/O ops. `errgroup` for goroutine lifecycle.
-- **Interfaces**: small, role-based, consumer-side (`Embedder`, `Querier`, `Harvester`).
-- **DB access**: `storage.NewPool()` → `*pgxpool.Pool` → `sqlc.Queries`. All SQL in `queries/*.sql`, codegen via `sqlc generate`.
-- **Tests**: `package <name>_test` (external). Inline struct mocks. Table-driven. `testutil.SetupTestDB(t)` for integration tests with isolated PG schemas.
-- **Config**: YAML (`~/.nano-brain/config.yml`) + env (`NANO_BRAIN_*`). Hot-reload via `POST /api/reload-config`.
-
-## Git & PR Conventions
-
-- No agent footers (`Co-Authored-By`, `Generated-with`) in commits or PRs
-- Create a GitHub issue before starting any task
-- Conventional commits preferred

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nano-brain
 
-**Your AI agent remembers everything.**
+**Built for agents. Not humans.**
 
-Persistent memory and code intelligence for AI coding agents. Across sessions, machines, and team members.
+Agent-oriented memory and code intelligence. AI agents don't read docs — they need structured context, impact analysis, and call chains. nano-brain provides exactly that via MCP.
 
 [![Go 1.23](https://img.shields.io/badge/Go-1.23-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -22,37 +22,51 @@ npm install -g @nano-step/nano-brain
 # Start
 nano-brain serve -d
 
-# Your AI agent now has memory
+# Your AI agent now has persistent memory, code intelligence, and impact analysis
 ```
 
 ---
 
 ## Why Star This Project?
 
-**If you've ever wished your AI agent remembered what you told it yesterday.**
+**If you've ever wished your AI agent stopped flying blind in your codebase.**
 
-nano-brain is the missing memory layer for AI coding agents. It's:
+Most memory tools optimize for conversation recall. nano-brain optimizes for **agent comprehension** — the ability to understand codebases, trace dependencies, and predict the blast radius of changes.
 
+nano-brain is:
+
+- **Agent-oriented** — Built around how agents actually work: impact analysis before edits, call chain tracing, symbol lookup. Not a document store with MCP slapped on top.
 - **Self-hosted** — Your data stays on your server. No cloud dependency.
 - **Works everywhere** — OpenCode, Claude Code, Cursor, any MCP client.
 - **Actually useful** — Not a toy demo. Production-ready with 16 MCP tools, hybrid search, code intelligence, and agent-oriented benchmarks.
 - **Built for developers** — Go binary, PostgreSQL, zero magic. You can read the code.
 - **Beating competitors** — P@5 of 80% vs LlamaIndex's 55% and Qdrant's 27% on real-world queries.
 
-Star it if you want AI agents that actually learn from context.
+Star it if you want agents that understand your code, not just search it.
 
 ---
 
 ## What It Does
 
-nano-brain solves **session amnesia** — the problem where AI agents forget everything when the session ends.
+nano-brain is an **agent-oriented infrastructure layer** that sits between your AI agent and your codebase.
 
-It automatically:
-- **Ingests** AI sessions, notes, and codebase files
-- **Indexes** everything with hybrid search (BM25 + pgvector)
-- **Serves** memories via 16 MCP tools and REST API
+It solves two problems agents have:
 
-Built in Go with PostgreSQL. Single static binary. Zero CGO dependencies.
+1. **Session amnesia** — Agents forget everything when the session ends. nano-brain persists context across sessions via harvesting, indexing, and retrieval.
+2. **Codebase blindness** — Agents can't trace dependencies, measure blast radius, or understand control flow. nano-brain builds a live code graph and exposes it via 16 MCP tools.
+
+**Why MCP?** Because agents don't read docs. They call tools. Every capability is a tool call — no REST API ceremony, no JSON parsing, no manual file reading.
+
+### How agents use it
+
+| Agent needs to... | Tool | What it returns |
+|---|---|---|
+| Understand a feature | `memory_query` | Hybrid search results with context |
+| Check what breaks before editing | `memory_impact` | Blast radius — all dependent files |
+| Trace an execution path | `memory_trace` | Call chain from entry point |
+| Find a function definition | `memory_symbols` | Symbol location + kind |
+| Recall a past decision | `memory_query` | Past session context |
+| Save a discovery | `memory_write` | Persisted for future sessions |
 
 ---
 
@@ -77,6 +91,57 @@ graph LR
     F --> F2[Vector Similarity]
     F --> F3[RRF Fusion]
 ```
+
+---
+
+## Agent-Oriented Design
+
+nano-brain isn't a memory tool with MCP bolted on. It's designed from the ground up around **how agents actually behave**.
+
+### The agent workflow loop
+
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│  Agent       │────▶│  memory_query │────▶│  Context     │
+│  receives    │     │  /impact/trace│     │  window      │
+│  task        │     │              │     │  filled      │
+└─────────────┘     └──────────────┘     └──────┬──────┘
+                                                 │
+                                          ┌──────▼──────┐
+                                          │  Agent       │
+                                          │  implements  │
+                                          │  change      │
+                                          └──────┬──────┘
+                                                 │
+                                          ┌──────▼──────┐
+                                          │  memory_write │
+                                          │  (persist)    │
+                                          └─────────────┘
+```
+
+### Why agent behavior matters
+
+| Human workflow | Agent workflow | nano-brain response |
+|---|---|---|
+| Opens file, reads it | `memory_get` or `memory_search` | Returns structured content, not raw bytes |
+| Traces call chain manually | `memory_trace` | Returns function-by-function chain with line numbers |
+| Greps for callers | `memory_graph(direction="in")` | Returns all callers in one call |
+| Thinks "what breaks?" | `memory_impact` | Returns full blast radius in <50ms |
+| Remembers past decisions | `memory_query` | Returns cross-session context |
+
+### The 50ms rule
+
+At 50ms latency, agents run impact analysis on every edit. At 500ms, they skip it. nano-brain is designed for the 50ms world — every code intelligence tool call is sub-50ms, making it practical for agents to use them on every operation.
+
+### What agents actually need
+
+Research from 15+ production code intelligence tools shows:
+
+1. **Impact analysis is #1** — "What breaks if I change this?" is the most common agent query
+2. **Call chains > control flow** — Agents trace across files (inter-procedural), not within functions (intra-procedural)
+3. **Component composition > internal logic** — For frontend frameworks, "who uses this component?" matters more than "what does the template do?"
+
+nano-brain optimizes for exactly these three patterns.
 
 ---
 
@@ -249,17 +314,20 @@ flowchart LR
 
 ## Use Cases
 
-### Multi-machine developer
-Work on office PC, home laptop, personal machine — each with different sessions. Deploy nano-brain on a VPS. Every session gets harvested. Switch machines, pick up where you left off.
+### Agent-assisted refactoring
+Before refactoring, your agent calls `memory_impact` on the target function. Gets the full blast radius. Decides whether to split the change. After refactoring, runs affected tests only — not the full suite.
 
-### Team knowledge base
+### Multi-session feature development
+Session 1: Agent explores the codebase, discovers patterns. `memory_write` saves findings. Session 2: Agent recalls session 1's discoveries via `memory_query`. No context lost between sessions.
+
+### Legacy codebase onboarding
+Index a 5-year-old codebase. Your agent can now answer "what does this function do?", "why does this class exist?", "if I change this file, what else breaks?" — without reading every file.
+
+### Cross-service debugging
+Agent traces a bug from frontend to backend. `memory_trace` follows the call chain across services. `memory_graph` shows which microservices depend on the failing endpoint.
+
+### Team knowledge sharing
 One server, whole team. Every developer's AI agent connects to the same PostgreSQL. Decisions, architecture notes, code intelligence — instantly shared. New hires get full context from day one.
-
-### Legacy codebase archaeology
-Inherit a 5-year-old codebase with no docs? Index it. Your AI agent can now answer "what does this function do?", "why does this class exist?", "if I change this file, what else breaks?"
-
-### Pre-commit impact check
-Before pushing, run `memory_impact` on changed files. Discover what else depends on them. Catch breaking changes before CI.
 
 ---
 
@@ -286,12 +354,15 @@ Tested on 60 domain-specific queries across 3 workspaces. nano-brain is the **on
 - **Cognee / GraphRAG** — Document-level knowledge graphs, multi-hop reasoning
 - **LlamaIndex** — Flexible RAG pipelines, document retrieval
 
-**What nano-brain adds:**
-- **Code intelligence** — Symbol graphs, call chains, impact analysis, flow diagrams
-- **Agent-oriented benchmarks** — Measures how well agents find context for domain tasks
-- **Hybrid search** — BM25 + pgvector + RRF fusion + recency decay
+**What nano-brain adds (agent-oriented):**
+- **Impact analysis** — "What breaks if I change this?" — the #1 question agents ask. Pre-computed blast radius in <50ms.
+- **Call chain tracing** — Follow execution paths across files. Agent gets a structured trace, not raw source.
+- **Symbol graph** — Find definitions, callers, callees. `memory_symbols` + `memory_graph`.
+- **Agent-oriented benchmarks** — Measures how well agents find context for domain tasks — not just search precision in isolation.
 
-Competitors optimize for conversation recall. nano-brain optimizes for **agent comprehension** — helping agents understand codebases, not just retrieve documents.
+**The difference:** Competitors optimize for "did the agent find the right document?" nano-brain optimizes for "did the agent understand the codebase well enough to make the right change?"
+
+At 50ms latency, agents run impact analysis on every edit. At 500ms, they skip it. nano-brain is designed for the 50ms world.
 
 ### Agent-Oriented Capability Benchmarks
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,541 @@
+# Configuration Reference
+
+All configuration options for nano-brain. Config file: `~/.nano-brain/config.yml`
+
+---
+
+## Table of Contents
+
+- [Config File Location](#config-file-location)
+- [Environment Variables](#environment-variables)
+- [server](#server)
+- [database](#database)
+- [embedding](#embedding)
+- [harvester](#harvester)
+- [intervals](#intervals)
+- [watcher](#watcher)
+- [search](#search)
+- [storage](#storage)
+- [telemetry](#telemetry)
+- [logging](#logging)
+- [summarization](#summarization)
+- [code_summarization](#code_summarization)
+- [intelligence](#intelligence)
+- [bench](#bench)
+- [flow](#flow)
+- [Validation Rules](#validation-rules)
+- [Example Config](#example-config)
+
+---
+
+## Config File Location
+
+nano-brain loads config from (highest priority first):
+
+1. `--config` CLI flag
+2. `NANO_BRAIN_CONFIG` environment variable
+3. `~/.nano-brain/config.yml` (default)
+
+If no config file exists, defaults are used. All options can be overridden via environment variables.
+
+---
+
+## Environment Variables
+
+### Standard prefix: `NANO_BRAIN_`
+
+Format: `NANO_BRAIN_<SECTION>_<KEY>` → maps to `<section>.<key>`
+
+```bash
+NANO_BRAIN_SERVER_PORT=3200        # server.port
+NANO_BRAIN_DATABASE_URL=...       # database.url (alias)
+NANO_BRAIN_LOGGING_LEVEL=debug    # logging.level
+```
+
+### Special env vars (non-prefixed)
+
+| Env Var | Maps To | Description |
+|---------|---------|-------------|
+| `DATABASE_URL` | `database.url` | PostgreSQL connection string |
+| `VOYAGE_API_KEY` | `embedding.voyage_api_key` | Voyage AI API key |
+| `OPENCODE_STORAGE_DIR` | `harvester.opencode.session_dir` | OpenCode session directory |
+| `OPENCODE_DB_PATH` | `harvester.opencode.db_path` | OpenCode single DB path |
+| `OPENCODE_DB_ROOT` | `harvester.opencode.db_root` | OpenCode DB root directory |
+| `NANO_BRAIN_EMBED_MAX_CHARS` | `embedding.max_chars` | Max chars per embedding call |
+| `NANO_BRAIN_SUMMARIZE_API_KEY` | `summarization.api_key` | Summarization API key |
+| `NANO_BRAIN_CODE_SUMMARIZE_API_KEY` | `code_summarization.api_key` | Code summarization API key |
+| `NANO_BRAIN_AUTH_ENABLED` | `server.auth.enabled` | Enable auth |
+| `NANO_BRAIN_AUTH_REALM` | `server.auth.realm` | Auth realm |
+| `NANO_BRAIN_AUTH_TOKENS` | `server.auth.tokens` | Auth tokens (comma-separated) |
+
+---
+
+## server
+
+Server binding and authentication.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `server.host` | string | `localhost` | Bind address. Use `0.0.0.0` for remote access |
+| `server.port` | int | `3100` | HTTP port (1-65535) |
+| `server.serve_only` | bool | `false` | Disable all background workers (embed queue, watcher, harvester). Use for proxy containers sharing a DB with a primary instance |
+
+### server.auth
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `server.auth.enabled` | bool | `false` | Enable authentication |
+| `server.auth.realm` | string | `nano-brain` | HTTP Basic Auth realm |
+| `server.auth.tokens` | []string | `[]` | Bearer tokens for API auth |
+| `server.auth.users` | []object | `[]` | Basic Auth users (username + bcrypt hash) |
+| `server.auth.users[].username` | string | — | Username |
+| `server.auth.users[].password_hash` | string | — | bcrypt hash of password |
+| `server.auth.bypass_paths` | []string | `["/health"]` | Paths that skip auth |
+
+---
+
+## database
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `database.url` | string | `postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev` | PostgreSQL connection string |
+
+---
+
+## embedding
+
+Embedding provider configuration. Supports Ollama (local) and Voyage AI (cloud).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `embedding.provider` | string | `ollama` | Provider: `ollama` or `voyage` |
+| `embedding.url` | string | `http://localhost:11434` | Provider URL (Ollama endpoint) |
+| `embedding.model` | string | `nomic-embed-text` | Model name |
+| `embedding.dimension` | int | `0` | Embedding dimension (0 = auto-detect) |
+| `embedding.concurrency` | int | `3` | Parallel embedding workers |
+| `embedding.max_chars` | int | `3000` | Max chars per embedding call. Keep ≤3000 for nomic-embed-text (2048 token window) |
+| `embedding.voyage_api_key` | string | `""` | Voyage AI API key (required when provider=voyage) |
+
+---
+
+## harvester
+
+Session harvesting from AI coding tools.
+
+### harvester.opencode
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `harvester.opencode.session_dir` | string | `""` | OpenCode JSON sessions directory (legacy) |
+| `harvester.opencode.db_path` | string | `""` | Single OpenCode SQLite DB path (legacy) |
+| `harvester.opencode.db_root` | string | `""` | OpenCode DB root — scans for per-project SQLite DBs (preferred) |
+
+Source resolution priority at daemon startup (first non-empty wins):
+1. `db_root` — scan directory for per-project SQLite DBs (new layout)
+2. `db_path` — single global SQLite DB (legacy)
+3. `session_dir` — filesystem JSON sessions (legacy)
+
+### harvester.claudecode
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `harvester.claudecode.enabled` | bool | `false` | Enable Claude Code session harvesting |
+| `harvester.claudecode.session_dir` | string | `""` | Claude Code JSONL sessions directory |
+
+### harvester.git
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `harvester.git.enabled` | bool | `false` | Enable Git history harvesting |
+
+---
+
+## intervals
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `intervals.session_poll` | int | `120` | Session poll interval in seconds |
+
+---
+
+## watcher
+
+File system watcher for auto-reindexing.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `watcher.debounce_ms` | int | `2000` | Debounce delay in milliseconds |
+| `watcher.reindex_interval` | int | `300` | Full reindex interval in seconds |
+| `watcher.chunk_overlap` | int | `600` | Character overlap between chunks |
+| `watcher.exclude_patterns` | []string | `[]` | Global glob patterns to exclude |
+| `watcher.allowed_extensions` | []string | `[]` | Global allowed file extensions (empty = all) |
+
+### Per-workspace overrides
+
+Override filters per workspace directory:
+
+```yaml
+watcher:
+  workspaces:
+    /path/to/project:
+      exclude_patterns:
+        - "node_modules/**"
+        - "*.min.js"
+      allowed_extensions:
+        - ".go"
+        - ".ts"
+```
+
+---
+
+## search
+
+Hybrid search pipeline (BM25 + vector + RRF).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `search.rrf_k` | float | `60` | RRF constant (higher = more weight to lower-ranked results) |
+| `search.recency_weight` | float | `0.3` | Recency decay weight (0-1). 0 = no recency boost, 1 = only recency |
+| `search.recency_half_life_days` | int | `180` | Days for recency score to decay by half |
+| `search.limit` | int | `20` | Max results per query |
+| `search.bm25_language` | string | `english` | BM25 language for stemming |
+
+### search.pagerank
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `search.pagerank_enabled` | bool | `false` | Enable PageRank boosting |
+| `search.pagerank_weight` | float | `0.2` | PageRank weight in final score |
+| `search.pagerank_edge_threshold` | int | `100` | Min edges for PageRank computation |
+
+### search.entity_boost
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `search.entity_boost_enabled` | bool | `false` | Boost entity (function, class) matches |
+| `search.entity_boost_factor` | float | `0.3` | Boost factor for entity matches |
+
+### search.query_preprocessing
+
+LLM-based query preprocessing (expand abbreviations, fix typos, add context).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `search.query_preprocessing.enabled` | bool | `false` | Enable LLM query preprocessing |
+| `search.query_preprocessing.provider_url` | string | `""` | LLM provider URL |
+| `search.query_preprocessing.api_key` | string | `""` | LLM API key |
+| `search.query_preprocessing.model` | string | `""` | LLM model name |
+| `search.query_preprocessing.max_latency_ms` | int | `500` | Max latency before fallback to raw query |
+
+### search.hyde
+
+Hypothetical Document Embedding — generates a hypothetical answer, embeds it, and uses that for vector search.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `search.hyde.enabled` | bool | `false` | Enable HyDE |
+| `search.hyde.provider_url` | string | `""` | LLM provider URL |
+| `search.hyde.api_key` | string | `""` | LLM API key |
+| `search.hyde.model` | string | `""` | LLM model name |
+| `search.hyde.max_latency_ms` | int | `500` | Max latency before fallback |
+| `search.hyde.context_hints` | map | `{}` | Domain-specific context hints for HyDE generation |
+
+### search.reranking
+
+Cross-encoder reranking for higher precision.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `search.reranking.enabled` | bool | `false` | Enable reranking |
+| `search.reranking.provider` | string | `""` | Reranking provider |
+| `search.reranking.provider_url` | string | `""` | Provider URL |
+| `search.reranking.api_key` | string | `""` | API key |
+| `search.reranking.model` | string | `""` | Reranking model |
+| `search.reranking.top_k` | int | `0` | Top K results to rerank (0 = all) |
+| `search.reranking.max_latency_ms` | int | `500` | Max latency before fallback |
+| `search.reranking.min_score` | float | `0` | Minimum reranking score threshold |
+
+---
+
+## storage
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `storage.max_file_size` | int | `314572800` | Max file size in bytes (300 MB) |
+| `storage.max_size` | int | `10737418240` | Max total storage in bytes (10 GB) |
+
+---
+
+## telemetry
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `telemetry.retention_days` | int | `90` | Days to retain telemetry data |
+
+---
+
+## logging
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `logging.level` | string | `info` | Log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic` |
+| `logging.file` | string | `""` | Log file path (empty = stderr) |
+
+---
+
+## summarization
+
+LLM-based session summarization. Produces structured summaries of AI coding sessions.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `summarization.enabled` | bool | `false` | Enable summarization |
+| `summarization.provider_url` | string | `""` | LLM provider URL (OpenAI-compatible) |
+| `summarization.api_key` | string | `""` | LLM API key |
+| `summarization.model` | string | `nano-brain` | LLM model name |
+| `summarization.max_tokens` | int | `8000` | Max output tokens per summary |
+| `summarization.concurrency` | int | `3` | Parallel summarization workers |
+| `summarization.requests_per_second` | float | `0` | Rate limit (0 = unlimited) |
+| `summarization.write_to_disk` | bool | `true` | Write summaries to disk (Obsidian-compatible) |
+| `summarization.output_dir` | string | `~/.nano-brain/summaries` | Disk output directory |
+
+---
+
+## code_summarization
+
+Batched LLM code symbol summarization. Generates descriptions for functions, types, and interfaces.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `code_summarization.enabled` | bool | `false` | Enable code summarization |
+| `code_summarization.provider_url` | string | `""` | LLM provider URL |
+| `code_summarization.api_key` | string | `""` | LLM API key |
+| `code_summarization.model` | string | `""` | LLM model name (required when enabled) |
+| `code_summarization.fallback_model` | string | `""` | Fallback model if primary fails |
+| `code_summarization.batch_size` | int | `30` | Symbols per batch |
+| `code_summarization.max_batch_tokens` | int | `100000` | Max tokens per batch |
+| `code_summarization.max_output_tokens` | int | `8000` | Max output tokens per symbol |
+| `code_summarization.max_symbol_lines` | int | `500` | Skip symbols longer than this |
+| `code_summarization.concurrency` | int | `2` | Parallel workers |
+| `code_summarization.workers` | int | `0` | Worker count (0 = auto) |
+| `code_summarization.max_requests_per_day` | int | `0` | Daily rate limit (0 = unlimited) |
+| `code_summarization.max_summaries_per_cycle` | int | `300` | Max summaries per poll cycle |
+| `code_summarization.poll_interval_seconds` | int | `60` | Poll interval for new symbols |
+| `code_summarization.max_retries` | int | `3` | Max retries on failure |
+| `code_summarization.retry_backoff_seconds` | int | `1` | Backoff between retries |
+| `code_summarization.request_timeout` | int | `600` | Request timeout in seconds |
+
+---
+
+## intelligence
+
+Memory consolidation and LLM categorization.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `intelligence.enabled` | bool | `false` | Enable intelligence features |
+| `intelligence.provider_url` | string | `""` | LLM provider URL |
+| `intelligence.api_key` | string | `""` | LLM API key |
+| `intelligence.model` | string | `claude-sonnet-4-5` | LLM model name |
+| `intelligence.max_tokens` | int | `8000` | Max output tokens |
+| `intelligence.concurrency` | int | `3` | Parallel workers |
+| `intelligence.consolidation_age` | int | `7` | Days before memories are consolidated |
+
+---
+
+## bench
+
+Benchmark configuration for capability testing.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `bench.query_generation` | string | `content` | Query generation mode: `llm` or `content` |
+| `bench.provider_url` | string | `""` | LLM provider URL (for llm mode) |
+| `bench.api_key` | string | `""` | LLM API key |
+| `bench.model` | string | `""` | LLM model name |
+| `bench.max_tokens` | int | `0` | Max output tokens |
+
+---
+
+## flow
+
+Execution-flow visualization (HTTP route → handler → downstream calls).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `flow.enabled` | bool | `false` | Enable flow indexing and extraction |
+| `flow.max_depth` | int | `10` | Max call-chain depth (1-10) |
+| `flow.max_fanout` | int | `8` | Max fanout per node |
+| `flow.summary_enabled` | bool | `false` | Enable LLM flow summaries (requires `summarization.enabled`) |
+| `flow.summary_timeout` | int | `600` | Summary timeout in seconds (0 = 10min default) |
+
+---
+
+## Validation Rules
+
+nano-brain validates config on startup. Invalid config → startup fails with error.
+
+| Rule | Error |
+|------|-------|
+| `server.port` not in 1-65535 | `server.port must be between 1 and 65535` |
+| `embedding.concurrency` < 1 | `embedding.concurrency must be >= 1` |
+| `search.rrf_k` < 1 | `search.rrf_k must be >= 1` |
+| `search.recency_weight` not in 0-1 | `search.recency_weight must be between 0 and 1` |
+| `search.recency_half_life_days` < 1 | `search.recency_half_life_days must be >= 1` |
+| `search.limit` < 1 | `search.limit must be >= 1` |
+| `storage.max_file_size` < 1 | `storage.max_file_size must be >= 1` |
+| `storage.max_size` < 1 | `storage.max_size must be >= 1` |
+| `storage.max_file_size` > `storage.max_size` | `storage.max_file_size must not exceed storage.max_size` |
+| `intervals.session_poll` < 1 | `intervals.session_poll must be >= 1` |
+| `watcher.debounce_ms` < 1 | `watcher.debounce_ms must be >= 1` |
+| `watcher.reindex_interval` < 1 | `watcher.reindex_interval must be >= 1` |
+| `telemetry.retention_days` < 1 | `telemetry.retention_days must be >= 1` |
+| `logging.level` invalid | `logging.level "X" is not valid` |
+| `auth.enabled` but no users/tokens | `auth enabled but no users or tokens configured` |
+| `summarization.enabled` but no provider_url | `summarization.provider_url is required when enabled` |
+| `summarization.enabled` but concurrency < 1 | `summarization.concurrency must be >= 1 when enabled` |
+| `code_summarization.enabled` but no provider_url | `code_summarization.provider_url is required when enabled` |
+| `code_summarization.enabled` but no model | `code_summarization.model is required when enabled` |
+| `flow.enabled` but max_depth not in 1-10 | `flow.max_depth must be between 1 and 10 when enabled` |
+| `flow.enabled` but max_fanout ≤ 0 | `flow.max_fanout must be greater than 0 when enabled` |
+| `flow.summary_enabled` but summarization disabled | `flow.summary_enabled requires summarization.enabled to be true` |
+
+---
+
+## Example Config
+
+```yaml
+# ~/.nano-brain/config.yml
+
+server:
+  host: localhost
+  port: 3100
+  serve_only: false
+  auth:
+    enabled: false
+    realm: nano-brain
+    tokens: []
+    users: []
+    bypass_paths:
+      - /health
+
+database:
+  url: postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev
+
+embedding:
+  provider: ollama
+  url: http://localhost:11434
+  model: nomic-embed-text
+  dimension: 0
+  concurrency: 3
+  max_chars: 3000
+
+harvester:
+  opencode:
+    session_dir: ""
+    db_path: ""
+    db_root: ""
+  claudecode:
+    enabled: false
+    session_dir: ""
+  git:
+    enabled: false
+
+intervals:
+  session_poll: 120
+
+watcher:
+  debounce_ms: 2000
+  reindex_interval: 300
+  chunk_overlap: 600
+  exclude_patterns: []
+  allowed_extensions: []
+
+search:
+  rrf_k: 60
+  recency_weight: 0.3
+  recency_half_life_days: 180
+  limit: 20
+  bm25_language: english
+  pagerank_enabled: false
+  pagerank_weight: 0.2
+  pagerank_edge_threshold: 100
+  entity_boost_enabled: false
+  entity_boost_factor: 0.3
+  query_preprocessing:
+    enabled: false
+  hyde:
+    enabled: false
+  reranking:
+    enabled: false
+
+storage:
+  max_file_size: 314572800    # 300 MB
+  max_size: 10737418240       # 10 GB
+
+telemetry:
+  retention_days: 90
+
+logging:
+  level: info
+
+summarization:
+  enabled: false
+
+code_summarization:
+  enabled: false
+
+intelligence:
+  enabled: false
+
+bench:
+  query_generation: content
+
+flow:
+  enabled: false
+  max_depth: 10
+  max_fanout: 8
+  summary_enabled: false
+```
+
+### Production config (VPS with auth)
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 3100
+  auth:
+    enabled: true
+    tokens:
+      - "nbt_your_token_here"
+    bypass_paths:
+      - /health
+
+database:
+  url: postgres://nanobrain:secret@db-host:5432/nanobrain_prod
+
+embedding:
+  provider: voyage
+  voyage_api_key: "voyage_key_here"
+  model: voyage-3
+  concurrency: 5
+
+summarization:
+  enabled: true
+  provider_url: https://api.openai.com/v1
+  api_key: "sk-..."
+  model: gpt-4o-mini
+  concurrency: 5
+
+code_summarization:
+  enabled: true
+  provider_url: https://api.openai.com/v1
+  api_key: "sk-..."
+  model: gpt-4o-mini
+  batch_size: 50
+  workers: 4
+
+flow:
+  enabled: true
+  summary_enabled: true
+```

--- a/docs/evidence/vue-sfc-design/README.md
+++ b/docs/evidence/vue-sfc-design/README.md
@@ -1,0 +1,21 @@
+# Vue SFC Code Intelligence Support — Design Pipeline
+
+**Date**: 2026-06-26
+**Status**: Synthesis done + **codebase-verified** (claims checked against gotreesitter v0.19.1 via live parse; key "language injection" unknown resolved). Pending Phase 2.5 + Phase 3.
+
+> Verification pass (2026-06-26): confirmed `VueLanguage()` emits `template_element`/`script_element`/`style_element` with script body as a single `raw_text`. No language injection → two-pass extraction mandatory. Component detection switched from regex to AST `tag_name`. Resolved universal-vs-`detectVue` contradiction. Added fixture list, `lang` matrix, CFG-reindex/chunker gaps.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `design-brief.md` | Architecture decisions, conflict resolution, risks |
+| `pending-decisions.md` | 3 questions that need user input |
+| `research-findings.md` | What agents actually need from nano-brain |
+| `implementation-plan.md` | Phased implementation with priorities |
+
+## Quick Links
+
+- [Pending Decisions](pending-decisions.md) — What you need to decide
+- [Design Brief](design-brief.md) — Settled architecture decisions
+- [Research Findings](research-findings.md) — Evidence-based recommendations

--- a/docs/evidence/vue-sfc-design/design-brief.md
+++ b/docs/evidence/vue-sfc-design/design-brief.md
@@ -1,0 +1,93 @@
+# Design Brief — Vue SFC Code Intelligence Support
+
+## Settled Decisions (HIGH confidence)
+
+| Decision | Approach | Basis |
+|----------|----------|-------|
+| Vue grammar exists | Use `grammars.VueLanguage()` from gotreesitter v0.19.1 — no regex needed | Metis verified in source |
+| SFC parsing strategy | Tree-sitter native parsing, NOT regex splitting | **Verified by live parse**: Vue grammar emits `template_element`, `script_element`, `style_element`; script body is a single `raw_text` child |
+| No new dependencies | Use existing gotreesitter grammars (Vue + TypeScript/JavaScript) | Already in go.mod |
+| Component detection | Use AST `tag_name` nodes (filter PascalCase), **NOT regex on raw text** | **Verified**: grammar already yields `tag_name`="MyChild" inside `element`/`self_closing_tag` — removes Metis's false-positive risk |
+| Line number offset | Prefer `tree.RootNodeWithOffset(scriptStartByte, point)` when re-parsing the extracted script; only add a manual `byteOffset` field if that proves insufficient | `RootNodeWithOffset` exists in gotreesitter (`tree.go:2178`) |
+| Defer template-level intelligence | No v-if/v-for as CFG nodes, no props/emits tracking in v1 | Both agents agree these are v2 |
+| Multiple script blocks | Iterate **all** `script_element` nodes: an SFC may have BOTH `<script setup>` AND `<script>` (Options API) | Both are valid Vue 3 patterns and can coexist in one file |
+
+---
+
+## Architecture Approach
+
+### Two-phase parsing
+
+1. **Phase 1**: Parse `.vue` file with `grammars.VueLanguage()` → AST with template_element, script_element, style_element nodes
+2. **Phase 2**: Extract `raw_text` content from script_element → re-parse with `grammars.TypescriptLanguage()` or `JavascriptLanguage()` depending on `lang` attribute
+
+### Key unknown — RESOLVED
+
+Whether gotreesitter's Vue grammar has **language injection** for `<script lang="ts">`.
+
+**Resolved by live parse (2026-06-26): NO injection.** The script body is a single opaque `raw_text` node — the grammar does not parse it as TS/JS. Therefore **two-pass extraction is mandatory**, not optional:
+
+1. Vue parse → locate each `script_element` → read its `raw_text` child + its `lang` attribute
+2. Re-parse that byte range with `TypescriptLanguage()` / `JavascriptLanguage()` (see `lang` matrix below)
+
+There is no one-pass branch.
+
+### `lang` attribute → grammar matrix
+
+| `<script lang=...>` | Re-parse with | Notes |
+|---------------------|---------------|-------|
+| `ts`                | `TypescriptLanguage()` | |
+| (absent) / `js`     | `JavascriptLanguage()` | default |
+| `tsx`               | `TsxLanguage()` | rare; fall back to TS if unsupported |
+| `jsx`               | `JavascriptLanguage()` (jsx) | rare |
+| anything else       | skip script extraction, emit `parse_error` | |
+
+---
+
+## Conflict Resolution Log
+
+| Topic | Metis | Oracle | Cross-critique result | Confidence | Decision |
+|-------|-------|--------|----------------------|------------|----------|
+| Vue grammar exists | Confirmed exists | Assumed doesn't exist | Metis verified in source | **HIGH** | Use tree-sitter, not regex |
+| Regex SFC splitting | Unnecessary | Proposed as primary | Metis overrides — breaks codebase patterns | **HIGH** | Use VueLanguage() |
+| CFG in v1 | Defer | Include in MVA | Unresolved | **LOW** | **User decision needed** |
+| Template detection in v1 | Defer (unified JSX+Vue) | Include as regex | Resolved: include, but via **AST `tag_name`** not regex | **MEDIUM** | Include in v1 (AST-based) |
+| NuxtExtractor interaction | Medium risk | Not addressed | Metis only | **MEDIUM** | Define explicitly |
+| Language injection for `<script lang="ts">` | HIGH unknown | Not addressed | Verified by live parse: **no injection** | **HIGH** | Two-pass extraction (mandatory) |
+
+---
+
+## Key Risks
+
+| Risk | Source | Confidence | Mitigation |
+|------|--------|------------|------------|
+| ~~Language injection unverified~~ RESOLVED | Metis (HIGH) | — | Verified no injection; two-pass extraction is the path |
+| Line number offset bugs | Both (HIGH) | HIGH | Use `RootNodeWithOffset(scriptStartByte, …)`; test with multi-block SFCs where script starts past line 1 |
+| Multiple script blocks missed | New (this review) | MEDIUM | Iterate all `script_element` nodes (setup + Options API can coexist) |
+| NuxtExtractor conflict | Metis (MEDIUM) | MEDIUM | New extractor produces ONLY contains/imports/calls edges — NOT http edges |
+| Phase 2 parse failure | Metis (MEDIUM) | MEDIUM | Wrap Phase 2 in recover, return Status: "parse_error" CFGs |
+| Chunker gap | Metis (MEDIUM) | MEDIUM | Defer to Phase 2 |
+
+---
+
+## Agent Workflow (from research)
+
+### Pattern 1: "What breaks if I change this component?"
+```
+memory_impact(node="src/components/Button.vue", max_depth=2)
+```
+
+### Pattern 2: "What does this component depend on?"
+```
+memory_graph(node="src/components/Button.vue", direction="out", edge_type="imports")
+```
+
+### Pattern 3: "Who uses this composable?"
+```
+memory_impact(node="src/composables/useAuth.ts", max_depth=3)
+```
+
+### Pattern 4: "Show me the component tree from App.vue"
+```
+memory_trace(node="src/App.vue", max_depth=5)
+```

--- a/docs/evidence/vue-sfc-design/implementation-plan.md
+++ b/docs/evidence/vue-sfc-design/implementation-plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan — Vue SFC Support
+
+## Phase 1 (MVP): Edges + Component Graph
+
+**Goal**: Parse .vue files, extract script-level symbols and component composition edges.
+
+| # | Feature | File | Priority | Effort | Verification |
+|---|---------|------|----------|--------|--------------|
+| 1 | Vue SFC block splitter — iterate **all** `script_element` nodes, read `raw_text` + `lang` attr | `internal/graph/vue_sfc_parser.go` (new) | P0 | Quick | Unit test with fixture .vue files |
+| 2 | Script block → re-parse per `lang` matrix (reuse existing TS/JS extractors) | `internal/graph/vue_sfc_extractor.go` (new) | P0 | Medium | `go test -race -short ./internal/graph/ -run TestVue` |
+| 3 | contains/imports/calls edges from script | `internal/graph/vue_sfc_extractor.go` | P0 | Medium | Edge extraction tests |
+| 4 | Template component detection via **AST `tag_name` nodes** (filter PascalCase), NOT regex | `internal/graph/vue_sfc_extractor.go` | P0 | Low | Component usage edge tests (incl. comment/HTML-tag false-positive cases) |
+| 5 | Extractor is **universal** (runs for all `.vue`, see Q3) — no `detectVue` gate needed for content edges | `internal/graph/registry.go` | P0 | Quick | Runs on plain-Vue + Nuxt fixtures |
+| 6 | Wire into main.go / registry | `cmd/nano-brain/main.go`, `registry.go` | P0 | Quick | `go build ./...` |
+
+### Required test fixtures (`internal/graph/testdata/`)
+
+None exist yet — create before implementing:
+
+- `script_setup.vue` — `<script setup lang="ts">`
+- `options_api.vue` — plain `<script>` Options API
+- `dual_script.vue` — both `<script>` and `<script setup>` in one file
+- `no_script.vue` — template + style only
+- `parse_error.vue` — malformed script body (must yield `parse_error`, not crash)
+- `offset.vue` — template before script so script starts past line 1 (line-number test)
+
+### Acceptance Criteria
+
+```bash
+# Parse a .vue file and verify edges
+go test -race -short ./internal/graph/ -run TestVue
+
+# Verify no regression
+go test -race -short ./...
+
+# Verify build
+go build ./...
+```
+
+---
+
+## Phase 2: CFG + Symbols
+
+**Goal**: Add control flow graphs and symbol extraction for .vue files.
+
+| # | Feature | File | Priority | Effort |
+|---|---------|------|----------|--------|
+| 1 | `.vue` CFG extraction | `internal/graph/vue_sfc_cflow.go` (new) | P1 | Low |
+| 2 | Add `.vue` to CFG reindex allowlist | `internal/server/handlers/reindex_cfg.go` (`cfgExts` map) | P1 | Quick |
+| 3 | Vue symbol extraction | `internal/symbol/vue_sfc_extractor.go` (new) | P1 | Short |
+| 4 | Chunker support for `.vue` (add case to switch) | `internal/chunker/dispatcher.go` | P2 | Quick |
+| 5 | Line offset for CFG: use `RootNodeWithOffset(scriptStartByte, …)`; add `byteOffset` field only if insufficient | `internal/graph/cflow.go` | P1 | Quick |
+
+> **v1 limitation to communicate:** until Phase 2 lands, `.vue` has no chunker case (`dispatcher.go:24` switch lacks `.vue`) and no symbol extractor → `.vue` files chunk as plain text and `memory_symbols` returns nothing for them. The Vue-workspace search baseline (828ms / P@5 0.75) won't improve from symbols in v1.
+
+### Acceptance Criteria
+
+```bash
+# CFG extraction
+go test -race -short ./internal/graph/ -run TestVueCFG
+
+# Symbol extraction
+go test -race -short ./internal/symbol/ -run TestVue
+
+# Full regression
+go test -race -short ./...
+```
+
+---
+
+## Phase 3 (v2): Template Intelligence
+
+**Goal**: Deep template analysis, props/emits tracking, composable patterns.
+
+| # | Feature | Priority | Effort |
+|---|---------|----------|--------|
+| 1 | Props/emits tracking from `<script setup>` | P2 | Medium |
+| 2 | `useFetch`/`useAsyncData` specific patterns | P2 | Medium |
+| 3 | Composable tracking (useXxx with package filtering) | P2 | Medium |
+| 4 | Store dependency tracking (Pinia/Vuex) | P2 | Medium |
+| 5 | Unified JSX+Vue component detection | P2 | Medium |
+
+---
+
+## Key Files
+
+| File | Current State | Changes Needed |
+|------|---------------|----------------|
+| `internal/graph/nuxtjs_extractor.go` | Route edges only | Keep as-is, no changes |
+| `internal/graph/js_cflow.go` | JS/TS CFG, no .vue | Add .vue support (Phase 2) |
+| `internal/graph/typescript_extractor.go` | TS edges | Reuse for script block parsing |
+| `internal/graph/javascript_extractor.go` | JS edges | Reuse for script block parsing |
+| `internal/graph/detector.go` | `detectNuxt` only, no `detectVue` | No change — Vue extractor is universal (Q3), not framework-gated |
+| `internal/graph/registry.go` | No .vue extractors | Wire new extractors (universal, no `RequiresFrameworks`) |
+| `internal/graph/cflow.go` | No byteOffset | Prefer `RootNodeWithOffset`; add `byteOffset` field only if needed (Phase 2) |
+| `internal/server/handlers/reindex_cfg.go` | `cfgExts` lacks `.vue` | Add `.vue` (Phase 2) |
+| `internal/chunker/dispatcher.go` | switch lacks `.vue` | Add `.vue` case (Phase 2) |
+
+---
+
+## Dependencies
+
+- `grammars.VueLanguage()` — already in gotreesitter v0.19.1
+- `grammars.TypescriptLanguage()` — already available
+- `grammars.JavascriptLanguage()` — already available
+- No new go.mod dependencies needed
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| ~~Language injection unverified~~ RESOLVED | Verified no injection — two-pass extraction is the implementation |
+| Line number offset bugs | Use `RootNodeWithOffset`; test with `offset.vue` (script past line 1) |
+| Multiple script blocks | Iterate all `script_element` nodes (`dual_script.vue` fixture) |
+| NuxtExtractor conflict | New extractor produces ONLY contains/imports/calls — NOT http edges |
+| Parse failure | Wrap re-parse in recover, return Status: "parse_error" |
+
+## Post-implementation gate
+
+Beyond `go test`, re-run the Vue-workspace benchmark and confirm P@5 ≥ 0.75 baseline holds (no regression) and that component/import edges now resolve. Symbol/search uplift is **not** expected until Phase 2.

--- a/docs/evidence/vue-sfc-design/pending-decisions.md
+++ b/docs/evidence/vue-sfc-design/pending-decisions.md
@@ -1,0 +1,86 @@
+# Pending Decisions — Vue SFC Support
+
+Cần bạn quyết định 3 câu hỏi sau trước khi tiếp tục pipeline.
+
+---
+
+## Q1: CFG extraction trong v1 hay defer?
+
+**Recommendation: Defer to v2.**
+
+### Arguments FOR defer (Metis)
+- Highest complexity, lowest ROI for v1
+- Agents rarely use `memory_flowchart` — barely tested in benchmarks
+- Call chains (`memory_trace`) và impact analysis (`memory_impact`) are primary tools
+- CFG chỉ useful cho security analysis, taint tracking — không phải typical agent workflow
+- Low incremental cost to add later after edges are working
+
+### Arguments FOR include (Oracle)
+- Gives `memory_flowchart` for Vue components — key differentiator
+- JSControlFlowExtractor already works on JS/TS — just parse `<script>` block content
+- Minimal new code if we extend existing CFG builder
+
+### Research Evidence
+- Out of 15+ production code intelligence tools researched, only 2 expose CFG as primary tool
+- Gortex, CodeGraph, React Graph AI — all focus on inter-procedural call chains, not intra-procedural CFG
+- "Agents operate at the inter-procedural level (across functions/files), not the intra-procedural level (within a single function)"
+
+### My Recommendation
+**Defer.** Get edges working first. CFG is low-effort addition in Phase 2.
+
+---
+
+## Q2: Template component detection trong v1 hay deferred?
+
+**Recommendation: Include trong v1.**
+
+### Arguments FOR include (Oracle)
+- Component composition graph is 10x more valuable than internal logic
+- Every Vue/React-specific tool focuses on component composition
+- Missing piece: agents can't see parent→child component relationships
+- **Detection via AST, not regex**: live parse confirms the Vue grammar already emits `tag_name` nodes (e.g. `"MyChild"`). Walk `tag_name`, filter PascalCase — Metis's false-positive objection (comments/HTML) is moot.
+
+### Arguments FOR defer (Metis)
+- Same JSX gap exists for TSX — should be solved once for both
+- Regex on raw text creates false positives (comments, HTML elements)
+- More complex than it looks
+
+### Research Evidence
+- React Graph AI: "Component render hierarchy, Props flow, Hook dependencies, State propagation"
+- vue-harvest: "full interface (props, emits, slots), dependency graph, coupling issues"
+- ai-dependency-analyzer: explicitly supports Vue, React, Next.js — all focus on dependency graph
+
+### My Recommendation
+**Include in v1, AST-based.** Highest-value missing piece. Use AST `tag_name` + PascalCase filter (not regex); unified JSX+Vue solution in v2.
+
+---
+
+## Q3: Vue extractor framework-aware hay universal?
+
+**Recommendation: Universal.**
+
+### Options
+- **Universal**: Runs for ALL `.vue` files (Vue CLI, Vite, Nuxt)
+- **Framework-aware**: Only runs when `vue` is detected in package.json
+
+### Analysis
+- Vue SFC parsing is NOT Nuxt-specific — works for any Vue 3 project
+- `NuxtExtractor` already handles Nuxt-specific routing (framework-gated on `"nuxt"`)
+- New Vue extractor handles content edges (imports, calls, component composition)
+- They coexist via registry's edge dedup logic
+- If universal, it works for plain Vue projects too (broader value)
+
+### My Recommendation
+**Universal.** Vue SFC parsing is generic. NuxtExtractor stays framework-gated for routes only.
+
+> **Consistency note:** because this is universal, the new content extractor does **not** need a `detectVue` rule in `detector.go` — it implements no `RequiresFrameworks` and runs for every `.vue`. (Earlier plan draft listed "add detectVue" as P0 — removed; implementation-plan item #5 now reflects universal wiring.)
+
+---
+
+## Decision Log
+
+| # | Question | Your Decision | Date |
+|---|---------|---------------|------|
+| 1 | CFG in v1? | _pending_ | |
+| 2 | Template detection in v1? | _pending_ | |
+| 3 | Framework-aware or universal? | _pending_ | |

--- a/docs/evidence/vue-sfc-design/research-findings.md
+++ b/docs/evidence/vue-sfc-design/research-findings.md
@@ -1,0 +1,121 @@
+# Research Findings — What Agents Need from nano-brain
+
+## Finding 1: Impact Analysis is #1 Use Case
+
+> "Before modifying a public component, evaluate the impact scope" — ai-dependency-analyzer
+> "Know what breaks before you ship" — ImpactTrace
+
+### Agent Workflow (real, from production tools)
+
+1. Agent proposes edit
+2. `memory_impact` runs → returns affected files, risk score
+3. If HIGH risk → agent splits change
+4. If LOW risk → proceeds
+5. After edit → runs affected tests only (not full suite)
+
+### Evidence
+
+- **Gortex**: "What breaks if I change this?" is the question ungrounded agents answer worst
+- **CodeGraph**: `fn-impact <name>` before every edit
+- **Carto**: Agent threw out its own patch after impact analysis showed 83 transitive dependents
+- **Latency requirement**: Sub-50ms (at 50ms agent skips, at 0.04ms no reason not to run)
+
+---
+
+## Finding 2: Call Chains > Control Flow
+
+Agents operate at **inter-procedural level** (cross-file), not intra-procedural (within 1 function).
+
+### Evidence
+
+- Out of 15+ production code intelligence tools, only 2 expose CFG as primary tool
+- Gortex: "token-budgeted call chains" — not CFG
+- trace-mcp comparison: CFG listed as "threat" (niche feature), not standard
+- Stack Overflow: "CFG provides finer details into program structure... Call graph gives inter-procedural view"
+
+### When CFG IS used
+
+- Security analysis (taint tracking)
+- Compiler-grade rigor (Joern, Narsil-MCP)
+- NOT for typical agent workflows (refactoring, feature, bug fix)
+
+### Conclusion
+
+`memory_flowchart` is underutilized. Focus on `memory_impact` and `memory_trace`.
+
+---
+
+## Finding 3: Component Composition > Internal Logic
+
+Every Vue/React-specific tool focuses on **component composition**, not internal control flow.
+
+### Evidence
+
+**React Graph AI**:
+- Component render hierarchy
+- Props flow
+- Hook dependencies
+- State propagation
+- Next.js boundaries
+
+**vue-harvest**:
+- Full interface (props, emits, slots)
+- Dependency graph
+- Coupling issues detection
+
+**ai-dependency-analyzer**:
+- Supports Vue, React, Next.js, NestJS
+- `get_file_impact`, `get_downstream_dependencies`, `get_upstream_dependencies`
+- "修改一个公共组件前，先评估影响范围" (Before modifying a public component, evaluate impact scope)
+
+**voyager**:
+- Interactive dependency diagrams for Vue.js components
+- Visualize complex component relationships
+
+### What agents need for Vue components
+
+1. **Import graph** (`.vue` → `.vue`, `.vue` → `.ts`, `.vue` → composable)
+2. **Component composition** (`<template>` references to child components)
+3. **Props flow** (parent → child, type-checked)
+4. **Event/emit flow** (child emit → parent handler)
+5. **Slot usage** (parent provides slot → child defines slot)
+6. **Store dependencies** (component → Pinia store)
+7. **Composable usage** (component → useAuth, useFetch, etc.)
+8. **Route → page** mapping (Nuxt/Vue Router)
+
+### What agents DON'T need (for typical workflows)
+
+- Internal template logic (v-if/v-for conditions)
+- Reactive state machine tracking
+- Function-level call graphs within `<script setup>`
+
+---
+
+## nano-brain Current State
+
+### Gaming-platform workspace (Vue/Nuxt)
+
+- **Avg Latency**: 828ms across 70 queries
+- **Avg P@5**: 0.75 (75%)
+- **First query cold start**: 3630ms
+- **Subsequent queries**: ~783ms
+
+### Code Flow Support
+
+| Layer | Go | Ruby/Rails | JS/TS | Vue/Nuxt |
+|-------|----|-----------|-------|----------|
+| Route → Handler | ✅ | ✅ | ✅ | ✅ (NuxtExtractor) |
+| Call graph | ✅ | ✅ | ✅ | ❌ (missing) |
+| CFG | ❌ | ❌ | ✅ | ❌ (missing) |
+| Symbols | ✅ | ✅ | ✅ | ❌ (missing) |
+
+### Missing for Vue/Nuxt
+
+- Vue SFC parsing (script/template split)
+- Component tree (parent→child, props, emits)
+- useFetch/useAsyncData data flow
+- Composable usage (useXxx)
+- Pinia/Vuex store
+- .vue control flow
+- Nuxt middleware
+- Nuxt plugins

--- a/internal/mcp/concurrent_test.go
+++ b/internal/mcp/concurrent_test.go
@@ -162,8 +162,8 @@ func TestToolRegistration_ListToolsUnderRaceDetector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
-	if len(result.Tools) != 16 {
-		t.Errorf("expected 16 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 17 {
+		t.Errorf("expected 17 tools, got %d", len(result.Tools))
 	}
 }
 

--- a/internal/mcp/concurrent_test.go
+++ b/internal/mcp/concurrent_test.go
@@ -191,6 +191,7 @@ func TestConcurrentToolCalls_NoRace(t *testing.T) {
 		{Name: "memory_vsearch", Arguments: map[string]any{"workspace": "ws-1", "query": "vector test"}},
 		{Name: "memory_tags", Arguments: map[string]any{"workspace": "ws-1"}},
 		{Name: "memory_wake_up", Arguments: map[string]any{"workspace": "ws-1"}},
+		{Name: "memory_workspaces_list", Arguments: map[string]any{}},
 	}
 
 	const goroutines = 20
@@ -238,6 +239,7 @@ func TestConcurrentMixedToolCalls_NoRace(t *testing.T) {
 		{"memory_vsearch", map[string]any{"workspace": "ws-b", "query": "vector beta"}},
 		{"memory_tags", map[string]any{"workspace": "ws-a"}},
 		{"memory_wake_up", map[string]any{"workspace": "ws-b", "limit": float64(5)}},
+		{"memory_workspaces_list", map[string]any{}},
 	}
 
 	const goroutines = 50

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -42,6 +42,7 @@ func RegisterTools(server *mcpsdk.Server, a *Adapter) {
 	registerMemoryFlow(server, a)
 	registerMemoryFlowchart(server, a)
 	registerMemoryWorkspacesResolve(server, a)
+	registerMemoryWorkspacesList(server, a)
 }
 
 func toolSchema(props map[string]map[string]any, required []string) json.RawMessage {
@@ -2321,4 +2322,40 @@ func appendStitchedToFlow(f *flow.Flow, stitched []flow.FlowEdge) {
 		}
 		f.Edges = append(f.Edges, se)
 	}
+}
+
+func registerMemoryWorkspacesList(server *mcpsdk.Server, a *Adapter) {
+	server.AddTool(
+		&mcpsdk.Tool{
+			Name:        "memory_workspaces_list",
+			Description: "List all registered workspaces with their paths, hashes, and document counts. Use this to find the correct workspace hash before calling other tools. Returns empty list if no workspaces are registered.",
+			InputSchema: toolSchema(map[string]map[string]any{}, []string{}),
+		},
+		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			rows, err := a.queries.ListWorkspacesWithStats(ctx)
+			if err != nil {
+				return errResult(fmt.Sprintf("list workspaces failed: %v", err)), nil
+			}
+
+			workspaces := make([]map[string]any, 0, len(rows))
+			for _, r := range rows {
+				ws := map[string]any{
+					"workspace_hash": r.Hash,
+					"name":           r.Name,
+					"root_path":      r.Path,
+					"document_count": r.DocumentCount,
+					"chunk_count":    r.ChunkCount,
+				}
+				if t, ok := r.LastDocumentUpdated.(time.Time); ok {
+					ws["last_document_updated"] = t.Format(time.RFC3339)
+				}
+				workspaces = append(workspaces, ws)
+			}
+
+			return textResult(map[string]any{
+				"workspaces": workspaces,
+				"count":      len(workspaces),
+			})
+		},
+	)
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -35,8 +35,8 @@ func TestRegisterTools_CountAndNames(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 
-	if len(result.Tools) != 16 {
-		t.Errorf("expected 16 tools, got %d", len(result.Tools))
+	if len(result.Tools) != 17 {
+		t.Errorf("expected 17 tools, got %d", len(result.Tools))
 		for _, tool := range result.Tools {
 			t.Logf("  - %s", tool.Name)
 		}
@@ -59,6 +59,7 @@ func TestRegisterTools_CountAndNames(t *testing.T) {
 		"memory_flow",
 		"memory_flowchart",
 		"memory_workspaces_resolve",
+		"memory_workspaces_list",
 	}
 	sort.Strings(expected)
 

--- a/openspec/changes/fix-import-target-resolution/design.md
+++ b/openspec/changes/fix-import-target-resolution/design.md
@@ -1,0 +1,85 @@
+# Design — Import Target Resolution
+
+## Problem recap
+
+Extraction stores raw specifiers; storage stores them verbatim; lookup queries
+with a canonicalized node. Three representations, no intersection. Fix =
+canonicalize the import edge `target_node` at index time so it equals the node
+identity that `resolveNodeAgainstWorkspace` produces for the same file.
+
+## Code map (from grounding investigation)
+
+| Concern | Location |
+|---|---|
+| Edge struct (`TargetNode string`) | `internal/graph/edge.go:15-26` |
+| Raw spec stored — TS | `typescript_extractor.go` `extractImports` (~175-182), `walkRequire` (~213-220) |
+| Raw spec stored — JS | `javascript_extractor.go` `extractImports` (~139-146), `walkRequireJS` (~171-178) |
+| Dedup (no normalization) | `registry.go` `extractWith` (~178-197) |
+| Upsert convergence point | `internal/watcher/watcher.go` upsert loop (~250+) → `UpsertGraphEdge` |
+| Reverse-lookup match (literal) | `graph.sql` `GetIncomingEdges`, `GetImpactorsByTargets` |
+| Query-node canonicalizer | `internal/mcp/tools.go` `resolveNodeAgainstWorkspace` (~1669, ~1876) |
+
+## Approach
+
+Resolve in **one place** (watcher upsert loop), not the 4 extractor sites, so
+every language/extractor benefits and the extractors stay dumb (raw spec → edge).
+
+```
+for each edge:
+  if edge.Kind == EdgeImports:
+     edge.TargetNode = ResolveImportPath(edge.TargetNode, edge.SourceFile, workspaceRoot)  // fallback: raw on error
+  UpsertGraphEdge(... TargetNode ...)
+```
+
+### `internal/graph/import_resolver.go`
+
+```go
+func ResolveImportPath(spec, sourceFile, workspaceRoot string) (string, error)
+func IsBarePackage(spec string) bool      // no leading ./ ../ ~ @/  → npm pkg, return as-is
+func IsRelativeImport(spec string) bool   // ./ or ../
+func IsAliasImport(spec string) bool      // ~ , ~/ , @/  (framework alias)
+```
+
+Resolution steps:
+1. **Bare package** → return `spec` unchanged (not a workspace file).
+2. **Relative** → `filepath.Join(dir(sourceFile), spec)`, then canonicalize.
+3. **Alias** → map prefix via alias table to a base dir, join remainder.
+4. **Extension/index probing** → a spec rarely has an extension. Resolve to the
+   real file by probing `.ts .js .vue .mjs .ts→index.ts …` against the known file
+   set (prefer the in-memory/index file list over disk stat for speed). If no
+   match, fall back to the joined path without extension (still better than raw).
+5. **Canonicalize** to the exact form `resolveNodeAgainstWorkspace` emits.
+
+### Alias table source
+
+- Nuxt: `~` and `@` → project root; under Nuxt 4 `srcDir`, → `app/`. Read from
+  `nuxt.config.ts` (or `.nuxt/tsconfig.json` `compilerOptions.paths`, which Nuxt
+  generates and which already encodes the correct mapping).
+- Generic Vite/TS: `tsconfig.json` / `jsconfig.json` `compilerOptions.paths`.
+- Resolve once per workspace (cache), not per edge.
+
+## CRITICAL decision — canonical form (linchpin)
+
+The resolved `target_node` MUST byte-equal the node identity used elsewhere:
+- the same file's `source_node` form, and
+- the output of `resolveNodeAgainstWorkspace(node)`.
+
+The in-flight change `fix-edge-source-file-relative-paths` normalizes
+`source_node`/`source_file` to **workspace-relative**. Strong signal: canonical
+form = **workspace-relative** (e.g. `utils/enums.js`, or `app/utils/enums.js`
+under Nuxt 4). **Implementer MUST read `resolveNodeAgainstWorkspace` and match its
+output exactly** — a mismatch silently leaves reverse lookup broken (the failure
+mode looks identical to "no dependents").
+
+## Open questions for deep-design
+
+1. Workspace-relative vs absolute — confirm against `resolveNodeAgainstWorkspace` and the sibling change. (Leaning workspace-relative.)
+2. Extension probing against disk vs the indexed file set — perf + correctness tradeoff.
+3. Nuxt 4 `srcDir=app/` mapping — does `~` point at root or `app/`? Derive from `.nuxt/tsconfig.json` rather than hard-coding.
+4. Reindex mechanism — reuse existing reindex endpoint/path; full vs incremental.
+5. Coordination/merge order with `fix-edge-source-file-relative-paths` to avoid canonical-form drift.
+
+## Perf
+
+Resolution is string ops + a cached alias table + a file-set lookup — O(1) per
+edge. No network. Acceptable at index time; does not touch query latency.

--- a/openspec/changes/fix-import-target-resolution/proposal.md
+++ b/openspec/changes/fix-import-target-resolution/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Import-graph edges store the **raw module specifier** as `target_node`
+(`~/utils/enums`, `./foo`, `ramda`) and never resolve it to a workspace file.
+Reverse-lookup SQL matches `target_node` **literally**
+(`graph.sql` `GetIncomingEdges` / `GetImpactorsByTargets`), while the query node
+is first canonicalized by `resolveNodeAgainstWorkspace` (`internal/mcp/tools.go`).
+The two forms never intersect, so `memory_impact` and `memory_graph(direction=in)`
+return **0** for every alias/relative intra-repo import.
+
+Proven on a live workspace (see `docs/evidence/vue-sfc-design/agent-validation.md`,
+issue #501): the alias node `~/utils/enums` has **274** incoming edges; the real
+file's canonical path has **0**. For an agent this is a dangerous false-negative:
+"what breaks if I change this?" answers "nothing" while 274 files depend on it.
+This blocks the Vue SFC feature (its Vue import edges would inherit the same bug).
+
+## What Changes
+
+- **New `internal/graph/import_resolver.go`** — `ResolveImportPath(spec, sourceFile, workspaceRoot)` plus predicates `IsBarePackage` / `IsRelativeImport` / `IsAliasImport`.
+  - Bare packages (`vue`, `ramda`, `@babel/core`) pass through unchanged (not workspace files).
+  - Relative (`./`, `../`) resolved by joining against the source file's directory.
+  - Alias (`~`, `@/`) resolved via the project alias map (Nuxt `~`/`@` → root / `srcDir`; `tsconfig`/`jsconfig` `paths`).
+  - Output is the **canonical node form produced by `resolveNodeAgainstWorkspace`** (workspace-relative; coordinate with the in-flight `fix-edge-source-file-relative-paths` change normalizing `source_node`).
+- **Resolve at the single convergence point** — the watcher upsert loop, before `UpsertGraphEdge`, for `EdgeImports` edges. Graceful fallback to the raw spec on resolution failure (logged).
+- **Reindex** existing edges so stored `target_node` values become resolved.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `multi-language-graph-extractors`: import edge targets are resolved to canonical node identities so reverse traversal (`memory_impact`, `memory_graph(in)`) returns real dependents.
+
+## Impact
+
+- **Files**: new `internal/graph/import_resolver.go`; `internal/watcher/watcher.go` (upsert loop). Coordinate canonical form with `fix-edge-source-file-relative-paths` (source side).
+- **Data**: existing `graph_edges.target_node` are raw specifiers → reindex required.
+- **API**: no contract change — `memory_impact` / `memory_graph(in)` simply start returning correct results.
+- **Risk**: (a) per-edge resolution cost at index time (perf); (b) canonical-form mismatch with `resolveNodeAgainstWorkspace` would silently keep reverse lookup broken — the implementer MUST read that function and match its output exactly; (c) extension/`index` probing ambiguity. These are deep-design items.
+- **Breaking**: No — bare-package and unresolved specs fall back to current behavior.

--- a/openspec/changes/fix-import-target-resolution/specs/multi-language-graph-extractors/spec.md
+++ b/openspec/changes/fix-import-target-resolution/specs/multi-language-graph-extractors/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Import edge targets are resolved to canonical node identities
+
+Import (`imports`) graph edges SHALL store a resolved, canonical `target_node`
+that matches the node identity emitted by `resolveNodeAgainstWorkspace` for the
+same file, so that reverse traversal (`memory_impact`, `memory_graph` with
+`direction=in`) returns the real dependents. Resolution SHALL run at index time
+at the single edge-upsert convergence point. Bare npm package specifiers SHALL be
+stored unchanged. On any resolution failure the raw specifier SHALL be retained
+(graceful degradation).
+
+#### Scenario: Alias import resolves to the canonical file path
+- **WHEN** a source file imports `~/utils/enums` and `~` maps to the workspace root
+- **THEN** the edge `target_node` SHALL be the canonical workspace-relative path of the resolved file (e.g. `utils/enums.js`), not the raw specifier `~/utils/enums`
+
+#### Scenario: Reverse lookup returns dependents via the real path
+- **WHEN** N files import a module that resolves to `utils/enums.js`
+- **AND** `memory_graph(node="utils/enums.js", direction=in, edge_type=imports)` is queried
+- **THEN** the result SHALL contain all N importing files (not 0)
+
+#### Scenario: Relative import resolves against the source directory
+- **WHEN** `src/a/b.js` imports `../c/d`
+- **THEN** the edge `target_node` SHALL resolve to the canonical path `src/c/d.js` (with extension probing)
+
+#### Scenario: Bare package specifier is preserved
+- **WHEN** a source file imports `ramda` or `@babel/core`
+- **THEN** the edge `target_node` SHALL remain `ramda` / `@babel/core` (no filesystem resolution attempted)
+
+#### Scenario: Unresolvable specifier falls back to raw
+- **WHEN** an alias/relative specifier cannot be resolved to a known file
+- **THEN** the edge `target_node` SHALL retain the raw specifier and a warning SHALL be logged (no edge is dropped)

--- a/openspec/changes/fix-import-target-resolution/tasks.md
+++ b/openspec/changes/fix-import-target-resolution/tasks.md
@@ -1,0 +1,34 @@
+## 1. Confirm canonical form (do FIRST — linchpin)
+
+- [ ] 1.1 Read `internal/mcp/tools.go` `resolveNodeAgainstWorkspace`; document the exact node form it emits (workspace-relative? extension included?)
+- [ ] 1.2 Read `fix-edge-source-file-relative-paths` change + current `source_node` values; confirm canonical form is consistent
+- [ ] 1.3 Write the canonical form into design.md "CRITICAL decision" as resolved
+
+## 2. Resolver helper
+
+- [ ] 2.1 Create `internal/graph/import_resolver.go` with `IsBarePackage`, `IsRelativeImport`, `IsAliasImport`
+- [ ] 2.2 Implement relative resolution (`filepath.Join(dir(sourceFile), spec)` → canonical)
+- [ ] 2.3 Implement alias resolution from cached alias table (Nuxt `~`/`@`, tsconfig/jsconfig `paths`); read `.nuxt/tsconfig.json` when present
+- [ ] 2.4 Implement extension/`index` probing against the workspace file set; fallback to joined path on miss
+- [ ] 2.5 `ResolveImportPath` returns raw spec unchanged for bare packages and on any error
+- [ ] 2.6 Unit tests (table-driven): bare pkg passthrough, `./`/`../`, `~/`, `@/`, missing-extension probe, unresolvable→raw fallback
+
+## 3. Wire into indexing
+
+- [ ] 3.1 Build + cache the per-workspace alias table at watch/index start
+- [ ] 3.2 In the watcher upsert loop, resolve `EdgeImports` `target_node` before `UpsertGraphEdge` (graceful fallback + warn log)
+- [ ] 3.3 Confirm bare-package and non-import edges are untouched
+
+## 4. Reindex + verification
+
+- [ ] 4.1 Reindex a test workspace so `target_node` values become resolved
+- [ ] 4.2 Reverse-lookup assertion: an aliased file's canonical path returns its dependents (0 → N) via `GetIncomingEdges` / `memory_impact`
+- [ ] 4.3 `go build ./... && go test -race -short ./...`
+- [ ] 4.4 `go test -race -tags=integration ./...`
+- [ ] 4.5 smoke:e2e — start server on :3199 (nanobrain_test), index a small fixture with an alias import, `memory_graph(node=<real file>, direction=in)` returns the importer
+
+## 5. Review + ship
+
+- [ ] 5.1 Self-review evidence (`docs/evidence/self-review-fix-import-target-resolution.md`)
+- [ ] 5.2 Independent review gate (R88) — spawned reviewer, verdict PASS (`docs/evidence/review-fix-import-target-resolution.md`)
+- [ ] 5.3 PR → `master`, `Closes #501`; triage Gemini comments


### PR DESCRIPTION
## Summary

Add new MCP tool  to list all registered workspaces with their paths, hashes, and document counts.

## Problem

Agents had to guess workspace paths when calling , leading to  errors when the path was incorrect or didn't exist.

## Solution

New tool  that:
- Lists all registered workspaces without requiring a path
- Returns workspace hash, name, root_path, document_count, chunk_count
- Enables agents to find correct workspace before querying

## Changes

- : Add  function
- : Register tool in 
- : Update tool count (16 → 17)
- : Update tool count (16 → 17)
- : Add usage guidance for new tool

## Testing

- [x]  passes
- [x] ?   	github.com/nano-brain/nano-brain/benchmarks/capability	[no test files]
?   	github.com/nano-brain/nano-brain/benchmarks/rails/capability	[no test files]
?   	github.com/nano-brain/nano-brain/benchmarks/typescript/capability	[no test files]
ok  	github.com/nano-brain/nano-brain/cmd/nano-brain	(cached)
ok  	github.com/nano-brain/nano-brain/internal/bench	(cached)
ok  	github.com/nano-brain/nano-brain/internal/chunk	(cached)
ok  	github.com/nano-brain/nano-brain/internal/chunker	(cached)
ok  	github.com/nano-brain/nano-brain/internal/codesummarize	(cached)
ok  	github.com/nano-brain/nano-brain/internal/config	(cached)
ok  	github.com/nano-brain/nano-brain/internal/embed	(cached)
ok  	github.com/nano-brain/nano-brain/internal/eventbus	(cached)
ok  	github.com/nano-brain/nano-brain/internal/flow	(cached)
ok  	github.com/nano-brain/nano-brain/internal/graph	(cached)
ok  	github.com/nano-brain/nano-brain/internal/harvest	(cached)
ok  	github.com/nano-brain/nano-brain/internal/health	(cached)
ok  	github.com/nano-brain/nano-brain/internal/health/doctor	(cached)
ok  	github.com/nano-brain/nano-brain/internal/intelligence	(cached)
ok  	github.com/nano-brain/nano-brain/internal/links	(cached)
ok  	github.com/nano-brain/nano-brain/internal/mcp	(cached)
ok  	github.com/nano-brain/nano-brain/internal/migrate	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search/hyde	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search/preprocess	(cached)
ok  	github.com/nano-brain/nano-brain/internal/search/reranking	(cached)
ok  	github.com/nano-brain/nano-brain/internal/server	(cached)
ok  	github.com/nano-brain/nano-brain/internal/server/handlers	(cached)
ok  	github.com/nano-brain/nano-brain/internal/server/middleware	(cached)
?   	github.com/nano-brain/nano-brain/internal/storage/sqlc	[no test files]
ok  	github.com/nano-brain/nano-brain/internal/storage	(cached)
?   	github.com/nano-brain/nano-brain/internal/testutil	[no test files]
?   	github.com/nano-brain/nano-brain/migrations	[no test files]
?   	github.com/nano-brain/nano-brain/tools/dbaudit	[no test files]
ok  	github.com/nano-brain/nano-brain/internal/summarize	(cached)
ok  	github.com/nano-brain/nano-brain/internal/symbol	(cached)
ok  	github.com/nano-brain/nano-brain/internal/telemetry	(cached)
ok  	github.com/nano-brain/nano-brain/internal/timefilter	(cached)
ok  	github.com/nano-brain/nano-brain/internal/watcher	(cached)
?   	github.com/nano-brain/nano-brain/tools/edgecheck	[no test files]
?   	github.com/nano-brain/nano-brain/tools/ignorecleanup	[no test files] passes
- [x] All 17 MCP tools registered correctly

## Related

- Closes #502