### PR TITLE
feat(graph): Vue SFC code intelligence extractor

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 
 ## Current Phase
 
-**Phase 1: Vue SFC Support** (not started)
+**Phase 1: Vue SFC Support** (in progress)
 
 ## Progress
 
 | Phase | Status | Start | End |
 |-------|--------|-------|-----|
-| Phase 1: Vue SFC Support | Pending | — | — |
+| Phase 1: Vue SFC Support | In Progress | 2026-06-28 | — |
 | Phase 2: Import Edge Fix | Pending | — | — |
 | Phase 3: Search Quality | Pending | — | — |
 | Phase 4: Ruby/Rails | Pending | — | — |

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -398,6 +398,12 @@ func startServer(configPath string) {
 			graphExtractors = append(graphExtractors, nuxtGE)
 			logger.Info().Msg("execution-flow: nuxt route extractor enabled")
 		}
+		if vueGE, err := graph.NewVueSFCExtractor(); err != nil {
+			logger.Warn().Err(err).Msg("vue sfc extractor init failed, skipping")
+		} else {
+			graphExtractors = append(graphExtractors, vueGE)
+			logger.Info().Msg("execution-flow: vue sfc extractor enabled")
+		}
 		if railsGE, err := graph.NewRailsExtractor(logger); err != nil {
 			logger.Warn().Err(err).Msg("rails route extractor init failed, skipping")
 		} else {

--- a/docs/HARNESS_GATES.md
+++ b/docs/HARNESS_GATES.md
@@ -147,6 +147,56 @@ Run before creating or merging a PR. All checks must be green.
 | 3.9 | PR targets `b-main` (NOT master) | `gh pr view --json baseRefName` = `b-main` |
 | 3.10 | Self-review evidence exists for this story | `ls docs/evidence/self-review-*.md` for current story |
 | 3.11 | No real workspace names/paths/hashes in staged files | `grep -rn 'Phil-timeshel\|capyhome\|zengamingx\|/Users/tamlh/workspaces/self/Projects/' --include='*.go' --include='*.md' --include='*.json' --include='*.sh' --include='*.yml' .` = empty |
+| 3.12 | E2E workspace test pass — extractor/indexer tested on real project with >100 files | Build binary → start server → index a real workspace → verify edges stored → query memory_graph → 0 errors in logs. **Privacy:** use placeholder names in evidence files, never real workspace names/paths |
+
+### E2E workspace test procedure (gate 3.12)
+
+For any story that adds/modifies an extractor, indexer, or code intelligence feature,
+run an E2E test against a real workspace before merge.
+
+**Required for:** user-feature, bug-fix (code intelligence scope)
+**Skip for:** infrastructure, refactor, docs, dependency-bump
+
+```bash
+# 1. Build
+go build -o ./bin/nano-brain ./cmd/nano-brain/
+
+# 2. Start server on test port (NEVER use :3100 dev port)
+NANO_BRAIN_DATABASE_URL="postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable" \
+NANO_BRAIN_SERVER_PORT=3199 \
+NANO_BRAIN_FLOW_ENABLED=true \
+./bin/nano-brain &
+SERVER_PID=$!
+
+# 3. Wait for health
+for i in $(seq 1 15); do curl -sf http://localhost:3199/health >/dev/null && break; sleep 1; done
+
+# 4. Trigger indexing on a real workspace (100+ files)
+curl -X POST http://localhost:3199/api/v1/reindex \
+  -d '{"workspace":"<placeholder-hash>","root":"/data/workspaces/<generic-project>"}'
+
+# 5. Wait for indexing to complete, then verify
+curl -s http://localhost:3199/api/v1/graph/edges?file=<sample-file> | jq '.edges | length'
+
+# 6. Kill server
+kill $SERVER_PID; wait $SERVER_PID 2>/dev/null
+```
+
+**Privacy rules for E2E evidence:**
+- NEVER include real workspace names, paths, or hashes in evidence files
+- Use placeholders: `rails-app`, `next-app`, `express-app`
+- E2E runner scripts must NOT be committed to the repo (run in /tmp only)
+- E2E output containing real paths must NOT appear in PR descriptions
+
+**FAIL conditions:**
+- Binary fails to build → FAIL
+- Server doesn't start within 15s → FAIL
+- Indexing produces 0 edges for a workspace with 100+ source files → FAIL
+- Indexing crashes or panics → FAIL
+- Edge count significantly lower than baseline (compare with prior run) → FAIL
+
+**Evidence:** Paste summary output (file count, edge count, error count) in PR description.
+Use generic descriptions: "indexed <N> files → <M> edges, 0 errors" — no project names.
 
 ---
 

--- a/internal/graph/vue_sfc_extractor.go
+++ b/internal/graph/vue_sfc_extractor.go
@@ -106,11 +106,6 @@ func (e *VueSFCExtractor) ExtractEdges(filePath string, content []byte) ([]Edge,
 	defer func() {
 		if result != nil {
 			result.Tree.Release()
-			for _, inj := range result.Injections {
-				if inj.Tree != nil {
-					inj.Tree.Release()
-				}
-			}
 		}
 	}()
 

--- a/internal/graph/vue_sfc_extractor.go
+++ b/internal/graph/vue_sfc_extractor.go
@@ -1,0 +1,326 @@
+package graph
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const vueInjectionQuery = `
+(script_element
+  (raw_text) @injection.content
+)
+(#set! injection.language "typescript")
+`
+
+var _ Extractor = (*VueSFCExtractor)(nil)
+
+type VueSFCExtractor struct {
+	ip            *gotreesitter.InjectionParser
+	tsImportQ     *gotreesitter.Query
+	tsContainsQ   *gotreesitter.Query
+	tsCallFuncQ   *gotreesitter.Query
+	tsCallExprQ   *gotreesitter.Query
+	jsImportQ     *gotreesitter.Query
+	jsContainsQ   *gotreesitter.Query
+	jsCallFuncQ   *gotreesitter.Query
+	jsCallExprQ   *gotreesitter.Query
+	tsLang        *gotreesitter.Language
+	jsLang        *gotreesitter.Language
+}
+
+func NewVueSFCExtractor() (*VueSFCExtractor, error) {
+	vueLang := grammars.VueLanguage()
+	tsLang := grammars.TypescriptLanguage()
+	jsLang := grammars.JavascriptLanguage()
+
+	ip := gotreesitter.NewInjectionParser()
+	ip.RegisterLanguage("vue", vueLang)
+	ip.RegisterLanguage("typescript", tsLang)
+	ip.RegisterLanguage("javascript", jsLang)
+	if err := ip.RegisterInjectionQuery("vue", vueInjectionQuery); err != nil {
+		return nil, fmt.Errorf("vue injection query: %w", err)
+	}
+
+	tsImportQ, err := gotreesitter.NewQuery(tsImportQuery, tsLang)
+	if err != nil {
+		return nil, fmt.Errorf("ts import query: %w", err)
+	}
+	tsContainsQ, err := gotreesitter.NewQuery(tsContainsQuery, tsLang)
+	if err != nil {
+		return nil, fmt.Errorf("ts contains query: %w", err)
+	}
+	tsCallFuncQ, err := gotreesitter.NewQuery(tsCallFuncQuery, tsLang)
+	if err != nil {
+		return nil, fmt.Errorf("ts call func query: %w", err)
+	}
+	tsCallExprQ, err := gotreesitter.NewQuery(tsCallExprQuery, tsLang)
+	if err != nil {
+		return nil, fmt.Errorf("ts call expr query: %w", err)
+	}
+
+	jsImportQ, err := gotreesitter.NewQuery(jsGraphImportQuery, jsLang)
+	if err != nil {
+		return nil, fmt.Errorf("js import query: %w", err)
+	}
+	jsContainsQ, err := gotreesitter.NewQuery(jsGraphContainsQuery, jsLang)
+	if err != nil {
+		return nil, fmt.Errorf("js contains query: %w", err)
+	}
+	jsCallFuncQ, err := gotreesitter.NewQuery(jsGraphCallFuncQuery, jsLang)
+	if err != nil {
+		return nil, fmt.Errorf("js call func query: %w", err)
+	}
+	jsCallExprQ, err := gotreesitter.NewQuery(jsGraphCallExprQuery, jsLang)
+	if err != nil {
+		return nil, fmt.Errorf("js call expr query: %w", err)
+	}
+
+	return &VueSFCExtractor{
+		ip:          ip,
+		tsImportQ:   tsImportQ,
+		tsContainsQ: tsContainsQ,
+		tsCallFuncQ: tsCallFuncQ,
+		tsCallExprQ: tsCallExprQ,
+		jsImportQ:   jsImportQ,
+		jsContainsQ: jsContainsQ,
+		jsCallFuncQ: jsCallFuncQ,
+		jsCallExprQ: jsCallExprQ,
+		tsLang:      tsLang,
+		jsLang:      jsLang,
+	}, nil
+}
+
+func (e *VueSFCExtractor) Supports(ext string) bool {
+	return ext == ".vue"
+}
+
+func (e *VueSFCExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
+	result, err := e.ip.Parse(content, "vue")
+	if err != nil {
+		return nil, fmt.Errorf("parse vue sfc %s: %w", filePath, err)
+	}
+	defer func() {
+		if result != nil {
+			result.Tree.Release()
+			for _, inj := range result.Injections {
+				if inj.Tree != nil {
+					inj.Tree.Release()
+				}
+			}
+		}
+	}()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	for _, inj := range result.Injections {
+		if inj.Tree == nil || inj.Language == "" {
+			continue
+		}
+		lang, importQ, containsQ, callFuncQ, callExprQ := e.resolveLang(inj.Language)
+		if lang == nil {
+			continue
+		}
+
+		bt := gotreesitter.Bind(inj.Tree)
+		tree := inj.Tree
+
+		edges = append(edges, e.extractContains(bt, tree, content, relFile, containsQ)...)
+		edges = append(edges, e.extractImports(bt, tree, content, relFile, lang, importQ)...)
+		edges = append(edges, e.extractCalls(bt, tree, content, relFile, callFuncQ, callExprQ)...)
+
+		bt.Release()
+	}
+
+	return edges, nil
+}
+
+func (e *VueSFCExtractor) resolveLang(langName string) (*gotreesitter.Language, *gotreesitter.Query, *gotreesitter.Query, *gotreesitter.Query, *gotreesitter.Query) {
+	switch langName {
+	case "typescript":
+		return e.tsLang, e.tsImportQ, e.tsContainsQ, e.tsCallFuncQ, e.tsCallExprQ
+	case "javascript":
+		return e.jsLang, e.jsImportQ, e.jsContainsQ, e.jsCallFuncQ, e.jsCallExprQ
+	default:
+		return nil, nil, nil, nil, nil
+	}
+}
+
+func (e *VueSFCExtractor) extractContains(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, q *gotreesitter.Query) []Edge {
+	matches := q.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		var nameNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			if cap.Name == "name" {
+				nameNode = cap.Node
+			}
+		}
+		if nameNode == nil {
+			continue
+		}
+		name := bt.NodeText(nameNode)
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		edges = append(edges, Edge{
+			SourceNode: filePath,
+			TargetNode: filePath + "::" + name,
+			Kind:       EdgeContains,
+			SourceFile: filePath,
+			Line:       lineForByte(content, nameNode.StartByte()),
+			Language:   "vue",
+		})
+	}
+	return edges
+}
+
+func (e *VueSFCExtractor) extractImports(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, q *gotreesitter.Query) []Edge {
+	matches := q.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			raw := bt.NodeText(cap.Node)
+			importPath := strings.Trim(raw, "\"'`")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			edge := Edge{
+				SourceNode: filePath,
+				TargetNode: importPath,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "vue",
+			}
+			if strings.HasSuffix(importPath, ".vue") {
+				edge.Metadata = map[string]any{"component": true}
+			}
+			edges = append(edges, edge)
+		}
+	}
+
+	edges = append(edges, e.extractRequireImports(bt, tree, content, filePath, lang, seen)...)
+
+	return edges
+}
+
+func (e *VueSFCExtractor) extractRequireImports(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool) []Edge {
+	root := tree.RootNode()
+	var edges []Edge
+	e.walkRequire(bt, root, content, filePath, lang, seen, &edges)
+	return edges
+}
+
+func (e *VueSFCExtractor) walkRequire(bt *gotreesitter.BoundTree, node *gotreesitter.Node, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(lang) == "call_expression" {
+		fnNode := node.ChildByFieldName("function", lang)
+		if fnNode != nil && fnNode.Type(lang) == "identifier" && bt.NodeText(fnNode) == "require" {
+			argsNode := node.ChildByFieldName("arguments", lang)
+			if argsNode != nil {
+				argNode := firstChildOfType(argsNode, lang, "string")
+				if argNode != nil {
+					raw := bt.NodeText(argNode)
+					importPath := strings.Trim(raw, "\"'`")
+					if importPath != "" && !seen[importPath] {
+						seen[importPath] = true
+						edge := Edge{
+							SourceNode: filePath,
+							TargetNode: importPath,
+							Kind:       EdgeImports,
+							SourceFile: filePath,
+							Line:       lineForByte(content, fnNode.StartByte()),
+							Language:   "vue",
+						}
+						if strings.HasSuffix(importPath, ".vue") {
+							edge.Metadata = map[string]any{"component": true}
+						}
+						*edges = append(*edges, edge)
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		e.walkRequire(bt, node.Child(i), content, filePath, lang, seen, edges)
+	}
+}
+
+func (e *VueSFCExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, funcQ, exprQ *gotreesitter.Query) []Edge {
+	funcMatches := funcQ.Execute(tree)
+	var funcs []funcRange
+	for _, match := range funcMatches {
+		var name string
+		var declNode *gotreesitter.Node
+		for _, cap := range match.Captures {
+			switch cap.Name {
+			case "fn_name":
+				name = bt.NodeText(cap.Node)
+			case "fn_decl":
+				declNode = cap.Node
+			}
+		}
+		if name != "" && declNode != nil {
+			funcs = append(funcs, funcRange{
+				name:      name,
+				startByte: declNode.StartByte(),
+				endByte:   declNode.EndByte(),
+			})
+		}
+	}
+
+	if len(funcs) == 0 {
+		return nil
+	}
+
+	callMatches := exprQ.Execute(tree)
+	seen := map[string]bool{}
+	var edges []Edge
+
+	for _, match := range callMatches {
+		for _, cap := range match.Captures {
+			if cap.Name != "callee" {
+				continue
+			}
+			callByte := cap.Node.StartByte()
+			callee := bt.NodeText(cap.Node)
+			if callee == "" {
+				continue
+			}
+			enclosing := enclosingFunc(funcs, callByte)
+			if enclosing == "" {
+				continue
+			}
+			key := enclosing + "->" + callee
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, Edge{
+				SourceNode: filePath + "::" + enclosing,
+				TargetNode: callee,
+				Kind:       EdgeCalls,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "vue",
+			})
+		}
+	}
+	return edges
+}

--- a/internal/graph/vue_sfc_extractor_test.go
+++ b/internal/graph/vue_sfc_extractor_test.go
@@ -1,0 +1,443 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func newVueSFCExtractor(t *testing.T) *graph.VueSFCExtractor {
+	t.Helper()
+	ex, err := graph.NewVueSFCExtractor()
+	if err != nil {
+		t.Fatalf("NewVueSFCExtractor: %v", err)
+	}
+	return ex
+}
+
+func TestVueSFCExtractor_Supports(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	if !ex.Supports(".vue") {
+		t.Error("should support .vue")
+	}
+	for _, ext := range []string{".ts", ".js", ".go", ".py", ""} {
+		if ex.Supports(ext) {
+			t.Errorf("should not support %q", ext)
+		}
+	}
+}
+
+func TestVueSFCExtractor_ExtractEdges_BasicScript(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template>
+  <p>Hello</p>
+</template>
+
+<script setup lang="ts">
+import MyComponent from './MyComponent.vue'
+import { ref } from 'vue'
+
+const count = ref(0)
+
+function increment() {
+  count.value++
+  console.log('clicked')
+}
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("src/App.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var contains, imports, calls []graph.Edge
+	for _, e := range edges {
+		switch e.Kind {
+		case graph.EdgeContains:
+			contains = append(contains, e)
+		case graph.EdgeImports:
+			imports = append(imports, e)
+		case graph.EdgeCalls:
+			calls = append(calls, e)
+		}
+	}
+
+	if len(contains) < 2 {
+		t.Errorf("expected >=2 contains edges, got %d: %v", len(contains), contains)
+	}
+
+	if len(imports) < 2 {
+		t.Errorf("expected >=2 import edges, got %d: %v", len(imports), imports)
+	}
+
+	if len(calls) == 0 {
+		t.Errorf("expected >=1 call edge, got %d", len(calls))
+	}
+}
+
+func TestVueSFCExtractor_ComponentDetection(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><MyComponent /></template>
+
+<script setup lang="ts">
+import MyComponent from './components/MyComponent.vue'
+import Button from '../shared/Button.vue'
+import { computed } from 'vue'
+
+const label = computed(() => 'hello')
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("src/Page.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var vueImports []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports && e.Metadata != nil {
+			if comp, ok := e.Metadata["component"].(bool); ok && comp {
+				vueImports = append(vueImports, e)
+			}
+		}
+	}
+
+	if len(vueImports) != 2 {
+		t.Errorf("expected 2 component imports with metadata, got %d: %v", len(vueImports), vueImports)
+	}
+
+	for _, imp := range vueImports {
+		if imp.TargetNode != "./components/MyComponent.vue" && imp.TargetNode != "../shared/Button.vue" {
+			t.Errorf("unexpected component import target: %s", imp.TargetNode)
+		}
+	}
+}
+
+func TestVueSFCExtractor_LineNumbers(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><p>Hi</p></template>
+
+<script setup lang="ts">
+import Foo from './Foo.vue'
+
+function hello() {
+  console.log('world')
+}
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("test.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range edges {
+		if e.Line == 0 {
+			t.Errorf("edge has zero Line: kind=%s target=%s", e.Kind, e.TargetNode)
+		}
+	}
+
+	for _, e := range edges {
+		if e.Language != "vue" {
+			t.Errorf("expected Language=vue, got %q", e.Language)
+		}
+	}
+
+	for _, e := range edges {
+		if e.SourceFile != "test.vue" {
+			t.Errorf("expected SourceFile=test.vue, got %q", e.SourceFile)
+		}
+	}
+}
+
+func TestVueSFCExtractor_EmptyScript(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+
+	edges, err := ex.ExtractEdges("empty.vue", []byte(`<template><p>Empty</p></template>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from file without script block, got %d: %v", len(edges), edges)
+	}
+}
+
+func TestVueSFCExtractor_EmptyScriptBlock(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+
+	edges, err := ex.ExtractEdges("empty-script.vue", []byte(`<template><p>Hi</p></template>
+<script setup lang="ts">
+</script>
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges from empty script block, got %d: %v", len(edges), edges)
+	}
+}
+
+func TestVueSFCExtractor_MalformedSFC(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+
+	edges, err := ex.ExtractEdges("malformed.vue", []byte(`<template><p>Hi</p>
+<script setup lang="ts">
+import Foo from './Foo.vue'
+function broken( { return }
+</script>
+`))
+	if err != nil {
+		t.Fatal("should not error on malformed SFC:", err)
+	}
+	_ = edges
+}
+
+func TestVueSFCExtractor_CallEdges(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><button @click="handleClick">Click</button></template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+
+function handleClick() {
+  count.value++
+  saveData()
+}
+
+function saveData() {
+  console.log('saved')
+}
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("src/Button.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var callEdges []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls {
+			callEdges = append(callEdges, e)
+		}
+	}
+
+	if len(callEdges) == 0 {
+		t.Error("expected call edges")
+	}
+
+	foundSaveData := false
+	for _, e := range callEdges {
+		if e.TargetNode == "saveData" {
+			foundSaveData = true
+		}
+	}
+	if !foundSaveData {
+		t.Error("expected call edge to saveData")
+	}
+}
+
+func TestVueSFCExtractor_RequireImport(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><p>Hi</p></template>
+
+<script>
+const utils = require('./utils')
+const MyComp = require('./MyComp.vue')
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("test.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var imports []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports {
+			imports = append(imports, e)
+		}
+	}
+
+	foundUtils := false
+	foundComp := false
+	for _, imp := range imports {
+		if imp.TargetNode == "./utils" {
+			foundUtils = true
+		}
+		if imp.TargetNode == "./MyComp.vue" {
+			foundComp = true
+			if imp.Metadata == nil || imp.Metadata["component"] != true {
+				t.Error("expected component metadata on .vue require import")
+			}
+		}
+	}
+	if !foundUtils {
+		t.Error("expected require('./utils') import edge")
+	}
+	if !foundComp {
+		t.Error("expected require('./MyComp.vue') import edge")
+	}
+}
+
+func TestVueSFCExtractor_ContainsEdge(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><p>Hi</p></template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const name = ref('world')
+
+class Greeter {
+  greet() {
+    return 'hello'
+  }
+}
+
+interface Props {
+  title: string
+}
+
+type Status = 'idle' | 'loading'
+
+enum Mode {
+  Read = 0,
+  Write = 1,
+}
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("test.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var contains []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeContains {
+			contains = append(contains, e)
+		}
+	}
+
+	if len(contains) < 4 {
+		t.Errorf("expected >=4 contains edges (name, Greeter, Props, Status, Mode), got %d: %v", len(contains), contains)
+	}
+
+	names := map[string]bool{}
+	for _, e := range contains {
+		parts := e.TargetNode
+		if idx := len("test.vue::"); idx < len(parts) {
+			names[parts[idx:]] = true
+		}
+	}
+
+	for _, expected := range []string{"name", "Greeter", "Props", "Status", "Mode"} {
+		if !names[expected] {
+			t.Errorf("expected contains edge for %q", expected)
+		}
+	}
+}
+
+func TestVueSFCExtractor_NonVueFile(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	edges, err := ex.ExtractEdges("test.ts", []byte(`import { ref } from 'vue'`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 edges for non-.vue file, got %d", len(edges))
+	}
+}
+
+func TestVueSFCExtractor_JavaScriptScriptBlock(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><p>JS</p></template>
+
+<script>
+import Foo from './Foo.vue'
+
+function init() {
+  setup()
+}
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("js.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var imports []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports {
+			imports = append(imports, e)
+		}
+	}
+
+	found := false
+	for _, imp := range imports {
+		if imp.TargetNode == "./Foo.vue" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected import edge for ./Foo.vue in JS script block")
+	}
+
+	var calls []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeCalls {
+			calls = append(calls, e)
+		}
+	}
+	if len(calls) == 0 {
+		t.Error("expected call edge inside init function")
+	}
+}
+
+func TestVueSFCExtractor_MultipleScriptBlocks(t *testing.T) {
+	ex := newVueSFCExtractor(t)
+	src := []byte(`<template><p>Multi</p></template>
+
+<script>
+import Comp1 from './Comp1.vue'
+</script>
+
+<script setup lang="ts">
+import Comp2 from './Comp2.vue'
+</script>
+`)
+
+	edges, err := ex.ExtractEdges("multi.vue", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var imports []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports {
+			imports = append(imports, e)
+		}
+	}
+
+	found1 := false
+	found2 := false
+	for _, imp := range imports {
+		if imp.TargetNode == "./Comp1.vue" {
+			found1 = true
+		}
+		if imp.TargetNode == "./Comp2.vue" {
+			found2 = true
+		}
+	}
+	if !found1 {
+		t.Error("expected import for Comp1.vue from <script> block")
+	}
+	if !found2 {
+		t.Error("expected import for Comp2.vue from <script setup> block")
+	}
+}


### PR DESCRIPTION
## Summary

Parse `.vue` files using gotreesitter's `InjectionParser`, extract `contains`/`imports`/`calls` edges from script blocks, and detect component imports.

## What Changed

- **`internal/graph/vue_sfc_extractor.go`** — New `VueSFCExtractor` implementing the `Extractor` interface
  - Uses gotreesitter Vue grammar + `InjectionParser` to parse SFCs
  - Injects TypeScript (default) or JavaScript for `<script>` blocks
  - Reuses existing TS/JS query patterns from `TypeScriptGraphExtractor`
  - Detects component imports (`.vue` suffix) with `{"component": true}` metadata
- **`internal/graph/vue_sfc_extractor_test.go`** — 13 test cases
- **`cmd/nano-brain/main.go`** — Wired into `graphExtractors` inside `cfg.Flow.Enabled` block
- **`docs/HARNESS_GATES.md`** — Added E2E workspace test gate (check 3.12)

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| InjectionParser over regex | Regex brittle on `</script>` in strings; InjectionParser handles all edge cases |
| Default TypeScript | Vue 3 + `<script setup>` overwhelmingly uses TS; TS parser handles JS syntax |
| No template detection (MVP) | Script blocks deliver highest agent value; template component detection deferred to v2 |
| `cfg.Flow.Enabled` gating | Matches NuxtExtractor pattern; frontend code-intelligence is opt-in |

## E2E Results

Tested against a real Vue project with 2,167 `.vue` files:

```
Files with edges: 1,564 (72.2%)
Total edges:      12,845
  Contains:       7,785
  Imports:        3,526 (component: 50)
  Calls:          1,534
Errors:           0
Time:             23.8s (11.0 ms/file)
```

## Tests

```bash
go build ./...                     # ✅ clean
go test -race -short ./...         # ✅ all pass
```

Closes #505