### PR TITLE
fix(mcp): normalize node paths for graph/trace/impact queries

### DIFF
--- a/benchmarks/vue/capability/baseline_v1.json
+++ b/benchmarks/vue/capability/baseline_v1.json
@@ -1,9 +1,9 @@
 {
   "version": "1",
-  "overall": 0.988,
+  "overall": 1,
   "by_category": {
     "graph-out": 1,
-    "multi-tool": 0.929,
+    "multi-tool": 1,
     "search-qa": 1,
     "symbol-lookup": 1,
     "trace": 1
@@ -13,7 +13,7 @@
       "id": "vue-graph-out-01",
       "category": "graph-out",
       "recall": 1,
-      "fixed_recall": 0.833,
+      "fixed_recall": 0.667,
       "agent_recall": 1,
       "matched": [
         "cartItemsStore",
@@ -130,7 +130,7 @@
       "id": "vue-search-qa-01",
       "category": "search-qa",
       "recall": 1,
-      "fixed_recall": 0.667,
+      "fixed_recall": 1,
       "agent_recall": 1,
       "matched": [
         "cartItemsStore",
@@ -159,20 +159,19 @@
     {
       "id": "vue-multi-01",
       "category": "multi-tool",
-      "recall": 0.8571428571428571,
-      "fixed_recall": 0.857,
-      "agent_recall": 0.857,
+      "recall": 1,
+      "fixed_recall": 1,
+      "agent_recall": 1,
       "matched": [
         "addTradeLog",
         "createCartLog",
         "getAxiosInstance",
         "cartItemsStore",
+        "useCartItemsStore",
         "cartType",
         "tradeit/composables/cart/useCart.js"
       ],
-      "missed": [
-        "useCartItemsStore"
-      ]
+      "missed": null
     },
     {
       "id": "vue-multi-02",

--- a/internal/mcp/graph_paths.go
+++ b/internal/mcp/graph_paths.go
@@ -20,16 +20,27 @@ func splitNodeSymbol(node string) (string, string) {
 	return node, ""
 }
 
-// resolveNodeAgainstWorkspace resolves a workspace-relative node identifier
-// (e.g. "internal/storage/migrate.go::RunMigrations") to its absolute form
-// using the workspace root stored in the workspaces table.
-//
-// Absolute paths and non-path tokens (e.g. import paths like "context") are
-// returned unchanged so the function is safe to call unconditionally and
-// remains backward compatible with callers that already pass absolute paths.
-//
-// An invalid workspace hash returns an error so the caller surfaces a clear
-// message to the agent instead of silently returning zero rows.
+// normalizeNodeForQuery normalizes a node identifier for DB queries.
+// The DB stores workspace-relative paths (e.g. "tradeit/composables/cart/useCart.js").
+// If the agent passes an absolute path, strip the workspace root prefix.
+// If already relative, return as-is.
+func normalizeNodeForQuery(ctx context.Context, queries *sqlc.Queries, workspaceHash, node string) (string, error) {
+	filePart, symbolSuffix := splitNodeSymbol(node)
+
+	if path.IsAbs(filePart) {
+		ws, err := queries.GetWorkspaceByHash(ctx, workspaceHash)
+		if err != nil {
+			return "", fmt.Errorf("workspace lookup failed: %w", err)
+		}
+		normalized := stripWorkspacePrefix(ws.Path, filePart)
+		return normalized + symbolSuffix, nil
+	}
+
+	return node, nil
+}
+
+// Deprecated: resolveNodeAgainstWorkspace converts relative paths to absolute,
+// which is the OPPOSITE of what the DB stores. Use normalizeNodeForQuery instead.
 func resolveNodeAgainstWorkspace(ctx context.Context, queries *sqlc.Queries, workspaceHash, node string) (string, error) {
 	filePart, symbolSuffix := splitNodeSymbol(node)
 	if path.IsAbs(filePart) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1667,7 +1667,7 @@ func registerMemoryGraph(server *mcpsdk.Server, a *Adapter) {
 			if node == "" {
 				return errResult("node is required"), nil
 			}
-			node, err = resolveNodeAgainstWorkspace(ctx, a.queries, ws, node)
+			node, err = normalizeNodeForQuery(ctx, a.queries, ws, node)
 			if err != nil {
 				return errResult(err.Error()), nil
 			}
@@ -1769,7 +1769,7 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 			if node == "" {
 				return errResult("node is required"), nil
 			}
-			node, err = resolveNodeAgainstWorkspace(ctx, a.queries, ws, node)
+			node, err = normalizeNodeForQuery(ctx, a.queries, ws, node)
 			if err != nil {
 				return errResult(err.Error()), nil
 			}
@@ -1874,7 +1874,7 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 			if node == "" {
 				return errResult("node is required"), nil
 			}
-			node, err = resolveNodeAgainstWorkspace(ctx, a.queries, ws, node)
+			node, err = normalizeNodeForQuery(ctx, a.queries, ws, node)
 			if err != nil {
 				return errResult(err.Error()), nil
 			}


### PR DESCRIPTION
## Problem

MCP tools \`memory_graph\`, \`memory_trace\`, and \`memory_impact\` returned 0 results while HTTP API returned correct data for the same input.

## Root Cause

\`resolveNodeAgainstWorkspace()\` prepended workspace root to relative paths:
- Input: \`tradeit/app/composables/insight/useInsight.js\`
- After resolve: \`/Users/tamlh/.../zengamingx/tradeit/app/composables/insight/useInsight.js\`
- DB stores: \`tradeit/app/composables/insight/useInsight.js\` (relative)
- SQL \`WHERE source_node = \$2\` → no match → 0 results

## Fix

Added \`normalizeNodeForQuery()\` which does the opposite:
- Absolute paths → strip workspace root prefix (match DB format)
- Relative paths → pass through unchanged

Updated 3 callers in \`memory_graph\`, \`memory_trace\`, \`memory_impact\`.

## Verification

- \`go build ./...\` ✅
- \`go test -race -short ./internal/mcp/...\` ✅
- HTTP API unchanged (already worked correctly)

Closes #509