### PR TITLE
fix(watcher): backfill fingerprint on dedup path so DB-warmed fast-path works (999.1 Fix B gap)

### DIFF
--- a/internal/storage/queries/documents.sql
+++ b/internal/storage/queries/documents.sql
@@ -159,3 +159,14 @@ WHERE workspace_hash = $1
   AND source_path != ''
   AND mod_time IS NOT NULL
   AND file_size IS NOT NULL;
+
+-- name: UpdateDocumentFileState :exec
+-- Backfills the mtime+size fingerprint on the content-hash-match (dedup) path so
+-- the DB-warmed fast-path can skip this file on the next restart (999.1 Fix B
+-- gap: unchanged files — and rows indexed before migration 00029 — otherwise keep
+-- NULL mod_time/file_size forever and warmed stays 0). Touches only
+-- mod_time/file_size; title/content/updated_at are left intact so the
+-- documents_title_propagate trigger does not re-rank chunks.
+UPDATE documents
+SET mod_time = $3, file_size = $4
+WHERE source_path = $1 AND workspace_hash = $2;

--- a/internal/storage/sqlc/documents.sql.go
+++ b/internal/storage/sqlc/documents.sql.go
@@ -654,6 +654,35 @@ func (q *Queries) PreloadFileStateByWorkspace(ctx context.Context, arg PreloadFi
 	return items, nil
 }
 
+const updateDocumentFileState = `-- name: UpdateDocumentFileState :exec
+UPDATE documents
+SET mod_time = $3, file_size = $4
+WHERE source_path = $1 AND workspace_hash = $2
+`
+
+type UpdateDocumentFileStateParams struct {
+	SourcePath    string
+	WorkspaceHash string
+	ModTime       sql.NullTime
+	FileSize      sql.NullInt64
+}
+
+// Backfills the mtime+size fingerprint on the content-hash-match (dedup) path so
+// the DB-warmed fast-path can skip this file on the next restart (999.1 Fix B
+// gap: unchanged files — and rows indexed before migration 00029 — otherwise keep
+// NULL mod_time/file_size forever and warmed stays 0). Touches only
+// mod_time/file_size; title/content/updated_at are left intact so the
+// documents_title_propagate trigger does not re-rank chunks.
+func (q *Queries) UpdateDocumentFileState(ctx context.Context, arg UpdateDocumentFileStateParams) error {
+	_, err := q.db.ExecContext(ctx, updateDocumentFileState,
+		arg.SourcePath,
+		arg.WorkspaceHash,
+		arg.ModTime,
+		arg.FileSize,
+	)
+	return err
+}
+
 const updateDocumentsCollection = `-- name: UpdateDocumentsCollection :exec
 UPDATE documents SET collection = $2 WHERE collection = $1 AND workspace_hash = $3
 `

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -47,6 +47,7 @@ type WatcherQuerier interface {
 	InsertChunkEntity(ctx context.Context, arg sqlc.InsertChunkEntityParams) error
 	ListChunksByDocumentID(ctx context.Context, arg sqlc.ListChunksByDocumentIDParams) ([]sqlc.ListChunksByDocumentIDRow, error)
 	PreloadFileStateByWorkspace(ctx context.Context, arg sqlc.PreloadFileStateByWorkspaceParams) ([]sqlc.PreloadFileStateByWorkspaceRow, error)
+	UpdateDocumentFileState(ctx context.Context, arg sqlc.UpdateDocumentFileStateParams) error
 }
 
 type watchedCollection struct {
@@ -64,6 +65,15 @@ type fileState struct {
 	ModTime time.Time
 	Size    int64
 	Hash    string
+}
+
+// sameMtime compares two mtimes at microsecond precision. The persisted
+// fingerprint (Postgres TIMESTAMPTZ) that warms the cache only has microsecond
+// resolution, while os.Stat returns nanoseconds — a raw .Equal() would always
+// miss after a DB warm and defeat the fast-path. Truncating both sides keeps the
+// fast-path effective across restarts (999.1 Fix B).
+func sameMtime(a, b time.Time) bool {
+	return a.Truncate(time.Microsecond).Equal(b.Truncate(time.Microsecond))
 }
 
 type Watcher struct {
@@ -769,7 +779,7 @@ func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePa
 	cached, exists := w.fileCache[filePath]
 	w.fileCacheMu.RUnlock()
 
-	if exists && cached.ModTime.Equal(info.ModTime()) && cached.Size == info.Size() {
+	if exists && cached.Size == info.Size() && sameMtime(cached.ModTime, info.ModTime()) {
 		return
 	}
 
@@ -801,6 +811,24 @@ func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePa
 		WorkspaceHash: col.workspaceHash,
 	})
 	if err == nil && existing.ContentHash == contentHash {
+		// Backfill the persisted mtime+size fingerprint when missing or stale so
+		// the DB-warmed fast-path (warmFileCacheFromDB) can skip this file on the
+		// next restart. Without this, unchanged files — and rows indexed before
+		// migration 00029 — keep NULL mod_time/file_size forever (warmed stays 0).
+		// Only mod_time/file_size are written; title/content/updated_at are left
+		// intact so the documents_title_propagate trigger does not re-rank chunks.
+		if !existing.ModTime.Valid || !existing.FileSize.Valid ||
+			existing.FileSize.Int64 != info.Size() ||
+			!sameMtime(existing.ModTime.Time, info.ModTime()) {
+			if upErr := w.queries.UpdateDocumentFileState(ctx, sqlc.UpdateDocumentFileStateParams{
+				SourcePath:    filePath,
+				WorkspaceHash: col.workspaceHash,
+				ModTime:       sql.NullTime{Time: info.ModTime(), Valid: true},
+				FileSize:      sql.NullInt64{Int64: info.Size(), Valid: true},
+			}); upErr != nil {
+				w.logger.Warn().Err(upErr).Str("file", filePath).Msg("backfill file fingerprint failed")
+			}
+		}
 		w.fileCacheMu.Lock()
 		w.fileCache[filePath] = fileState{ModTime: info.ModTime(), Size: info.Size(), Hash: contentHash}
 		w.fileCacheMu.Unlock()

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -27,6 +27,7 @@ type mockQuerier struct {
 	deleteChunkCalls      atomic.Int64
 	deleteDocCalls        atomic.Int64
 	getDocBySourcePathCalls atomic.Int64
+	updateFileStateCalls    atomic.Int64
 	sourcePathHash        map[string]string
 }
 
@@ -87,6 +88,11 @@ func (m *mockQuerier) ListChunksByDocumentID(_ context.Context, _ sqlc.ListChunk
 
 func (m *mockQuerier) PreloadFileStateByWorkspace(_ context.Context, _ sqlc.PreloadFileStateByWorkspaceParams) ([]sqlc.PreloadFileStateByWorkspaceRow, error) {
 	return nil, nil
+}
+
+func (m *mockQuerier) UpdateDocumentFileState(_ context.Context, _ sqlc.UpdateDocumentFileStateParams) error {
+	m.updateFileStateCalls.Add(1)
+	return nil
 }
 
 func testConfig(debounceMs, pollSec int) config.Config {
@@ -240,6 +246,64 @@ func TestProcessFile_SkipsSameHash(t *testing.T) {
 	w.processFile(context.Background(), col, fp)
 	if mq.upsertDocCalls.Load() != 1 {
 		t.Fatalf("expected hash skip on second call, got %d total upserts", mq.upsertDocCalls.Load())
+	}
+}
+
+// TestProcessFile_BackfillsFingerprintOnDedup covers the 999.1 Fix B gap: a file
+// already indexed (matching content hash) but with a NULL persisted fingerprint
+// — e.g. indexed before migration 00029 — must have its mod_time/file_size
+// backfilled on the dedup path, without re-indexing, so the DB-warmed fast-path
+// can skip it after a restart. A second scan must hit the in-memory fast-path.
+func TestProcessFile_BackfillsFingerprintOnDedup(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "doc.md")
+	content := []byte("# stable\nunchanged across restart")
+	if err := os.WriteFile(fp, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+
+	mq := newMockQuerier()
+	// Simulate a document indexed by an older binary: hash present, fingerprint NULL.
+	mq.sourcePathHash[fp] = hash
+
+	w := newTestWatcher(mq, 2000, 300)
+	col := watchedCollection{name: "testcol", dirPath: dir, workspaceHash: "ws123", globPattern: "*.md"}
+
+	// Cold cache: content hash matches, fingerprint NULL → backfill once, no re-index.
+	w.processFile(context.Background(), col, fp)
+	if got := mq.updateFileStateCalls.Load(); got != 1 {
+		t.Fatalf("expected 1 fingerprint backfill on dedup match, got %d", got)
+	}
+	if got := mq.upsertDocCalls.Load(); got != 0 {
+		t.Fatalf("expected no re-index on dedup match, got %d upserts", got)
+	}
+
+	// Second scan: the dedup path warmed the in-memory cache, so the fast-path
+	// must skip before any DB lookup or further backfill.
+	getsBefore := mq.getDocBySourcePathCalls.Load()
+	w.processFile(context.Background(), col, fp)
+	if mq.getDocBySourcePathCalls.Load() != getsBefore {
+		t.Error("fast-path should skip without a DB lookup after the cache is warmed")
+	}
+	if got := mq.updateFileStateCalls.Load(); got != 1 {
+		t.Errorf("expected no second backfill, got %d", got)
+	}
+}
+
+// TestSameMtime_MicrosecondTolerance guards the precision fix: the persisted
+// fingerprint (Postgres TIMESTAMPTZ) is microsecond-resolution, while os.Stat
+// mtimes are nanosecond. The fast-path comparison must ignore sub-microsecond
+// differences (else a DB-warmed entry never matches) but still detect a real
+// >= 1µs change.
+func TestSameMtime_MicrosecondTolerance(t *testing.T) {
+	base := time.Unix(1700000000, 123456000) // .123456 s — microsecond-aligned
+	if !sameMtime(base, base.Add(789*time.Nanosecond)) {
+		t.Error("sameMtime must treat sub-microsecond (nanosecond) differences as equal")
+	}
+	if sameMtime(base, base.Add(2*time.Microsecond)) {
+		t.Error("sameMtime must detect a >= 1µs difference")
 	}
 }
 


### PR DESCRIPTION
## Problem (found via live logs)

After 999.1 (#513) shipped, the daemon still logged `warmed file cache from DB ... warmed=0` on every startup — **Fix B delivered no benefit**. Two reasons:

1. The content-hash-match (dedup) early-return in `processFile` **never persisted** `mod_time`/`file_size`. So unchanged files — and every row indexed before migration `00029` — kept NULL fingerprints forever, and `PreloadFileStateByWorkspace` (which filters `IS NOT NULL`) returned nothing → `warmed=0`.
2. Postgres `TIMESTAMPTZ` is microsecond-resolution while `os.Stat` mtimes are nanosecond. The fast-path's raw `cached.ModTime.Equal(info.ModTime())` would therefore miss even after a successful warm, defeating the skip.

(Fix A from #513 — skipping graph-edge extraction for unchanged content — was already working: the `graph edges extracted` storm is gone. This PR makes the *cheap* read/hash skip survive restart.)

## Fix

- **`UpdateDocumentFileState`** query — UPDATEs only `mod_time`/`file_size` (leaves `title`/`content`/`updated_at` intact, so the `documents_title_propagate` trigger does not re-rank chunks).
- **Backfill on the dedup path** when the persisted fingerprint is missing or stale. Guarded so it writes at most once per file (afterwards the in-memory cache, then the DB-warmed cache, short-circuit earlier).
- **`sameMtime()`** compares mtimes truncated to microsecond; the fast-path now uses it so a DB-warmed entry matches the nanosecond `os.Stat` value.

## Tests / evidence

- `go test -race -short ./internal/watcher/` ✓ — new `TestProcessFile_BackfillsFingerprintOnDedup` (dedup match → exactly one backfill, no re-index, then fast-path skip) and `TestSameMtime_MicrosecondTolerance` (ignores sub-µs, detects ≥1µs).
- `go test -race -tags=integration ./internal/watcher/ -run TestWarmFileCache` ✓ (test DB `nanobrain_test`).
- Build ✓ · independent review: no blockers.

After this + a restart, the first scan backfills fingerprints; subsequent restarts warm the cache and skip unchanged files with no read/hash/extraction.