### PR TITLE
docs: unify install instructions on @nano-step/nano-brain + pgvector (drop stale Qdrant refs)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -400,7 +400,7 @@
                     <div class="step-num">1</div>
                     <h3>Install</h3>
                     <code>npm install -g @nano-step/nano-brain</code>
-                    <p class="step-note">Or build from source: <code style="display:inline;padding:2px 6px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:11px">CGO_ENABLED=0 go build ./cmd/nano-brain</code></p>
+                    <p class="step-note">Or build from source: <code style="display:inline;padding:2px 6px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:11px">CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain</code></p>
                 </div>
                 <div class="step">
                     <div class="step-num">2</div>

--- a/docs/reference-prd.md
+++ b/docs/reference-prd.md
@@ -628,7 +628,7 @@ YAML at `~/.nano-brain/config.yml`, auto-generated from `config.default.yml`. Se
 | `logging` | `enabled`, `level`, `file`, `maxSize`, `maxFiles` | enabled, `info`, 10 MB, 5 files |
 | `database` | `url` | `postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev` |
 | `embedding` | `provider`, `url`, `model`, `apiKey`, `dimensions`, `maxChars` | Ollama `nomic-embed-text`; or OpenAI-compatible with custom `url` |
-| `codebase` | `enabled`, `languages`, `exclude`, `maxFileSize` | true, [go/ts/js], standard, 1 MB |
+| `codebase` | `enabled`, `languages`, `exclude`, `maxFileSize` | true, [go/ts/js/py/rb], standard, 1 MB |
 | `watcher` | `debounce`, `reindexInterval`, `chokidarIntervalMs` | 300 ms, 300 s, 5000 ms |
 | `intervals` | `sessionPoll`, `healthCheck` | 120 s, 60 s |
 | `storage` | `maxSize`, `retention.{sessions,logs}` | 10 GB, 90 d, 30 d |

--- a/docs/reference-prd.md
+++ b/docs/reference-prd.md
@@ -43,14 +43,14 @@
 
 ## 1. Product summary
 
-nano-brain is a **persistent memory and code intelligence server for AI coding agents**. It runs as a local daemon (Docker container, launchd service, or stdio MCP process) and gives any MCP-capable agent two things their host model cannot do alone:
+nano-brain is a **persistent memory and code intelligence server for AI coding agents**. It runs as a local daemon and gives any MCP-capable agent two things their host model cannot do alone:
 
-1. **Cross-session recall** — automatically harvested AI sessions, curated notes, and codebase symbols, indexed with a 6-signal hybrid search pipeline (BM25 + vector + RRF + PageRank + supersede demotion + neural reranking).
-2. **Code intelligence** — Tree-sitter symbol graph, call-flow detection, file dependency graph with PageRank centrality and Louvain clustering, and cross-repo infrastructure symbol tracking (Redis keys, MySQL tables, API endpoints, Bull queues).
+1. **Cross-session recall** — automatically harvested AI sessions, curated notes, and codebase symbols, indexed with a hybrid search pipeline (BM25 full-text + pgvector HNSW cosine similarity + RRF + recency decay).
+2. **Code intelligence** — symbol graph, call-flow detection, file dependency graph, and impact analysis.
 
-The product is exposed through three integration surfaces — **CLI** (29 commands), **MCP** (24 tools across stdio / HTTP / SSE transports), and a **REST + streaming HTTP API** (29 endpoints) — backed by a self-tuning learning loop (Thompson Sampling bandits, preference learning, importance scoring, query-sequence pattern detection).
+The product is exposed through two primary integration surfaces — **CLI** and **MCP** (16 tools over HTTP transport) — backed by a PostgreSQL + pgvector storage layer.
 
-It is **privacy-first by default** (100% local with Ollama + sqlite-vec) and **production-ready when scaled** (VoyageAI + Qdrant, per-workspace SQLite isolation, automatic corruption recovery).
+It is **privacy-first by default** (100% local with Ollama + self-hosted PostgreSQL). No external cloud services are required.
 
 ---
 
@@ -89,7 +89,7 @@ Modern AI coding agents (Claude Code, OpenCode, Cursor, etc.) have three structu
 - **G2.** Hybrid retrieval that beats BM25 alone and beats vector-only on code-heavy corpora (validated by `bench` suite).
 - **G3.** Code intelligence (symbol graph, call graph, dependency graph, flow detection) for TypeScript / JavaScript / Python.
 - **G4.** Self-learning loop that improves retrieval quality over time without manual tuning.
-- **G5.** Privacy-first deployment: 100% local option (Ollama + sqlite-vec), no required cloud calls.
+- **G5.** Privacy-first deployment: 100% local option (Ollama + self-hosted PostgreSQL), no required cloud calls.
 - **G6.** Multi-workspace isolation with cross-workspace queries (`scope=all`).
 - **G7.** First-class MCP support: stdio, HTTP, SSE transports.
 - **G8.** Operational reliability: automatic corruption recovery, retention enforcement, daemon lifecycle.
@@ -109,16 +109,12 @@ Modern AI coding agents (Claude Code, OpenCode, Cursor, etc.) have three structu
 
 | Capability | nano-brain | Mem0 | Zep / Graphiti | Letta | Claude native |
 |---|---|---|---|---|---|
-| 6-signal hybrid search | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Code intelligence (AST + call graph) | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Cross-repo infra symbol tracking | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Hybrid search (BM25 + pgvector + RRF) | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Code intelligence (symbol graph, impact) | ✓ | ✗ | ✗ | ✗ | ✗ |
 | Session auto-harvesting | ✓ | ✗ | ✗ | ✗ | partial |
-| Neural reranking | ✓ | ✗ | ✗ | ✗ | ✗ |
-| Self-tuning (Thompson Sampling) | ✓ | ✗ | ✗ | ✗ | ✗ |
 | 100% local option | ✓ | ✗ | partial | ✓ | ✓ |
-| MCP-native (stdio / HTTP / SSE) | ✓ | ✗ | ✗ | ✗ | partial |
-| Per-workspace isolation | ✓ | ✗ | partial | partial | ✗ |
-| 22 MCP tools / 29 HTTP endpoints | ✓ | 4–9 tools | 9–10 | 7 | 0 |
+| MCP-native (HTTP) | ✓ | ✗ | ✗ | ✗ | partial |
+| 16 MCP tools | ✓ | 4–9 tools | 9–10 | 7 | 0 |
 
 The combination — **code intelligence + AI-session harvesting + self-tuning hybrid retrieval + MCP** — is unique in the agent-memory category.
 
@@ -130,51 +126,49 @@ The combination — **code intelligence + AI-session harvesting + self-tuning hy
                         ┌──────────────────────────┐
                         │  AI agent (OpenCode etc) │
                         └──────────┬───────────────┘
-                                   │ MCP (stdio / HTTP / SSE)
+                                   │ MCP (HTTP)
                                    ▼
             ┌──────────────────────────────────────────┐
             │  nano-brain server                       │
             │  ┌────────────┐  ┌────────────────────┐ │
-            │  │ MCP server │  │ HTTP / SSE server  │ │
-            │  │ (24 tools) │  │ (29 endpoints)     │ │
+            │  │ MCP server │  │ HTTP server        │ │
+            │  │ (16 tools) │  │                    │ │
             │  └─────┬──────┘  └─────────┬──────────┘ │
             │        └──────────┬────────┘            │
             │                   ▼                     │
             │  ┌─────────────────────────────────┐    │
             │  │  Search pipeline                │    │
-            │  │  BM25 + vector + RRF + PageRank │    │
-            │  │  + supersede demote + rerank    │    │
+            │  │  BM25 + pgvector + RRF          │    │
+            │  │  + recency decay                │    │
             │  └────────┬───────┬────────┬───────┘    │
             │           ▼       ▼        ▼            │
-            │   ┌──────┐  ┌────────┐  ┌──────────┐    │
-            │   │ FTS5 │  │ vec DB │  │ Symbol   │    │
-            │   │      │  │ Qdrant │  │ graph    │    │
-            │   │      │  │ /sqlite│  │          │    │
-            │   └──────┘  └────────┘  └──────────┘    │
-            │           SQLite (per-workspace)        │
+            │   ┌────────────────────┐  ┌──────────┐  │
+            │   │ PostgreSQL         │  │ Symbol   │  │
+            │   │ tsvector + pgvector│  │ graph    │  │
+            │   │ (pg17, HNSW index) │  │          │  │
+            │   └────────────────────┘  └──────────┘  │
             │                                         │
             │  ┌──────────────────────────────────┐   │
             │  │ Background jobs                  │   │
-            │  │ harvest │ index │ embed │ learn  │   │
-            │  │ consolidate │ prune │ importance │   │
+            │  │ harvest │ index │ embed          │   │
             │  └──────────────────────────────────┘   │
             └──────────────────────────────────────────┘
-                       │              │
-                       ▼              ▼
-              ┌────────────┐  ┌─────────────────┐
-              │ Embedding  │  │ Reranker        │
-              │ (VoyageAI/ │  │ (VoyageAI       │
-              │  Ollama)   │  │  rerank-2.5)    │
-              └────────────┘  └─────────────────┘
+                                │
+                                ▼
+                       ┌────────────────┐
+                       │ Embedding      │
+                       │ (Ollama /      │
+                       │  OpenAI-compat)│
+                       └────────────────┘
 ```
 
 **Data flow (write path):**
-`source files / AI sessions` → harvester / file watcher → chunker (900 tokens, 15% overlap) → SQLite + FTS5 → async embedder → vector store → entity extractor → knowledge graph → categorizer (`auto:*` + `llm:*` tags).
+`source files / AI sessions` → harvester / file watcher → chunker → PostgreSQL (tsvector index + async pgvector embedding).
 
 **Data flow (read path):**
-agent query → MCP / HTTP → query expansion (optional) → parallel BM25 + vector + symbol search → RRF fusion (k=60) → PageRank boost (0.1×) → supersede demote (0.05×) → usage / length / recency / category boosts → top-K candidates → neural reranker → position-aware blending (75/25, 60/40, 40/60) → results.
+agent query → MCP / HTTP → parallel BM25 + pgvector search → RRF fusion (k=60) → recency decay → results.
 
-**Isolation:** Each workspace gets a dedicated SQLite file `~/.nano-brain/data/{name}-{12-char-hash}.sqlite`. Cross-workspace queries (`scope=all`) open multiple stores and RRF-fuse the results.
+**Storage:** PostgreSQL 17 + pgvector 0.8.2. Each workspace is partitioned by a workspace hash. Cross-workspace queries (`scope=all`) union results across workspaces.
 
 ---
 
@@ -215,38 +209,33 @@ Three parallel ingestion pipelines run in the background, all governed by `~/.na
 
 ### 6.2 Storage & reliability
 
-#### 6.2.1 SQLite schema (24 tables, 5 groups)
+#### 6.2.1 PostgreSQL schema
 
-**Core documents (3):** `documents`, `content` (SHA-256 keyed), `chunks` (virtual via triggers).
-**Search indexes (2):** `documents_fts` (FTS5, porter unicode61 stemming), `content_vectors` (sqlite-vec).
-**Code intelligence (5):** `code_symbols`, `symbol_edges`, `file_edges`, `execution_flows`, `flow_steps`.
-**Knowledge graph (2):** `entities`, `relationships`.
-**Learning & intelligence (9):** `search_telemetry`, `bandit_stats`, `config_versions`, `consolidations`, `importance_scores`, `workspace_profiles`, `global_learning`, `llm_cache`, `token_usage`.
-**Query pattern detection (2):** `query_chain_membership`, `query_clusters`.
+Storage backend is **PostgreSQL 17 + pgvector 0.8.2**. Schema is managed by goose migrations in `migrations/`.
 
-Triggers auto-maintain FTS5 index on insert / delete / hash-update.
+Key table groups:
+- **Documents** — content, metadata, tsvector index for BM25 full-text search
+- **Vectors** — pgvector HNSW index (cosine similarity) for semantic search
+- **Code intelligence** — symbols, call edges, file dependency edges, execution flows
+- **Session / workspace** — workspace registry, harvest state
+
+Run `nano-brain db:migrate` to apply pending migrations.
 
 #### 6.2.2 Per-workspace isolation
 
+Each workspace is identified by a hash of its root path. The `workspace_hash` column partitions data within PostgreSQL. Cross-workspace queries (`scope=all`) union across all workspace hashes.
+
+#### 6.2.3 PostgreSQL setup
+
+```bash
+docker run -d --name nanobrain-pg -p 5432:5432 \
+  -e POSTGRES_USER=nanobrain \
+  -e POSTGRES_PASSWORD=nanobrain \
+  -e POSTGRES_DB=nanobrain_dev \
+  pgvector/pgvector:pg17
 ```
-{dirName}-{first12CharsOfSha256(workspacePath)}.sqlite
-```
 
-Example: `nano-brain-a1b2c3d4e5f6.sqlite`.
-The `project_hash` column further partitions data within each DB. Cross-workspace queries open multiple stores.
-
-> **Known issue (2026-05-22):** `POST /api/query` and `POST /api/search` ignore the client's CWD and use the server-startup `currentProjectHash`. CLI does not send a workspace identifier. Tracked for OpenSpec proposal.
-
-#### 6.2.3 Content-addressed storage
-
-Every chunk: `hash = SHA-256(content)`, stored once in `content`, referenced by `documents.hash`. Identical content across documents shares a single row. `chunks` records `(hash, seq, pos, startLine, endLine)`.
-
-#### 6.2.4 Corruption detection & recovery
-
-- `PRAGMA quick_check` runs in `createStore()` before any DB ops (50–500 ms).
-- On corruption: rename file to `index.db.corrupted.{ISO-timestamp}` (last 5 retained), delete `-wal` / `-shm`, reapply schema with pragmas (`journal_mode=WAL`, `foreign_keys=ON`, `busy_timeout=15s`, `synchronous=NORMAL`), run migrations, verify, emit metric `database_corruption_detected`.
-- launchd (macOS) auto-restarts on fatal exit (10 s throttle).
-- Recovery is safe because the DB is a derivable cache: sessions re-harvest, codebase re-indexes, vectors regenerate.
+Connection configured via `database.url` in `~/.nano-brain/config.yml` (see §7).
 
 ### 6.3 Search pipeline
 
@@ -254,22 +243,12 @@ Hybrid retrieval over BM25 + vector + symbol-name match, fused and reranked.
 
 | Stage | Detail | Default |
 |---|---|---|
-| 1. Query expansion | 2–3 variants, weight 1.0× each, original 2.0× | provider stub, off |
-| 2. BM25 (FTS5) | porter stemmer, 5 s timeout | — |
-| 3. Vector search | sqlite-vec or Qdrant, cosine, 5 s timeout | — |
-| 4. Symbol search | exact-name match against `code_symbols` | — |
-| 5. RRF fusion | `Σ weight / (k + rank + 1)` | k = 60 |
-| 6. Centrality boost | `× (1 + w · centrality)` | w = 0.1 |
-| 7. Supersede demotion | `× supersede_demotion` if replaced | 0.05 |
-| 8. Usage boost | `log₂(1+access) · 1/(1 + days/30)` | weight 0.15 |
-| 9. Length normalization | `× 1/(1 + log₂(chars/anchor))` | anchor 2000 chars |
-| 10. Recency boost | exponential half-life | weight 0.3, half-life 180 d |
-| 11. Category weights | `auto:*` / `llm:*` tag multipliers | 0.5×–2.0× from preference learning |
-| 12. Importance boost | document importance score | optional |
-| 13. Top-K selection | candidate pool for reranker | top_k = 15 |
-| 14. Neural reranking | VoyageAI `rerank-2.5-lite`, cached | — |
-| 15. Position-aware blend | top 3: 75/25, ranks 4–10: 60/40, ranks 11+: 40/60 | RRF / rerank |
-| 16. Output | `limit=10`, snippets ≤ 700 chars | — |
+| 1. BM25 (tsvector/tsquery) | PostgreSQL full-text search, 5 s timeout | — |
+| 2. Vector search | pgvector HNSW cosine, 5 s timeout | — |
+| 3. Symbol search | exact-name match against symbol table | — |
+| 4. RRF fusion | `Σ weight / (k + rank + 1)` | k = 60 |
+| 5. Recency boost | exponential half-life | weight 0.3, half-life 180 d |
+| 6. Output | `limit=20` | — |
 
 Snippets are enriched with symbol info, cluster labels, and flow counts when applicable.
 
@@ -391,21 +370,16 @@ Maintenance mode (`POST /api/maintenance/prepare` / `/resume`) pauses watcher an
 
 | Provider | Config | Dim | Max chars | Notes |
 |---|---|---|---|---|
-| **VoyageAI** | `provider: openai`, `url: https://api.voyageai.com` | 1024 | 8000 | `voyage-code-3` recommended; needs `VOYAGE_API_KEY` |
-| **Ollama** | `provider: ollama`, `url: http://localhost:11434` | auto | auto | Local, free, no key |
-| **OpenAI-compatible** | `provider: openai`, custom `url` | model-dep. | model-dep. | Azure, LM Studio, etc. |
+| **Ollama** | `provider: ollama`, `url: http://localhost:11434` | auto | auto | Local, free, no key required |
+| **OpenAI-compatible** | `provider: openai`, custom `url` | model-dep. | model-dep. | VoyageAI, Azure, LM Studio, etc. |
 
 Default concurrency: **3** (override via `NANO_BRAIN_EMBEDDING_CONCURRENCY`).
 
-#### Reranker
-- **VoyageAI `rerank-2.5-lite`** — only supported reranker. Falls back to RRF-only blend if unavailable.
+#### Vector store
+- **pgvector** — HNSW index on PostgreSQL 17. Configured via `database.url` in `config.yml`. No separate vector service required.
 
-#### Vector stores
-- **Qdrant** (production) — bundled in `docker compose`, ports 6333 (gRPC) / 6334 (HTTP).
-- **sqlite-vec** (embedded) — default if Qdrant absent. Migration tool: `nano-brain qdrant migrate`.
-
-#### LLM providers (consolidation, extraction, categorization)
-- OpenAI-compatible (default `gpt-4o-mini`).
+#### LLM providers (optional — session summarization)
+- OpenAI-compatible endpoint (configure `url` + `apiKey`).
 - Ollama (set `provider: ollama`).
 
 ### 6.9 Chunking strategy
@@ -445,9 +419,8 @@ Code fences are tracked: cuts inside fences prefer the nearest fence boundary. E
 | **Memory** | `write [--tags --supersedes]`, `get`, `tags` |
 | **Index** | `update`, `reindex [--root]`, `embed [--force]` |
 | **Collections** | `collection {add\|remove\|list\|rename}` |
-| **Cleanup** | `reset [--databases --sessions --memory --logs --vectors --confirm --dry-run]`, `rm <ws> [--list --dry-run]`, `harvest` |
+| **Cleanup** | `reset [--databases --sessions --memory --logs --vectors --confirm --dry-run]`, `workspaces`, `harvest` |
 | **Docker** | `docker {start\|stop\|restart [svc]\|status}` |
-| **Qdrant** | `qdrant {up\|down\|status\|migrate\|verify\|activate\|cleanup\|recreate}` |
 | **Cache** | `cache {clear [--all --type]\|stats}` |
 | **Logs** | `logs [-f -n --date --clear \| path]` |
 | **Code intel** | `context <sym>`, `code-impact <sym> [--direction --max-depth --min-confidence --file]`, `detect-changes [--scope]`, `focus <file>`, `graph-stats`, `symbols [--type --pattern --repo --operation]`, `impact --type --pattern` |
@@ -566,11 +539,9 @@ Default command (no args) → `mcp` in stdio mode.
 
 | Mode | Command | Use case |
 |---|---|---|
-| **Docker compose** (recommended) | `npx nano-brain docker start` | One-command full stack: nano-brain (port 3100) + Qdrant (6333/6334), 2 GB memory limit, restart `unless-stopped`, 30 s health check. |
-| **Standalone HTTP daemon** | `npx nano-brain mcp --http --daemon --port=8282` | Single-process, PID at `~/.nano-brain/server.pid`. |
-| **launchd (macOS)** | `launchctl load ~/Library/LaunchAgents/com.tamlh.nano-brain.plist` | OS-managed, auto-restart on exit (10 s throttle), survives corruption recovery. |
-| **stdio MCP** | `npx nano-brain mcp` (default) | Direct integration with local agents (OpenCode, Claude Code). |
-| **MCP remote (HTTP/SSE)** | client connects to `host.docker.internal:3100/mcp` or `/sse` | Container deployments, remote agents. |
+| **Standalone HTTP daemon** (recommended) | `nano-brain serve -d` | Single Go binary + external PostgreSQL. PID managed by the process. |
+| **launchd (macOS)** | `launchctl load ~/Library/LaunchAgents/com.nano-brain.plist` | OS-managed, auto-restart on exit. |
+| **Foreground** | `nano-brain serve` | Development / debugging. |
 
 Container detection: `/proc/1/cgroup` for Docker, `KUBERNETES_SERVICE_HOST` for K8s, `LAUNCHD_PROCESS_PID` for launchd. Adjusts host resolution (`host.docker.internal` vs `localhost`) and stdio handling.
 
@@ -655,11 +626,9 @@ YAML at `~/.nano-brain/config.yml`, auto-generated from `config.default.yml`. Se
 | Section | Key fields | Default |
 |---|---|---|
 | `logging` | `enabled`, `level`, `file`, `maxSize`, `maxFiles` | enabled, `info`, 10 MB, 5 files |
-| `collections` | `{name: {path, pattern, update, excludeFolders}}` | `memory`, `sessions` (both `**/*.md`) |
-| `vector` | `provider`, `url`, `collection` | `qdrant`, `http://qdrant:6333`, `nano-brain` |
-| `embedding` | `provider`, `url`, `model`, `apiKey`, `dimensions`, `maxChars` | Ollama `nomic-embed-text` or VoyageAI `voyage-code-3` |
-| `reranker` | `model`, `apiKey`, `provider` | `rerank-2.5-lite` |
-| `codebase` | `enabled`, `languages`, `exclude`, `maxFileSize` | true, [ts/js/py], standard, 1 MB |
+| `database` | `url` | `postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev` |
+| `embedding` | `provider`, `url`, `model`, `apiKey`, `dimensions`, `maxChars` | Ollama `nomic-embed-text`; or OpenAI-compatible with custom `url` |
+| `codebase` | `enabled`, `languages`, `exclude`, `maxFileSize` | true, [go/ts/js], standard, 1 MB |
 | `watcher` | `debounce`, `reindexInterval`, `chokidarIntervalMs` | 300 ms, 300 s, 5000 ms |
 | `intervals` | `sessionPoll`, `healthCheck` | 120 s, 60 s |
 | `storage` | `maxSize`, `retention.{sessions,logs}` | 10 GB, 90 d, 30 d |
@@ -719,10 +688,8 @@ YAML at `~/.nano-brain/config.yml`, auto-generated from `config.default.yml`. Se
 
 | Resource | Typical | Limit |
 |---|---|---|
-| Node heap | ~ 500 MB | 1.5 GB (`NODE_OPTIONS=--max-old-space-size=1536`) |
-| Container memory | ~ 800 MB | 2 GB (compose) |
-| SQLite DB size | ~ 100 MB / 10 K docs | `storage.maxSize` (10 GB default) |
-| Qdrant disk | ~ 50 MB / 10 K vectors | depends on Qdrant config |
+| Go binary RSS | ~ 100–200 MB | depends on index size |
+| PostgreSQL data | ~ 100 MB / 10 K docs | depends on pgvector index size |
 | Embedding queue | drains at ~ 3 / s (Ollama local) | adaptive backoff |
 
 ### 8.2 Reliability
@@ -734,8 +701,8 @@ YAML at `~/.nano-brain/config.yml`, auto-generated from `config.default.yml`. Se
 
 ### 8.3 Privacy
 
-- Default Docker stack: 100% local (Ollama + Qdrant). No outbound calls.
-- Cloud providers (VoyageAI, OpenAI) opt-in via config.
+- Default setup: 100% local (Ollama + self-hosted PostgreSQL). No outbound calls.
+- Cloud embedding providers (VoyageAI, OpenAI-compatible) opt-in via config.
 - No telemetry phoning home. All logs and telemetry stay on disk.
 
 ### 8.4 Multi-workspace behaviour
@@ -746,10 +713,10 @@ YAML at `~/.nano-brain/config.yml`, auto-generated from `config.default.yml`. Se
 
 ### 8.5 Compatibility
 
-- Node.js ≥ 22 (uses `node:22-slim` in compose).
+- Go 1.23+, compiled with `CGO_ENABLED=0` (single static binary).
+- PostgreSQL 17 + pgvector 0.8.2.
 - Tested on Linux + macOS. Windows not officially supported.
-- Tree-sitter languages: TypeScript, JavaScript, Python.
-- MCP SDK: `@modelcontextprotocol/sdk` (stdio + HTTP/SSE transports).
+- MCP transport: HTTP (connect via `http://localhost:3100/mcp`).
 
 ---
 

--- a/docs/reference-readme.md
+++ b/docs/reference-readme.md
@@ -96,7 +96,7 @@ Claude Code JSONL  ──┤─→ Harvester → LLM Summarizer → Indexer → 
 
 **File watching** — Monitors workspace for changes and reindexes automatically
 
-**Codebase indexing** — Parses Go, TypeScript, JavaScript source files for symbols and call graphs
+**Codebase indexing** — Parses Go, TypeScript, JavaScript, Python, and Ruby source files for symbols and call graphs
 
 ## MCP Tools (16 Total)
 

--- a/docs/reference-readme.md
+++ b/docs/reference-readme.md
@@ -1,10 +1,10 @@
 # nano-brain
 
-[![npm version](https://img.shields.io/npm/v/nano-brain?color=blue&label=npm)](https://www.npmjs.com/package/nano-brain)
-[![npm downloads](https://img.shields.io/npm/dm/nano-brain?color=blue)](https://www.npmjs.com/package/nano-brain)
+[![npm version](https://img.shields.io/npm/v/@nano-step/nano-brain?color=blue&label=npm)](https://www.npmjs.com/package/@nano-step/nano-brain)
+[![npm downloads](https://img.shields.io/npm/dm/@nano-step/nano-brain?color=blue)](https://www.npmjs.com/package/@nano-step/nano-brain)
 [![Publish Stable](https://github.com/nano-step/nano-brain/actions/workflows/publish-stable.yml/badge.svg?branch=master)](https://github.com/nano-step/nano-brain/actions/workflows/publish-stable.yml)
 [![Publish Beta](https://github.com/nano-step/nano-brain/actions/workflows/publish-beta.yml/badge.svg?branch=develop)](https://github.com/nano-step/nano-brain/actions/workflows/publish-beta.yml)
-[![Node.js](https://img.shields.io/node/v/nano-brain)](https://nodejs.org)
+[![Go 1.23](https://img.shields.io/badge/Go-1.23-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 Persistent memory and code intelligence for AI coding agents.
@@ -13,24 +13,19 @@ Persistent memory and code intelligence for AI coding agents.
 
 A persistent memory server for AI coding agents. It solves the #1 problem with AI assistants: **they forget everything between sessions.**
 
-nano-brain automatically ingests your AI sessions, notes, and codebase, indexes everything with full-text search + vector embeddings + knowledge graph, serves memories via 22 MCP tools, and learns which memories matter most to you over time.
+nano-brain automatically ingests your AI sessions, notes, and codebase, indexes everything with full-text search + vector embeddings + knowledge graph, and serves memories via 16 MCP tools.
 
 ## Key Features
 
-- **Hybrid search pipeline** — BM25 + vector + RRF fusion + VoyageAI neural reranking with 6 ranking signals
-- **Code intelligence** — symbol graph, call flow detection, impact analysis, change detection via Tree-sitter AST
-- **Automatic data ingestion** — session harvesting (2min poll), file watching (chokidar), codebase indexing
-- **Multi-workspace isolation** — per-workspace SQLite databases, cross-workspace search with `--scope=all`
-- **Flexible embedding providers** — VoyageAI, Ollama, OpenAI-compatible
-- **Dual vector stores** — Qdrant (production) or sqlite-vec (embedded)
+- **Hybrid search pipeline** — BM25 full-text + pgvector HNSW cosine similarity + RRF fusion with recency decay
+- **Code intelligence** — symbol graph, call flow detection, impact analysis
+- **Session harvesting** — auto-ingest from OpenCode and Claude Code sessions
+- **Multi-workspace isolation** — per-workspace data, cross-workspace search with `scope=all`
+- **Flexible embedding providers** — Ollama, OpenAI-compatible, VoyageAI
+- **PostgreSQL + pgvector** — single well-understood data store; no separate vector service required
 - **Privacy-first** — 100% local processing option, your code never leaves your machine
-- **MCP + CLI** — stdio/HTTP/SSE transports for local or containerized environments
-- **Automatic corruption recovery** — detects & recovers from database corruption on startup with zero user intervention
-- **Self-learning system** — Thompson Sampling tunes search parameters, preference learning personalizes results
-- **Knowledge graph** — LLM-extracted entities and relationships, graph traversal, temporal queries
-- **Memory intelligence** — LLM categorization, entity pruning, proactive suggestions
-
-Inspired by [QMD](https://github.com/tobi/qmd) and [OpenClaw](https://github.com/openclaw/openclaw).
+- **MCP + REST** — HTTP transport for local or containerized environments
+- **Self-hosted** — Go static binary, PostgreSQL, zero magic
 
 ## Architecture
 
@@ -39,461 +34,139 @@ User Query
     │
     ▼
 ┌─────────────────┐
-│ Query Expansion  │ ← (currently stubbed, planned)
-│ (optional)       │   generates 2-3 query variants
-└────────┬────────┘
-         │
-    ┌────┴────┐
-    ▼         ▼
-┌────────┐ ┌──────────┐
-│ BM25   │ │ Vector   │
-│ (FTS5) │ │ (Qdrant  │
-│        │ │  or      │
-│        │ │ sqlite-  │
-│        │ │  vec)    │
-└───┬────┘ └────┬─────┘
-    │           │
-    ▼           ▼
-┌─────────────────┐
-│  RRF Fusion     │ ← k=60, original query 2× weight
-│                 │
+│  BM25 (tsvector)│
+│  +              │
+│  pgvector HNSW  │
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│ PageRank Boost  │ ← Centrality from file dependency graph
-│                 │   weight: 0.1 (default)
+│  RRF Fusion     │  k=60
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│ Supersede       │ ← 0.3× demotion for replaced documents
-│ Demotion        │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ Neural Reranking│ ← VoyageAI rerank-2.5-lite
-│ (optional)      │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ Position-Aware  │ ← top 3: 75/25, 4-10: 60/40, 11+: 40/60
-│ Blending        │   (RRF weight / rerank weight)
+│  Recency Decay  │  weight: 0.3
 └────────┬────────┘
          │
          ▼
     Final Results
 ```
 
-### Write Pipeline
+### Session Harvesting
 
 ```
-Memory Write
-    │
-    ▼
-┌─────────────────┐
-│ Save to File     │ → ~/.nano-brain/memory/
-│ Hash + DB Insert │ → documents + content tables
-│ FTS5 Index       │ → documents_fts (auto-trigger)
-└────────┬────────┘
-         │
-    ┌────┴────┐
-    ▼         ▼
-┌────────┐ ┌──────────┐
-│Keyword │ │  Async   │ (fire-and-forget)
-│Categorize│ │ Processes│
-│auto:*  │ │          │
-└────────┘ ├──────────┤
-           │ LLM      │ → llm:* tags
-           │ Categorize│
-           ├──────────┤
-           │ Entity   │ → knowledge graph
-           │ Extract  │
-           └──────────┘
+OpenCode DB        ──┐
+Claude Code JSONL  ──┤─→ Harvester → LLM Summarizer → Indexer → PostgreSQL
 ```
 
-## Search Pipeline (3 Tiers)
+## Search Pipeline
 
-**`memory_search`** — BM25 only (fast, exact keyword matching)
+**`memory_search`** — BM25 full-text only (fast, exact keyword matching)
 
-**`memory_vsearch`** — Vector only (semantic similarity via embeddings)
+**`memory_vsearch`** — Vector only (semantic similarity via pgvector)
 
-**`memory_query`** — Full hybrid pipeline with 6 ranking signals:
+**`memory_query`** — Full hybrid pipeline:
 
-1. **BM25 full-text scoring** — SQLite FTS5 with porter stemming
-2. **Vector cosine similarity** — Qdrant or sqlite-vec embeddings
-3. **RRF fusion** — k=60, original query weighted 2×
-4. **PageRank centrality boost** — from file dependency graph (weight: 0.1)
-5. **Supersede demotion** — 0.3× penalty for replaced documents
-6. **VoyageAI neural reranking** — rerank-2.5-lite with position-aware blending:
-   - Top 3 results: 75% RRF / 25% rerank
-   - Ranks 4-10: 60% RRF / 40% rerank
-   - Ranks 11+: 40% RRF / 60% rerank
-
-Query expansion generates 2-3 query variants before search. The pipeline supports it, but no expansion provider is currently active.
+1. **BM25 full-text scoring** — PostgreSQL tsvector/tsquery
+2. **Vector cosine similarity** — pgvector HNSW index
+3. **RRF fusion** — k=60
+4. **Recency boost** — exponential decay, weight 0.3
 
 ## Code Intelligence
 
-Built on Tree-sitter AST parsing for TypeScript, JavaScript, and Python:
+**`memory_graph`** — One-hop callers/callees/imports
 
-**`code_context`** — 360° view of a code symbol:
-- Direct callers and callees
-- Transitive call flows (upstream/downstream)
-- File location, definition, and references
-- Centrality score (PageRank) and cluster membership
+**`memory_trace`** — Downstream call chain trace
 
-**`code_impact`** — Change impact analysis:
-- Upstream dependencies (what calls this?)
-- Downstream dependencies (what does this call?)
-- BFS traversal with configurable depth
-- Risk assessment for refactoring
+**`memory_impact`** — Pre-change blast radius analysis
 
-**`code_detect_changes`** — Map git diff to affected symbols:
-- Parses `git diff` output
-- Identifies modified symbols via Tree-sitter
-- Returns symbol names, types, and file locations
-- Scope: `staged`, `unstaged`, or `all`
+**`memory_symbols`** — Symbol search (functions, types, interfaces)
 
-**`memory_focus`** — File dependency context:
-- Import/export graph for a file
-- Centrality score (PageRank)
-- Cluster membership (Louvain algorithm)
-- Direct dependencies and dependents
+**`memory_flow`** — HTTP route execution flow
 
-**`memory_graph_stats`** — Dependency graph overview:
-- Total files, symbols, edges
-- Cycle detection
-- Clustering coefficient
-- Top central files
-
-**Symbol tracking** — Cross-repo symbol queries:
-- Redis keys, PubSub channels
-- MySQL tables, columns
-- API endpoints (Express, FastAPI)
-- Bull/BullMQ queues
-- GraphQL types, queries, mutations
+**`memory_flowchart`** — Function-level control-flow graph
 
 ## Data Ingestion
 
-All data sources are indexed automatically:
+**Session harvesting** — Converts OpenCode and Claude Code sessions into searchable content:
+- OpenCode: reads from the OpenCode SQLite DB
+- Claude Code: reads JSONL session files
+- Incremental harvest with hash-based deduplication
 
-**Session harvesting** — Converts OpenCode JSON sessions into searchable markdown:
-- Polls `~/.opencode/sessions/` every 2 minutes
-- Extracts user queries, assistant responses, tool calls
-- Incremental append (hash-based deduplication)
+**File watching** — Monitors workspace for changes and reindexes automatically
 
-**File watching** — Monitors collections for changes:
-- Chokidar watches configured directories
-- Dirty-flag tracking for incremental updates
-- Reindexes every 5 minutes if changes detected
+**Codebase indexing** — Parses Go, TypeScript, JavaScript source files for symbols and call graphs
 
-**Codebase indexing** — Tree-sitter AST → symbol graph:
-- Parses TS/JS/Python files
-- Extracts functions, classes, methods, variables
-- Builds call graph (caller → callee edges)
-- Computes PageRank centrality
-- Detects clusters via Louvain algorithm
-- Identifies call flows (entry points → leaf functions)
-
-**Incremental behavior**:
-- Hash-based file skipping (SHA-256 content addressing)
-- Adaptive embedding backoff (exponential retry)
-- Batch processing for large codebases
-
-## Background Jobs
-
-nano-brain runs 9 background jobs to keep your memory fresh and intelligent:
-
-| Job | Interval | What It Does |
-|-----|----------|-------------|
-| File reindex | 5 min | Watch collections, reindex changed files |
-| Session harvest | 2 min | Convert OpenCode sessions → searchable markdown |
-| Embedding | 60s (adaptive) | Generate vector embeddings for new docs |
-| Learning cycle | 10 min | Thompson Sampling + preference weight updates |
-| Consolidation | 1 hour | LLM summarizes related memories |
-| Importance | 30 min | Rescore document importance from usage |
-| Sequence analysis | 30 min | Detect query patterns for proactive suggestions |
-| Pruning (soft) | 6 hours | Soft-delete contradicted/orphan entities |
-| Pruning (hard) | 7 days | Permanently delete old soft-deleted entities |
-
-## Chunking Strategy
-
-Heading-aware markdown chunking that respects document structure:
-
-- **Target size:** 900 tokens (~3600 characters)
-- **Overlap:** 15% between chunks (~540 characters)
-- **Respects boundaries:** Code fences, headings, paragraphs
-- **Break point scoring:** h1=100, h2=90, h3=80, code-fence=80, hr=60, blank-line=40
-- **Content-addressed storage:** SHA-256 hash deduplication
-
-## Storage & Infrastructure
-
-**SQLite** (via better-sqlite3):
-- `documents` — metadata, content, embeddings
-- `chunks` — heading-aware markdown chunks (900 tokens, 15% overlap)
-- `fts_index` — FTS5 virtual table with porter stemming
-- `vec_index` — sqlite-vec extension (cosine distance)
-- `symbols` — code symbols (functions, classes, variables)
-- `call_edges` — caller → callee relationships
-- `file_deps` — import/export graph
-- `clusters` — Louvain clustering results
-- `flows` — detected call flows (entry → leaf)
-
-**Qdrant** (optional, production vector store):
-- Included in `nano-brain docker start` compose stack, or managed standalone via `qdrant up/down/status` commands
-- Automatic migration from sqlite-vec
-- Verification and cleanup tools
-
-**Embedding providers**:
-- **VoyageAI** — voyage-code-3 (1024 dims, code-optimized)
-- **Ollama** — local models (nomic-embed-text, etc.)
-- **OpenAI-compatible** — Azure, LM Studio, custom endpoints
-
-**Reranking**:
-- **VoyageAI** — rerank-2.5-lite (neural reranking)
-
-**Storage management**:
-- Per-workspace SQLite databases (isolated)
-- Content-addressed storage (SHA-256 deduplication)
-- Retention policies (maxSize budget, auto-cleanup)
-- Disk space checks before indexing
-
-## Database Schema
-
-nano-brain uses 18 SQLite tables organized into 5 functional groups:
-
-| Table | Purpose |
-|-------|---------|
-| **Core Documents** | |
-| `documents` | Document metadata, content, embeddings |
-| `chunks` | Heading-aware markdown chunks (900 tokens, 15% overlap) |
-| `content` | Raw content storage (content-addressed) |
-| **Search Indexes** | |
-| `documents_fts` | FTS5 full-text search index (porter stemming) |
-| `vec_index` | sqlite-vec vector index (cosine distance) |
-| **Code Intelligence** | |
-| `symbols` | Code symbols (functions, classes, variables) |
-| `call_edges` | Caller → callee relationships |
-| `file_deps` | Import/export graph |
-| `clusters` | Louvain clustering results |
-| `flows` | Detected call flows (entry → leaf) |
-| **Knowledge Graph** | |
-| `entities` | LLM-extracted entities (people, concepts, tools) |
-| `relationships` | Entity-to-entity connections |
-| **Learning & Intelligence** | |
-| `telemetry` | Search queries, results, expand feedback |
-| `bandit_variants` | Thompson Sampling search parameter tuning |
-| `config_versions` | Search config version history |
-| `consolidations` | LLM-generated memory summaries |
-| `query_sequences` | Query pattern detection for proactive suggestions |
-| `category_preferences` | Per-workspace category weights from expand patterns |
-
-## Database Reliability & Corruption Recovery
-
-**Why corruption happens**:
-SQLite databases can become corrupted due to:
-- Unexpected process termination during write operations
-- Filesystem crashes or power loss during WAL (Write-Ahead Log) checkpoint
-- Disk I/O errors or hardware faults
-- Rare race conditions in concurrent access (even with better-sqlite3 serialization)
-
-**Automatic corruption detection**:
-nano-brain automatically detects database corruption on startup via `PRAGMA integrity_check`:
-- Runs before any database operations in `createStore()`
-- Checks database file integrity without modifying data
-- Takes 50-500ms depending on database size
-
-**Automatic recovery**:
-When corruption is detected:
-1. **Backup corrupted file** — Renamed to `.corrupted.{ISO-timestamp}` for forensics/recovery
-2. **Clear WAL/SHM files** — Removes Write-Ahead Log and shared memory files
-3. **Initialize fresh database** — Creates clean SQLite database from scratch
-4. **Verify fresh database** — Runs integrity check to confirm recovery succeeded
-5. **Emit metric** — `database_corruption_detected` counter for monitoring/alerting
-
-**Why this works**:
-The database is a **cache/index** — all data is re-derivable from source files. Recovery involves:
-- Session harvesting (re-ingests from session logs)
-- Codebase reindexing (rescan source files)
-- Memory re-embedding (regenerates vectors)
-- Call graph rebuilding (reparses symbols)
-
-**Automatic restart with launchd**:
-On macOS, nano-brain runs as a launchd service (`com.tamlh.nano-brain`):
-- If corruption causes a fatal error, process exits
-- launchd automatically restarts it after 10-second throttle
-- On restart, `checkAndRecoverDB()` detects corruption and recovers
-- Service comes back online automatically with fresh database
-
-**Installation (macOS)**:
-```bash
-# Copy plist to launchd directory
-cp ~/.config/nano-brain/launchd/com.tamlh.nano-brain.plist ~/Library/LaunchAgents/
-
-# Load the service
-launchctl load ~/Library/LaunchAgents/com.tamlh.nano-brain.plist
-
-# Check status
-launchctl list | grep nano-brain
-```
-
-**Monitoring**:
-Check for corruption metrics in your monitoring/alerting system:
-- Counter: `database_corruption_detected`
-- Alert threshold: > 3 events per 24 hours (indicates underlying hardware/filesystem issue)
-
-**Troubleshooting**:
-If corruption happens frequently:
-1. Check system logs for disk I/O errors: `log stream --predicate 'eventMessage contains[c] "I/O error"'`
-2. Verify filesystem health: `diskutil verifyVolume /` (macOS)
-3. Check disk space: `df -h ~/.nano-brain/`
-4. Review database size: `ls -lh ~/.nano-brain/index.db`
-5. Consider moving database to a different drive if corruption persists
-
-**Forensics**:
-Corrupted backups are kept for analysis:
-- Located at: `~/.nano-brain/index.db.corrupted.{ISO-timestamp}`
-- Last 5 backups are kept by default; older ones are auto-cleaned
-- File size indicates when corruption occurred (if truncated vs intact)
-
-## MCP Tools (22+ Total)
-
-### Search & Retrieval
+## MCP Tools (16 Total)
 
 | Tool | Description |
 |------|-------------|
-| `memory_search` | BM25 keyword search (fast, exact matching) |
-| `memory_vsearch` | Semantic vector search (embeddings) |
-| `memory_query` | Full hybrid search (BM25 + vector + RRF + reranking) |
-| `memory_get` | Retrieve document by path or docid (#abc123) |
-| `memory_multi_get` | Batch retrieve by glob pattern |
-
-### Memory Management
-
-| Tool | Description |
-|------|-------------|
-| `memory_write` | Write to daily log (supports tags, supersedes) |
-| `memory_tags` | List all tags with document counts |
-| `memory_status` | Index health, collections, model status, graph stats |
-| `memory_update` | Trigger reindex of all collections |
-| `memory_consolidate` | Trigger LLM memory consolidation |
-| `memory_suggestions` | Proactive next-query predictions based on patterns |
-
-### Code Intelligence
-
-| Tool | Description |
-|------|-------------|
-| `code_context` | 360° view of a code symbol (callers, callees, flows, centrality) |
-| `code_impact` | Change impact analysis (upstream/downstream BFS) |
-| `code_detect_changes` | Map git diff to affected symbols (staged/unstaged/all) |
-| `memory_index_codebase` | Index codebase files in current workspace (Tree-sitter AST) |
-
-### Dependency Graph
-
-| Tool | Description |
-|------|-------------|
-| `memory_focus` | File dependency context (imports/exports, centrality, cluster) |
-| `memory_graph_stats` | Dependency graph overview (files, symbols, edges, cycles) |
-| `memory_symbols` | Cross-repo symbol query (Redis, MySQL, API endpoints, queues) |
-| `memory_impact` | Cross-repo impact analysis (writers vs readers) |
-| `memory_graph_query` | BFS traversal from entity through knowledge graph |
-| `memory_related` | Find related memories via entity graph connections |
-| `memory_timeline` | Temporal view of entity changes over time |
+| `memory_query` | Hybrid search — default first tool for broad questions |
+| `memory_search` | BM25 keyword search for exact text/errors |
+| `memory_vsearch` | Vector similarity for fuzzy concepts |
+| `memory_get` | Get document by path or ID |
+| `memory_write` | Write/update document |
+| `memory_graph` | One-hop callers/callees/imports |
+| `memory_trace` | Downstream call chain trace |
+| `memory_impact` | Pre-change blast radius analysis |
+| `memory_symbols` | Symbol search (functions, types, interfaces) |
+| `memory_flow` | HTTP route execution flow |
+| `memory_flowchart` | Function-level control-flow graph |
+| `memory_workspaces_resolve` | Resolve path to workspace hash |
+| `memory_tags` | List tags with counts |
+| `memory_status` | Server and queue health |
+| `memory_update` | Trigger re-embedding |
+| `memory_wake_up` | Session-start workspace briefing |
 
 ## Installation & Quick Start
 
 ```bash
 # Install globally
-npm install -g nano-brain
+npm install -g @nano-step/nano-brain
 
-# Initialize (creates config, indexes codebase, generates embeddings)
-npx nano-brain init --root=/path/to/your/project
-
-# Check everything is working
-npx nano-brain status
+# Or build from source
+CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain
 ```
 
-### Docker Deployment (Recommended)
-
-The simplest way to run nano-brain as a persistent service:
+### Start PostgreSQL
 
 ```bash
-# Start nano-brain + Qdrant containers
-npx nano-brain docker start
-
-# Check status
-npx nano-brain docker status
-
-# Stop
-npx nano-brain docker stop
+docker run -d --name nanobrain-pg -p 5432:5432 \
+  -e POSTGRES_USER=nanobrain \
+  -e POSTGRES_PASSWORD=nanobrain \
+  -e POSTGRES_DB=nanobrain_dev \
+  pgvector/pgvector:pg17
 ```
 
-This runs the bundled `docker-compose.yml` which starts nano-brain (HTTP/SSE on port 3100) and Qdrant (ports 6333/6334). A `config.default.yml` is included as a starting template — copy it to `~/.nano-brain/config.yml` and customize.
+### Start nano-brain
 
-**Environment variables:**
-- `NANO_BRAIN_APP` — Path to nano-brain source directory (default: package install location)
-- `NANO_BRAIN_HOME` — Path to `~/.nano-brain` data directory (default: `~/.nano-brain`)
-- `NANO_BRAIN_WORKSPACE` — Path to your project workspace to index (mounted read-only and passed as `--root`)
+```bash
+nano-brain serve -d
+```
 
-**HTTP API** (available when Docker is running):
+### Register your project
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/health` | GET | Health check |
-| `/api/status` | GET | Index health, collections, model status |
-| `/api/query` | POST | Hybrid search (body: `{query, tags, scope, limit}`) |
-| `/api/search` | POST | BM25 keyword search (body: `{query, limit}`) |
-| `/api/write` | POST | Write memory (body: `{content, tags, supersedes}`) |
-| `/api/reindex` | POST | Trigger reindex (body: `{root}`) |
-| `/mcp` | — | MCP endpoint (for AI agent integration) |
-| `/sse` | — | SSE transport (for MCP remote clients) |
+```bash
+nano-brain init --root=/path/to/your/project
+```
+
+### Check status
+
+```bash
+nano-brain status
+```
 
 ### MCP Configuration
 
-Add to your AI agent's MCP config (e.g., `~/.config/opencode/opencode.json`):
+Add to your AI agent's MCP config (Claude Code, OpenCode, Cursor, etc.):
 
-**Docker mode (recommended):**
 ```json
 {
   "mcp": {
     "nano-brain": {
-      "type": "remote",
-      "url": "http://host.docker.internal:3100/mcp",
-      "enabled": true
-    }
-  }
-}
-```
-
-Start the server via Docker:
-```bash
-npx nano-brain docker start       # Start nano-brain + Qdrant containers
-npx nano-brain docker status      # Check if running
-npx nano-brain docker stop        # Stop containers
-```
-
-**Local mode (stdio, for development):**
-```json
-{
-  "mcp": {
-    "nano-brain": {
-      "type": "local",
-      "command": ["npx", "nano-brain", "mcp"],
-      "enabled": true
-    }
-  }
-}
-```
-
-**Claude Code (`.mcp.json`):**
-```json
-{
-  "mcpServers": {
-    "nano-brain": {
-      "command": "npx",
-      "args": ["mcp-remote", "http://localhost:3100/sse"]
+      "type": "http",
+      "url": "http://localhost:3100/mcp"
     }
   }
 }
@@ -501,604 +174,148 @@ npx nano-brain docker stop        # Stop containers
 
 ## Configuration
 
-Create `~/.nano-brain/config.yml` (auto-generated by `init`):
+Config file: `~/.nano-brain/config.yml` (see `config.default.yml` / README for the full reference).
 
 ```yaml
-# Collections (directories to index)
-collections:
-  memory:
-    path: ~/.nano-brain/memory
-    pattern: "**/*.md"
-    update: auto
-  sessions:
-    path: ~/.nano-brain/sessions
-    pattern: "**/*.md"
-    update: auto
+server:
+  host: localhost
+  port: 3100
 
-# Vector store (qdrant or sqlite-vec)
-vector:
-  provider: qdrant
-  url: http://localhost:6333
-  collection: nano_brain
-  # OR: provider: sqlite-vec (embedded, no external service)
+database:
+  url: postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev
 
-# Embedding provider
 embedding:
-  provider: openai                    # 'ollama' or 'openai' (OpenAI-compatible)
-  url: https://api.voyageai.com       # VoyageAI, Azure, LM Studio, etc.
-  model: voyage-code-3
-  apiKey: ${VOYAGE_API_KEY}
-  dimensions: 1024                    # Output dimensions (default: 1024); omit to use model default
-  # OR: provider: ollama, url: http://localhost:11434, model: nomic-embed-text
+  provider: ollama
+  url: http://localhost:11434
+  model: nomic-embed-text
 
-# Reranker (uses embedding.apiKey if not set separately)
-reranker:
-  model: rerank-2.5-lite
-  # apiKey: ${VOYAGE_API_KEY}  # optional, falls back to embedding.apiKey
-
-# Codebase indexing
-codebase:
-  enabled: true
-  languages: [typescript, javascript, python]
-  exclude: [node_modules, dist, build, .git]
-  maxFileSize: 1048576  # 1MB
-
-# File watcher
-watcher:
-  enabled: true
-  debounce: 300         # ms
-  reindexInterval: 300  # seconds (5 minutes)
-
-# Search configuration
 search:
   rrf_k: 60
-  top_k: 30
-  expansion:
-    enabled: true
-    weight: 1
-  reranking:
-    enabled: true
-  blending:
-    top3:
-      rrf: 0.75
-      rerank: 0.25
-    mid:
-      rrf: 0.60
-      rerank: 0.40
-    tail:
-      rrf: 0.40
-      rerank: 0.60
-  centrality_weight: 0.1
-  supersede_demotion: 0.3
-
-# Polling intervals
-intervals:
-  sessionHarvest: 120   # seconds (2 minutes)
-  healthCheck: 60       # seconds
-
-# Storage management
-storage:
-  maxSize: 10737418240  # 10GB
-  retention:
-    sessions: 90        # days
-    logs: 30            # days
-
-# Workspaces
-workspaces:
-  isolation: true       # Per-workspace SQLite databases
-  defaultScope: current # or 'all' for cross-workspace search
-
-# Entity pruning (Memory Intelligence v2)
-pruning:
-  enabled: true
-  interval_ms: 21600000      # 6 hours
-  contradicted_ttl_days: 30
-  orphan_ttl_days: 90
-  batch_size: 100
-  hard_delete_after_days: 30
-
-# LLM categorization (Memory Intelligence v2)
-categorization:
-  llm_enabled: true
-  confidence_threshold: 0.6
-  max_content_length: 2000
-
-# Preference learning (Memory Intelligence v2)
-preferences:
-  enabled: true
-  min_queries: 20
-  weight_min: 0.5
-  weight_max: 2.0
-  baseline_expand_rate: 0.1
-
-# Logging
-logging:
-  level: info           # debug, info, warn, error
-  file: ~/.nano-brain/logs/nano-brain.log
-  maxSize: 10485760     # 10MB
-  maxFiles: 5
+  recency_weight: 0.3
+  limit: 20
 ```
 
-**Data directory layout (`~/.nano-brain/`):**
-```
-~/.nano-brain/
-├── config.yml    # Configuration
-├── data/         # SQLite databases (per-workspace)
-├── memory/       # Curated notes
-├── sessions/     # Harvested sessions
-└── logs/         # Application logs
-```
+See [Configuration](CONFIGURATION.md) for full options.
 
-## CLI Commands (27 Total)
+## CLI Commands
 
 ### Setup & Initialization
 
 ```bash
-nano-brain init               # Full initialization (config, index, embed, AGENTS.md)
+nano-brain init               # Full initialization (config, index, embed)
 nano-brain init --root=/path  # Initialize for specific project
 nano-brain status             # Show index health, collections, model status
+nano-brain doctor             # Check prerequisites (PostgreSQL, pgvector, embedder)
 ```
 
-### MCP Server
+### Server
 
 ```bash
-nano-brain mcp                                      # Start MCP server (stdio)
-nano-brain mcp --http                               # Start MCP server (HTTP/SSE, default port 8282)
-nano-brain mcp --http --port=3100 --host=0.0.0.0   # Custom port (e.g. Docker default 3100)
+nano-brain serve -d           # Start server as background daemon
+nano-brain serve              # Start server in foreground
+nano-brain stop               # Stop the running daemon
 ```
-
-### Remote Server (Daemon)
-
-```bash
-nano-brain mcp --http --daemon --port=8282   # Start HTTP/SSE server as background daemon
-nano-brain mcp --http --daemon --port=3100   # Custom port (e.g. Docker default)
-```
-
-### Docker Deployment
-
-```bash
-nano-brain docker start       # Start nano-brain + Qdrant via docker compose
-nano-brain docker status      # Check container status
-nano-brain docker stop        # Stop containers
-```
-
-The `docker start` command runs the bundled `docker-compose.yml` which starts:
-- **nano-brain** — HTTP/SSE server on port 3100 (node:22-slim)
-- **Qdrant** — Vector store on ports 6333/6334
-
-Environment variables for volume mounts:
-- `NANO_BRAIN_APP` — Path to nano-brain source (default: current directory)
-- `NANO_BRAIN_HOME` — Path to data directory (default: `~/.nano-brain`)
-- `NANO_BRAIN_WORKSPACE` — Path to your project workspace to index as codebase (mounted read-only, passed as `--root`)
-
-Runtime environment variables:
-- `OPENCODE_STORAGE_DIR` — Override OpenCode session storage path (useful in Docker where container homedir differs from host). Example: `/Users/tamlh/.local/share/opencode/storage`
-- `NANO_BRAIN_EMBEDDING_CONCURRENCY` — Number of parallel embedding requests to Ollama (default: `3`)
 
 ### Search
 
 ```bash
-nano-brain search "query"           # BM25 keyword search
-nano-brain vsearch "query"          # Vector semantic search
-nano-brain query "query"            # Hybrid search (BM25 + vector + reranking)
-nano-brain query "query" --tags=bug,fix  # Filter by tags
-nano-brain query "query" --scope=all     # Cross-workspace search
+nano-brain search "query"     # BM25 keyword search
+nano-brain vsearch "query"    # Vector semantic search
+nano-brain query "query"      # Hybrid search (BM25 + vector + RRF)
 ```
 
 ### Memory Management
 
 ```bash
-nano-brain write "content"          # Write to daily log
+nano-brain write "content"            # Write to memory
 nano-brain write "content" --tags=decision,architecture
-nano-brain write "content" --supersedes=abc123  # Mark as replacement
-nano-brain get <path>               # Retrieve document by path
-nano-brain get "#abc123"            # Retrieve by docid
-nano-brain tags                     # List all tags with counts
+nano-brain get <path>                 # Retrieve document by path
+nano-brain tags                       # List all tags with counts
 ```
 
 ### Index Management
 
 ```bash
-nano-brain update               # Reindex all collections
-nano-brain reindex              # Index codebase in current workspace
-nano-brain reset --confirm      # Reset all data (requires confirmation)
-nano-brain reset --dry-run      # Preview what would be deleted
-```
-
-### Collections
-
-```bash
-nano-brain collection add <name> <path>     # Add collection
-nano-brain collection remove <name>         # Remove collection
-nano-brain collection list                  # List collections
-```
-
-### Workspace Management
-
-```bash
-nano-brain rm --list                        # List all workspaces
-nano-brain rm <workspace> --dry-run         # Preview what would be deleted
-nano-brain rm <workspace>                   # Remove workspace and all its data
-# <workspace> can be: absolute path, hash prefix, or workspace name
-```
-
-### Qdrant Management
-
-> **Note:** If using `nano-brain docker start`, Qdrant is already included in the compose stack. These commands manage a standalone Qdrant container separately.
-
-```bash
-nano-brain qdrant up            # Start Qdrant Docker container
-nano-brain qdrant down          # Stop Qdrant container
-nano-brain qdrant status        # Check Qdrant status
-nano-brain qdrant migrate       # Migrate from sqlite-vec to Qdrant
-nano-brain qdrant verify        # Verify Qdrant data integrity
-nano-brain qdrant activate      # Switch to Qdrant (update config)
-nano-brain qdrant cleanup       # Remove orphaned vectors
-```
-
-### Cache Management
-
-```bash
-nano-brain cache clear          # Clear all caches
-nano-brain cache clear --type=embeddings  # Clear specific cache type
-nano-brain cache stats          # Show cache statistics
-```
-
-### Benchmarking
-
-Measures search quality (P@5, R@10, MRR) and latency across FTS, vector, and hybrid modes.
-
-```bash
-nano-brain bench generate               # Generate fixtures (scale-100)
-nano-brain bench generate --scale=1000  # Larger corpus (valid: 100,1000,5000,10000,100000)
-nano-brain bench run                    # Run benchmark suite (scale-100)
-nano-brain bench run --scale=1000       # Run at larger scale
-nano-brain bench compare new.json baseline.json  # Regression check
-nano-brain bench compare new.json baseline.json --save=baseline.json --force  # Save + force
-```
-
-See [`benchmarks/README.md`](benchmarks/README.md) for full explanation of metrics, corpus generation, and regression detection.
-
-Current results on v2026.8.3 (100 docs, Ollama local):
-
-```
-Mode      P@5     R@10    MRR     Latency (p50)
-FTS       0.975   0.985   1.000   1ms
-Vector    0.875   0.925   1.000   29ms
-Hybrid    0.835   0.970   1.000   34ms
-```
-
-### Logging
-
-```bash
-nano-brain logs                 # Show recent logs (last 50 lines)
-nano-brain logs -f              # Tail logs in real-time
-nano-brain logs -n 100          # Show last 100 lines
-nano-brain logs --date=2026-03-01  # Show log for specific date
-nano-brain logs --clear         # Delete all log files
-nano-brain logs path            # Print log directory path
+nano-brain reindex            # Reindex codebase in current workspace
+nano-brain harvest            # Run session harvest manually
 ```
 
 ### Code Intelligence
 
 ```bash
-nano-brain context <symbol>            # 360° view of a code symbol (callers, callees, flows)
-nano-brain code-impact <symbol>        # Analyze impact of changing a symbol
-nano-brain detect-changes              # Map current git changes to affected symbols and flows
-nano-brain wake-up                     # Generate a compact context briefing for session start
+nano-brain context <symbol>   # 360° view of a code symbol
+nano-brain code-impact <sym>  # Analyze impact of changing a symbol
+nano-brain detect-changes     # Map current git changes to affected symbols
+nano-brain wake-up            # Session-start workspace briefing
 ```
 
-### Memory Intelligence
+### Workspace Management
 
 ```bash
-nano-brain consolidate                 # Run consolidation job manually
-nano-brain categorize-backfill         # Backfill LLM categorization on existing documents
-nano-brain learning rollback [id]      # Manage self-learning system; rollback to a previous config version
+nano-brain workspaces         # List all workspaces
+```
+
+### Logs
+
+```bash
+nano-brain logs               # Show recent logs
+nano-brain logs -f            # Tail logs in real-time
+```
+
+### Benchmarking
+
+```bash
+nano-brain bench generate     # Generate fixtures
+nano-brain bench run          # Run benchmark suite
+nano-brain bench compare new.json baseline.json
 ```
 
 ## Project Structure
 
 ```
-src/
-├── index.ts          # CLI entry point
-├── server.ts         # MCP server (22+ tools, stdio/HTTP/SSE)
-├── store.ts          # SQLite storage (FTS5 + sqlite-vec)
-├── storage.ts        # Storage management (retention, disk space)
-├── vector-store.ts   # Vector store abstraction (Qdrant + sqlite-vec)
-├── search.ts         # Hybrid search pipeline (RRF, reranking, blending)
-├── chunker.ts        # Heading-aware markdown chunking
-├── collections.ts    # YAML config, collection scanning
-├── embeddings.ts     # Embedding providers (VoyageAI, Ollama, OpenAI-compatible)
-├── reranker.ts       # VoyageAI reranker
-├── expansion.ts      # Query expansion (interface only, no active provider)
-├── harvester.ts      # OpenCode session → markdown converter
-├── watcher.ts        # File watcher (chokidar, dirty flags)
-├── codebase.ts       # Codebase indexing orchestrator
-├── treesitter.ts     # Tree-sitter AST parsing
-├── symbols.ts        # Symbol extraction (functions, classes, variables)
-├── graph.ts          # File dependency graph (imports/exports)
-├── symbol-graph.ts   # Symbol call graph (caller → callee)
-├── flow-detection.ts # Call flow detection (entry → leaf)
-├── types.ts          # TypeScript interfaces
-└── providers/        # Vector store implementations
-    ├── qdrant.ts     # Qdrant vector store
-    └── sqlite-vec.ts # sqlite-vec vector store
-bin/
-└── cli.js            # CLI wrapper
-
-test/
-└── *.test.ts         # 760+ tests (vitest)
-SKILL.md              # AI agent routing instructions (auto-loaded by OpenCode)
-AGENTS_SNIPPET.md     # Optional project-level AGENTS.md managed block
+nano-brain/
+├── cmd/nano-brain/       # CLI dispatcher + server startup
+├── internal/
+│   ├── config/           # Configuration management
+│   ├── server/           # HTTP server + handlers
+│   ├── storage/          # PostgreSQL + sqlc
+│   ├── search/           # Hybrid search pipeline
+│   ├── embed/            # Embedding queue
+│   ├── watcher/          # File system watcher
+│   ├── harvest/          # Session harvesting
+│   ├── mcp/              # MCP protocol tools
+│   ├── graph/            # Code intelligence
+│   └── ...
+├── migrations/           # Database migrations (goose)
+└── benchmarks/           # Performance benchmarks
 ```
 
 ## Tech Stack
 
-- **TypeScript + Node.js** (via tsx)
-- **better-sqlite3** + **sqlite-vec** for embedded storage
-- **Qdrant** for production vector store (optional)
-- **Tree-sitter** for AST parsing (TS, JS, Python)
-- **@modelcontextprotocol/sdk** for MCP server (stdio/HTTP/SSE transports)
-- **chokidar** for file watching
-- **vitest** for testing (760+ tests)
+- **Go 1.23** — Single static binary (`CGO_ENABLED=0`)
+- **PostgreSQL 17** — Full-text search (tsvector/tsquery)
+- **pgvector 0.8.2** — HNSW vector indexing
+- **Echo v4** — HTTP framework
+- **sqlc** — Type-safe SQL code generation
+- **goose v3** — Database migrations
+- **zerolog** — Structured JSON logging
+- **koanf** — YAML + env configuration
 
-## Embedding & Reranking Providers
+## Embedding Providers
 
-**Embeddings:**
-- **VoyageAI** — voyage-code-3 (1024 dims, code-optimized, recommended)
-- **Ollama** — nomic-embed-text, mxbai-embed-large, etc. (local, free)
-- **OpenAI-compatible** — Azure OpenAI, LM Studio, custom endpoints
-
-**Reranking:**
-- **VoyageAI** — rerank-2.5-lite (neural reranking, recommended)
-
-**Query Expansion:**
-- Pipeline support exists but no active provider. The interface is ready for future integration.
+- **Ollama** — nomic-embed-text, mxbai-embed-large, etc. (local, free, recommended for getting started)
+- **OpenAI-compatible** — Azure OpenAI, LM Studio, VoyageAI, custom endpoints
 
 ## How nano-brain Compares
 
-| | nano-brain | Mem0 / OpenMemory | Zep / Graphiti | OMEGA | Letta (MemGPT) | Claude Native |
-|---|---|---|---|---|---|---|
-| **Search** | Hybrid (BM25 + vector + 6 ranking signals) | Vector only | Graph traversal + vector | Semantic + BM25 | Agent-managed | Text file read |
-| **Storage** | SQLite + Qdrant (optional) | PostgreSQL + Qdrant | Neo4j | SQLite | PostgreSQL / SQLite | Flat text files |
-| **MCP Tools** | 22+ | 4-9 | 9-10 | 12 | 7 | 0 |
-| **Code Intelligence** | Yes (Tree-sitter AST, symbol graph, impact analysis) | No | No | No | No | No |
-| **Codebase Indexing** | Yes (AST → symbols → call graph → flows) | No | No | No | No | No |
-| **Session Recall** | Yes (auto-harvests past sessions) | No | No | No | No | Limited (CLAUDE.md) |
-| **Query Expansion** | Pipeline ready (no active provider) | No | No | No | No | No |
-| **Neural Reranking** | Yes (VoyageAI rerank-2.5-lite) | No | No | No | No | No |
-| **Local-First** | Yes (Ollama + sqlite-vec) | Requires OpenAI API key | Requires Docker + Neo4j | Yes | Yes | Yes |
-| **Cloud Option** | Yes (VoyageAI, OpenAI-compatible) | Cloud API (OpenAI) | Cloud API | Local ONNX | Cloud API | None |
-| **Privacy** | 100% local option available | Cloud API calls | Cloud or self-host | 100% local | Self-host or cloud | Local files |
-| **Dependencies** | SQLite + embedding API (+ optional Qdrant) | Docker + PostgreSQL + Qdrant + OpenAI key | Docker + Neo4j | SQLite + ONNX | PostgreSQL | None |
-| **Pricing** | Free (open source, MIT) | Free tier / Pro $249/mo | Free self-host / Cloud $25-475/mo | Free (Apache-2.0) | Free (Apache-2.0) | Free (with Claude) |
-| **GitHub Stars** | New | ~47K | ~23K | ~25 | ~21K | N/A |
-
-### Where nano-brain shines
-
-- **6-signal hybrid search** — BM25 + vector + RRF + PageRank + supersede + neural reranking in a single pipeline
-- **Code intelligence** — Tree-sitter AST parsing, symbol graph, call flow detection, impact analysis
-- **Codebase indexing** — index your source files with structural boundary detection, not just conversations
-- **Session recall** — automatically harvests and indexes past AI coding sessions
-- **Flexible deployment** — 100% local (Ollama + sqlite-vec) or cloud (VoyageAI + Qdrant)
-- **Privacy-first** — local processing option, your code never leaves your machine
-
-### Consider alternatives if
-
-- You need a knowledge graph with temporal reasoning (Zep/Graphiti)
-- You want a full agent framework, not just memory (Letta)
-- You need cloud-hosted memory shared across teams (Mem0 Cloud)
-- You only need basic session notes (Claude native memory)
-
-## AI Agent Integration
-
-nano-brain ships with a SKILL.md that teaches AI agents when and how to use memory tools. When loaded as an OpenCode skill, agents automatically:
-
-- **Check memory before starting work** — recall past decisions, patterns, and context
-- **Save context after completing work** — persist key decisions and debugging insights
-- **Route queries to the right search tool** — BM25 for exact terms, vector for concepts, hybrid for best quality
-- **Use code intelligence** — understand symbol relationships, assess change impact, detect affected code
-
-### SKILL.md (Auto-loaded)
-
-The skill file at `SKILL.md` provides routing rules, trigger phrases, tool selection guides, and integration patterns. It's automatically loaded when any agent references the `nano-brain` skill.
-
-### AGENTS_SNIPPET.md (Optional, project-level)
-
-For project-level integration, `AGENTS_SNIPPET.md` provides a managed block that can be injected into a project's `AGENTS.md`:
-
-```bash
-npx nano-brain init --root=/path/to/project
-```
-
-This adds a managed block to your project's `AGENTS.md` with quick reference tables for CLI commands and MCP tools (if available).
-
-See [SKILL.md](./SKILL.md) for full routing rules and [AGENTS_SNIPPET.md](./AGENTS_SNIPPET.md) for the project-level snippet.
-
-## Self-Learning Configuration
-
-nano-brain includes an adaptive self-learning system that improves search quality over time.
-
-### Quick Start
-
-Add to your `config.yml`:
-
-```yaml
-telemetry:
-  enabled: true          # Log search queries and feedback (default: true)
-  retention_days: 90     # How long to keep telemetry data
-
-learning:
-  enabled: true          # Enable adaptive search tuning
-  update_interval_ms: 600000  # Cold-path update interval (10 min)
-
-consolidation:
-  enabled: true          # Enable memory consolidation
-  interval_ms: 3600000   # Consolidation interval (60 min)
-  model: gpt-4o-mini     # LLM model for consolidation
-  endpoint: https://api.openai.com/v1  # OpenAI-compatible endpoint
-  apiKey: sk-...         # API key (not required for Ollama)
-  provider: openai       # 'openai' (default) or 'ollama'
-
-extraction:
-  enabled: true          # Enable fact extraction from sessions
-  model: gpt-4o-mini     # LLM model for extraction
-  endpoint: https://api.openai.com/v1
-  apiKey: sk-...
-  maxFactsPerSession: 20 # Max facts to extract per session
-
-importance:
-  enabled: true          # Enable importance scoring
-  weight: 0.1            # Importance boost weight
-  decay_half_life_days: 30
-
-intents:
-  enabled: true          # Enable query intent classification
-```
-
-### How It Works
-
-1. **Telemetry**: Every search query is logged with results and timing. When you expand a result, it's recorded as positive feedback.
-2. **Thompson Sampling**: Search parameters (rrf_k, centrality_weight) are automatically tuned using multi-armed bandits based on expand feedback.
-3. **Consolidation**: Periodically, an LLM reviews recent memories and finds connections, generating consolidated insights.
-4. **Importance Scoring**: Documents accessed frequently get boosted in search results. Unused documents decay over time.
-5. **Intent Classification**: Queries are classified by intent (lookup, explanation, architecture, recall) and routed to optimized search configs.
-
-### CLI Commands
-
-- `nano-brain learning rollback [version_id]` — View or rollback to a previous config version
-- `nano-brain consolidate` — Trigger a manual consolidation cycle
-
-### MCP Tools
-
-- `memory_consolidate` — Trigger consolidation manually
-- `memory_consolidation_status` — View consolidation queue stats and recent logs
-- `memory_importance` — View document importance scores
-- `memory_status` — View learning system status (telemetry records, bandit variants, config version)
-
-## Memory Intelligence v2
-
-nano-brain includes three advanced intelligence features that make your memory smarter over time.
-
-### Entity Pruning
-
-Automatically cleans up outdated or contradicted information from the knowledge graph.
-
-**How it works:**
-- Background job runs every 6 hours
-- Soft-deletes contradicted entities after 30 days (when newer information supersedes them)
-- Soft-deletes orphan entities after 90 days (entities with no relationships)
-- Hard-deletes soft-deleted entities after 30-day retention period
-- Processes in batches of 100 to avoid SQLite lock contention
-
-**Configuration:**
-```yaml
-pruning:
-  enabled: true
-  interval_ms: 21600000      # 6 hours
-  contradicted_ttl_days: 30  # How long before contradicted entities are soft-deleted
-  orphan_ttl_days: 90        # How long before orphan entities are soft-deleted
-  batch_size: 100            # Max entities to process per cycle
-  hard_delete_after_days: 30 # Retention period for soft-deleted entities
-```
-
-**Why this matters:** Prevents your knowledge graph from accumulating stale information. When you update a decision or pattern, the old version is automatically pruned after the TTL expires.
-
-### LLM Categorization
-
-Adds semantic categorization to your memories using an LLM, going beyond simple keyword matching.
-
-**How it works:**
-- Runs asynchronously after the keyword categorizer (fire-and-forget)
-- Uses the same LLM provider configured for consolidation (same endpoint/model/apiKey)
-- Adds tags prefixed with `llm:` (e.g., `llm:architecture-decision`, `llm:debugging-insight`)
-- Only processes documents under 2000 characters (configurable)
-- Requires confidence threshold of 0.6 or higher (configurable)
-
-**7 semantic categories:**
-1. `llm:architecture-decision` — System design choices, trade-offs, patterns
-2. `llm:debugging-insight` — Root cause analysis, fix patterns, gotchas
-3. `llm:tool-config` — Setup instructions, configuration patterns
-4. `llm:pattern` — Reusable code patterns, best practices
-5. `llm:preference` — User preferences, workflow choices
-6. `llm:context` — Background information, explanations
-7. `llm:workflow` — Process documentation, how-to guides
-
-**Configuration:**
-```yaml
-categorization:
-  llm_enabled: true
-  confidence_threshold: 0.6   # Minimum confidence to apply a category
-  max_content_length: 2000    # Skip documents longer than this
-```
-
-**Why this matters:** Enables semantic filtering like `--tags=llm:architecture-decision` to find all design decisions, even if they don't use the word "architecture."
-
-### Preference Learning
-
-Learns which types of memories you expand most often and boosts them in future searches.
-
-**How it works:**
-- Tracks expand events per category per workspace
-- Calculates category weights based on expand rate vs baseline (10% default)
-- Applies weights as multipliers in search scoring (0.5× to 2.0× range)
-- Cold start: uses neutral weights until 20 queries collected
-- Updates every 10 minutes via learning cycle background job
-
-**Example:** If you expand `llm:debugging-insight` memories 30% of the time (vs 10% baseline), those memories get a 1.5× boost in future searches.
-
-**Configuration:**
-```yaml
-preferences:
-  enabled: true
-  min_queries: 20             # Minimum queries before personalization kicks in
-  weight_min: 0.5             # Minimum category weight (demotion)
-  weight_max: 2.0             # Maximum category weight (boost)
-  baseline_expand_rate: 0.1   # Expected expand rate (10%)
-```
-
-**Why this matters:** Your memory system adapts to your workflow. If you're debugging, debugging insights automatically surface higher. If you're designing, architecture decisions get prioritized.
-
-## Proactive Intelligence
-
-nano-brain can predict what you'll need next based on your query patterns.
-
-### How It Works
-
-1. **Query chains**: Groups of related queries within 5-minute windows are detected
-2. **Clustering**: Similar queries are grouped into semantic clusters using embeddings
-3. **Transition learning**: The system learns which clusters follow which (e.g., "auth questions" → "token refresh questions")
-4. **Predictions**: When you ask about topic A, nano-brain predicts you'll need topic B next
-
-### Configuration
-
-```yaml
-proactive:
-  enabled: true
-  chain_timeout_ms: 300000      # 5 min window for grouping queries
-  min_queries_for_prediction: 50 # Minimum queries before predictions activate
-  max_suggestions: 5
-  confidence_threshold: 0.3
-  cluster_count: 50
-  analysis_interval_ms: 1800000  # Rebuild every 30 min
-```
-
-### MCP Tool
-
-- `memory_suggestions` — Get predicted next queries based on current context
-  - `context` (optional): Current query or topic
-  - `workspace` (optional): Workspace path
-  - `limit` (optional): Max suggestions (default 3)
-
-## Troubleshooting
-
-**LLM provider unreachable**: Check endpoint URL and network connectivity. For Ollama, ensure `ollama serve` is running.
-
-**Invalid API key**: Verify `apiKey` in config or `CONSOLIDATION_API_KEY` env var. Ollama doesn't require an API key.
-
-**Empty LLM responses**: Check model name is correct. For Ollama, run `ollama list` to see available models.
-
-**Consolidation not running**: Ensure `consolidation.enabled: true` and check `memory_consolidation_status` for queue state.
+| | nano-brain | Mem0 | Zep / Graphiti | Letta |
+|---|---|---|---|---|
+| **Search** | Hybrid (BM25 + pgvector + RRF) | Vector only | Graph + vector | Agent-managed |
+| **Storage** | PostgreSQL + pgvector | PostgreSQL + external vector DB | Neo4j | PostgreSQL / SQLite |
+| **MCP Tools** | 16 | 4-9 | 9-10 | 7 |
+| **Code Intelligence** | Yes (symbol graph, impact analysis, call tracing) | No | No | No |
+| **Session Recall** | Yes (OpenCode + Claude Code) | No | No | No |
+| **Local-First** | Yes (Ollama) | Requires OpenAI key | Requires Docker + Neo4j | Yes |
 
 ## License
 


### PR DESCRIPTION
## Why

Install/setup instructions were duplicated across docs and inconsistent: the public docs/README used the scoped npm package `@nano-step/nano-brain` + PostgreSQL/pgvector, while the reference docs still showed the **unscoped `nano-brain`** package and the **old Qdrant/sqlite-vec** architecture. README.md is the canonical source and was already correct — this aligns the rest.

## Changes

- **docs/index.html** — build-from-source snippet now matches README exactly: `CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain` (was missing `-o nano-brain`).
- **docs/reference-readme.md** — modernized: scoped package name, PostgreSQL + pgvector (removed Qdrant/sqlite-vec/dual-store), `nano-brain serve -d`, CLI commands verified against `cmd/nano-brain`. Stale Qdrant-era content removed (−1051/+235 lines).
- **docs/reference-prd.md** — 9 targeted edits removing Qdrant/sqlite-vec across architecture, storage, search pipeline, provider abstraction, CLI surface, deployment modes, config, and goals.

Per maintainer decision: rewrite the stale reference docs to current reality; only align the **user-facing** build command (left the `./bin/` dev-build convention in HARNESS.md/DASHBOARD docs untouched).

## Verification

- `grep -rniE "qdrant|6333|6334|sqlite-vec" docs/reference-readme.md docs/reference-prd.md` → **0**
- `grep -rnE "install -g nano-brain\b" docs/` (unscoped) → **0**
- All `nano-brain <subcommand>` referenced in the docs verified to exist in `cmd/nano-brain` (serve, init, status, query, search, vsearch, harvest, reindex, code-impact, detect-changes, workspaces, wake-up, …).
- Canonical package name confirmed against `package.json` (`@nano-step/nano-brain`).

Docs-only; no code changes.