### PR TITLE
fix(summary): backfill existing session summaries to disk on harvest skip path

### DIFF
--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -134,6 +134,21 @@ func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile st
 		WorkspaceHash: h.workspace,
 	})
 	if err == nil && existing.ContentHash == contentHash {
+		// Opportunistically backfill disk: if this summary was created before
+		// write_to_disk was enabled, the file may be absent. The type assertion
+		// keeps the SessionSummarizer interface stable — mocks and other
+		// implementations that do not support disk backfill are unaffected.
+		if dw, ok := h.summarizer.(interface {
+			EnsureSummaryOnDisk(context.Context, string, SummaryMeta) error
+		}); ok {
+			_ = dw.EnsureSummaryOnDisk(ctx, existing.Content, SummaryMeta{
+				Source:        "claude",
+				SessionID:     sessionID,
+				Title:         "Claude Code Session " + sessionID,
+				CreatedAt:     existing.CreatedAt,
+				WorkspaceHash: h.workspace,
+			})
+		}
 		return harvestSkipped, nil
 	}
 

--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -139,9 +139,9 @@ func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile st
 		// keeps the SessionSummarizer interface stable — mocks and other
 		// implementations that do not support disk backfill are unaffected.
 		if dw, ok := h.summarizer.(interface {
-			EnsureSummaryOnDisk(context.Context, string, SummaryMeta) error
+			EnsureSummaryOnDisk(context.Context, string, SummaryMeta)
 		}); ok {
-			_ = dw.EnsureSummaryOnDisk(ctx, existing.Content, SummaryMeta{
+			dw.EnsureSummaryOnDisk(ctx, existing.Content, SummaryMeta{
 				Source:        "claude",
 				SessionID:     sessionID,
 				Title:         "Claude Code Session " + sessionID,

--- a/internal/harvest/engine.go
+++ b/internal/harvest/engine.go
@@ -143,9 +143,9 @@ func (e *Engine) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harves
 				// before write_to_disk was enabled, the file may be absent.
 				// Type assertion keeps SessionSummarizer interface stable.
 				if dw, ok := e.summarizer.(interface {
-					EnsureSummaryOnDisk(context.Context, string, SummaryMeta) error
+					EnsureSummaryOnDisk(context.Context, string, SummaryMeta)
 				}); ok {
-					_ = dw.EnsureSummaryOnDisk(ctx, existing.Content, SummaryMeta{
+					dw.EnsureSummaryOnDisk(ctx, existing.Content, SummaryMeta{
 						Source:        e.source.Name(),
 						SessionID:     sess.SessionID,
 						Title:         sess.Title,

--- a/internal/harvest/engine.go
+++ b/internal/harvest/engine.go
@@ -139,6 +139,20 @@ func (e *Engine) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harves
 			contentHash := hex.EncodeToString(sum[:])
 
 			if lookupErr == nil && existing.ContentHash == contentHash {
+				// Opportunistically backfill disk: if this summary was created
+				// before write_to_disk was enabled, the file may be absent.
+				// Type assertion keeps SessionSummarizer interface stable.
+				if dw, ok := e.summarizer.(interface {
+					EnsureSummaryOnDisk(context.Context, string, SummaryMeta) error
+				}); ok {
+					_ = dw.EnsureSummaryOnDisk(ctx, existing.Content, SummaryMeta{
+						Source:        e.source.Name(),
+						SessionID:     sess.SessionID,
+						Title:         sess.Title,
+						CreatedAt:     existing.CreatedAt,
+						WorkspaceHash: wsHash,
+					})
+				}
 				skipped++
 				continue
 			}

--- a/internal/summarize/ensure_disk_assert_test.go
+++ b/internal/summarize/ensure_disk_assert_test.go
@@ -1,0 +1,16 @@
+package summarize
+
+import (
+	"context"
+
+	"github.com/nano-brain/nano-brain/internal/harvest"
+)
+
+// Compile-time guarantee: *HarvestSummarizer satisfies the exact inline
+// interface the harvesters (claudecode.go, engine.go) type-assert against on
+// their content-unchanged skip path. If the adapter method signature drifts
+// (e.g. gains an error return), this fails to compile and the backfill would
+// silently stop firing (ok=false at runtime). 999.1 / summary-disk-backfill.
+var _ interface {
+	EnsureSummaryOnDisk(context.Context, string, harvest.SummaryMeta)
+} = (*HarvestSummarizer)(nil)

--- a/internal/summarize/ensure_disk_integration_test.go
+++ b/internal/summarize/ensure_disk_integration_test.go
@@ -5,7 +5,6 @@ package summarize
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -52,10 +51,7 @@ func TestEnsureSummaryOnDisk_BackfillsAndIsIdempotent(t *testing.T) {
 	p := NewPersister(pgDB, nil, true, outputDir, zerolog.Nop())
 
 	// Confirm the file does NOT exist yet.
-	expectedPath := filepath.Join(outputDir, wsName,
-		BuildDiskPath("", wsName, wsHash, string(SourceClaude), meta.Title, createdAt)[len(""):])
-	// Build the expected path the same way BuildDiskPath does.
-	expectedPath = BuildDiskPath(outputDir, wsName, wsHash, string(SourceClaude), meta.Title, createdAt)
+	expectedPath := BuildDiskPath(outputDir, wsName, wsHash, string(SourceClaude), meta.Title, createdAt)
 
 	if _, err := os.Stat(expectedPath); err == nil {
 		t.Fatalf("precondition failed: file already exists at %s", expectedPath)

--- a/internal/summarize/ensure_disk_integration_test.go
+++ b/internal/summarize/ensure_disk_integration_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+package summarize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+// TestEnsureSummaryOnDisk_BackfillsAndIsIdempotent verifies:
+//  1. EnsureSummaryOnDisk writes a .md file at the expected BuildDiskPath location
+//     when the file is absent (backfill case).
+//  2. A second call with identical content does NOT rewrite the file (idempotent):
+//     the file's mtime is unchanged.
+func TestEnsureSummaryOnDisk_BackfillsAndIsIdempotent(t *testing.T) {
+	pgDB := setupPersistTestPG(t)
+	ctx := context.Background()
+	q := sqlc.New(pgDB)
+	outputDir := t.TempDir()
+
+	// Register a workspace so GetWorkspaceByHash succeeds inside persistToDisk.
+	wsHash := "test-ws-ensure-disk-001"
+	wsName := "ensure-disk-workspace"
+	if _, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: wsHash,
+		Name: wsName,
+		Path: "/tmp/ensure-disk-test-" + wsHash,
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+
+	// First, insert the summary document into the DB (simulates the case where
+	// the summary was created when write_to_disk was false).
+	const summaryMarkdown = "# Backfill Test\n\nThis summary was in DB but not on disk.\n"
+	createdAt := time.Date(2026, 6, 30, 10, 0, 0, 0, time.UTC)
+
+	meta := SessionMetadata{
+		Source:        SourceClaude,
+		SessionID:     "ses-ensure-disk-001",
+		Title:         "Claude Code Session ses-ensure-disk-001",
+		CreatedAt:     createdAt,
+		WorkspaceHash: wsHash,
+	}
+
+	// Construct persister with writeToDisk=true.
+	p := NewPersister(pgDB, nil, true, outputDir, zerolog.Nop())
+
+	// Confirm the file does NOT exist yet.
+	expectedPath := filepath.Join(outputDir, wsName,
+		BuildDiskPath("", wsName, wsHash, string(SourceClaude), meta.Title, createdAt)[len(""):])
+	// Build the expected path the same way BuildDiskPath does.
+	expectedPath = BuildDiskPath(outputDir, wsName, wsHash, string(SourceClaude), meta.Title, createdAt)
+
+	if _, err := os.Stat(expectedPath); err == nil {
+		t.Fatalf("precondition failed: file already exists at %s", expectedPath)
+	}
+
+	// --- Call 1: should create the file ---
+	p.EnsureSummaryOnDisk(ctx, summaryMarkdown, meta)
+
+	info1, err := os.Stat(expectedPath)
+	if err != nil {
+		t.Fatalf("EnsureSummaryOnDisk did not create file at %s: %v", expectedPath, err)
+	}
+	content, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(content) != summaryMarkdown {
+		t.Errorf("file content mismatch\n got:  %q\n want: %q", string(content), summaryMarkdown)
+	}
+
+	mtime1 := info1.ModTime()
+
+	// Small sleep so that any rewrite would produce a visibly different mtime.
+	time.Sleep(20 * time.Millisecond)
+
+	// --- Call 2: identical content — must NOT rewrite ---
+	p.EnsureSummaryOnDisk(ctx, summaryMarkdown, meta)
+
+	info2, err := os.Stat(expectedPath)
+	if err != nil {
+		t.Fatalf("file disappeared after second call: %v", err)
+	}
+	mtime2 := info2.ModTime()
+
+	if !mtime2.Equal(mtime1) {
+		t.Errorf("idempotency violated: file was rewritten on second call\n  mtime1=%v\n  mtime2=%v", mtime1, mtime2)
+	}
+}
+
+// TestEnsureSummaryOnDisk_NoopWhenDisabled verifies that EnsureSummaryOnDisk
+// is a no-op when writeToDisk is false, leaving outputDir empty.
+func TestEnsureSummaryOnDisk_NoopWhenDisabled(t *testing.T) {
+	pgDB := setupPersistTestPG(t)
+	ctx := context.Background()
+	q := sqlc.New(pgDB)
+	outputDir := t.TempDir()
+
+	wsHash := "test-ws-ensure-disk-002"
+	wsName := "ensure-disk-disabled-workspace"
+	if _, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: wsHash,
+		Name: wsName,
+		Path: "/tmp/ensure-disk-test-" + wsHash,
+	}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+
+	p := NewPersister(pgDB, nil, false, outputDir, zerolog.Nop())
+
+	meta := SessionMetadata{
+		Source:        SourceClaude,
+		SessionID:     "ses-ensure-disk-002",
+		Title:         "Claude Code Session ses-ensure-disk-002",
+		CreatedAt:     time.Date(2026, 6, 30, 10, 0, 0, 0, time.UTC),
+		WorkspaceHash: wsHash,
+	}
+
+	p.EnsureSummaryOnDisk(ctx, "# Should not appear\n", meta)
+
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty outputDir, found %d entries", len(entries))
+	}
+}

--- a/internal/summarize/harvest_adapter.go
+++ b/internal/summarize/harvest_adapter.go
@@ -30,7 +30,7 @@ func (s *HarvestSummarizer) SetLinkExtractor(resolver *links.Resolver, extractor
 // the same mapping as SummarizeAndPersist, then delegates to the Persister.
 // This is called on the harvester content-unchanged skip path to backfill
 // summaries created before write_to_disk was enabled.
-func (s *HarvestSummarizer) EnsureSummaryOnDisk(ctx context.Context, summaryMarkdown string, meta harvest.SummaryMeta) error {
+func (s *HarvestSummarizer) EnsureSummaryOnDisk(ctx context.Context, summaryMarkdown string, meta harvest.SummaryMeta) {
 	sessionMeta := SessionMetadata{
 		Source:        Source(meta.Source),
 		SessionID:     meta.SessionID,
@@ -46,7 +46,6 @@ func (s *HarvestSummarizer) EnsureSummaryOnDisk(ctx context.Context, summaryMark
 		WorkspaceHash: meta.WorkspaceHash,
 	}
 	s.persister.EnsureSummaryOnDisk(ctx, summaryMarkdown, sessionMeta)
-	return nil
 }
 
 func (s *HarvestSummarizer) SummarizeAndPersist(ctx context.Context, content string, meta harvest.SummaryMeta) error {

--- a/internal/summarize/harvest_adapter.go
+++ b/internal/summarize/harvest_adapter.go
@@ -25,6 +25,30 @@ func (s *HarvestSummarizer) SetLinkExtractor(resolver *links.Resolver, extractor
 	s.persister.SetLinkExtractor(resolver, extractor)
 }
 
+// EnsureSummaryOnDisk writes an already-stored summary markdown to disk if the
+// file is absent. It maps harvest.SummaryMeta → summarize.SessionMetadata using
+// the same mapping as SummarizeAndPersist, then delegates to the Persister.
+// This is called on the harvester content-unchanged skip path to backfill
+// summaries created before write_to_disk was enabled.
+func (s *HarvestSummarizer) EnsureSummaryOnDisk(ctx context.Context, summaryMarkdown string, meta harvest.SummaryMeta) error {
+	sessionMeta := SessionMetadata{
+		Source:        Source(meta.Source),
+		SessionID:     meta.SessionID,
+		Title:         meta.Title,
+		Agent:         meta.Agent,
+		ProjectPath:   meta.ProjectPath,
+		CreatedAt:     meta.CreatedAt,
+		Duration:      meta.Duration,
+		ParentID:      meta.ParentID,
+		Branch:        meta.Branch,
+		Cwd:           meta.Cwd,
+		Tags:          meta.Tags,
+		WorkspaceHash: meta.WorkspaceHash,
+	}
+	s.persister.EnsureSummaryOnDisk(ctx, summaryMarkdown, sessionMeta)
+	return nil
+}
+
 func (s *HarvestSummarizer) SummarizeAndPersist(ctx context.Context, content string, meta harvest.SummaryMeta) error {
 	s.logger.Info().
 		Str("session_id", meta.SessionID).

--- a/internal/summarize/harvest_adapter.go
+++ b/internal/summarize/harvest_adapter.go
@@ -31,6 +31,13 @@ func (s *HarvestSummarizer) SetLinkExtractor(resolver *links.Resolver, extractor
 // This is called on the harvester content-unchanged skip path to backfill
 // summaries created before write_to_disk was enabled.
 func (s *HarvestSummarizer) EnsureSummaryOnDisk(ctx context.Context, summaryMarkdown string, meta harvest.SummaryMeta) {
+	// Reached via a structural type assertion in the harvesters, which bypasses
+	// the interface-nil safety the rest of the call path relies on. A typed-nil
+	// *HarvestSummarizer would satisfy that assertion (ok=true) and panic here,
+	// so guard the nil receiver / nil persister explicitly.
+	if s == nil || s.persister == nil {
+		return
+	}
 	sessionMeta := SessionMetadata{
 		Source:        Source(meta.Source),
 		SessionID:     meta.SessionID,

--- a/internal/summarize/persist.go
+++ b/internal/summarize/persist.go
@@ -209,13 +209,16 @@ func (p *Persister) persistToDisk(ctx context.Context, summaryMarkdown string, m
 		p.logger.Warn().Err(err).Str("path", targetPath).Msg("disk persist: resolveCollision failed")
 		return
 	}
-	// Idempotent skip: if the file already exists with identical content, do
-	// not rewrite. ResolveCollision already returned the base path when content
-	// matches (see diskwrite.go), but we also guard here so WriteFileAtomic is
-	// never called unnecessarily (avoids spurious fsync + rename each cycle).
-	if existing, readErr := os.ReadFile(finalPath); readErr == nil && string(existing) == summaryMarkdown {
-		p.logger.Debug().Str("path", finalPath).Str("session_id", meta.SessionID).Msg("disk persist: file unchanged, skipping rewrite")
-		return
+	// Idempotent skip: ResolveCollision returns the base path (targetPath)
+	// when the file exists with matching content. If finalPath == targetPath
+	// and the file exists, the content already matches — skip the write.
+	// This avoids a second full file read; os.Stat is sufficient to confirm
+	// existence (ResolveCollision already did the byte comparison).
+	if finalPath == targetPath {
+		if _, statErr := os.Stat(finalPath); statErr == nil {
+			p.logger.Debug().Str("path", finalPath).Str("session_id", meta.SessionID).Msg("disk persist: file unchanged, skipping rewrite")
+			return
+		}
 	}
 	if err := WriteFileAtomic(finalPath, []byte(summaryMarkdown)); err != nil {
 		p.logger.Warn().Err(err).Str("path", finalPath).Msg("disk persist: writeFileAtomic failed")

--- a/internal/summarize/persist.go
+++ b/internal/summarize/persist.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/nano-brain/nano-brain/internal/chunk"
@@ -187,6 +188,11 @@ func (p *Persister) Save(ctx context.Context, summaryMarkdown string, meta Sessi
 // persistToDisk writes the summary markdown to a file under outputDir. Errors
 // are logged but never propagated — DB persist already succeeded; disk is a
 // derivative view. See issue #258.
+//
+// The write is idempotent: if the file already exists at the resolved path and
+// its content is byte-for-byte identical to summaryMarkdown, the function
+// returns without rewriting. This prevents per-cycle rewrites when the
+// harvester calls EnsureSummaryOnDisk on unchanged sessions.
 func (p *Persister) persistToDisk(ctx context.Context, summaryMarkdown string, meta SessionMetadata, _ uuid.UUID, q *sqlc.Queries) {
 	ws, err := q.GetWorkspaceByHash(ctx, meta.WorkspaceHash)
 	var wsName string
@@ -203,11 +209,33 @@ func (p *Persister) persistToDisk(ctx context.Context, summaryMarkdown string, m
 		p.logger.Warn().Err(err).Str("path", targetPath).Msg("disk persist: resolveCollision failed")
 		return
 	}
+	// Idempotent skip: if the file already exists with identical content, do
+	// not rewrite. ResolveCollision already returned the base path when content
+	// matches (see diskwrite.go), but we also guard here so WriteFileAtomic is
+	// never called unnecessarily (avoids spurious fsync + rename each cycle).
+	if existing, readErr := os.ReadFile(finalPath); readErr == nil && string(existing) == summaryMarkdown {
+		p.logger.Debug().Str("path", finalPath).Str("session_id", meta.SessionID).Msg("disk persist: file unchanged, skipping rewrite")
+		return
+	}
 	if err := WriteFileAtomic(finalPath, []byte(summaryMarkdown)); err != nil {
 		p.logger.Warn().Err(err).Str("path", finalPath).Msg("disk persist: writeFileAtomic failed")
 		return
 	}
 	p.logger.Info().Str("path", finalPath).Str("session_id", meta.SessionID).Msg("summary written to disk")
+}
+
+// EnsureSummaryOnDisk writes an already-stored summary to disk if the file is
+// absent. It is a no-op when writeToDisk is false, outputDir is empty, or the
+// file already exists with identical content (idempotent). Errors are logged
+// inside persistToDisk and never propagated.
+//
+// This is used by harvesters on the content-unchanged skip path to backfill
+// summaries that were created before write_to_disk was enabled.
+func (p *Persister) EnsureSummaryOnDisk(ctx context.Context, summaryMarkdown string, meta SessionMetadata) {
+	if !p.writeToDisk || p.outputDir == "" {
+		return
+	}
+	p.persistToDisk(ctx, summaryMarkdown, meta, uuid.Nil, sqlc.New(p.db))
 }
 
 // buildSourcePath returns the canonical source path for summary documents.


### PR DESCRIPTION
## Problem

After enabling `summarization.write_to_disk`, existing session summaries (created while it was off — e.g. 106 for one workspace) never appear on disk. Disk-write only happens inside `Persister.Save`, but harvesters skip content-unchanged sessions **before** summarize/persist runs, so already-stored summaries never re-flow and never backfill. Enabling the flag is not retroactive.

## Fix (self-healing)

On the harvester content-unchanged skip path, opportunistically write the already-stored summary (`existing.Content`) to disk if the file is absent — no LLM, no DB write.

- `persistToDisk` is now **idempotent**: if the resolved file already exists with byte-identical content, it returns without rewriting (no per-cycle fsync/rename churn).
- New `Persister.EnsureSummaryOnDisk` (no-op when `write_to_disk` off or `output_dir` empty) → delegates to the idempotent `persistToDisk`.
- New `HarvestSummarizer.EnsureSummaryOnDisk` adapter.
- `claudecode.go` and `engine.go` skip paths call it via a **type assertion** (keeps the `SessionSummarizer` interface stable — mocks/other impls unaffected), building meta from the existing doc (same title/source/createdAt the normal path uses).
- A **compile-time assertion** guarantees `*HarvestSummarizer` satisfies the exact inline interface the harvesters assert against, so the signature can't silently drift and disable the backfill.

**Effect:** after deploy, the next harvest cycle (~`session_poll`s) writes every existing summary to disk under `<output_dir>/<workspace>/<source>_<title>_<date>.md`, and keeps them there going forward.

## Tests / evidence

- `go test -race -short ./internal/summarize/ ./internal/harvest/` ✓
- `go test -race -tags=integration ./internal/summarize/ -run TestEnsureSummaryOnDisk` ✓ on test DB (`nanobrain_test`): writes the file when absent; **mtime unchanged on a second call** (idempotent); no-op when disabled.
- `CGO_ENABLED=0 go build ./...` ✓
- Independent review of the diff caught + reconciled an error-vs-void signature drift between the assertion and the adapter; the compile-time assertion now prevents recurrence.

Requires daemon rebuild + restart to take effect.