### PR TITLE
fix(harvest): presence-based dedup for Claude sessions (stop re-summarizing every cycle; backfill disk)

### DIFF
--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -133,7 +133,13 @@ func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile st
 		SourcePath:    sourcePath,
 		WorkspaceHash: h.workspace,
 	})
-	if err == nil && existing.ContentHash == contentHash {
+	// Presence-based dedup (mirrors OpenCodeSQLiteHarvester): once a session
+	// has been summarized, skip it — don't re-run the LLM every cycle. The old
+	// `existing.ContentHash == contentHash` compared the transcript hash against
+	// the stored SUMMARY hash, which never matched, so every session was
+	// re-summarized on every harvest cycle (burning tokens, never reaching the
+	// disk-backfill skip path).
+	if err == nil && existing.ContentHash != "" {
 		// Opportunistically backfill disk: if this summary was created before
 		// write_to_disk was enabled, the file may be absent. The type assertion
 		// keeps the SessionSummarizer interface stable — mocks and other

--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -133,6 +134,12 @@ func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile st
 		SourcePath:    sourcePath,
 		WorkspaceHash: h.workspace,
 	})
+	// A non-"no rows" DB error (e.g. a connection blip) must NOT fall through to
+	// re-summarization — that would burn an LLM call on every session every cycle
+	// during an outage. Skip this session for now; the next cycle retries.
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return harvestSkipped, fmt.Errorf("lookup existing summary: %w", err)
+	}
 	// Presence-based dedup (mirrors OpenCodeSQLiteHarvester): once a session
 	// has been summarized, skip it — don't re-run the LLM every cycle. The old
 	// `existing.ContentHash == contentHash` compared the transcript hash against

--- a/internal/harvest/claudecode_dedup_integration_test.go
+++ b/internal/harvest/claudecode_dedup_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package harvest
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/nano-brain/nano-brain/internal/storage"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	"github.com/rs/zerolog"
+)
+
+// countingSummarizer records how many times SummarizeAndPersist runs and, like
+// the real persister, writes a summary document so the next harvest cycle can
+// detect it and skip (presence-based dedup).
+type countingSummarizer struct {
+	db    *sqlc.Queries
+	calls atomic.Int64
+}
+
+func (c *countingSummarizer) SummarizeAndPersist(ctx context.Context, content string, meta SummaryMeta) error {
+	c.calls.Add(1)
+	_, err := c.db.UpsertDocumentBySourcePath(ctx, sqlc.UpsertDocumentBySourcePathParams{
+		WorkspaceHash: meta.WorkspaceHash,
+		ContentHash:   "summary-hash-" + meta.SessionID,
+		Title:         "Summary: " + meta.Title,
+		Content:       "# summary\nstored",
+		SourcePath:    "summary://claude/" + meta.SessionID,
+		Collection:    "sessions",
+	})
+	return err
+}
+
+// TestClaudeHarvester_PresenceBasedSkip proves that once a session has been
+// summarized, a second harvest cycle skips it (does NOT re-run the summarizer).
+// Before the fix the skip compared transcript-hash vs summary-hash (never
+// matched) and re-summarized every session every cycle.
+func TestClaudeHarvester_PresenceBasedSkip(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	q := sqlc.New(db)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	wsHash, err := storage.WorkspaceHash(dir)
+	if err != nil {
+		t.Fatalf("workspace hash: %v", err)
+	}
+	if _, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{Hash: wsHash, Path: dir, Name: "dedup-test"}); err != nil {
+		t.Fatalf("register workspace: %v", err)
+	}
+
+	// One real-schema transcript line so parseJSONLFile yields a session.
+	line, _ := json.Marshal(map[string]any{
+		"type": "user", "timestamp": "2026-01-01T10:00:00Z",
+		"message": map[string]any{"role": "user", "content": "hello"},
+	})
+	if err := os.WriteFile(filepath.Join(dir, "ses_dedup.jsonl"), append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := &countingSummarizer{db: q}
+	h := NewClaudeCodeHarvester(db, zerolog.Nop(), dir, wsHash).WithSummarizer(sum)
+
+	// First cycle: no existing doc → summarize once.
+	h.HarvestAll(ctx, nil)
+	if got := sum.calls.Load(); got != 1 {
+		t.Fatalf("first cycle: summarizer calls = %d, want 1", got)
+	}
+
+	// Second cycle: doc now exists → presence-based skip, summarizer NOT called again.
+	_, skipped, _ := h.HarvestAll(ctx, nil)
+	if got := sum.calls.Load(); got != 1 {
+		t.Errorf("second cycle re-summarized (calls=%d) — presence-based skip not working", got)
+	}
+	if skipped < 1 {
+		t.Errorf("second cycle skipped=%d, want >=1", skipped)
+	}
+}

--- a/internal/harvest/engine.go
+++ b/internal/harvest/engine.go
@@ -138,7 +138,7 @@ func (e *Engine) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harves
 			sum := sha256.Sum256([]byte(md))
 			contentHash := hex.EncodeToString(sum[:])
 
-			if lookupErr == nil && existing.ContentHash == contentHash {
+			if lookupErr == nil && existing.ContentHash != "" {
 				// Opportunistically backfill disk: if this summary was created
 				// before write_to_disk was enabled, the file may be absent.
 				// Type assertion keeps SessionSummarizer interface stable.

--- a/internal/harvest/engine.go
+++ b/internal/harvest/engine.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -133,6 +134,14 @@ func (e *Engine) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harves
 				SourcePath:    sourcePath,
 				WorkspaceHash: wsHash,
 			})
+
+			// A non-"no rows" DB error must NOT fall through to re-summarization
+			// (would burn an LLM call per session during a DB outage). Skip now.
+			if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
+				e.logger.Warn().Err(lookupErr).Str("session_id", sess.SessionID).Msg("engine: lookup existing summary failed, skipping")
+				errCount++
+				continue
+			}
 
 			md := RenderMarkdown(sess)
 			sum := sha256.Sum256([]byte(md))

--- a/internal/summarize/persist.go
+++ b/internal/summarize/persist.go
@@ -87,6 +87,12 @@ func (p *Persister) Save(ctx context.Context, summaryMarkdown string, meta Sessi
 	})
 	if lookupErr == nil && existing.ContentHash == contentHash {
 		p.logger.Debug().Str("source_path", sourcePath).Msg("summary unchanged, skipping")
+		// Still ensure the summary exists on disk: an unchanged summary that was
+		// persisted before write_to_disk was enabled has no file yet. Idempotent
+		// (persistToDisk skips when the file already matches).
+		if p.writeToDisk && p.outputDir != "" {
+			p.persistToDisk(ctx, summaryMarkdown, meta, existing.ID, q)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

The Claude harvester re-summarized **every session on every harvest cycle** — burning LLM tokens and (because it never hit the skip path) never backfilling summaries to disk.

Root cause: `harvestSession` skipped only when `existing.ContentHash == contentHash`, where `contentHash` is the hash of the **transcript** but `existing.ContentHash` is the hash of the stored **summary**. Those never match, so the skip never fired. (`OpenCodeSQLiteHarvester` already uses presence-based dedup and skips correctly.)

## Fix

- **claudecode.go / engine.go**: switch to presence-based dedup — skip once a summary exists (`existing.ContentHash != ""`), mirroring `OpenCodeSQLiteHarvester`. Unchanged sessions now route through the skip path → the existing `EnsureSummaryOnDisk` backfill writes them to disk, and the LLM is not re-run.
- **persist.go**: on `Save`'s unchanged early-return, also call `persistToDisk` (idempotent) so any path reaching `Save` still backfills disk.

**Behavior note:** like OpenCode, a session is summarized once and not re-summarized as its transcript grows. This is the established harvester behavior and the intended trade-off (was effectively broken before — it re-did everything every cycle). Incremental re-summary of growing sessions would be a separate enhancement.

## Tests / evidence

- New integration test `TestClaudeHarvester_PresenceBasedSkip` (test DB): harvest twice → second cycle skips, summarizer **not** re-called.
- `TestEnsureSummaryOnDisk` (idempotent disk backfill) still ✓.
- `go test -race -short ./internal/harvest/ ./internal/summarize/` ✓ · `CGO_ENABLED=0 go build ./...` ✓.

After deploy + restart: existing summaries (incl. the ~106 for one workspace) backfill to `~/.nano-brain/summaries/<workspace>/` within the next harvest cycle, with no token-burning re-summarization.