### PR TITLE
fix(watcher): gate code-summarize notify on files that yield symbols

### DIFF
--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -894,8 +894,8 @@ func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePa
 	w.extractAndInsertEntities(ctx, col.workspaceHash, chunks, chunkIDs)
 
 	if w.symbolRegistry != nil {
-		w.extractAndUpsertSymbols(ctx, col, filePath, content)
-		if w.summarizeNotify != nil {
+		numSyms := w.extractAndUpsertSymbols(ctx, col, filePath, content)
+		if numSyms > 0 && w.summarizeNotify != nil {
 			w.summarizeNotify()
 		}
 	}
@@ -909,14 +909,17 @@ func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePa
 	}
 }
 
-func (w *Watcher) extractAndUpsertSymbols(ctx context.Context, col watchedCollection, filePath string, content []byte) {
+// extractAndUpsertSymbols parses filePath for language symbols and upserts them
+// as summary-eligible chunks. Returns the number of symbols found so callers can
+// avoid waking the code-summarization worker for files with none (e.g. JSON/text).
+func (w *Watcher) extractAndUpsertSymbols(ctx context.Context, col watchedCollection, filePath string, content []byte) int {
 	syms, err := w.symbolRegistry.Extract(filePath, content)
 	if err != nil {
 		w.logger.Warn().Err(err).Str("file", filePath).Msg("symbol extraction failed")
-		return
+		return 0
 	}
 	if len(syms) == 0 {
-		return
+		return 0
 	}
 
 	for _, s := range syms {
@@ -965,6 +968,8 @@ func (w *Watcher) extractAndUpsertSymbols(ctx context.Context, col watchedCollec
 		Str("file", filePath).
 		Int("symbols", len(syms)).
 		Msg("symbols extracted")
+
+	return len(syms)
 }
 
 // buildEdgeMetadata merges e.Metadata (if non-nil) with {"line", "language"},

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -18,17 +18,18 @@ import (
 	"github.com/nano-brain/nano-brain/internal/config"
 	"github.com/nano-brain/nano-brain/internal/graph"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/symbol"
 	"github.com/rs/zerolog"
 )
 
 type mockQuerier struct {
-	upsertDocCalls        atomic.Int64
-	upsertChunkCalls      atomic.Int64
-	deleteChunkCalls      atomic.Int64
-	deleteDocCalls        atomic.Int64
+	upsertDocCalls          atomic.Int64
+	upsertChunkCalls        atomic.Int64
+	deleteChunkCalls        atomic.Int64
+	deleteDocCalls          atomic.Int64
 	getDocBySourcePathCalls atomic.Int64
 	updateFileStateCalls    atomic.Int64
-	sourcePathHash        map[string]string
+	sourcePathHash          map[string]string
 }
 
 func newMockQuerier() *mockQuerier {
@@ -246,6 +247,51 @@ func TestProcessFile_SkipsSameHash(t *testing.T) {
 	w.processFile(context.Background(), col, fp)
 	if mq.upsertDocCalls.Load() != 1 {
 		t.Fatalf("expected hash skip on second call, got %d total upserts", mq.upsertDocCalls.Load())
+	}
+}
+
+// fakeExtractor only recognizes one extension, mimicking how real language
+// extractors report zero symbols for files they don't parse (e.g. JSON).
+type fakeExtractor struct{ ext string }
+
+func (f fakeExtractor) Supports(ext string) bool { return ext == f.ext }
+
+func (f fakeExtractor) Extract(filePath string, _ []byte) ([]symbol.Symbol, error) {
+	return []symbol.Symbol{{Name: "Foo", Kind: symbol.KindFunction, File: filePath, Signature: "func Foo()", Language: "go"}}, nil
+}
+
+func TestProcessFile_SummarizeNotifyOnlyWhenSymbolsFound(t *testing.T) {
+	dir := t.TempDir()
+	mq := newMockQuerier()
+	w := newTestWatcher(mq, 2000, 300)
+	w.WithSymbolRegistry(symbol.NewRegistry(fakeExtractor{ext: ".go"}))
+
+	var notified atomic.Int64
+	w.WithSummarizeNotify(func() { notified.Add(1) })
+
+	col := watchedCollection{
+		name:          "code",
+		dirPath:       dir,
+		workspaceHash: "ws123",
+		globPattern:   "*",
+	}
+
+	jsonFile := filepath.Join(dir, "cache.json")
+	if err := os.WriteFile(jsonFile, []byte(`{"a":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w.processFile(context.Background(), col, jsonFile)
+	if notified.Load() != 0 {
+		t.Fatalf("expected no summarize notify for a file with zero extracted symbols, got %d", notified.Load())
+	}
+
+	goFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main\nfunc Foo() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	w.processFile(context.Background(), col, goFile)
+	if notified.Load() != 1 {
+		t.Fatalf("expected summarize notify once a file yields symbols, got %d", notified.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary
- `extractAndUpsertSymbols` in `internal/watcher/watcher.go` now returns the number of symbols found (0 on error or no match) instead of nothing.
- `processFile` only calls `w.summarizeNotify()` when that count is `> 0`. Previously it fired unconditionally for any file in a symbol-registry-enabled ("code") collection, including non-code files (JSON/text caches matched by a broad watch glob), waking the code-summarization worker pool and causing a wasted `GetUnsummarizedSymbols` scan across every registered workspace for nothing.
- Added `TestProcessFile_SummarizeNotifyOnlyWhenSymbolsFound` covering both cases (zero-symbol file → no notify; symbol-bearing file → notify fires).

## Review
- Independent code-reviewer agent (author != implementer): **APPROVE**.
- `/simplify` (reuse/simplification/efficiency/altitude angles): clean, no changes needed.
- `/code-review` (8 finder angles + verify): reuse/simplification/efficiency/conventions/cross-file all clean. Two non-blocking findings, both confirmed pre-existing (not introduced by this diff):
  - `internal/codesummarize/service.go:88` — `Notify()` carries no workspace identity, so any wake still rescans every registered workspace. Real, separate improvement — not addressed here.
  - This fix delays (not skips) discovery of other pending symbols in the same workspace by up to `poll_interval` (default 60s) if only zero-symbol files are touched afterward — bounded by the existing ticker backstop, not a correctness regression.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -short ./...` — full repo green
- [x] `smoke:e2e` — built binary, booted server against `nanobrain_test:3199`, `GET /api/status` → 200, clean shutdown, zero unintended side effects (summarization explicitly disabled for this run — see issue for context on an earlier unsafe attempt)

Closes #520