### PR TITLE
fix(cli): make -h/--help useful, hint at help on bare invocation, sync usage list

### DIFF
--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -54,6 +54,10 @@ func main() {
 	flag.BoolVar(&serveOnlyFlag, "serve-only", false, "disable background workers (embed queue, watcher, harvester) — issue #282")
 	flag.IntVar(&verbose, "v", 0, "verbosity: 0=info, 1=debug, 2=trace")
 	flag.IntVar(&verbose, "verbose", 0, "")
+	// stdlib flag intercepts -h/--help (and flag-parse errors) before this
+	// function's command dispatch below ever runs; without this override
+	// the user would see only the global flags above, not the command list.
+	flag.Usage = printUsage
 	flag.Parse()
 
 	initCLILog(configPath)
@@ -176,7 +180,10 @@ func main() {
 		}
 	}
 
-	// No args: start server foreground (backward compat)
+	// No args: start server foreground (backward compat). Hint at `help`
+	// first since this is an easy accidental trigger for anyone exploring
+	// the CLI (e.g. running `nano-brain` alone expecting usage output).
+	fmt.Fprintln(os.Stderr, "No command given — starting server in foreground. Run 'nano-brain help' to see available commands.")
 	startServer(configPath)
 }
 

--- a/cmd/nano-brain/main.go
+++ b/cmd/nano-brain/main.go
@@ -57,7 +57,10 @@ func main() {
 	// stdlib flag intercepts -h/--help (and flag-parse errors) before this
 	// function's command dispatch below ever runs; without this override
 	// the user would see only the global flags above, not the command list.
-	flag.Usage = printUsage
+	// Routed to stderr to match flag's own default Output() and to keep
+	// error-path usage text out of stdout (so e.g. a bad flag doesn't
+	// pollute stdout for a caller checking command output).
+	flag.Usage = func() { printUsage(os.Stderr) }
 	flag.Parse()
 
 	initCLILog(configPath)
@@ -171,11 +174,11 @@ func main() {
 			runVersionCmd(args[1:])
 			return
 		case "help":
-			printUsage()
+			printUsage(os.Stdout)
 			return
 		default:
 			fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", args[0])
-			printUsage()
+			printUsage(os.Stderr)
 			os.Exit(1)
 		}
 	}

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -542,8 +542,14 @@ func runGooseMigrateCmd(jsonFlag bool) {
 	}
 }
 
-func printUsage() {
-	fmt.Printf(`nano-brain %s — persistent memory for AI coding agents
+// printUsage writes the full command list to w. Callers choose the stream:
+// the explicit `help` command writes to stdout (successful, informational
+// output), while -h/--help/flag-parse-errors and unknown-command errors
+// write to stderr (matching flag package's own default Output() and
+// keeping error-path text out of stdout for callers checking command
+// output).
+func printUsage(w io.Writer) {
+	fmt.Fprintf(w, `nano-brain %s — persistent memory for AI coding agents
 
 Usage: nano-brain [command] [flags]
 

--- a/cmd/nano-brain/ops.go
+++ b/cmd/nano-brain/ops.go
@@ -576,6 +576,14 @@ Commands:
   docker             Manage Docker Compose (start/stop/status)
   db:migrate         Run database migrations
   bench              Benchmarking suite (generate/run/compare/stress)
+  context            Show symbol definition + call sites     [--workspace <hash>]
+  code-impact        Show blast radius of a symbol change    [--workspace <hash>] [--depth N]
+  detect-changes     List changed symbols since last commit  [--workspace <hash>] [--staged|--all]
+  auth               Manage auth credentials (hash/token)
+  reset-embeddings   Clear embeddings to force re-embedding  [--workspace=<hash>] [--dry-run]
+  backfill-summaries Export DB summaries to disk as .md      [--dry-run]
+  cleanup-stale-raw  Delete superseded raw session docs      [--dry-run]
+  cleanup-orphan-workspaces  Delete docs/chunks with no matching workspace [--dry-run]
   help               Show this help
 
 Global flags:

--- a/cmd/nano-brain/ops_usage_test.go
+++ b/cmd/nano-brain/ops_usage_test.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"io"
-	"os"
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -20,30 +19,10 @@ var dispatchedCommands = []string{
 	"tags", "multi-get", "auth", "mcp-url", "version", "help",
 }
 
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	orig := os.Stdout
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	fn()
-
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(out)
-}
-
 func TestPrintUsage_ListsAllDispatchedCommands(t *testing.T) {
-	out := captureStdout(t, printUsage)
+	var buf bytes.Buffer
+	printUsage(&buf)
+	out := buf.String()
 
 	for _, cmd := range dispatchedCommands {
 		if !strings.Contains(out, cmd) {
@@ -53,8 +32,9 @@ func TestPrintUsage_ListsAllDispatchedCommands(t *testing.T) {
 }
 
 func TestPrintUsage_MentionsHelpCommand(t *testing.T) {
-	out := captureStdout(t, printUsage)
-	if !strings.Contains(out, "nano-brain help") && !strings.Contains(out, "help") {
+	var buf bytes.Buffer
+	printUsage(&buf)
+	if !strings.Contains(buf.String(), "help") {
 		t.Error("printUsage() should mention the help command")
 	}
 }

--- a/cmd/nano-brain/ops_usage_test.go
+++ b/cmd/nano-brain/ops_usage_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// dispatchedCommands must be kept in sync with the case labels in main()'s
+// command-dispatch switch (main.go). This regression test exists because
+// printUsage() previously drifted out of sync with that switch (8 live
+// commands were undocumented) — see issue #527.
+var dispatchedCommands = []string{
+	"serve", "stop", "restart", "collection", "init", "write", "query",
+	"search", "vsearch", "workspaces", "harvest", "reindex", "bench",
+	"db:migrate", "logs", "docker", "status", "config", "doctor", "context",
+	"code-impact", "detect-changes", "reset-embeddings", "backfill-summaries",
+	"cleanup-stale-raw", "cleanup-orphan-workspaces", "wake-up", "get",
+	"tags", "multi-get", "auth", "mcp-url", "version", "help",
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func TestPrintUsage_ListsAllDispatchedCommands(t *testing.T) {
+	out := captureStdout(t, printUsage)
+
+	for _, cmd := range dispatchedCommands {
+		if !strings.Contains(out, cmd) {
+			t.Errorf("printUsage() output missing dispatched command %q — main.go's dispatch switch and printUsage() have drifted out of sync", cmd)
+		}
+	}
+}
+
+func TestPrintUsage_MentionsHelpCommand(t *testing.T) {
+	out := captureStdout(t, printUsage)
+	if !strings.Contains(out, "nano-brain help") && !strings.Contains(out, "help") {
+		t.Error("printUsage() should mention the help command")
+	}
+}


### PR DESCRIPTION
## Summary
- `flag.Usage = printUsage`: stdlib's `flag` package intercepts `-h`/`--help` (and flag-parse errors) before `main()`'s command dispatch ever runs. Previously this showed only the 6 global flags with no command list at all — now `-h`, `--help`, and parse-error paths all print the full usage.
- Bare `nano-brain` (no args) still starts a server in the foreground for backward compat, but now prints `No command given — starting server in foreground. Run 'nano-brain help' to see available commands.` first, since this is an easy accidental trigger for anyone just exploring the CLI (confirmed firsthand: it connects to the configured DB immediately with zero warning).
- `printUsage()`'s command list had drifted 8 commands stale — `context`, `code-impact`, `detect-changes`, `reset-embeddings`, `backfill-summaries`, `cleanup-stale-raw`, `cleanup-orphan-workspaces`, `auth` were all live in `main()`'s dispatch switch but undocumented. Added them, plus a regression test (`TestPrintUsage_ListsAllDispatchedCommands`) that fails if the two ever drift apart again.

Lane: Tiny (per docs/FEATURE_INTAKE.md — narrow, bounded-blast-radius CLI copy/wiring change, no auth/data-model/security/public-API-contract impact).

Closes #527

## Test plan
- [x] `go build ./...` — green
- [x] `go test -race -short ./...` — full suite green
- [x] Manual verification of the real binary:
  - `nano-brain --help` and `nano-brain -h` now print the full command list (previously only 6 global flags)
  - `nano-brain --bogus-flag` (flag-parse-error path) also now prints the full usage
  - Bare `nano-brain` (safely pointed at the test DB config) prints the help hint before attempting to start the server
- [x] New regression test `TestPrintUsage_ListsAllDispatchedCommands` asserts every case label in `main()`'s dispatch switch appears in `printUsage()`'s output