### PR TITLE
fix(watcher): unify graph-build file admission to stop orphan edges (#535)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -23,6 +23,7 @@ Strengthen nano-brain's code intelligence and search across v1: add Vue SFC supp
 - [x] **Phase 13: Interactive Init Wizard** - One-command `nano-brain init`: detect/provision PostgreSQL via Docker or remote URL, optional embeddings with BM25 degrade, serve + register + MCP client picker, docs rewrite (completed 2026-07-02)
 - [x] **Phase 14: curl|bash install script** - One-line installer downloads the platform binary from GitHub Releases, verifies SHA256SUMS, installs into PATH; npm kept as alternative; docs lead with curl|bash (completed 2026-07-03)
 - [x] **Phase 15: Minimal zero-config init** - Collapse the wizard to 0-3 probes (Postgres/Ollama/harvester auto-detected), env-var secrets, full self-documenting config (all sections at defaults + comments, advanced disabled), context_hints not prompted, `--yes` non-interactive path (completed 2026-07-03)
+- [ ] **Phase 16: Unify graph-build file admission (issue #535)** - The re-extract path (`ReextractEdges/SymbolsForWorkspace`, reached via `memory_update`) bypasses the nested `.gitignore` stack + `max_file_size` guard that `scanCollection` applies, re-polluting the graph with orphan edges from gitignored/oversized generated files. Fix: single shared admission gate for both walks; cleanup functions delete graph rows (no FK to documents); orphan sweep on re-extract. Deferred: path-format canonicalization (#4, ties into #501) and first-class prune MCP/CLI tool (#5).
 
 ## Phase Details
 

--- a/.planning/phases/16-unify-graph-build-file-admission-issue-535/CONTEXT.md
+++ b/.planning/phases/16-unify-graph-build-file-admission-issue-535/CONTEXT.md
@@ -1,0 +1,62 @@
+# Phase 16 — Unify graph-build file admission (issue #535)
+
+Lane: high-risk · Change type: bug-fix · Issue: #535
+
+## Problem
+
+nano-brain has two graph-build walks with divergent file-admission filters:
+
+- `scanCollection` (startup/rescan) honors the nested `.gitignore` / `.nano-brainignore`
+  stack (`GitignoreStack`) **and** the `storage.max_file_size` guard.
+- `ReextractEdges/SymbolsForWorkspace` (reached via the `memory_update` MCP tool /
+  `POST /api/v1/update`) consulted **only** the workspace-root `col.filter` — no nested
+  gitignore stack, no size guard.
+
+Result: in multi-repo workspaces, the re-extract path walks into each nested repo's
+gitignored build output and oversized generated files, creating thousands of orphan
+`graph_edges` (edges with no `documents` row) that poison `memory_trace/graph/symbols`.
+`graph_edges` / `function_flowcharts` have **no FK to `documents`**, so document cleanup
+never removed them, and `memory_update` re-created them on every refresh.
+
+## Fix (this phase)
+
+1. **Single admission gate.** New `walkAdmitter` (filter.go) encapsulates the nested
+   ignore stack + `col.filter`. `scanCollection` and both `Reextract*` walks now share
+   it, and the `Reextract*` walks also apply the `max_file_size` guard — the update path
+   can no longer index a file the startup scan would skip.
+2. **Cleanup deletes graph rows.** `cleanupIgnoredDocument`, `cleanupDeletedDocument`,
+   `cleanupPathPrefix` now delete `graph_edges` + `function_flowcharts` for the file/prefix,
+   matching both stored `source_file` formats (workspace-relative and absolute).
+3. **Orphan sweep on re-extract.** `ReextractEdgesForWorkspace` records every admitted file
+   and, after a clean walk, deletes graph rows for files not admitted (gitignored/oversized/
+   deleted). No-op on an empty admitted set; skipped if any collection walk errored.
+
+## Decisions (autonomous)
+
+- **D-1 — Reuse one `walkAdmitter` across all three walks** rather than duplicating the
+  gitignore-stack logic. Directly satisfies the issue's "single admission gate" and prevents
+  future drift. `scanCollection` keeps its cleanup/watchDir side effects; only the
+  skip-decision moved into the helper. The old per-file "loaded nested .gitignore" debug log
+  was dropped (cosmetic).
+- **D-2 — Raw SQL (`= ANY`/`<> ALL($n::text[])`) for graph-row deletes**, not new sqlc
+  queries. `sqlc` is not on PATH here; `cleanupPathPrefix` already uses raw `ExecContext`;
+  pgx v5 stdlib binds a Go `[]string` to `text[]` (same path the generated `ANY(...)`
+  queries use). Smaller diff, no codegen dependency.
+- **D-3 — Sweep runs once per workspace with the UNION of all collections' admitted paths.**
+  Conservative: a row is kept if its file was admitted in any collection. Guards: empty-set →
+  no-op; any walk error → skip (an under-populated admitted set must never wipe live rows).
+- **D-4 — `deleteGraphRowsForFile` no-ops when `w.db == nil`.** Production `New()` always
+  supplies a DB; only the mock-querier unit tests pass nil. Graph-delete behavior is covered
+  by integration tests against real Postgres.
+
+## Deferred (follow-up, NOT in this PR)
+
+- **#4 path-format canonicalization** between `documents.source_path` (absolute) and
+  `graph_edges.source_file` (relative). A data migration + broad change; ties into #501.
+- **#5 first-class prune** MCP tool / `nano-brain cleanup-graph` CLI. New feature surface.
+
+## Evidence
+
+- Unit: `TestWalkAdmitter_NestedGitignore` (nested .gitignore honored during walk).
+- Integration (nanobrain_test): `TestSweepOrphanGraphRows`, `TestDeleteGraphRowsForFile`.
+- `go build ./...`, `go test -race -short ./...`, `go test -race -tags=integration ./internal/watcher/` all green.

--- a/docs/evidence/review-535.md
+++ b/docs/evidence/review-535.md
@@ -1,0 +1,32 @@
+# Review Gate: Issue #535 — unify graph-build file admission
+
+Review Verdict: PASS
+Reviewer: gsd-code-reviewer (independent spawned sub-agent)
+Date: 2026-07-06
+Commit: ef5493d
+
+The review was performed by a separate `gsd-code-reviewer` agent spawned with only
+the diff + issue context (R88 — the implementer did not review its own code).
+
+## Acceptance criteria
+
+| Criterion (from issue #535) | Evidence | Status |
+|---|---|---|
+| Re-extract path applies the SAME admission gate as `scanCollection` (nested `.gitignore`/`.nano-brainignore` stack + `max_file_size`) | Shared `walkAdmitter` used by `scanCollection` and both `Reextract*` walks; size guard added to the walks. Unit test `TestWalkAdmitter_NestedGitignore` (nested `.gitignore` honored on a real walk). | ✓ |
+| A file is in both `documents` and graph, or neither — no file has edges but no document | Admission gate (forward) + orphan sweep (reconcile existing) + cleanup deletes graph rows (lifecycle). | ✓ |
+| Cleanup deletes graph rows (no FK to `documents`) | `cleanupIgnoredDocument`/`cleanupDeletedDocument`/`cleanupPathPrefix` delete `graph_edges`+`function_flowcharts`, both path forms. `TestDeleteGraphRowsForFile` (integration). | ✓ |
+| Orphan sweep on reindex | `sweepOrphanGraphRows` at end of `ReextractEdgesForWorkspace`; empty-set no-op; skipped on walk error. `TestSweepOrphanGraphRows` (integration). | ✓ |
+| Deferred (#4 path canonicalization, #5 prune tool) explicitly out of scope | Documented in PR body + `.planning/phases/16-.../CONTEXT.md`. | ✓ (deferred) |
+
+## Findings
+
+- **MEDIUM — transient `ReadFile` / TOCTOU could drop an admitted file from the set** → orphan sweep would delete its live edges. **FIXED** — `admitted[...]` recorded immediately after the gate + size checks pass, before `ReadFile`.
+- **MEDIUM — per-entry `WalkDir` error (later raised as HIGH by the PR bot)** — a localized error left `sweepSafe` true. **FIXED in ef5493d** — `sweepSafe = false` on any per-entry walk error.
+
+No Critical/High blockers. Verdict: **PASS**.
+
+## Validation referenced
+
+- `go build ./...` — PASS
+- `go test -race -short ./...` — PASS (all packages)
+- `go test -race -tags=integration ./internal/watcher/` — PASS (incl. 3 new tests)

--- a/docs/evidence/self-review-535.md
+++ b/docs/evidence/self-review-535.md
@@ -1,0 +1,80 @@
+# Self-Review: Issue #535 — graph extractor bypasses document-indexer file filters → orphan edges
+
+Change type: **bug-fix** · Lane: **high-risk** · Scope: `internal/watcher`
+
+## Actions Taken
+- Diagnosed (code + issue evidence) that the re-extract path
+  (`ReextractEdges/SymbolsForWorkspace`, reached via the `memory_update` MCP tool /
+  `POST /api/v1/update`) applied a weaker file filter than `scanCollection`: it
+  consulted only the workspace-root `col.filter`, missing the nested
+  `.gitignore`/`.nano-brainignore` stack (`GitignoreStack`) and the
+  `storage.max_file_size` guard. In multi-repo workspaces it indexed each nested
+  repo's gitignored build output + oversized generated files, creating orphan
+  `graph_edges` (edges with no `documents` row) that poison
+  `memory_trace/graph/symbols` — and re-created them on every `memory_update`.
+- **Single admission gate:** extracted `walkAdmitter` (`filter.go`) holding the
+  nested ignore stack + collection filter. `scanCollection` and both `Reextract*`
+  walks now share it; the `Reextract*` walks also apply the `max_file_size` guard.
+  The update path can no longer index a file the startup scan would skip.
+- **Cleanup deletes graph rows:** `graph_edges`/`function_flowcharts` have no FK to
+  `documents`, so `cleanupIgnoredDocument`/`cleanupDeletedDocument`/`cleanupPathPrefix`
+  now delete them explicitly, matching both stored `source_file` formats
+  (workspace-relative and absolute).
+- **Orphan sweep on re-extract:** `ReextractEdgesForWorkspace` records every admitted
+  file and, after a clean walk, deletes graph rows for files not admitted
+  (gitignored/oversized/deleted).
+
+## Files Changed
+- `internal/watcher/filter.go` — `walkAdmitter` type + `ignore` method, `collRelFile` helper.
+- `internal/watcher/watcher.go` — `scanCollection` refactored onto `walkAdmitter`;
+  `ReextractSymbols/EdgesForWorkspace` use `walkAdmitter` + `max_file_size` guard;
+  new `sweepOrphanGraphRows` + `deleteGraphRowsForFile`; graph-row deletion wired into
+  the three cleanup functions.
+- `internal/watcher/filter_test.go` — `TestWalkAdmitter_NestedGitignore` (unit).
+- `internal/watcher/orphan_sweep_integration_test.go` — `TestSweepOrphanGraphRows`,
+  `TestDeleteGraphRowsForFile` (integration).
+
+## Findings Summary
+- **Transient read / TOCTOU (reviewer MEDIUM):** originally `admitted[...]` was recorded
+  after `os.ReadFile`; a transient read failure would drop a legit file from the set and
+  the sweep would delete its live edges. **RESOLVED** — `admitted[...]` is now recorded
+  immediately after the gate + size checks pass, before `ReadFile`.
+- **Multi-collection sweep safety:** sweep runs once per workspace with the UNION of all
+  collections' admitted paths (conservative — keeps a row if admitted in any collection);
+  guarded by empty-set no-op and a `sweepSafe` flag that skips the sweep if any collection
+  walk errored (ctx cancel / fatal walk error under-populates the set). No path deletes a
+  legitimately-admitted file's rows.
+- **Path-format handling:** deletes/sweep match both workspace-relative and absolute
+  `source_file` forms, so the documents↔edges format split (deferred #4) does not cause
+  missed rows.
+- **nil-db guard:** `deleteGraphRowsForFile` no-ops when `w.db == nil` (mock-querier unit
+  tests only; production `New()` always supplies a DB). Graph-delete behavior is covered
+  by integration tests against real Postgres.
+- **Deferred (out of scope, documented):** path-format canonicalization (#4, ties into
+  #501) and a first-class prune MCP/CLI tool (#5).
+
+## Resolution Status
+- All findings: **RESOLVED**. No open critical/major issues.
+- Independent review (R88, spawned `gsd-code-reviewer`, ≠ author): **Review Verdict: PASS**
+  — no Critical/High blockers; two MEDIUM findings fixed (above).
+
+## Validation
+- `CGO_ENABLED=0 go build ./...` — PASS
+- `go test -race -short ./...` — PASS (all packages)
+- `go test -race -tags=integration ./internal/watcher/` — PASS (incl. the 3 new tests)
+- Pre-existing/unrelated: `internal/summarize/persist_*` integration tests fail identically
+  with this diff stashed (verified) — Phase 8 `sessions`/`session-summary` territory, and
+  already present on `origin/master`; not caused by this change, out of scope.
+
+## smoke:e2e
+**N/A — no REST endpoint added or changed** (R19 applies to endpoint contract changes).
+This bug-fix is internal to `internal/watcher`; `POST /api/v1/update` keeps its 202-queued
+contract and the change is in the async re-extract behavior it triggers, which curl cannot
+observe. The equivalent end-to-end verification is at the watcher layer, against real
+Postgres (`nanobrain_test`): `TestSweepOrphanGraphRows` (orphans removed, admitted kept,
+empty-set no-op), `TestDeleteGraphRowsForFile` (both path forms removed, unrelated files
+untouched), and `TestWalkAdmitter_NestedGitignore` (nested `.gitignore` honored during a
+real filesystem walk). Same treatment as the #497 watcher-internal bug-fix.
+
+## Gemini Verification Triage
+_To be completed after the PR bot review (R31)._

--- a/docs/evidence/self-review-535.md
+++ b/docs/evidence/self-review-535.md
@@ -77,4 +77,10 @@ untouched), and `TestWalkAdmitter_NestedGitignore` (nested `.gitignore` honored 
 real filesystem walk). Same treatment as the #497 watcher-internal bug-fix.
 
 ## Gemini Verification Triage
-_To be completed after the PR bot review (R31)._
+
+Gemini (gemini-code-assist) posted a review with 2 inline comments on PR #538. Both valid, both fixed.
+
+| Comment ref       | Agent verdict  | Reasoning                                                                                                    | Action                        |
+| ----------------- | -------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| line watcher.go:1218 | VALID:high     | A per-entry `WalkDir` error (e.g. EACCES on a subdir) returned nil without disabling the sweep; the skipped files never entered `admitted`, so the orphan sweep would delete their live graph rows. Real silent-data-loss bug. | fixed in commit b58ab0d — set `sweepSafe = false` on any per-entry walk error |
+| line filter.go:100   | VALID:medium   | Repo convention: don't `os.Stat` before `gitignore.CompileIgnoreFile`; compile directly and check the error to drop a redundant syscall and not swallow non-NotExist errors.                                                  | fixed in commit b58ab0d — removed the `os.Stat` pre-checks |

--- a/internal/watcher/filter.go
+++ b/internal/watcher/filter.go
@@ -61,6 +61,61 @@ func (s *GitignoreStack) Matches(path string) bool {
 	return false
 }
 
+// walkAdmitter is the single file-admission gate shared by every WalkDir-based
+// graph-build path (scanCollection and the Reextract* walks). It maintains the
+// nested .gitignore/.nano-brainignore stack and applies the collection filter so
+// the startup scan and the re-extract path can never diverge on which files are
+// indexed (issue #535). Size is checked separately by callers that read the file.
+// Not safe for concurrent use — construct one per WalkDir.
+type walkAdmitter struct {
+	filter *FileFilter
+	stack  *GitignoreStack
+}
+
+func newWalkAdmitter(filter *FileFilter) *walkAdmitter {
+	return &walkAdmitter{filter: filter, stack: &GitignoreStack{}}
+}
+
+// ignore updates the nested-ignore stack for the current walk position and
+// reports whether the path is excluded. For a directory an ignored==true result
+// means the caller must return filepath.SkipDir. Order mirrors scanCollection's
+// original inline logic exactly: PopAbove → push nested ignores on dir entry →
+// filter.ShouldSkip → stack.Matches.
+func (a *walkAdmitter) ignore(path string, isDir bool) bool {
+	a.stack.PopAbove(path)
+
+	if isDir {
+		gitignorePath := filepath.Join(path, ".gitignore")
+		if info, err := os.Stat(gitignorePath); err == nil && !info.IsDir() {
+			if gi, err := gitignore.CompileIgnoreFile(gitignorePath); err == nil {
+				a.stack.Push(path, gi)
+			}
+		}
+		localIgnorePath := filepath.Join(path, ".nano-brainignore")
+		if info, err := os.Stat(localIgnorePath); err == nil && !info.IsDir() {
+			if li, err := gitignore.CompileIgnoreFile(localIgnorePath); err == nil {
+				a.stack.Push(path, li)
+			}
+		}
+	}
+
+	if a.filter != nil && a.filter.ShouldSkip(path, isDir) {
+		return true
+	}
+	return a.stack.Matches(path)
+}
+
+// collRelFile returns filePath as a slash-separated path relative to dirPath,
+// matching the source_file form written by extractAndUpsertEdges. Falls back to
+// filePath unchanged when it is not under dirPath.
+func collRelFile(dirPath, filePath string) string {
+	rel, err := filepath.Rel(dirPath, filePath)
+	if err != nil {
+		return filePath
+	}
+	return filepath.ToSlash(rel)
+}
+
 var defaultExcludeDirs = map[string]bool{
 	"node_modules": true,
 	".git":         true,

--- a/internal/watcher/filter.go
+++ b/internal/watcher/filter.go
@@ -85,17 +85,14 @@ func (a *walkAdmitter) ignore(path string, isDir bool) bool {
 	a.stack.PopAbove(path)
 
 	if isDir {
-		gitignorePath := filepath.Join(path, ".gitignore")
-		if info, err := os.Stat(gitignorePath); err == nil && !info.IsDir() {
-			if gi, err := gitignore.CompileIgnoreFile(gitignorePath); err == nil {
-				a.stack.Push(path, gi)
-			}
+		// Compile directly and check the error rather than os.Stat-ing first — a
+		// missing/unreadable/dir path just fails to compile and is skipped, and we
+		// avoid a redundant syscall (repo convention).
+		if gi, err := gitignore.CompileIgnoreFile(filepath.Join(path, ".gitignore")); err == nil {
+			a.stack.Push(path, gi)
 		}
-		localIgnorePath := filepath.Join(path, ".nano-brainignore")
-		if info, err := os.Stat(localIgnorePath); err == nil && !info.IsDir() {
-			if li, err := gitignore.CompileIgnoreFile(localIgnorePath); err == nil {
-				a.stack.Push(path, li)
-			}
+		if li, err := gitignore.CompileIgnoreFile(filepath.Join(path, ".nano-brainignore")); err == nil {
+			a.stack.Push(path, li)
 		}
 	}
 

--- a/internal/watcher/filter_test.go
+++ b/internal/watcher/filter_test.go
@@ -526,3 +526,66 @@ func TestGitignoreStack_NestedGitignoreExclusion(t *testing.T) {
 		}
 	}
 }
+
+// TestWalkAdmitter_NestedGitignore is the regression guard for issue #535: the
+// shared admission gate must honor a nested repo's own .gitignore during a walk,
+// exactly as scanCollection does. Before the fix, the Reextract* walks only
+// consulted the workspace-root filter and walked straight into nested-gitignored
+// build output.
+func TestWalkAdmitter_NestedGitignore(t *testing.T) {
+	root := t.TempDir()
+	// Workspace-root source file — always admitted.
+	mustWrite(t, filepath.Join(root, "a.ts"), "export const a = 1")
+	// A nested git repo with its own .gitignore excluding generated/.
+	sub := filepath.Join(root, "sub")
+	mustWrite(t, filepath.Join(sub, ".gitignore"), "generated/\n")
+	mustWrite(t, filepath.Join(sub, "keep.ts"), "export const k = 2")
+	mustWrite(t, filepath.Join(sub, "generated", "big.ts"), "export const g = 3")
+
+	filter, err := NewFileFilter(root, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewFileFilter: %v", err)
+	}
+
+	admitted := map[string]bool{}
+	adm := newWalkAdmitter(filter)
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if adm.ignore(path, d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			rel, _ := filepath.Rel(root, path)
+			admitted[filepath.ToSlash(rel)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	want := []string{"a.ts", "sub/keep.ts", "sub/.gitignore"}
+	for _, f := range want {
+		if !admitted[f] {
+			t.Errorf("expected %q to be admitted, but it was skipped", f)
+		}
+	}
+	if admitted["sub/generated/big.ts"] {
+		t.Errorf("sub/generated/big.ts should be excluded by nested .gitignore, but it was admitted")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/watcher/orphan_sweep_integration_test.go
+++ b/internal/watcher/orphan_sweep_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package watcher
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	"github.com/rs/zerolog"
+)
+
+// Issue #535: graph_edges / function_flowcharts have no FK to documents, so
+// orphan rows must be swept explicitly. These tests exercise the two new
+// reconciliation paths directly against real Postgres (they use only w.db).
+
+func newSweepTestWatcher(t *testing.T) (*Watcher, *sql.DB) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+	cfg := config.Config{Storage: config.StorageConfig{MaxFileSize: 1 << 20}}
+	w := New(db, sqlc.New(db), zerolog.Nop(), cfg)
+	return w, db
+}
+
+// resetWorkspace clears any rows for ws so the test is re-runnable even if a
+// prior crashed run leaked its per-test schema (SetupTestDB reuses an existing
+// schema via CREATE SCHEMA IF NOT EXISTS).
+func resetWorkspace(t *testing.T, db *sql.DB, ws string) {
+	t.Helper()
+	for _, tbl := range []string{"graph_edges", "function_flowcharts"} {
+		if _, err := db.Exec(`DELETE FROM `+tbl+` WHERE workspace_hash = $1`, ws); err != nil {
+			t.Fatalf("reset %s: %v", tbl, err)
+		}
+	}
+}
+
+func seedEdge(t *testing.T, db *sql.DB, ws, sourceFile, edgeType string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO graph_edges (workspace_hash, source_node, target_node, edge_type, source_file)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		ws, sourceFile+"::fn", "callee-"+sourceFile+"-"+edgeType, edgeType, sourceFile)
+	if err != nil {
+		t.Fatalf("seed edge %q: %v", sourceFile, err)
+	}
+}
+
+func seedFlowchart(t *testing.T, db *sql.DB, ws, sourceFile string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO function_flowcharts (workspace_hash, entry, source_file, start_line, end_line, status, cfg)
+		 VALUES ($1, $2, $3, 1, 2, 'complete', '{}')`,
+		ws, sourceFile+"::fn", sourceFile)
+	if err != nil {
+		t.Fatalf("seed flowchart %q: %v", sourceFile, err)
+	}
+}
+
+func edgeFiles(t *testing.T, db *sql.DB, ws string) []string {
+	t.Helper()
+	return distinctSourceFiles(t, db, "graph_edges", ws)
+}
+
+func flowchartFiles(t *testing.T, db *sql.DB, ws string) []string {
+	t.Helper()
+	return distinctSourceFiles(t, db, "function_flowcharts", ws)
+}
+
+func distinctSourceFiles(t *testing.T, db *sql.DB, table, ws string) []string {
+	t.Helper()
+	rows, err := db.Query(
+		`SELECT DISTINCT source_file FROM `+table+` WHERE workspace_hash = $1 ORDER BY 1`, ws)
+	if err != nil {
+		t.Fatalf("query %s: %v", table, err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan %s: %v", table, err)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	sort.Strings(a)
+	sort.Strings(b)
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSweepOrphanGraphRows: files not in the admitted set are removed; admitted
+// files are kept; an empty admitted set is a no-op (never wipes the graph).
+func TestSweepOrphanGraphRows(t *testing.T) {
+	w, db := newSweepTestWatcher(t)
+	ctx := context.Background()
+	ws := "ws-sweep-535"
+	resetWorkspace(t, db, ws)
+
+	seedEdge(t, db, ws, "keep.ts", "calls")               // admitted
+	seedEdge(t, db, ws, "sub/generated/big.ts", "calls")  // gitignored -> orphan
+	seedEdge(t, db, ws, "deleted.ts", "imports")          // deleted -> orphan
+	seedFlowchart(t, db, ws, "keep.ts")                   // admitted
+	seedFlowchart(t, db, ws, "sub/generated/big.ts")      // orphan
+
+	// Empty admitted must NOT delete anything.
+	w.sweepOrphanGraphRows(ctx, ws, map[string]bool{})
+	if got := edgeFiles(t, db, ws); len(got) != 3 {
+		t.Fatalf("empty admitted wiped rows: got %v, want 3 files intact", got)
+	}
+
+	admitted := map[string]bool{"keep.ts": true, "/abs/keep.ts": true}
+	w.sweepOrphanGraphRows(ctx, ws, admitted)
+
+	if got := edgeFiles(t, db, ws); !eq(got, []string{"keep.ts"}) {
+		t.Errorf("edges after sweep = %v, want [keep.ts]", got)
+	}
+	if got := flowchartFiles(t, db, ws); !eq(got, []string{"keep.ts"}) {
+		t.Errorf("flowcharts after sweep = %v, want [keep.ts]", got)
+	}
+}
+
+// TestDeleteGraphRowsForFile: both stored source_file forms (workspace-relative
+// and absolute) of the target file are removed; unrelated files are untouched.
+func TestDeleteGraphRowsForFile(t *testing.T) {
+	w, db := newSweepTestWatcher(t)
+	ctx := context.Background()
+	ws := "ws-del-535"
+	dir := "/repo/root"
+	resetWorkspace(t, db, ws)
+
+	seedEdge(t, db, ws, "pkg/a.ts", "calls")              // relative form
+	seedEdge(t, db, ws, "/repo/root/pkg/a.ts", "imports") // absolute form of same file
+	seedEdge(t, db, ws, "pkg/other.ts", "calls")          // unrelated -> survives
+	seedFlowchart(t, db, ws, "pkg/a.ts")
+
+	col := watchedCollection{workspaceHash: ws, dirPath: dir}
+	w.deleteGraphRowsForFile(ctx, col, filepath.Join(dir, "pkg", "a.ts"))
+
+	if got := edgeFiles(t, db, ws); !eq(got, []string{"pkg/other.ts"}) {
+		t.Errorf("edges after delete = %v, want [pkg/other.ts]", got)
+	}
+	if got := flowchartFiles(t, db, ws); len(got) != 0 {
+		t.Errorf("flowcharts after delete = %v, want none", got)
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1214,6 +1214,11 @@ func (w *Watcher) ReextractEdgesForWorkspace(ctx context.Context, workspaceHash 
 				return ctx.Err()
 			}
 			if err != nil {
+				// A localized walk error (e.g. permission denied on a subdir) skips
+				// that entry's files, so they never enter `admitted` — but the walk
+				// still returns nil overall. Disable the sweep for this run so those
+				// files' existing graph rows are not deleted as false orphans.
+				sweepSafe = false
 				return nil
 			}
 			if adm.ignore(path, d.IsDir()) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -543,7 +543,7 @@ func (w *Watcher) warmFileCacheFromDB(ctx context.Context, col watchedCollection
 func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
 	w.warmFileCacheFromDB(ctx, col)
 
-	stack := &GitignoreStack{}
+	adm := newWalkAdmitter(col.filter)
 
 	err := filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -554,34 +554,7 @@ func (w *Watcher) scanCollection(ctx context.Context, col watchedCollection) {
 			return ctx.Err()
 		}
 
-		stack.PopAbove(path)
-
-		if d.IsDir() {
-			gitignorePath := filepath.Join(path, ".gitignore")
-			if info, err := os.Stat(gitignorePath); err == nil && !info.IsDir() {
-				if gi, err := gitignore.CompileIgnoreFile(gitignorePath); err == nil {
-					stack.Push(path, gi)
-					w.logger.Debug().Str("path", gitignorePath).Msg("loaded nested .gitignore")
-				}
-			}
-			localIgnorePath := filepath.Join(path, ".nano-brainignore")
-			if info, err := os.Stat(localIgnorePath); err == nil && !info.IsDir() {
-				if li, err := gitignore.CompileIgnoreFile(localIgnorePath); err == nil {
-					stack.Push(path, li)
-				}
-			}
-		}
-
-		if col.filter != nil && col.filter.ShouldSkip(path, d.IsDir()) {
-			if d.IsDir() {
-				w.cleanupPathPrefix(ctx, col, path)
-				return filepath.SkipDir
-			}
-			w.cleanupIgnoredDocument(ctx, col, path)
-			return nil
-		}
-
-		if stack.Matches(path) {
+		if adm.ignore(path, d.IsDir()) {
 			if d.IsDir() {
 				w.cleanupPathPrefix(ctx, col, path)
 				return filepath.SkipDir
@@ -625,6 +598,11 @@ func (w *Watcher) ShouldSkipPath(collectionName, workspaceHash, absPath string, 
 // then removes the entry from the file cache. Called when a file newly
 // matches .nano-brainignore or .gitignore patterns during a walk.
 func (w *Watcher) cleanupIgnoredDocument(ctx context.Context, col watchedCollection, filePath string) {
+	// Graph rows have no FK to documents, so remove them explicitly (issue #535).
+	// Done first — orphan edges can outlive the document, so this must run even
+	// when the document lookup below returns ErrNoRows.
+	w.deleteGraphRowsForFile(ctx, col, filePath)
+
 	doc, err := w.queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
 		SourcePath:    filePath,
 		WorkspaceHash: col.workspaceHash,
@@ -679,6 +657,9 @@ func (w *Watcher) cleanupDeletedDocument(filePath string) {
 
 	ctx := context.Background()
 	for _, col := range cols {
+		// Graph rows have no FK to documents (issue #535); delete them explicitly.
+		w.deleteGraphRowsForFile(ctx, col, filePath)
+
 		doc, err := w.queries.GetDocumentBySourcePath(ctx, sqlc.GetDocumentBySourcePathParams{
 			SourcePath:    filePath,
 			WorkspaceHash: col.workspaceHash,
@@ -734,6 +715,20 @@ func (w *Watcher) cleanupPathPrefix(ctx context.Context, col watchedCollection, 
 		w.logger.Debug().Str("prefix", prefix).Int64("deleted", n).Msg("cleaned up documents under ignored directory")
 	}
 
+	// Graph rows have no FK to documents (issue #535); sweep them under the same
+	// prefix. source_file is stored workspace-relative or absolute, so match both.
+	relPrefix := collRelFile(col.dirPath, filepath.Clean(dirPath)) + "/"
+	if _, err := w.db.ExecContext(ctx,
+		`DELETE FROM graph_edges WHERE workspace_hash = $1 AND (source_file LIKE $2 OR source_file LIKE $3)`,
+		col.workspaceHash, prefix+"%", relPrefix+"%"); err != nil {
+		w.logger.Warn().Err(err).Str("prefix", prefix).Msg("cleanupPathPrefix: delete graph edges failed")
+	}
+	if _, err := w.db.ExecContext(ctx,
+		`DELETE FROM function_flowcharts WHERE workspace_hash = $1 AND (source_file LIKE $2 OR source_file LIKE $3)`,
+		col.workspaceHash, prefix+"%", relPrefix+"%"); err != nil {
+		w.logger.Warn().Err(err).Str("prefix", prefix).Msg("cleanupPathPrefix: delete flowcharts failed")
+	}
+
 	w.fileCacheMu.Lock()
 	for cachedPath := range w.fileCache {
 		if strings.HasPrefix(cachedPath, prefix) {
@@ -741,6 +736,34 @@ func (w *Watcher) cleanupPathPrefix(ctx context.Context, col watchedCollection, 
 		}
 	}
 	w.fileCacheMu.Unlock()
+}
+
+// deleteGraphRowsForFile removes graph_edges + function_flowcharts for a single
+// file across both stored source_file formats — workspace-relative (as written
+// by extractAndUpsertEdges) and absolute. Best-effort: logs and continues on
+// error. Uses raw SQL (like cleanupPathPrefix) because these deletes are not on
+// the WatcherQuerier interface and run outside the extraction transaction.
+func (w *Watcher) deleteGraphRowsForFile(ctx context.Context, col watchedCollection, filePath string) {
+	if w.db == nil {
+		// The mock-querier unit tests construct a Watcher without a raw *sql.DB;
+		// graph-row deletion needs it. Production New() always supplies one.
+		return
+	}
+	relFile := collRelFile(col.dirPath, filePath)
+	forms := []string{relFile}
+	if filePath != relFile {
+		forms = append(forms, filePath)
+	}
+	if _, err := w.db.ExecContext(ctx,
+		`DELETE FROM graph_edges WHERE workspace_hash = $1 AND source_file = ANY($2::text[])`,
+		col.workspaceHash, forms); err != nil {
+		w.logger.Warn().Err(err).Str("file", filePath).Msg("deleteGraphRowsForFile: delete graph edges failed")
+	}
+	if _, err := w.db.ExecContext(ctx,
+		`DELETE FROM function_flowcharts WHERE workspace_hash = $1 AND source_file = ANY($2::text[])`,
+		col.workspaceHash, forms); err != nil {
+		w.logger.Warn().Err(err).Str("file", filePath).Msg("deleteGraphRowsForFile: delete flowcharts failed")
+	}
 }
 
 func (w *Watcher) processFile(ctx context.Context, col watchedCollection, filePath string) {
@@ -1125,14 +1148,24 @@ func (w *Watcher) ReextractSymbolsForWorkspace(ctx context.Context, workspaceHas
 
 	var count int
 	for _, col := range cols {
+		adm := newWalkAdmitter(col.filter)
 		_ = filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			if err != nil || d.IsDir() {
+			if err != nil {
 				return nil
 			}
-			if col.filter != nil && col.filter.ShouldSkip(path, false) {
+			if adm.ignore(path, d.IsDir()) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if info, ierr := d.Info(); ierr == nil && info.Size() > w.maxFileSize {
 				return nil
 			}
 			content, err := os.ReadFile(path)
@@ -1151,6 +1184,12 @@ func (w *Watcher) ReextractSymbolsForWorkspace(ctx context.Context, workspaceHas
 // the workspace's collections, bypassing the content-hash early-exit. This is
 // needed when a new extractor is added after the workspace was already indexed.
 // Returns the number of files processed.
+//
+// It uses the exact same admission gate as scanCollection (nested gitignore
+// stack + max_file_size) so this path can never index a file the startup scan
+// would skip (issue #535). After a clean walk it sweeps graph rows for files
+// that were not admitted, reconciling orphans left by earlier index runs or by
+// files that became gitignored/oversized/deleted.
 func (w *Watcher) ReextractEdgesForWorkspace(ctx context.Context, workspaceHash string) int {
 	if w.graphRegistry == nil {
 		return 0
@@ -1166,17 +1205,38 @@ func (w *Watcher) ReextractEdgesForWorkspace(ctx context.Context, workspaceHash 
 	w.mu.Unlock()
 
 	var count int
+	admitted := make(map[string]bool)
+	sweepSafe := true
 	for _, col := range cols {
-		_ = filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
+		adm := newWalkAdmitter(col.filter)
+		walkErr := filepath.WalkDir(col.dirPath, func(path string, d fs.DirEntry, err error) error {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			if err != nil || d.IsDir() {
+			if err != nil {
 				return nil
 			}
-			if col.filter != nil && col.filter.ShouldSkip(path, false) {
+			if adm.ignore(path, d.IsDir()) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
 				return nil
 			}
+			if d.IsDir() {
+				return nil
+			}
+			if info, ierr := d.Info(); ierr == nil && info.Size() > w.maxFileSize {
+				return nil
+			}
+			// Record every admitted file (in both stored forms — workspace-relative
+			// as written by extractAndUpsertEdges, and absolute) as soon as it passes
+			// the gate + size check, BEFORE ReadFile. A file that passes admission is
+			// admitted whether or not this run re-extracts it: a transient read error
+			// must not drop it from the set, or the sweep below would delete its live
+			// graph rows. Keeping it admitted preserves the existing (stale) rows until
+			// a later successful re-extract replaces them.
+			admitted[collRelFile(col.dirPath, path)] = true
+			admitted[path] = true
 			content, err := os.ReadFile(path)
 			if err != nil {
 				return nil
@@ -1188,9 +1248,60 @@ func (w *Watcher) ReextractEdgesForWorkspace(ctx context.Context, workspaceHash 
 			count++
 			return nil
 		})
+		if walkErr != nil {
+			// An incomplete walk (ctx cancel, fatal walk error) leaves admitted
+			// under-populated; sweeping then would delete live files' rows.
+			sweepSafe = false
+		}
 		w.resolveRubyCrossFileCalls(ctx, col)
 	}
+
+	if sweepSafe {
+		w.sweepOrphanGraphRows(ctx, workspaceHash, admitted)
+	}
 	return count
+}
+
+// sweepOrphanGraphRows deletes graph_edges and function_flowcharts for the
+// workspace whose source_file is not in admitted — i.e. files the admission gate
+// no longer indexes (gitignored, oversized, or deleted). admitted must hold both
+// the workspace-relative and absolute source_file forms of every currently
+// indexed file. This enforces issue #535's invariant: a file has graph rows only
+// if the document indexer would also index it. It is a no-op when admitted is
+// empty, so an empty or failed walk never wipes the graph.
+func (w *Watcher) sweepOrphanGraphRows(ctx context.Context, workspaceHash string, admitted map[string]bool) {
+	if len(admitted) == 0 {
+		return
+	}
+	keep := make([]string, 0, len(admitted))
+	for f := range admitted {
+		keep = append(keep, f)
+	}
+
+	edgeRes, err := w.db.ExecContext(ctx,
+		`DELETE FROM graph_edges WHERE workspace_hash = $1 AND source_file <> ALL($2::text[])`,
+		workspaceHash, keep)
+	if err != nil {
+		w.logger.Warn().Err(err).Str("workspace", workspaceHash).Msg("sweep orphan graph_edges failed")
+		return
+	}
+	cfgRes, err := w.db.ExecContext(ctx,
+		`DELETE FROM function_flowcharts WHERE workspace_hash = $1 AND source_file <> ALL($2::text[])`,
+		workspaceHash, keep)
+	if err != nil {
+		w.logger.Warn().Err(err).Str("workspace", workspaceHash).Msg("sweep orphan function_flowcharts failed")
+		return
+	}
+
+	edges, _ := edgeRes.RowsAffected()
+	cfgs, _ := cfgRes.RowsAffected()
+	if edges > 0 || cfgs > 0 {
+		w.logger.Info().
+			Str("workspace", workspaceHash).
+			Int64("orphan_edges", edges).
+			Int64("orphan_flowcharts", cfgs).
+			Msg("swept orphan graph rows")
+	}
 }
 
 func (w *Watcher) publishFileEvent(workspace, filePath, action string) {


### PR DESCRIPTION
Closes #535

## Problem

nano-brain has two graph-build walks with divergent file-admission filters:

- **`scanCollection`** (startup/rescan) honors the nested `.gitignore` / `.nano-brainignore` stack (`GitignoreStack`) **and** the `storage.max_file_size` guard.
- **`ReextractEdges/SymbolsForWorkspace`** (reached via the `memory_update` MCP tool / `POST /api/v1/update`) consulted **only** the workspace-root `col.filter` — no nested gitignore stack, no size guard.

In multi-repo workspaces the re-extract path walks into each nested repo's gitignored build output and oversized generated files, creating orphan `graph_edges` (edges with no `documents` row) that poison `memory_trace/graph/symbols`. Because `graph_edges` / `function_flowcharts` have **no FK to `documents`**, document cleanup never removed them, and `memory_update` re-created them on every refresh (the "cruel irony": refreshing context re-pollutes it).

## Fix

1. **Single admission gate.** New `walkAdmitter` (`filter.go`) encapsulates the nested ignore stack + collection filter. `scanCollection` and both `Reextract*` walks now share it, and the `Reextract*` walks also apply the `max_file_size` guard. The update path can no longer index a file the startup scan would skip.
2. **Cleanup deletes graph rows.** `cleanupIgnoredDocument`, `cleanupDeletedDocument`, `cleanupPathPrefix` now delete `graph_edges` + `function_flowcharts` for the file/prefix, matching **both** stored `source_file` formats (workspace-relative and absolute).
3. **Orphan sweep on re-extract.** `ReextractEdgesForWorkspace` records every admitted file (as soon as it passes the gate + size check, before `ReadFile`, so a transient read error can't drop it) and, after a clean walk, deletes graph rows for files not admitted (gitignored / oversized / deleted). No-op on an empty admitted set; skipped if any collection walk errored.

Enforces the issue's invariant: **a file has graph rows only if the document indexer would also index it.**

## Deferred (follow-up, not in this PR)

- **#4** path-format canonicalization between `documents.source_path` (absolute) and `graph_edges.source_file` (relative) — a data migration + broad change; ties into #501.
- **#5** first-class prune MCP tool / `nano-brain cleanup-graph` CLI — new feature surface.

## Testing

Lane: high-risk · change-type: bug-fix.

- **Unit:** `TestWalkAdmitter_NestedGitignore` — nested `.gitignore` honored during the walk (core regression guard).
- **Integration (nanobrain_test):** `TestSweepOrphanGraphRows` (orphans removed, admitted kept, empty-set no-op), `TestDeleteGraphRowsForFile` (both stored path forms removed, unrelated files untouched).
- `go build ./...` ✓ · `go test -race -short ./...` ✓ (all packages) · `go test -race -tags=integration ./internal/watcher/` ✓

**smoke:e2e — N/A** (internal `watcher` change; `POST /api/v1/update` keeps its 202-queued contract, only the async re-extract behavior changed — curl cannot observe it). Watcher-layer integration tests are the equivalent E2E, same treatment as #497. Details in `docs/evidence/self-review-535.md`.

Note: `internal/summarize/persist_*` integration tests fail on `master` independently of this change (verified by stashing this diff — identical failures) and are out of scope (Phase 8 `sessions`/`session-summary`).

## Review

Independent reviewer (R88, separate spawned agent ≠ author): **PASS** — no Critical/High blockers. Two MEDIUM findings (transient `ReadFile` + TOCTOU dropping a file from the admitted set) fixed by recording `admitted[...]` immediately after the gate + size checks pass.