### PR TITLE
docs(harness): document ultrathink fallback for deep-design gap analysis

### DIFF
--- a/docs/FEATURE_INTAKE.md
+++ b/docs/FEATURE_INTAKE.md
@@ -146,7 +146,10 @@ Steps:
    ```
    /deep-design
    ```
-   - If gaps found → revise artifacts → re-run deep-design.
+   - **Claude Code:** `/deep-design` (Metis/Oracle/Momus) isn't registered here —
+     run the ultrathink fallback instead (`docs/HARNESS.md` § Claude Code
+     fallback: ultrathink gap analysis).
+   - If gaps found → revise artifacts → re-run gap analysis.
    - Proceed only on clean pass.
       → `gh issue comment <N> --body "Deep-design synthesis: <gaps + resolutions>"`
 
@@ -208,6 +211,9 @@ Steps:
 2. **Deep-design gap analysis** — mandatory; do not skip.
    - All blocking gaps must be resolved before proceeding.
    - Record architecture decisions in `docs/decisions/`.
+   - **Claude Code:** no Metis/Oracle/Momus agents registered — use the
+     ultrathink fallback (`docs/HARNESS.md` § Claude Code fallback) and flag
+     the substitution to the human before requesting sign-off in step 3.
       → Issue: paste full Metis + Oracle synthesis as a comment.
 
 3. **Human confirmation** — present synthesis to human; get explicit go-ahead

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -219,6 +219,35 @@ deep-design finds gaps
 A gap is blocking if it touches: auth, data model, API contract, isolation
 boundary, or multi-domain scope. Stylistic gaps are non-blocking.
 
+### Claude Code fallback: ultrathink gap analysis
+
+`/gsd-deep-design` and the OpenCode `deep-design` skill (Metis + Oracle +
+Momus subagents) are **not registered on Claude Code** — no such skill or
+agent type exists in this runtime. Gate 1.7 still applies; it cannot be
+satisfied by skipping the step.
+
+When running under Claude Code, substitute a single-pass **ultrathink gap
+analysis** over `proposal.md` + `design.md`:
+
+1. Trigger extended reasoning (the `ultrathink` keyword, or equivalent
+   deliberate multi-angle reasoning).
+2. Reason from at least these two angles, one at a time:
+   - **Scope/risk** (Metis's role): hidden complexity, scope creep, missing
+     requirements, phasing.
+   - **Architecture/security** (Oracle's role): fit with existing code, MVA,
+     security/performance/data-integrity risks.
+3. Write the findings as a synthesis (gaps, ambiguities, open questions) —
+   same shape as the pipeline output above, minus the cross-critique round.
+4. Post it as Gate 1.7 evidence:
+   `gh issue comment <N> --body "Deep-design (ultrathink fallback): <gaps + resolutions>"`.
+5. **Disclose the substitution explicitly.** Do not present single-agent
+   output as if it were the full Metis+Oracle+Momus pipeline — confidence is
+   lower with no independent second opinion and no cross-critique.
+
+Satisfies Gate 1.7 for **normal** lane. For **high-risk** lane (mandatory,
+not skippable), flag the substitution to the human before requesting sign-off
+— they may prefer the real pipeline via OpenCode instead.
+
 ## Spec Lifecycle
 
 Ongoing work enters the harness as one of these input types:


### PR DESCRIPTION
## Summary
- /gsd-deep-design and the OpenCode deep-design skill (Metis+Oracle+Momus) are not registered as Claude Code skills/agent types, so Gate 1.7 had no achievable path on this runtime.
- Documents a single-pass "ultrathink" gap-analysis fallback (scope/risk + architecture/security angles) with mandatory confidence disclosure.
- Updates docs/FEATURE_INTAKE.md Normal + High-Risk lanes to point at the fallback.

## Test plan
- [x] `CGO_ENABLED=0 go build ./...` passes (docs-only change, no code touched)

Closes #548