### PR TITLE
fix(impact): requalify bare calls-edge targets in memory_impact + REST /graph/impact

### DIFF
--- a/docs/evidence/review-553.md
+++ b/docs/evidence/review-553.md
@@ -1,0 +1,54 @@
+## Review Verdict: PASS
+
+Reviewer: orchestrator (Opus) — independent of the implementer (a separate Sonnet
+executor authored the code; the orchestrator did not write it). The spawned
+`code-reviewer` sub-agent (R88) terminated on an account session limit; this cold
+review substitutes for it and the Gemini PR bot (gate 3.6) is the identity-bound
+external check. Substitution disclosed for honesty.
+Date: 2026-07-06
+Commit: 1516a24
+Issue: nano-step/nano-brain#553 (Phase 2, PR-A)
+
+Change: `memory_impact(direction:"in")` seeds the query frontier with the bare
+symbol suffix of qualified `file::symbol` entries so `GetImpactorsByTargets`
+matches bare-stored `calls`-edge targets. Query-time only; no schema/migration.
+
+| Acceptance Criterion | Evidence | Status |
+|---|---|---|
+| AC-A1: impact(file::B, in) returns direct caller A, count exact | `TestMemoryImpact_BareCallsTarget_DirectCallerReturned` PASS (seeds `TargetNode:"B"` bare; asserts count=1, node=`a.go::A`) | ✓ |
+| AC-A2: transitive callers resolve at depth (bare seed applied to every depth batch) | `TestMemoryImpact_BareCallsTarget_TransitiveCallersAtDepth` PASS (B@depth1, A@depth2); confirmed in code `frontier = impactFrontierWithBareSuffix(next)` inside the loop | ✓ |
+| AC-A3: single-repo exactness + no regression to out / qualified imports-in | `TestMemoryImpact_BareCallsTarget_NoRegressionOutAndQualifiedImports` PASS; `out` branch untouched (guarded by `if direction == "in"`); imports target has no `::` so helper is a no-op for it | ✓ |
+| G1: over-inclusion intentional, no ad-hoc per-repo scoping added | code comment on `impactFrontierWithBareSuffix` defers to root-cause C (#542 F2); no scoping logic present | ✓ |
+| Termination / no infinite loop | loop bounded by `depth <= maxDepth`; handler `seen` dedups result SourceNodes | ✓ |
+| Style: no `_ = err` constructors, surgical diff | pure helper + 2 seed lines; no unrelated changes | ✓ |
+| REST parity: `POST /api/v1/graph/impact` (`collectImpact`) had the SAME bug — fixed via shared `symbol.ExpandImpactFrontier` (no duplication) | `TestGraphImpact_BareCallsTarget_{DirectCallerReturned,TransitiveCallersAtDepth}` + `TestGraphImpact_NoRegression_QualifiedImportsTarget` PASS; HTTP smoke returns the caller | ✓ |
+| DRY: single implementation shared by MCP + REST | `internal/symbol/impact_frontier.go`; both call sites refactored to it | ✓ |
+
+### Validation evidence (run by orchestrator, not the implementer)
+
+- `CGO_ENABLED=0 go build ./...` → exit 0.
+- `go test -race -tags=integration ./internal/mcp/ -run Impact -v` → 4 PASS
+  (`TestMemoryImpact_RelativeInputAndOutput`, `..._DirectCallerReturned`,
+  `..._TransitiveCallersAtDepth`, `..._NoRegressionOutAndQualifiedImports`), `ok 2.378s`.
+- `go test -race -short ./...` (validate:quick) → 31 packages ok, 0 FAIL.
+- All against `nanobrain_test` (host.docker.internal:5432) — never dev DB / :3100.
+
+### smoke:e2e — PASS (real HTTP)
+
+Live server on :3199 / nanobrain_test, seeded a bare-target calls edge, hit the
+fixed REST endpoint:
+`POST /api/v1/graph/impact {"workspace":"smoke553","node":"b.go::B","edge_type":"calls","max_depth":1}`
+→ `HTTP/1.1 200` `{"node":"b.go::B","impacted":[{"node":"caller.go::doThing","depth":1,"edge_type":"calls"}]}`.
+Full transcript: `docs/evidence/smoke-e2e-impact.md`. The smoke gate is what
+surfaced the REST-handler gap (the initial fix was MCP-only) — now closed.
+
+Note: the earlier scope claim "no new HTTP surface" was wrong — `POST
+/api/v1/graph/impact` (`internal/server/handlers/impact.go`) is a second surface
+with the identical defect; it is now fixed via the shared helper and smoked above.
+
+### Deferred (tracked)
+
+- Multi-repo bare-name over-inclusion on impact-`in` → root-cause C, later phase.
+- Minor: a bare name may be re-queried across depth iterations (handler `seen`
+  tracks qualified SourceNodes only); results still deduped, bounded by maxDepth
+  — non-blocking inefficiency.

--- a/docs/evidence/self-review-impact-in-calls-requalify.md
+++ b/docs/evidence/self-review-impact-in-calls-requalify.md
@@ -45,9 +45,11 @@
 
 ## Gemini Verification Triage
 
-_Pending — PR not yet opened. Populate after the Gemini bot posts comments
-(one row per comment; verdict vocabulary per HARNESS.md § PR + Bot Review Loop)._
+PR #554. Gemini review state COMMENTED (non-blocking); 3 inline suggestions, all
+perf, no correctness/security. All applied.
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| PR#554 `internal/symbol/impact_frontier.go:22` | VALID:low | Prealloc `expanded`/`seen` at `2*len` + empty fast-path — genuine micro-opt, zero risk (helper doubles when nodes are qualified). | fixed in commit e146169 |
+| PR#554 `internal/server/handlers/impact.go:81` | VALID:medium | `queried` map to skip re-querying targets across depths — real (bounded) inefficiency; safe since results already deduped by `seen` and the query is deterministic. Matters for the tool's 50ms latency goal. | fixed in commit e146169 |
+| PR#554 `internal/mcp/tools.go:2071` | VALID:medium | Same `queried`-map dedup on the MCP path; kept consistent with the REST handler. | fixed in commit e146169 |

--- a/docs/evidence/self-review-impact-in-calls-requalify.md
+++ b/docs/evidence/self-review-impact-in-calls-requalify.md
@@ -1,0 +1,53 @@
+# Self-Review — Issue #553 (impact-in calls requalify, Phase 2 PR-A)
+
+## Actions Taken
+
+- Added `impactFrontierWithBareSuffix` in `internal/mcp/tools.go`: expands the
+  `memory_impact` `"in"` frontier with the bare symbol suffix of qualified
+  `file::symbol` entries (reusing `splitNodeSymbol`), so `GetImpactorsByTargets`
+  matches bare-stored `calls`-edge targets. Applied at the initial frontier and
+  every depth-loop batch (transitive callers).
+- No SQL/schema/migration change — the reverse query and `target` index already
+  existed; only the handler's frontier seeding was wrong.
+- Added `internal/mcp/impact_bare_calls_integration_test.go` (3 tests) seeding
+  bare `calls` edges against `nanobrain_test`.
+
+- REST parity: `POST /api/v1/graph/impact` (`collectImpact`) had the identical
+  bug. Extracted the frontier-expansion into a shared, self-contained
+  `internal/symbol/impact_frontier.go::ExpandImpactFrontier` (no import cycle;
+  leaf package), refactored the MCP tool to use it, and applied it to the REST
+  handler. One implementation, both surfaces. Surfaced by the smoke:e2e gate.
+
+## Files Changed
+
+- `internal/symbol/impact_frontier.go` (new): shared `ExpandImpactFrontier`.
+- `internal/mcp/tools.go`: use shared helper (local helper removed).
+- `internal/server/handlers/impact.go`: use shared helper at seed + each batch.
+- `internal/mcp/impact_bare_calls_integration_test.go` (new): MCP-tool tests.
+- `internal/server/handlers/impact_bare_calls_integration_test.go` (new): REST tests.
+
+## Findings Summary
+
+- Root cause was the impact handler never probing the bare name calls edges are
+  stored under (not "reverse edges missing" as #378 assumed).
+- G1 (Gate 1.7): bare match is intentionally workspace-wide; cross-repo
+  over-inclusion deferred to root-cause C (#542 F2). No per-repo scoping added.
+- Minor non-blocking: a bare name may be re-queried across depth iterations
+  (handler `seen` tracks qualified SourceNodes only); results still deduped,
+  loop bounded by `maxDepth`.
+
+## Resolution Status
+
+- All findings resolved or explicitly deferred (G1 → root-cause C). No unresolved
+  critical/major items.
+- validate:quick 31 pkgs ok; integration `-run Impact` 4 PASS; build exit 0. Full
+  independent review verdict PASS in `docs/evidence/review-553.md`.
+
+## Gemini Verification Triage
+
+_Pending — PR not yet opened. Populate after the Gemini bot posts comments
+(one row per comment; verdict vocabulary per HARNESS.md § PR + Bot Review Loop)._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-impact.md
+++ b/docs/evidence/smoke-e2e-impact.md
@@ -1,0 +1,59 @@
+# smoke:e2e — Issue #553 (impact-in calls requalify, Phase 2 PR-A)
+
+Real HTTP smoke of the fixed `POST /api/v1/graph/impact` endpoint against a live
+server on **:3199 / nanobrain_test** (never dev DB / :3100). The endpoint's
+`collectImpact` had the same bare-target bug as the MCP tool; this exercises the
+REST fix end-to-end.
+
+## Setup
+
+```
+# build + start test server (nanobrain_test, port 3199, embeddings off)
+CGO_ENABLED=0 go build -o ./bin/nano-brain ./cmd/nano-brain/
+NANO_BRAIN_DATABASE_URL=postgres://nanobrain:nanobrain@host.docker.internal:5432/nanobrain_test?sslmode=disable \
+NANO_BRAIN_SERVER_PORT=3199 NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1 NANO_BRAIN_EMBEDDING_PROVIDER="" \
+  ./bin/nano-brain --unsafe-no-auth &
+
+# seed one bare-target calls edge (as the extractors write it): caller.go::doThing --calls--> "B"
+psql "$NANO_BRAIN_DATABASE_URL" -c \
+  "INSERT INTO workspaces(hash,path,name,created_at,updated_at) VALUES('smoke553','/tmp/smoke553','smoke553',now(),now()) ON CONFLICT DO NOTHING;
+   INSERT INTO graph_edges(workspace_hash,source_node,target_node,edge_type,source_file,metadata)
+   VALUES('smoke553','caller.go::doThing','B','calls','caller.go','{}');"
+```
+
+## Request / response
+
+Health:
+
+```
+HTTP/1.1 200 OK
+{"status":"ok","ready":true,"version":"dev","uptime_s":23,"workspace_count":1673}
+```
+
+Impact (reverse / "in" is the endpoint's only mode — `GetImpactorsByTargets`):
+
+```
+curl -sS -i -X POST http://localhost:3199/api/v1/graph/impact \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace":"smoke553","node":"b.go::B","edge_type":"calls","max_depth":1}'
+```
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+
+{"node":"b.go::B","impacted":[{"node":"caller.go::doThing","depth":1,"edge_type":"calls"}]}
+```
+
+**Result:** the caller `caller.go::doThing` is returned for the bare-stored calls
+target `B` — before the fix `collectImpact` returned `impacted:[]` (the qualified
+`b.go::B` frontier never matched the bare row). Confirms the REST surface now
+resolves calls-edge callers, matching the MCP tool.
+
+## Note on execution
+
+`curl` is redirected by this environment's context-mode hook, so the request was
+issued via the sandbox's `fetch` with the identical method/path/JSON body shown
+above; the HTTP status and response body are verbatim. Server teardown killed
+only the captured PID (no broad-kill); the `smoke553` seed rows were deleted
+afterward.

--- a/internal/mcp/impact_bare_calls_integration_test.go
+++ b/internal/mcp/impact_bare_calls_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// --- Issue #553: memory_impact direction:"in" misses calls-edge callers ---
+//
+// calls-edge targets are stored bare (e.g. "checkAccess"), not "file::symbol".
+// Before the fix, registerMemoryImpact's "in" frontier only ever contained the
+// caller-supplied qualified node, so GetImpactorsByTargets's
+// target_node = ANY($2) never matched a bare-stored calls target and
+// memory_impact(direction:"in") returned count:0 for real callers.
+
+// AC-A1: a direct caller of a bare-target calls edge is returned.
+func TestMemoryImpact_BareCallsTarget_DirectCallerReturned(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "a.go::A",
+		TargetNode:    "B", // bare, as calls-edge extractors write it
+		EdgeType:      "calls",
+		SourceFile:    "a.go",
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert edge: %v", err)
+	}
+
+	result := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "b.go::B",
+		"direction": "in",
+	})
+	resp := unmarshalGraphResp(t, result)
+	impacted, _ := resp["impacted"].([]any)
+	if len(impacted) != 1 {
+		t.Fatalf("impacted count = %d, want 1 (caller A): %+v", len(impacted), impacted)
+	}
+	item := impacted[0].(map[string]any)
+	if item["node"].(string) != "a.go::A" {
+		t.Errorf("impacted[0].node = %q, want a.go::A", item["node"])
+	}
+	if got := int(resp["count"].(float64)); got != 1 {
+		t.Errorf("count = %d, want 1", got)
+	}
+}
+
+// AC-A2: transitive callers past depth 1 are also resolved — the bare-suffix
+// seeding must apply to every "next" frontier batch built during the depth
+// loop, not just the initial frontier.
+func TestMemoryImpact_BareCallsTarget_TransitiveCallersAtDepth(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	// A calls B, B calls C — both calls-edge targets stored bare.
+	edges := []struct{ source, target string }{
+		{"a.go::A", "B"},
+		{"b.go::B", "C"},
+	}
+	for _, e := range edges {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash,
+			SourceNode:    e.source,
+			TargetNode:    e.target,
+			EdgeType:      "calls",
+			SourceFile:    "",
+			Metadata:      []byte("{}"),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+
+	// depth=1 only resolves the direct caller of C (B).
+	depth1 := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "c.go::C",
+		"direction": "in",
+		"max_depth": float64(1),
+	})
+	depth1Resp := unmarshalGraphResp(t, depth1)
+	depth1Impacted, _ := depth1Resp["impacted"].([]any)
+	if len(depth1Impacted) != 1 {
+		t.Fatalf("depth=1 impacted count = %d, want 1 (B only): %+v", len(depth1Impacted), depth1Impacted)
+	}
+	if depth1Impacted[0].(map[string]any)["node"].(string) != "b.go::B" {
+		t.Errorf("depth=1 impacted[0].node = %q, want b.go::B", depth1Impacted[0].(map[string]any)["node"])
+	}
+
+	// depth=2 (and depth=3) must additionally resolve the transitive caller A.
+	for _, depth := range []float64{2, 3} {
+		result := callTool("memory_impact", map[string]any{
+			"workspace": wsHash,
+			"node":      "c.go::C",
+			"direction": "in",
+			"max_depth": depth,
+		})
+		resp := unmarshalGraphResp(t, result)
+		impacted, _ := resp["impacted"].([]any)
+		if len(impacted) != 2 {
+			t.Fatalf("max_depth=%v impacted count = %d, want 2 (B at depth1, A at depth2): %+v", depth, len(impacted), impacted)
+		}
+		seen := map[string]int{}
+		for _, im := range impacted {
+			m := im.(map[string]any)
+			seen[m["node"].(string)] = int(m["depth"].(float64))
+		}
+		if seen["b.go::B"] != 1 {
+			t.Errorf("max_depth=%v: b.go::B depth = %d, want 1", depth, seen["b.go::B"])
+		}
+		if seen["a.go::A"] != 2 {
+			t.Errorf("max_depth=%v: a.go::A depth = %d, want 2 (transitive caller must be found)", depth, seen["a.go::A"])
+		}
+	}
+}
+
+// AC-A3: no regression — direction:"out" is unaffected by the "in"-only
+// frontier expansion, and an already-qualified imports-edge target on the
+// "in" path keeps working exactly as before (single, non-bare match).
+func TestMemoryImpact_BareCallsTarget_NoRegressionOutAndQualifiedImports(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "a.go::A",
+		TargetNode:    "B", // bare calls target
+		EdgeType:      "calls",
+		SourceFile:    "a.go",
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert calls edge: %v", err)
+	}
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "consumer.ts",
+		TargetNode:    "lib.ts", // already-resolved import target, no "::" suffix
+		EdgeType:      "imports",
+		SourceFile:    "consumer.ts",
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert imports edge: %v", err)
+	}
+
+	// direction:"out" from A must return exactly the bare target "B" itself —
+	// unaffected by "in"-frontier bare-suffix expansion.
+	outResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "a.go::A",
+		"direction": "out",
+		"edge_type": "calls",
+	})
+	outResp := unmarshalGraphResp(t, outResult)
+	outImpacted, _ := outResp["impacted"].([]any)
+	if len(outImpacted) != 1 {
+		t.Fatalf("direction=out impacted count = %d, want 1: %+v", len(outImpacted), outImpacted)
+	}
+	if outImpacted[0].(map[string]any)["node"].(string) != "B" {
+		t.Errorf("direction=out impacted[0].node = %q, want B", outImpacted[0].(map[string]any)["node"])
+	}
+
+	// direction:"in" on an already-qualified (non-symbol) imports target
+	// keeps returning exactly its one real importer — no spurious matches.
+	inResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "lib.ts",
+		"direction": "in",
+		"edge_type": "imports",
+	})
+	inResp := unmarshalGraphResp(t, inResult)
+	inImpacted, _ := inResp["impacted"].([]any)
+	if len(inImpacted) != 1 {
+		t.Fatalf("direction=in imports impacted count = %d, want 1: %+v", len(inImpacted), inImpacted)
+	}
+	if inImpacted[0].(map[string]any)["node"].(string) != "consumer.ts" {
+		t.Errorf("direction=in imports impacted[0].node = %q, want consumer.ts", inImpacted[0].(map[string]any)["node"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nano-brain/nano-brain/internal/search"
 	"github.com/nano-brain/nano-brain/internal/storage"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/symbol"
 	pgvector_go "github.com/pgvector/pgvector-go"
 	"github.com/sqlc-dev/pqtype"
 )
@@ -2065,6 +2066,9 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 			pathStyle := argString(args, "paths")
 
 			frontier := []string{node}
+			if direction == "in" {
+				frontier = symbol.ExpandImpactFrontier(frontier)
+			}
 			seen := map[string]bool{node: true}
 
 			type impactItem struct {
@@ -2121,7 +2125,7 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 						})
 						next = append(next, r.SourceNode)
 					}
-					frontier = next
+					frontier = symbol.ExpandImpactFrontier(next)
 				}
 			}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2070,6 +2070,7 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 				frontier = symbol.ExpandImpactFrontier(frontier)
 			}
 			seen := map[string]bool{node: true}
+			queried := map[string]bool{}
 
 			type impactItem struct {
 				Node     string `json:"node"`
@@ -2104,9 +2105,21 @@ func registerMemoryImpact(server *mcpsdk.Server, a *Adapter) {
 					}
 					frontier = next
 				default:
+					targets := make([]string, 0, len(frontier))
+					for _, f := range frontier {
+						if queried[f] {
+							continue
+						}
+						queried[f] = true
+						targets = append(targets, f)
+					}
+					if len(targets) == 0 {
+						frontier = nil
+						break
+					}
 					rows, err := a.queries.GetImpactorsByTargets(ctx, sqlc.GetImpactorsByTargetsParams{
 						WorkspaceHash: ws,
-						Column2:       frontier,
+						Column2:       targets,
 						Column3:       edgeType,
 					})
 					if err != nil {

--- a/internal/server/handlers/impact.go
+++ b/internal/server/handlers/impact.go
@@ -79,10 +79,22 @@ func collectImpact(ctx context.Context, q ImpactQuerier, workspace, node, edgeTy
 	// G1: expand with the bare symbol suffix of qualified nodes so calls-edge targets
 	// stored bare (e.g. "checkAccess") are also matched. See symbol.ExpandImpactFrontier.
 	frontier := symbol.ExpandImpactFrontier([]string{node})
+	queried := map[string]bool{}
 	for depth := 1; depth <= maxDepth && len(frontier) > 0; depth++ {
+		targets := make([]string, 0, len(frontier))
+		for _, f := range frontier {
+			if queried[f] {
+				continue
+			}
+			queried[f] = true
+			targets = append(targets, f)
+		}
+		if len(targets) == 0 {
+			break
+		}
 		rows, err := q.GetImpactorsByTargets(ctx, sqlc.GetImpactorsByTargetsParams{
 			WorkspaceHash: workspace,
-			Column2:       frontier,
+			Column2:       targets,
 			Column3:       edgeType,
 		})
 		if err != nil {

--- a/internal/server/handlers/impact.go
+++ b/internal/server/handlers/impact.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/symbol"
 	"github.com/rs/zerolog"
 )
 
@@ -75,7 +76,9 @@ func collectImpact(ctx context.Context, q ImpactQuerier, workspace, node, edgeTy
 	seen := map[string]bool{node: true}
 	var result []impactNode
 
-	frontier := []string{node}
+	// G1: expand with the bare symbol suffix of qualified nodes so calls-edge targets
+	// stored bare (e.g. "checkAccess") are also matched. See symbol.ExpandImpactFrontier.
+	frontier := symbol.ExpandImpactFrontier([]string{node})
 	for depth := 1; depth <= maxDepth && len(frontier) > 0; depth++ {
 		rows, err := q.GetImpactorsByTargets(ctx, sqlc.GetImpactorsByTargetsParams{
 			WorkspaceHash: workspace,
@@ -98,7 +101,7 @@ func collectImpact(ctx context.Context, q ImpactQuerier, workspace, node, edgeTy
 			})
 			next = append(next, r.SourceNode)
 		}
-		frontier = next
+		frontier = symbol.ExpandImpactFrontier(next)
 	}
 	return result, nil
 }

--- a/internal/server/handlers/impact_bare_calls_integration_test.go
+++ b/internal/server/handlers/impact_bare_calls_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/nano-brain/nano-brain/internal/server/handlers"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// --- Issue #553 (REST gap): POST /api/v1/graph/impact misses calls-edge callers ---
+//
+// collectImpact (internal/server/handlers/impact.go) had the identical bug the
+// memory_impact MCP tool had: calls-edge targets are stored bare (e.g. "checkAccess"),
+// not "file::symbol", so a qualified-only frontier never matched a bare-stored calls
+// target via GetImpactorsByTargets's target_node = ANY($2) predicate. Fixed by routing
+// both surfaces through the shared symbol.ExpandImpactFrontier helper.
+
+func callGraphImpact(t *testing.T, q handlers.ImpactQuerier, wsHash, node, edgeType string, maxDepth int) map[string]interface{} {
+	t.Helper()
+	e := echo.New()
+	h := handlers.GraphImpact(q, nopLogger())
+
+	body, err := json.Marshal(map[string]interface{}{
+		"node":      node,
+		"edge_type": edgeType,
+		"max_depth": maxDepth,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/graph/impact", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", wsHash)
+
+	if err := h(c); err != nil {
+		t.Fatalf("GraphImpact handler: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode impact response: %v", err)
+	}
+	return resp
+}
+
+// AC-A1 + single-repo-exactness: a direct caller of a bare-target calls edge is
+// returned, and exactly once (no cross-repo/duplicate false positives within this
+// workspace-scoped fixture).
+func TestGraphImpact_BareCallsTarget_DirectCallerReturned(t *testing.T) {
+	q := newQueries(t)
+	ctx := context.Background()
+	wsHash := "ws_" + uuid.New().String()
+
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "caller.go::doThing",
+		TargetNode:    "B", // bare, as calls-edge extractors write it
+		EdgeType:      "calls",
+		SourceFile:    "caller.go",
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert edge: %v", err)
+	}
+
+	resp := callGraphImpact(t, q, wsHash, "b.go::B", "", 1)
+	impacted, _ := resp["impacted"].([]interface{})
+	if len(impacted) < 1 {
+		t.Fatalf("impacted count = %d, want >=1 (caller caller.go::doThing): %+v", len(impacted), impacted)
+	}
+
+	found := 0
+	for _, im := range impacted {
+		if im.(map[string]interface{})["node"].(string) == "caller.go::doThing" {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Errorf("caller.go::doThing found %d times in this workspace, want exactly 1 (single-repo exactness)", found)
+	}
+	if len(impacted) != 1 {
+		t.Errorf("impacted count = %d, want exactly 1 in this isolated workspace fixture: %+v", len(impacted), impacted)
+	}
+}
+
+// AC-A2: transitive callers past depth 1 are also resolved — the bare-suffix
+// seeding must apply to every "next" frontier batch built during the depth loop,
+// not just the initial seed.
+func TestGraphImpact_BareCallsTarget_TransitiveCallersAtDepth(t *testing.T) {
+	q := newQueries(t)
+	ctx := context.Background()
+	wsHash := "ws_" + uuid.New().String()
+
+	// A calls B, B calls C — both calls-edge targets stored bare.
+	edges := []struct{ source, target string }{
+		{"a.go::A", "B"},
+		{"b.go::B", "C"},
+	}
+	for _, e := range edges {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash,
+			SourceNode:    e.source,
+			TargetNode:    e.target,
+			EdgeType:      "calls",
+			SourceFile:    "",
+			Metadata:      []byte("{}"),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+
+	// depth=1 only resolves the direct caller of C (B).
+	depth1Resp := callGraphImpact(t, q, wsHash, "c.go::C", "", 1)
+	depth1Impacted, _ := depth1Resp["impacted"].([]interface{})
+	if len(depth1Impacted) != 1 {
+		t.Fatalf("depth=1 impacted count = %d, want 1 (B only): %+v", len(depth1Impacted), depth1Impacted)
+	}
+	if depth1Impacted[0].(map[string]interface{})["node"].(string) != "b.go::B" {
+		t.Errorf("depth=1 impacted[0].node = %v, want b.go::B", depth1Impacted[0].(map[string]interface{})["node"])
+	}
+
+	// depth=2 (and depth=3) must additionally resolve the transitive caller A.
+	for _, depth := range []int{2, 3} {
+		resp := callGraphImpact(t, q, wsHash, "c.go::C", "", depth)
+		impacted, _ := resp["impacted"].([]interface{})
+		if len(impacted) != 2 {
+			t.Fatalf("max_depth=%d impacted count = %d, want 2 (B at depth1, A at depth2): %+v", depth, len(impacted), impacted)
+		}
+		seen := map[string]int{}
+		for _, im := range impacted {
+			m := im.(map[string]interface{})
+			seen[m["node"].(string)] = int(m["depth"].(float64))
+		}
+		if seen["b.go::B"] != 1 {
+			t.Errorf("max_depth=%d: b.go::B depth = %d, want 1", depth, seen["b.go::B"])
+		}
+		if seen["a.go::A"] != 2 {
+			t.Errorf("max_depth=%d: a.go::A depth = %d, want 2 (transitive caller must be found)", depth, seen["a.go::A"])
+		}
+	}
+}
+
+// AC-A3 no-regression: an already-qualified imports-edge target with no "::" suffix
+// keeps working exactly as before — ExpandImpactFrontier is a no-op on it, so no
+// duplicate or spurious matches are introduced by the bare-suffix expansion.
+func TestGraphImpact_NoRegression_QualifiedImportsTarget(t *testing.T) {
+	q := newQueries(t)
+	ctx := context.Background()
+	wsHash := "ws_" + uuid.New().String()
+
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "consumer.ts",
+		TargetNode:    "lib.ts", // already-resolved import target, no "::" suffix
+		EdgeType:      "imports",
+		SourceFile:    "consumer.ts",
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert imports edge: %v", err)
+	}
+
+	resp := callGraphImpact(t, q, wsHash, "lib.ts", "imports", 1)
+	impacted, _ := resp["impacted"].([]interface{})
+	if len(impacted) != 1 {
+		t.Fatalf("impacted count = %d, want exactly 1: %+v", len(impacted), impacted)
+	}
+	if impacted[0].(map[string]interface{})["node"].(string) != "consumer.ts" {
+		t.Errorf("impacted[0].node = %v, want consumer.ts", impacted[0].(map[string]interface{})["node"])
+	}
+}

--- a/internal/symbol/impact_frontier.go
+++ b/internal/symbol/impact_frontier.go
@@ -18,8 +18,11 @@ import "strings"
 // (bare-name collision, #542 F2) fixes this centrally for both call sites in a later
 // phase. Deliberately not scoped per-repo here (Phase 2 Gate 1.7 decision G1).
 func ExpandImpactFrontier(nodes []string) []string {
-	expanded := make([]string, 0, len(nodes))
-	seen := make(map[string]bool, len(nodes))
+	if len(nodes) == 0 {
+		return nil
+	}
+	expanded := make([]string, 0, 2*len(nodes))
+	seen := make(map[string]bool, 2*len(nodes))
 	for _, n := range nodes {
 		if !seen[n] {
 			seen[n] = true

--- a/internal/symbol/impact_frontier.go
+++ b/internal/symbol/impact_frontier.go
@@ -1,0 +1,40 @@
+package symbol
+
+import "strings"
+
+// ExpandImpactFrontier expands a memory_impact "in"/impactors frontier with the bare
+// symbol suffix of any qualified "file::symbol" entries, so GetImpactorsByTargets's
+// target_node = ANY($2) also matches bare-stored calls-edge targets. calls-edge targets
+// are stored as bare identifiers (e.g. "checkAccess"), not "file::symbol" (see
+// internal/graph/*_extractor.go extractCalls), so a qualified-only frontier never matches
+// a bare-stored calls target without this expansion. Dedups the result. Shared by
+// internal/mcp (memory_impact tool) and internal/server/handlers (POST
+// /api/v1/graph/impact) so both surfaces resolve calls-edge callers identically.
+//
+// NOTE: this intentionally matches the bare symbol name workspace-wide, not scoped to the
+// file of the qualified node — same-named symbols in other files/repos can produce
+// false-positive callers here. This mirrors the existing ambiguity in memory_trace's
+// ResolveSymbolByName round trip (both mark/allow ambiguous matches); root-cause C
+// (bare-name collision, #542 F2) fixes this centrally for both call sites in a later
+// phase. Deliberately not scoped per-repo here (Phase 2 Gate 1.7 decision G1).
+func ExpandImpactFrontier(nodes []string) []string {
+	expanded := make([]string, 0, len(nodes))
+	seen := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		if !seen[n] {
+			seen[n] = true
+			expanded = append(expanded, n)
+		}
+		idx := strings.Index(n, "::")
+		if idx < 0 {
+			continue
+		}
+		bare := n[idx+2:]
+		if bare == "" || seen[bare] {
+			continue
+		}
+		seen[bare] = true
+		expanded = append(expanded, bare)
+	}
+	return expanded
+}


### PR DESCRIPTION
Closes #553

## Problem
`memory_impact(direction:"in")` and `POST /api/v1/graph/impact` returned empty for a `file::symbol` node whose callers exist. `calls`-edge targets are stored as **bare identifiers** (e.g. `checkAccess`, see `*_extractor.go` `extractCalls`), but both impact code paths only carried the caller-supplied **qualified** node — so `GetImpactorsByTargets`'s `target_node = ANY($2)` never matched a bare-stored target. The reverse SQL query + `idx_graph_edges_target` index were already correct; the defect was the handlers never probing the bare name. (Corrects #378's "reverse edges not stored" assumption.)

## Fix
New shared, self-contained helper `internal/symbol/impact_frontier.go::ExpandImpactFrontier` seeds the impact frontier with each qualified entry's **bare symbol suffix** — at the initial frontier **and every depth batch** (transitive callers). Applied to **both** surfaces that had the identical bug:
- `internal/mcp/tools.go` — `memory_impact` MCP tool (`"in"` direction)
- `internal/server/handlers/impact.go` — `collectImpact` behind `POST /api/v1/graph/impact`

One implementation, no duplication, no import cycle. **Query-time only: no schema change, no migration, no reindex.**

## Scope note (Gate 1.7 decision G1)
The bare match is intentionally workspace-wide (same-named symbols across files/repos can appear as callers) — mirrors the existing ambiguity in `memory_trace`; deferred to root-cause C (bare-name collision scoping, #542 F2) for a central fix across all surfaces. No ad-hoc per-repo scoping here.

## Tests (all against `nanobrain_test`, never dev DB / :3100)
- `internal/mcp/impact_bare_calls_integration_test.go` — 3 tests (direct caller; transitive B@1/A@2; single-repo exactness + no `out`/qualified-`imports` regression).
- `internal/server/handlers/impact_bare_calls_integration_test.go` — 3 REST tests (direct; transitive; no-regression).
- `go test -race -tags=integration ./internal/mcp/ ./internal/server/handlers/ -run Impact` → 7 PASS
- `go test -race -short ./...` (validate:quick) → 31 packages ok, 0 FAIL; `go build ./...` exit 0
- **smoke:e2e** — live server on :3199/nanobrain_test, `POST /api/v1/graph/impact {node:"b.go::B",edge_type:"calls"}` → `HTTP 200` `{"impacted":[{"node":"caller.go::doThing","depth":1,"edge_type":"calls"}]}`.

Independent review verdict PASS + smoke transcript: `docs/evidence/`. Part of Phase 2 (`.planning/phases/02-import-edge-fix/`); PR-B (JS/TS import specifier resolution, #501) follows.