### PR TITLE
fix(graph): resolve JS/TS/Vue import specifiers to workspace paths (reverse-impact)

### DIFF
--- a/docs/evidence/review-501.md
+++ b/docs/evidence/review-501.md
@@ -1,0 +1,32 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent gate, spawned; ≠ author — the implementer was a separate Sonnet executor).
+Date: 2026-07-07
+Commit: 82b55b3 (branch `fix/js-ts-import-resolution`, PR-B / #501)
+
+Change: JS/TS/Vue `imports` edges now store the **resolved** workspace-relative
+path (via new `internal/graph/import_resolver.go`, threaded through `registry.go`
++ `watcher.go`) instead of the raw specifier, so reverse-impact
+(`memory_impact direction:in`, edge_type=imports) finds importers. Extraction-time
+only; no schema change; backfill = post-merge ops step.
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | **G2 — resolved path byte-identical to stored `source_node` format** | PASS. Watcher writes nodes as `filepath.ToSlash(filepath.Rel(col.dirPath, filePath))`; resolver produces candidates in the same format via `path.Join`/`path.Clean`. Proven E2E by `TestMemoryImpact_ImportEdge_AliasAndRelativeResolved` (real extractor → persist → real `memory_impact` tool → `impacted=[repo-a/consumer.ts]`). |
+| 2 | Existence-check + ext/`index` + raw-specifier fallback | PASS (`import_resolver.go`; unit-tested). |
+| 3 | Path-escape clamp | PASS (`escapesRoot` on cleaned candidate; unit-tested). |
+| 4 | **G3 — nearest-ancestor tsconfig, not global** | PASS. `AliasIndex`/`AliasMapFor` per config dir; two-config fixture (repo-a/repo-b) + `TestMemoryImpact_ImportEdge_NoCrossRepoCollision` assert non-overlapping importer sets. |
+| 5 | Nuxt/Vite `~//@/` convention without evaluating `nuxt.config.ts` | PASS. |
+| 6 | Bare packages pass through (AC-B3) | PASS. |
+
+Full verdict transcript retained in the review agent's run log. PR-B's own tests
+pass (7 `ResolveImportTarget_*` unit + import-resolution integration). No new
+integration failures — the 9 red integration tests (Express/Rail/Ruby*,
+MemoryGraph_Relative*, MemoryTrace_RelativeInputAndOutput) are PRE-EXISTING,
+identical on `origin/master` (FAIL-set diffed). smoke:e2e PASS —
+`docs/evidence/smoke-e2e-js-ts-import-resolution.md`.
+
+### Repo-health note (out of scope, flag)
+The integration suite is red on master with 9 pre-existing failures. CI only runs
+`-short` (green), so they don't gate CI, but the manual `-tags=integration` suite
+needs repair. Recommend a separate tracking issue — not part of #501.

--- a/docs/evidence/self-review-js-ts-import-resolution.md
+++ b/docs/evidence/self-review-js-ts-import-resolution.md
@@ -46,9 +46,13 @@
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR (one row per inline
-comment; verdict vocabulary per HARNESS.md § PR + Bot Review Loop)._
+PR #555. Gemini review COMMENTED (non-blocking state); 5 inline comments, all
+legitimate — all fixed in commit f16ef75.
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| PR#555 `import_resolver.go:124` | VALID:high | Real tsconfig semantics: non-wildcard `paths` keys must match the specifier EXACTLY, only wildcard-derived keys prefix-match. `longestAliasMatch` used `HasPrefix` for all → wrong for exact mappings (fixture only had wildcards so tests missed it). | fixed in commit f16ef75 (+ `TestResolveImportTarget_ExactVsWildcardAliasMatch`) |
+| PR#555 `import_resolver.go:395` | VALID:high | `stripTrailingCommas` didn't track string literals → could corrupt a tsconfig string value containing `,}`/`,]`. Low real-world trigger but a genuine JSONC-parser flaw; fix is cheap+correct. | fixed in commit f16ef75 (+ `TestBuildAliasIndex_TolerantJSONCPreservesCommaInsideString`) |
+| PR#555 `watcher.go:1025` | VALID:medium | Cold-cache stampede: concurrent callers all run heavy `BuildAliasIndex` before `LoadOrStore`. Switched to `sync.Once`-per-entry so it builds exactly once per dir. | fixed in commit f16ef75 |
+| PR#555 `import_resolver.go:312` | VALID:medium | `parseTSConfigPaths` target join didn't normalize backslashes (Windows-authored tsconfig) before `path.Join`. | fixed in commit f16ef75 |
+| PR#555 `import_resolver.go:256` | VALID:low | Reading a nil map doesn't panic in Go (Gemini agrees), so defensive-only; but the `idx.aliasMaps == nil` early return is 2 lines and closes the comment cleanly. | fixed in commit f16ef75 |

--- a/docs/evidence/self-review-js-ts-import-resolution.md
+++ b/docs/evidence/self-review-js-ts-import-resolution.md
@@ -1,0 +1,54 @@
+# Self-Review — Issue #501 (JS/TS/Vue import resolution, Phase 2 PR-B)
+
+## Actions Taken
+
+- New `internal/graph/import_resolver.go`: `ResolveImportTarget` + `AliasIndex` /
+  `BuildAliasIndex` / `ImportContext`. Resolves relative (`./`,`../`) and aliased
+  (`~/`,`@/`, tsconfig/jsconfig `compilerOptions.paths`) JS/TS/Vue import
+  specifiers to workspace-relative paths; bare packages pass through unchanged.
+- G3: nearest-ancestor config resolution — `AliasIndex` maps each source file to
+  its nearest tsconfig/jsconfig, so per-repo `~/` roots don't cross repo
+  boundaries (verified with two-config fixture repo-a/repo-b).
+- G2: resolved path canonicalized to the stored `source_node` format + existence
+  check with `.ts/.js/.vue/.tsx/.jsx` + `/index.*` fallback; unresolved →
+  fall back to raw specifier; path-escape clamp drops paths above the root. Raw
+  specifier retained in `Edge.Metadata`.
+- Threaded via `registry.go` (`ExtractEdgesForFrameworksWithImports` + `ImportContext`,
+  old `ExtractEdgesForFrameworks` preserved) and `watcher.go` (per-collection
+  `sync.Map` alias-index cache) into the 3 JS/TS/Vue extractors — the shared
+  `Extractor` interface for the other ~17 extractors was NOT changed.
+
+## Files Changed
+
+- new: `internal/graph/import_resolver.go` (+ `_test.go`), `internal/mcp/import_resolution_501_integration_test.go`, `internal/graph/testdata/import-fixture/{repo-a,repo-b}/**`.
+- modified: `internal/graph/{javascript,typescript,vue_sfc}_extractor.go`, `internal/graph/registry.go`, `internal/watcher/watcher.go`.
+
+## Findings Summary
+
+- Root cause #501: extractors stored the raw specifier as `imports` target →
+  reverse-impact on the real file found nothing. Fixed at extraction time.
+- No schema change (`target_node TEXT` fits). **Backfill of existing rows is a
+  POST-MERGE ops step** (`memory_update` / `ReextractEdgesForWorkspace` per
+  workspace), documented — not code in this PR; watcher self-heals on file change.
+- Out of scope (flagged): worktree/path duplication (#501 related finding);
+  cross-repo bare-name collision (root-cause C).
+
+## Resolution Status
+
+- All in-scope items resolved; no unresolved critical/major.
+- PR-B's own tests PASS: 7 `ResolveImportTarget_*` unit tests + import-resolution
+  integration test. build exit 0; `go test -race -short ./...` 31 pkgs ok.
+- Pre-existing integration failures (9, identical on master: Express/Rail/Ruby*,
+  MemoryGraph_Relative*/MemoryTrace_Relative*) are NOT introduced by this PR —
+  verified by diffing the FAIL set against `origin/master`. Repo-health item,
+  out of scope. Independent review: `docs/evidence/review-501.md`. Smoke:
+  `docs/evidence/smoke-e2e-js-ts-import-resolution.md`.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR (one row per inline
+comment; verdict vocabulary per HARNESS.md § PR + Bot Review Loop)._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-js-ts-import-resolution.md
+++ b/docs/evidence/smoke-e2e-js-ts-import-resolution.md
@@ -1,0 +1,52 @@
+# smoke:e2e — Issue #501 (JS/TS/Vue import resolution, Phase 2 PR-B)
+
+Real HTTP smoke against a live server on **:3199 / nanobrain_test** (never dev DB
+/ :3100). PR-B makes JS/TS/Vue `imports` edges store the **resolved** workspace-
+relative path instead of the raw specifier; this confirms reverse-impact on the
+resolved path returns the importer over HTTP.
+
+## Setup
+
+```
+CGO_ENABLED=0 go build -o ./bin/nano-brain ./cmd/nano-brain/
+NANO_BRAIN_DATABASE_URL=...nanobrain_test NANO_BRAIN_SERVER_PORT=3199 \
+NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1 NANO_BRAIN_EMBEDDING_PROVIDER="" ./bin/nano-brain --unsafe-no-auth &
+
+# seed an imports edge in the POST-FIX shape the resolver now produces:
+# consumer.ts imports "~/utils/enums" → target resolved to repo-a/utils/enums.ts
+# (raw specifier retained in metadata).
+psql "$DB" -c "INSERT INTO graph_edges(workspace_hash,source_node,target_node,edge_type,source_file,metadata)
+  VALUES('smokeB501','repo-a/consumer.ts','repo-a/utils/enums.ts','imports','repo-a/consumer.ts','{\"raw_specifier\":\"~/utils/enums\"}');"
+```
+
+## Request / response
+
+```
+curl -sS -i -X POST http://localhost:3199/api/v1/graph/impact \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace":"smokeB501","node":"repo-a/utils/enums.ts","edge_type":"imports","max_depth":1}'
+```
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+
+{"node":"repo-a/utils/enums.ts","impacted":[{"node":"repo-a/consumer.ts","depth":1,"edge_type":"imports"}]}
+```
+
+**Result:** reverse-impact on the resolved import target `repo-a/utils/enums.ts`
+returns its importer `repo-a/consumer.ts`. **Before PR-B** the edge target was the
+raw specifier `~/utils/enums`, so `impact(node="repo-a/utils/enums.ts")` returned
+`impacted:[]` — the exact #501 false-negative. Now fixed.
+
+The resolver-produces-the-resolved-edge path (extraction E2E: index the fixture →
+edges carry resolved targets) is covered by the passing integration test
+`internal/mcp/import_resolution_501_integration_test.go` (indexes
+`internal/graph/testdata/import-fixture/`).
+
+## Note on execution
+
+`curl` is redirected by this environment's context-mode hook, so the request was
+issued via the sandbox `fetch` with the identical method/path/body; status and
+body are verbatim. Server teardown killed only the captured PID (no broad-kill);
+the `smokeB501` seed rows were deleted afterward; :3199 confirmed clean.

--- a/internal/graph/import_resolver.go
+++ b/internal/graph/import_resolver.go
@@ -112,10 +112,23 @@ func escapesRoot(p string) bool {
 	return clean == ".." || strings.HasPrefix(clean, "../")
 }
 
+// longestAliasMatch finds the best-matching alias key for specifier. Keys
+// derived from a wildcard tsconfig pattern (e.g. "@utils/*") are stored with
+// a trailing "/" (see parseTSConfigPaths/conventionAliases) and may
+// prefix-match. A key with no trailing slash came from a non-wildcard
+// mapping (e.g. "@utils") and, per tsconfig "paths" semantics, must match the
+// specifier exactly — otherwise "@utils-sibling" or "@utils/foo" would
+// wrongly match the "@utils" alias.
 func longestAliasMatch(specifier string, aliasMap map[string]string) (prefix, targetRoot string, ok bool) {
 	bestLen := -1
 	for p, root := range aliasMap {
-		if strings.HasPrefix(specifier, p) && len(p) > bestLen {
+		var match bool
+		if strings.HasSuffix(p, "/") {
+			match = strings.HasPrefix(specifier, p)
+		} else {
+			match = specifier == p
+		}
+		if match && len(p) > bestLen {
 			bestLen = len(p)
 			prefix, targetRoot, ok = p, root, true
 		}
@@ -251,7 +264,7 @@ func BuildAliasIndex(workspaceRootAbs string) (*AliasIndex, error) {
 // (workspace-relative path, forward-slash). Returns nil if the index has no
 // entries at all.
 func (idx *AliasIndex) AliasMapFor(sourceRelPath string) map[string]string {
-	if idx == nil {
+	if idx == nil || idx.aliasMaps == nil {
 		return nil
 	}
 	sourceDir := toWorkspaceRel(path.Dir(filepath.ToSlash(sourceRelPath)))
@@ -307,8 +320,12 @@ func parseTSConfigPaths(raw []byte, configDirRelSlash string) map[string]string 
 			continue
 		}
 		prefix := strings.TrimSuffix(key, "*")
-		target := strings.TrimSuffix(targetStr, "*")
-		joined := path.Join(configDirRelSlash, baseURL, target)
+		// Normalize backslashes: a tsconfig.json authored on Windows may use
+		// "./src\\utils" or a baseUrl with backslashes; path.Join only
+		// understands "/", so on a Linux/macOS indexing host those would
+		// otherwise survive verbatim in the resolved alias target.
+		target := strings.ReplaceAll(strings.TrimSuffix(targetStr, "*"), "\\", "/")
+		joined := path.Join(configDirRelSlash, strings.ReplaceAll(baseURL, "\\", "/"), target)
 		result[prefix] = toWorkspaceRel(joined)
 	}
 	return result
@@ -376,10 +393,31 @@ func stripJSONCComments(raw []byte) []byte {
 	return stripTrailingCommas(out)
 }
 
+// stripTrailingCommas strips a comma immediately followed (across
+// whitespace) by a closing "}"/"]", while tracking string-literal state
+// (with escape handling) so commas inside string values — e.g. a "," in a
+// glob pattern or regex stored as a JSON string — are never touched.
 func stripTrailingCommas(raw []byte) []byte {
 	var out []byte
+	inString, escaped := false, false
 	for i := 0; i < len(raw); i++ {
 		c := raw[i]
+		if inString {
+			if escaped {
+				escaped = false
+			} else if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				inString = false
+			}
+			out = append(out, c)
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			continue
+		}
 		if c == ',' {
 			j := i + 1
 			for j < len(raw) && (raw[j] == ' ' || raw[j] == '\t' || raw[j] == '\n' || raw[j] == '\r') {

--- a/internal/graph/import_resolver.go
+++ b/internal/graph/import_resolver.go
@@ -1,0 +1,408 @@
+package graph
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ImportContext carries the per-file resolution context threaded into the
+// JS/TS/Vue extractors so they can resolve raw import specifiers
+// (`~/utils/enums`, `./foo`, `vue`) to workspace-relative paths. It is passed
+// per call (never stored on an extractor's own struct fields), so a single
+// shared extractor instance stays safe for concurrent use across multiple
+// watched collections/workspaces that may have completely different alias
+// maps (see AliasIndex — G3, nearest-ancestor tsconfig resolution).
+type ImportContext struct {
+	// AliasMap maps an alias prefix (e.g. "~/", "@/", "@utils/") to the
+	// workspace-relative directory it substitutes to. Nil is a valid,
+	// safe no-op (only alias-style specifiers go unresolved; relative and
+	// bare-package resolution are unaffected).
+	AliasMap map[string]string
+	// Exists reports whether a candidate workspace-relative path
+	// corresponds to an admitted file. Nil disables the existence/suffix
+	// probe (a resolved candidate is accepted as-is, unverified).
+	Exists func(workspaceRelPath string) bool
+}
+
+// ImportResolvingExtractor is implemented by extractors that can resolve
+// import specifiers given an ImportContext. It intentionally does NOT
+// replace or modify the shared Extractor interface (internal/graph/edge.go)
+// — every other extractor is untouched. Registry callers that want
+// resolution type-assert for this interface and fall back to the plain
+// Extractor.ExtractEdges otherwise.
+type ImportResolvingExtractor interface {
+	Extractor
+	ExtractEdgesWithImportContext(filePath string, content []byte, ic ImportContext) ([]Edge, error)
+}
+
+// importSuffixCandidates are tried, in order, against ImportContext.Exists
+// when a resolved candidate doesn't exist verbatim — covers extension-omitted
+// specifiers and directory-index imports (e.g. `~/components` -> `components/index.ts`).
+var importSuffixCandidates = []string{"", ".ts", ".tsx", ".js", ".jsx", ".vue", "/index.ts", "/index.tsx", "/index.js", "/index.jsx", "/index.vue"}
+
+// ResolveImportTarget resolves rawSpecifier (exactly as written in an
+// import/require statement) to the workspace-relative path format used for
+// graph_edges.target_node / source_node / document paths: forward-slash,
+// relative to the workspace (collection) root, no leading "./". sourceRelPath
+// is the importing file's own path in that same format.
+//
+// Resolution order (per design.md "Fix B resolution algorithm"):
+//  1. Relative ("./", "../"): joined against the importing file's directory.
+//     Needs no alias map — always attempted first.
+//  2. Aliased: longest-matching prefix in aliasMap is substituted.
+//  3. Bare package (anything else): left unchanged — this is correct
+//     behavior, not a resolution gap.
+//
+// After steps 1/2 produce a candidate, it is verified against `exists`
+// (falling back through importSuffixCandidates for extension/index
+// omission). If nothing matches, the RAW specifier is returned unchanged
+// (fail-safe, never fail-silent-wrong) — this also implements the
+// path-escape clamp: a relative candidate that resolves above the workspace
+// root is never returned.
+func ResolveImportTarget(rawSpecifier, sourceRelPath string, aliasMap map[string]string, exists func(string) bool) string {
+	if rawSpecifier == "" {
+		return rawSpecifier
+	}
+
+	var candidate string
+	if strings.HasPrefix(rawSpecifier, "./") || strings.HasPrefix(rawSpecifier, "../") {
+		dir := path.Dir(filepath.ToSlash(sourceRelPath))
+		if dir == "." {
+			dir = ""
+		}
+		joined := path.Join(dir, rawSpecifier)
+		if escapesRoot(joined) {
+			return rawSpecifier
+		}
+		candidate = joined
+	} else {
+		prefix, targetRoot, ok := longestAliasMatch(rawSpecifier, aliasMap)
+		if !ok {
+			return rawSpecifier // bare package specifier — unchanged
+		}
+		remainder := strings.TrimPrefix(rawSpecifier, prefix)
+		joined := path.Join(targetRoot, remainder)
+		if escapesRoot(joined) {
+			return rawSpecifier
+		}
+		candidate = joined
+	}
+
+	if exists == nil {
+		return candidate
+	}
+	for _, suf := range importSuffixCandidates {
+		if try := candidate + suf; exists(try) {
+			return try
+		}
+	}
+	return rawSpecifier
+}
+
+// escapesRoot reports whether a joined, not-yet-cleaned relative path
+// resolves above the workspace root once cleaned (e.g. "../x" from a
+// top-level file importing "../../x").
+func escapesRoot(p string) bool {
+	clean := path.Clean(p)
+	return clean == ".." || strings.HasPrefix(clean, "../")
+}
+
+func longestAliasMatch(specifier string, aliasMap map[string]string) (prefix, targetRoot string, ok bool) {
+	bestLen := -1
+	for p, root := range aliasMap {
+		if strings.HasPrefix(specifier, p) && len(p) > bestLen {
+			bestLen = len(p)
+			prefix, targetRoot, ok = p, root, true
+		}
+	}
+	return prefix, targetRoot, ok
+}
+
+// resolveImport applies ic to a raw specifier found in sourceRelPath and
+// returns the Edge.TargetNode value plus (only when the specifier actually
+// changed) the {"raw_specifier": ...} metadata to attach — preserving the
+// original alias/relative string per #501's own suggestion. A zero-value
+// ImportContext still performs relative-import resolution (it needs no
+// alias map) but leaves alias/bare specifiers untouched, since AliasMap and
+// Exists are both nil.
+func resolveImport(ic ImportContext, rawSpecifier, sourceRelPath string) (target string, metadata map[string]any) {
+	resolved := ResolveImportTarget(rawSpecifier, sourceRelPath, ic.AliasMap, ic.Exists)
+	if resolved == rawSpecifier {
+		return rawSpecifier, nil
+	}
+	return resolved, map[string]any{"raw_specifier": rawSpecifier}
+}
+
+// --- Alias map loading (G3: nearest-ancestor, not a single global map) ---
+
+// conventionAliases are framework-convention specifiers (Nuxt/Vite `~/` and
+// `@/`) treated as built-in aliases pointing at the nearest config/package
+// root, without evaluating any TS (nuxt.config.ts is never parsed).
+var conventionAliases = []string{"~/", "@/"}
+
+// AliasIndex maps config directories (workspace-relative, forward-slash,
+// "" for the workspace root) to their tsconfig/jsconfig "paths" alias map.
+// It is built once per workspace/collection root (not per file) and looked
+// up per source file via nearest-ancestor resolution: a file nested under a
+// sub-package's own tsconfig uses THAT config's map, never a sibling
+// package's or a stale global one (a single global map is known-wrong for
+// multi-repo workspaces — each repo's "~/" points at its own root).
+type AliasIndex struct {
+	// configDirs is sorted longest-path-first so the nearest (most nested)
+	// ancestor is matched before a shallower one.
+	configDirs []string
+	aliasMaps  map[string]map[string]string
+}
+
+// skippedDirs are never descended into while searching for tsconfig/jsconfig
+// files — generated/vendored/dependency trees never define authoritative
+// aliases for the workspace's own source, and walking them wastes I/O on
+// large repos.
+var skippedDirs = map[string]bool{
+	"node_modules": true,
+	".git":         true,
+	"vendor":       true,
+	"dist":         true,
+	"build":        true,
+	".next":        true,
+	".nuxt":        true,
+	".output":      true,
+}
+
+// BuildAliasIndex walks workspaceRootAbs (an absolute filesystem path) for
+// tsconfig.json/jsconfig.json at any depth, parses `compilerOptions.paths`
+// (tolerating JSONC comments/trailing commas — see parseJSONC) into a
+// prefix->targetRoot alias map per config directory, and registers the
+// built-in "~/"/"@/" convention aliases for that same directory unless the
+// config already defines its own mapping for that prefix. If no config is
+// found anywhere, the workspace root still gets a synthetic entry so "~/"
+// and "@/" resolve workspace-wide (matches today's Nuxt convention usage
+// without needing any config file at all).
+func BuildAliasIndex(workspaceRootAbs string) (*AliasIndex, error) {
+	idx := &AliasIndex{aliasMaps: map[string]map[string]string{}}
+	found := false
+
+	walkErr := filepath.WalkDir(workspaceRootAbs, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // best-effort; skip unreadable entries
+		}
+		if d.IsDir() {
+			if p != workspaceRootAbs && skippedDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if name != "tsconfig.json" && name != "jsconfig.json" {
+			return nil
+		}
+		configDirAbs := filepath.Dir(p)
+		rel, relErr := filepath.Rel(workspaceRootAbs, configDirAbs)
+		if relErr != nil {
+			return nil
+		}
+		relSlash := toWorkspaceRel(rel)
+		raw, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil
+		}
+		merged := idx.aliasMaps[relSlash]
+		if merged == nil {
+			merged = map[string]string{}
+		}
+		for k, v := range parseTSConfigPaths(raw, relSlash) {
+			merged[k] = v
+		}
+		for _, conv := range conventionAliases {
+			if _, ok := merged[conv]; !ok {
+				merged[conv] = relSlash
+			}
+		}
+		idx.aliasMaps[relSlash] = merged
+		found = true
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if !found {
+		root := map[string]string{}
+		for _, conv := range conventionAliases {
+			root[conv] = ""
+		}
+		idx.aliasMaps[""] = root
+	}
+
+	for dir := range idx.aliasMaps {
+		idx.configDirs = append(idx.configDirs, dir)
+	}
+	sort.Slice(idx.configDirs, func(i, j int) bool {
+		return len(idx.configDirs[i]) > len(idx.configDirs[j])
+	})
+	return idx, nil
+}
+
+// AliasMapFor returns the nearest-ancestor alias map for a source file
+// (workspace-relative path, forward-slash). Returns nil if the index has no
+// entries at all.
+func (idx *AliasIndex) AliasMapFor(sourceRelPath string) map[string]string {
+	if idx == nil {
+		return nil
+	}
+	sourceDir := toWorkspaceRel(path.Dir(filepath.ToSlash(sourceRelPath)))
+	for _, cd := range idx.configDirs {
+		if cd == "" {
+			continue
+		}
+		if sourceDir == cd || strings.HasPrefix(sourceDir, cd+"/") {
+			return idx.aliasMaps[cd]
+		}
+	}
+	return idx.aliasMaps[""]
+}
+
+func toWorkspaceRel(rel string) string {
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return ""
+	}
+	return rel
+}
+
+// parseTSConfigPaths extracts compilerOptions.paths from a tsconfig/jsconfig
+// JSON(C) payload, resolving each target against compilerOptions.baseUrl
+// (default ".") and the config's own workspace-relative directory. Returns
+// nil (not an error) on any parse/shape failure — a malformed config simply
+// contributes no aliases, it must never abort indexing.
+func parseTSConfigPaths(raw []byte, configDirRelSlash string) map[string]string {
+	data, err := parseJSONC(raw)
+	if err != nil {
+		return nil
+	}
+	co, _ := data["compilerOptions"].(map[string]any)
+	if co == nil {
+		return nil
+	}
+	baseURL := "."
+	if b, ok := co["baseUrl"].(string); ok && b != "" {
+		baseURL = b
+	}
+	pathsRaw, _ := co["paths"].(map[string]any)
+	if pathsRaw == nil {
+		return nil
+	}
+	result := map[string]string{}
+	for key, val := range pathsRaw {
+		targets, ok := val.([]any)
+		if !ok || len(targets) == 0 {
+			continue
+		}
+		targetStr, ok := targets[0].(string)
+		if !ok {
+			continue
+		}
+		prefix := strings.TrimSuffix(key, "*")
+		target := strings.TrimSuffix(targetStr, "*")
+		joined := path.Join(configDirRelSlash, baseURL, target)
+		result[prefix] = toWorkspaceRel(joined)
+	}
+	return result
+}
+
+// parseJSONC parses JSON that may contain // and /* */ comments and trailing
+// commas (tsconfig.json is conventionally JSONC, not strict JSON). It tries
+// strict json.Unmarshal first and only pays the tolerant-parse cost on
+// failure.
+func parseJSONC(raw []byte) (map[string]any, error) {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err == nil {
+		return m, nil
+	}
+	stripped := stripJSONCComments(raw)
+	if err := json.Unmarshal(stripped, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// stripJSONCComments removes // line comments and /* */ block comments that
+// occur outside of JSON string literals, then strips trailing commas before
+// a closing "}" or "]". It is a minimal tolerant scanner, not a full JSONC
+// parser — sufficient for real-world tsconfig.json files.
+func stripJSONCComments(raw []byte) []byte {
+	var out []byte
+	inString, inLineComment, inBlockComment, escaped := false, false, false, false
+
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case inLineComment:
+			if c == '\n' {
+				inLineComment = false
+				out = append(out, c)
+			}
+		case inBlockComment:
+			if c == '*' && i+1 < len(raw) && raw[i+1] == '/' {
+				inBlockComment = false
+				i++
+			}
+		case inString:
+			out = append(out, c)
+			if escaped {
+				escaped = false
+			} else if c == '\\' {
+				escaped = true
+			} else if c == '"' {
+				inString = false
+			}
+		case c == '"':
+			inString = true
+			out = append(out, c)
+		case c == '/' && i+1 < len(raw) && raw[i+1] == '/':
+			inLineComment = true
+			i++
+		case c == '/' && i+1 < len(raw) && raw[i+1] == '*':
+			inBlockComment = true
+			i++
+		default:
+			out = append(out, c)
+		}
+	}
+	return stripTrailingCommas(out)
+}
+
+func stripTrailingCommas(raw []byte) []byte {
+	var out []byte
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if c == ',' {
+			j := i + 1
+			for j < len(raw) && (raw[j] == ' ' || raw[j] == '\t' || raw[j] == '\n' || raw[j] == '\r') {
+				j++
+			}
+			if j < len(raw) && (raw[j] == '}' || raw[j] == ']') {
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// DiskExistsChecker returns an ImportContext.Exists func backed by real
+// filesystem lookups under workspaceRootAbs — the existence/suffix-probe
+// step used by ResolveImportTarget when indexing an actual workspace.
+func DiskExistsChecker(workspaceRootAbs string) func(string) bool {
+	return func(relPath string) bool {
+		if relPath == "" {
+			return false
+		}
+		info, err := os.Stat(filepath.Join(workspaceRootAbs, relPath))
+		return err == nil && !info.IsDir()
+	}
+}

--- a/internal/graph/import_resolver_test.go
+++ b/internal/graph/import_resolver_test.go
@@ -58,6 +58,35 @@ func TestResolveImportTarget_LongestAliasPrefixWins(t *testing.T) {
 	}
 }
 
+func TestResolveImportTarget_ExactVsWildcardAliasMatch(t *testing.T) {
+	// "@utils" (no trailing slash) came from a non-wildcard tsconfig mapping
+	// ("@utils": ["./src/utils"]) and must match the specifier EXACTLY.
+	// "@utils/*" (stored with a trailing slash, see parseTSConfigPaths) is a
+	// wildcard mapping and may prefix-match.
+	aliasMap := map[string]string{
+		"@utils":  "src/exact-utils",
+		"@utils/": "src/wild-utils",
+	}
+
+	got := graph.ResolveImportTarget("@utils", "consumer.ts", aliasMap, nil)
+	if want := "src/exact-utils"; got != want {
+		t.Errorf("exact alias %q resolved to %q, want %q", "@utils", got, want)
+	}
+
+	got = graph.ResolveImportTarget("@utils/foo", "consumer.ts", aliasMap, nil)
+	if want := "src/wild-utils/foo"; got != want {
+		t.Errorf("wildcard alias %q resolved to %q, want %q", "@utils/foo", got, want)
+	}
+
+	// "@utils-sibling" must NOT match the exact "@utils" alias (it is neither
+	// an exact match nor prefixed by the wildcard "@utils/" key).
+	raw := "@utils-sibling"
+	got = graph.ResolveImportTarget(raw, "consumer.ts", aliasMap, nil)
+	if got != raw {
+		t.Errorf("non-alias specifier %q resolved to %q, want unchanged (raw fallback)", raw, got)
+	}
+}
+
 func TestResolveImportTarget_BarePackagePassthrough(t *testing.T) {
 	aliasMap := map[string]string{"~/": "repo-a"}
 	for _, raw := range []string{"vue", "ramda", "@scope/pkg", "lodash/debounce"} {
@@ -189,6 +218,33 @@ func TestBuildAliasIndex_TolerantJSONC(t *testing.T) {
 	m := idx.AliasMapFor("consumer.ts")
 	if m["~/"] != "" {
 		t.Errorf("JSONC-tolerant alias map[\"~/\"] = %q, want %q", m["~/"], "")
+	}
+}
+
+func TestBuildAliasIndex_TolerantJSONCPreservesCommaInsideString(t *testing.T) {
+	root := t.TempDir()
+	// The trailing comma after the "paths" object forces the tolerant JSONC
+	// path (strict json.Unmarshal fails). The alias target string itself
+	// contains a literal ",}" — a naive trailing-comma stripper that doesn't
+	// track string-literal state would mistake that for a real trailing
+	// comma before a closing brace and corrupt the string value.
+	mustWriteFile(t, filepath.Join(root, "tsconfig.json"), `{
+		"compilerOptions": {
+			"baseUrl": ".",
+			"paths": {
+				"@weird/*": ["./glob,}pattern/*"],
+			}
+		},
+	}`)
+
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	m := idx.AliasMapFor("consumer.ts")
+	want := "glob,}pattern"
+	if m["@weird/"] != want {
+		t.Errorf("alias target with embedded \",}\" in a string literal = %q, want %q (string content must survive intact)", m["@weird/"], want)
 	}
 }
 

--- a/internal/graph/import_resolver_test.go
+++ b/internal/graph/import_resolver_test.go
@@ -1,0 +1,370 @@
+package graph_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+// --- ResolveImportTarget: pure resolution logic (no disk access) ---
+
+func TestResolveImportTarget_Relative(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		sourceRel string
+		want      string
+	}{
+		{"same-dir", "./sibling", "repo-a/consumer.ts", "repo-a/sibling"},
+		{"parent-dir", "../shared/util", "repo-a/pkg/consumer.ts", "repo-a/shared/util"},
+		{"root-level-source", "./sibling", "consumer.ts", "sibling"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := graph.ResolveImportTarget(tc.raw, tc.sourceRel, nil, nil)
+			if got != tc.want {
+				t.Errorf("ResolveImportTarget(%q, %q) = %q, want %q", tc.raw, tc.sourceRel, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveImportTarget_Aliased(t *testing.T) {
+	aliasMap := map[string]string{"~/": "repo-a", "@/": "repo-a"}
+
+	got := graph.ResolveImportTarget("~/utils/enums", "repo-a/consumer.ts", aliasMap, nil)
+	want := "repo-a/utils/enums"
+	if got != want {
+		t.Errorf("aliased resolve = %q, want %q", got, want)
+	}
+
+	got = graph.ResolveImportTarget("@/utils/enums", "repo-a/consumer.ts", aliasMap, nil)
+	if got != want {
+		t.Errorf("@/ aliased resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveImportTarget_LongestAliasPrefixWins(t *testing.T) {
+	aliasMap := map[string]string{
+		"~/":       "repo-a",
+		"~/utils/": "repo-a/special-utils",
+	}
+	got := graph.ResolveImportTarget("~/utils/enums", "repo-a/consumer.ts", aliasMap, nil)
+	want := "repo-a/special-utils/enums"
+	if got != want {
+		t.Errorf("longest-prefix resolve = %q, want %q (should prefer the more specific \"~/utils/\" prefix)", got, want)
+	}
+}
+
+func TestResolveImportTarget_BarePackagePassthrough(t *testing.T) {
+	aliasMap := map[string]string{"~/": "repo-a"}
+	for _, raw := range []string{"vue", "ramda", "@scope/pkg", "lodash/debounce"} {
+		got := graph.ResolveImportTarget(raw, "repo-a/consumer.ts", aliasMap, func(string) bool { return true })
+		if got != raw {
+			t.Errorf("bare package %q resolved to %q, want unchanged", raw, got)
+		}
+	}
+}
+
+func TestResolveImportTarget_ExtIndexFallback(t *testing.T) {
+	admitted := map[string]bool{
+		"repo-a/utils/enums.ts": true,
+	}
+	exists := func(p string) bool { return admitted[p] }
+
+	got := graph.ResolveImportTarget("./utils/enums", "repo-a/consumer.ts", nil, exists)
+	want := "repo-a/utils/enums.ts"
+	if got != want {
+		t.Errorf("ext-fallback resolve = %q, want %q", got, want)
+	}
+
+	admittedIndex := map[string]bool{
+		"repo-a/components/index.vue": true,
+	}
+	existsIndex := func(p string) bool { return admittedIndex[p] }
+	got = graph.ResolveImportTarget("./components", "repo-a/consumer.ts", nil, existsIndex)
+	want = "repo-a/components/index.vue"
+	if got != want {
+		t.Errorf("index-fallback resolve = %q, want %q", got, want)
+	}
+}
+
+func TestResolveImportTarget_UnresolvedFallsBackToRaw(t *testing.T) {
+	exists := func(string) bool { return false }
+	raw := "~/nonexistent/thing"
+	got := graph.ResolveImportTarget(raw, "repo-a/consumer.ts", map[string]string{"~/": "repo-a"}, exists)
+	if got != raw {
+		t.Errorf("unresolved specifier = %q, want raw %q unchanged (fail-safe)", got, raw)
+	}
+}
+
+func TestResolveImportTarget_PathEscapeClamp(t *testing.T) {
+	raw := "../../../outside"
+	got := graph.ResolveImportTarget(raw, "consumer.ts", nil, func(string) bool { return true })
+	if got != raw {
+		t.Errorf("escaping relative import resolved to %q, want raw %q unchanged (path-escape clamp)", got, raw)
+	}
+}
+
+// --- AliasIndex / BuildAliasIndex: nearest-ancestor loading (G3) ---
+
+func TestBuildAliasIndex_NearestAncestorAcrossTwoConfigRoots(t *testing.T) {
+	root := fixtureRoot(t)
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+
+	aMap := idx.AliasMapFor("repo-a/consumer.ts")
+	if aMap["~/"] != "repo-a" {
+		t.Errorf("repo-a alias map[\"~/\"] = %q, want %q", aMap["~/"], "repo-a")
+	}
+
+	bMap := idx.AliasMapFor("repo-b/consumer.ts")
+	if bMap["~/"] != "repo-b/src" {
+		t.Errorf("repo-b alias map[\"~/\"] = %q, want %q", bMap["~/"], "repo-b/src")
+	}
+
+	// The critical G3 assertion: repo-a's map must NOT leak into repo-b's
+	// lookup (a single global map would fabricate a false cross-repo edge).
+	if aMap["~/"] == bMap["~/"] {
+		t.Fatalf("repo-a and repo-b resolved to the same alias root %q — nearest-ancestor isolation broken", aMap["~/"])
+	}
+}
+
+func TestBuildAliasIndex_NestedConfigWinsOverShallower(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "tsconfig.json"), `{"compilerOptions":{"baseUrl":".","paths":{"~/*":["./shallow/*"]}}}`)
+	mustWriteFile(t, filepath.Join(root, "pkg", "nested", "tsconfig.json"), `{"compilerOptions":{"baseUrl":".","paths":{"~/*":["./deep/*"]}}}`)
+
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+
+	nested := idx.AliasMapFor("pkg/nested/consumer.ts")
+	if want := "pkg/nested/deep"; nested["~/"] != want {
+		t.Errorf("nested config alias = %q, want %q (nearest ancestor must win)", nested["~/"], want)
+	}
+
+	shallow := idx.AliasMapFor("pkg/other/consumer.ts")
+	if want := "shallow"; shallow["~/"] != want {
+		t.Errorf("shallow-scoped file alias = %q, want %q (root config, no nested ancestor)", shallow["~/"], want)
+	}
+}
+
+func TestBuildAliasIndex_ConventionAliasesWithoutTsconfig(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "consumer.ts"), "export const x = 1;")
+
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	m := idx.AliasMapFor("consumer.ts")
+	if m["~/"] != "" || m["@/"] != "" {
+		t.Errorf("no-config convention aliases = %+v, want {\"~/\":\"\", \"@/\":\"\"}", m)
+	}
+}
+
+func TestBuildAliasIndex_TolerantJSONC(t *testing.T) {
+	root := t.TempDir()
+	// Comments + a trailing comma, as real-world tsconfig.json commonly has.
+	mustWriteFile(t, filepath.Join(root, "tsconfig.json"), `{
+		// alias config
+		"compilerOptions": {
+			"baseUrl": ".",
+			"paths": {
+				"~/*": ["./*"], /* trailing comma above, block comment here */
+			},
+		},
+	}`)
+
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	m := idx.AliasMapFor("consumer.ts")
+	if m["~/"] != "" {
+		t.Errorf("JSONC-tolerant alias map[\"~/\"] = %q, want %q", m["~/"], "")
+	}
+}
+
+func TestBuildAliasIndex_SkipsNodeModules(t *testing.T) {
+	root := t.TempDir()
+	// A tsconfig.json inside node_modules must never contribute an alias —
+	// dependency trees aren't part of the workspace's own source.
+	mustWriteFile(t, filepath.Join(root, "node_modules", "some-pkg", "tsconfig.json"), `{"compilerOptions":{"paths":{"~/*":["./should-not-appear/*"]}}}`)
+	mustWriteFile(t, filepath.Join(root, "consumer.ts"), "export const x = 1;")
+
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	m := idx.AliasMapFor("consumer.ts")
+	if m["~/"] != "" {
+		t.Errorf("node_modules tsconfig leaked into alias map: %+v", m)
+	}
+}
+
+// --- ExtractEdgesWithImportContext: real TypeScriptGraphExtractor end-to-end
+// against the committed testdata/import-fixture (AC-B1/B2/B3). ---
+
+func TestTypeScriptExtractor_ExtractEdgesWithImportContext_ResolvesAgainstFixture(t *testing.T) {
+	root := fixtureRoot(t)
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatalf("NewTypeScriptGraphExtractor: %v", err)
+	}
+
+	relFile := "repo-a/consumer.ts"
+	content, err := os.ReadFile(filepath.Join(root, relFile))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	ic := graph.ImportContext{
+		AliasMap: idx.AliasMapFor(relFile),
+		Exists:   graph.DiskExistsChecker(root),
+	}
+	edges, err := ex.ExtractEdgesWithImportContext(relFile, content, ic)
+	if err != nil {
+		t.Fatalf("ExtractEdgesWithImportContext: %v", err)
+	}
+
+	targets := map[string]graph.Edge{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports {
+			targets[e.TargetNode] = e
+		}
+	}
+
+	// AC-B1: alias-resolved import.
+	aliasEdge, ok := targets["repo-a/utils/enums.ts"]
+	if !ok {
+		t.Fatalf("no resolved edge for aliased import ~/utils/enums; got targets: %+v", targets)
+	}
+	if aliasEdge.Metadata["raw_specifier"] != "~/utils/enums" {
+		t.Errorf("aliased edge metadata = %+v, want raw_specifier=~/utils/enums", aliasEdge.Metadata)
+	}
+
+	// AC-B2: relative-resolved import.
+	relEdge, ok := targets["repo-a/sibling.ts"]
+	if !ok {
+		t.Fatalf("no resolved edge for relative import ./sibling; got targets: %+v", targets)
+	}
+	if relEdge.Metadata["raw_specifier"] != "./sibling" {
+		t.Errorf("relative edge metadata = %+v, want raw_specifier=./sibling", relEdge.Metadata)
+	}
+
+	// AC-B3: bare package specifier stays unresolved and unchanged.
+	if _, ok := targets["vue"]; !ok {
+		t.Fatalf("bare package 'vue' import missing or resolved; got targets: %+v", targets)
+	}
+}
+
+// TestTypeScriptExtractor_ExtractEdges_Unchanged pins down that the plain
+// (no ImportContext) ExtractEdges path is completely unaffected by this
+// feature — it must keep returning raw specifiers exactly as before.
+func TestTypeScriptExtractor_ExtractEdges_Unchanged(t *testing.T) {
+	root := fixtureRoot(t)
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatalf("NewTypeScriptGraphExtractor: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "repo-a/consumer.ts"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	edges, err := ex.ExtractEdges("repo-a/consumer.ts", content)
+	if err != nil {
+		t.Fatalf("ExtractEdges: %v", err)
+	}
+
+	raw := map[string]bool{}
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports {
+			raw[e.TargetNode] = true
+		}
+	}
+	for _, want := range []string{"~/utils/enums", "./sibling", "vue"} {
+		if !raw[want] {
+			t.Errorf("plain ExtractEdges missing raw target %q (edges: %+v)", want, raw)
+		}
+	}
+}
+
+// TestExtractEdgesWithImportContext_NoCrossRepoLeakage is the end-to-end
+// version of the G3 guard: resolving both repo-a's and repo-b's consumer.ts
+// against a SHARED AliasIndex built over the whole fixture root must not
+// collide on the same target, proving nearest-ancestor selection is applied
+// at extraction time, not just in the index lookup.
+func TestExtractEdgesWithImportContext_NoCrossRepoLeakage(t *testing.T) {
+	root := fixtureRoot(t)
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatalf("NewTypeScriptGraphExtractor: %v", err)
+	}
+
+	resolveOne := func(relFile string) string {
+		content, err := os.ReadFile(filepath.Join(root, relFile))
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", relFile, err)
+		}
+		ic := graph.ImportContext{AliasMap: idx.AliasMapFor(relFile), Exists: graph.DiskExistsChecker(root)}
+		edges, err := ex.ExtractEdgesWithImportContext(relFile, content, ic)
+		if err != nil {
+			t.Fatalf("extract %s: %v", relFile, err)
+		}
+		for _, e := range edges {
+			if e.Kind == graph.EdgeImports && e.Metadata["raw_specifier"] == "~/utils/enums" {
+				return e.TargetNode
+			}
+		}
+		t.Fatalf("no resolved ~/utils/enums edge found for %s", relFile)
+		return ""
+	}
+
+	aTarget := resolveOne("repo-a/consumer.ts")
+	bTarget := resolveOne("repo-b/consumer.ts")
+
+	if aTarget != "repo-a/utils/enums.ts" {
+		t.Errorf("repo-a resolved target = %q, want repo-a/utils/enums.ts", aTarget)
+	}
+	if bTarget != "repo-b/src/utils/enums.ts" {
+		t.Errorf("repo-b resolved target = %q, want repo-b/src/utils/enums.ts", bTarget)
+	}
+	if aTarget == bTarget {
+		t.Fatalf("repo-a and repo-b both resolved to %q — cross-repo collision", aTarget)
+	}
+}
+
+func fixtureRoot(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("testdata/import-fixture")
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	return abs
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/graph/javascript_extractor.go
+++ b/internal/graph/javascript_extractor.go
@@ -70,6 +70,8 @@ func (e *JavaScriptGraphExtractor) Supports(ext string) bool {
 	return ext == ".js" || ext == ".jsx"
 }
 
+var _ ImportResolvingExtractor = (*JavaScriptGraphExtractor)(nil)
+
 func (e *JavaScriptGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
 	parser := gotreesitter.NewParser(e.lang)
 	tree, err := parser.Parse(content)
@@ -84,6 +86,27 @@ func (e *JavaScriptGraphExtractor) ExtractEdges(filePath string, content []byte)
 	var edges []Edge
 	edges = append(edges, e.extractContains(bt, tree, content, relFile)...)
 	edges = append(edges, e.extractImports(bt, tree, content, relFile)...)
+	edges = append(edges, e.extractCalls(bt, tree, content, relFile)...)
+	return edges, nil
+}
+
+// ExtractEdgesWithImportContext is identical to ExtractEdges except imports
+// edges are resolved via ic (see ImportResolvingExtractor). ExtractEdges
+// itself is untouched so existing callers/tests keep seeing raw specifiers.
+func (e *JavaScriptGraphExtractor) ExtractEdgesWithImportContext(filePath string, content []byte, ic ImportContext) ([]Edge, error) {
+	parser := gotreesitter.NewParser(e.lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	edges = append(edges, e.extractContains(bt, tree, content, relFile)...)
+	edges = append(edges, e.extractImportsResolved(bt, tree, content, relFile, ic)...)
 	edges = append(edges, e.extractCalls(bt, tree, content, relFile)...)
 	return edges, nil
 }
@@ -183,6 +206,79 @@ func (e *JavaScriptGraphExtractor) walkRequireJS(bt *gotreesitter.BoundTree, nod
 	}
 	for i := 0; i < int(node.ChildCount()); i++ {
 		e.walkRequireJS(bt, node.Child(i), content, filePath, seen, edges)
+	}
+}
+
+// extractImportsResolved mirrors extractImports but resolves each raw import
+// specifier via ic (relative/aliased specifiers become workspace-relative
+// paths; bare packages and unresolvable specifiers pass through unchanged).
+func (e *JavaScriptGraphExtractor) extractImportsResolved(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, ic ImportContext) []Edge {
+	matches := e.importQuery.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			raw := bt.NodeText(cap.Node)
+			importPath := strings.Trim(raw, "\"'`")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			target, meta := resolveImport(ic, importPath, filePath)
+			edges = append(edges, Edge{
+				SourceNode: filePath,
+				TargetNode: target,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "javascript",
+				Metadata:   meta,
+			})
+		}
+	}
+
+	root := tree.RootNode()
+	e.walkRequireJSResolved(bt, root, content, filePath, seen, ic, &edges)
+
+	return edges
+}
+
+func (e *JavaScriptGraphExtractor) walkRequireJSResolved(bt *gotreesitter.BoundTree, node *gotreesitter.Node, content []byte, filePath string, seen map[string]bool, ic ImportContext, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(e.lang) == "call_expression" {
+		fnNode := node.ChildByFieldName("function", e.lang)
+		if fnNode != nil && fnNode.Type(e.lang) == "identifier" && bt.NodeText(fnNode) == "require" {
+			argsNode := node.ChildByFieldName("arguments", e.lang)
+			if argsNode != nil {
+				argNode := firstChildOfType(argsNode, e.lang, "string")
+				if argNode != nil {
+					raw := bt.NodeText(argNode)
+					importPath := strings.Trim(raw, "\"'`")
+					if importPath != "" && !seen[importPath] {
+						seen[importPath] = true
+						target, meta := resolveImport(ic, importPath, filePath)
+						*edges = append(*edges, Edge{
+							SourceNode: filePath,
+							TargetNode: target,
+							Kind:       EdgeImports,
+							SourceFile: filePath,
+							Line:       lineForByte(content, fnNode.StartByte()),
+							Language:   "javascript",
+							Metadata:   meta,
+						})
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		e.walkRequireJSResolved(bt, node.Child(i), content, filePath, seen, ic, edges)
 	}
 }
 

--- a/internal/graph/registry.go
+++ b/internal/graph/registry.go
@@ -136,6 +136,61 @@ func (r *Registry) ExtractEdgesForFrameworks(filePath string, content []byte, fr
 	return r.extractWith(filePath, content, ext, extractors, seen, all)
 }
 
+// ExtractEdgesForFrameworksWithImports is ExtractEdgesForFrameworks plus
+// import-specifier resolution (Fix B, #501): extractors implementing
+// ImportResolvingExtractor (the JS/TS/Vue graph extractors) are called via
+// ExtractEdgesWithImportContext(filePath, content, ic) instead of the plain
+// Extractor.ExtractEdges, so imports edges get resolved workspace-relative
+// target_node values. Every other extractor (the ~17 that don't implement
+// ImportResolvingExtractor) is invoked exactly as before — the shared
+// Extractor interface is untouched.
+func (r *Registry) ExtractEdgesForFrameworksWithImports(filePath string, content []byte, frameworks []string, ic ImportContext) ([]Edge, error) {
+	if isMinified(filePath, content) {
+		return nil, nil
+	}
+	ext := filepath.Ext(filePath)
+	var all []Edge
+	seen := make(map[string]struct{})
+
+	var extractors []Extractor
+	for _, ex := range r.extractors {
+		if fa, ok := ex.(FrameworkAwareExtractor); ok {
+			if req := fa.RequiresFrameworks(); len(req) > 0 && !hasIntersection(req, frameworks) {
+				continue
+			}
+		}
+		extractors = append(extractors, ex)
+	}
+	if len(extractors) == 0 {
+		extractors = r.extractors
+	}
+
+	for _, ex := range extractors {
+		if !ex.Supports(ext) {
+			continue
+		}
+		var edges []Edge
+		var err error
+		if iae, ok := ex.(ImportResolvingExtractor); ok {
+			edges, err = iae.ExtractEdgesWithImportContext(filePath, content, ic)
+		} else {
+			edges, err = ex.ExtractEdges(filePath, content)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("extract edges %s: %w", filePath, err)
+		}
+		for _, e := range edges {
+			key := fmt.Sprintf("%s:%s:%s:%d", e.Kind, e.SourceNode, e.TargetNode, e.Line)
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			all = append(all, e)
+		}
+	}
+	return all, nil
+}
+
 // isMinified reports whether a file looks like minified/generated output that
 // would only add noise to the graph (webpack/nuxt bundles, *.min.js, etc.).
 // Minified files pack everything onto a few extremely long lines, so a very

--- a/internal/graph/testdata/import-fixture/repo-a/consumer.ts
+++ b/internal/graph/testdata/import-fixture/repo-a/consumer.ts
@@ -1,0 +1,7 @@
+import { STATUS } from '~/utils/enums';
+import { helper } from './sibling';
+import { createApp } from 'vue';
+
+export function run() {
+  return STATUS + helper() + String(createApp);
+}

--- a/internal/graph/testdata/import-fixture/repo-a/sibling.ts
+++ b/internal/graph/testdata/import-fixture/repo-a/sibling.ts
@@ -1,0 +1,3 @@
+export function helper(): number {
+  return 1;
+}

--- a/internal/graph/testdata/import-fixture/repo-a/tsconfig.json
+++ b/internal/graph/testdata/import-fixture/repo-a/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // repo-a's own alias root — "~/" points at repo-a itself, never repo-b.
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"], // trailing comment + trailing comma below tolerate JSONC
+    }
+  }
+}

--- a/internal/graph/testdata/import-fixture/repo-a/utils/enums.ts
+++ b/internal/graph/testdata/import-fixture/repo-a/utils/enums.ts
@@ -1,0 +1,1 @@
+export const STATUS = 'ok-a';

--- a/internal/graph/testdata/import-fixture/repo-b/consumer.ts
+++ b/internal/graph/testdata/import-fixture/repo-b/consumer.ts
@@ -1,0 +1,5 @@
+import { STATUS } from '~/utils/enums';
+
+export function run() {
+  return STATUS;
+}

--- a/internal/graph/testdata/import-fixture/repo-b/src/utils/enums.ts
+++ b/internal/graph/testdata/import-fixture/repo-b/src/utils/enums.ts
@@ -1,0 +1,1 @@
+export const STATUS = 'ok-b';

--- a/internal/graph/testdata/import-fixture/repo-b/tsconfig.json
+++ b/internal/graph/testdata/import-fixture/repo-b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  }
+}

--- a/internal/graph/typescript_extractor.go
+++ b/internal/graph/typescript_extractor.go
@@ -101,6 +101,8 @@ func (e *TypeScriptGraphExtractor) Supports(ext string) bool {
 	return ext == ".ts" || ext == ".tsx"
 }
 
+var _ ImportResolvingExtractor = (*TypeScriptGraphExtractor)(nil)
+
 func (e *TypeScriptGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
 	lang, importQ, containsQ, callFuncQ, callExprQ := e.lang, e.importQuery, e.containsQuery, e.callFuncQuery, e.callExprQuery
 	if filepath.Ext(filePath) == ".tsx" {
@@ -120,6 +122,32 @@ func (e *TypeScriptGraphExtractor) ExtractEdges(filePath string, content []byte)
 	var edges []Edge
 	edges = append(edges, e.extractContains(bt, tree, content, relFile, containsQ)...)
 	edges = append(edges, e.extractImports(bt, tree, content, relFile, lang, importQ)...)
+	edges = append(edges, e.extractCalls(bt, tree, content, relFile, callFuncQ, callExprQ)...)
+	return edges, nil
+}
+
+// ExtractEdgesWithImportContext is identical to ExtractEdges except imports
+// edges are resolved via ic (see ImportResolvingExtractor). ExtractEdges
+// itself is untouched so existing callers/tests keep seeing raw specifiers.
+func (e *TypeScriptGraphExtractor) ExtractEdgesWithImportContext(filePath string, content []byte, ic ImportContext) ([]Edge, error) {
+	lang, importQ, containsQ, callFuncQ, callExprQ := e.lang, e.importQuery, e.containsQuery, e.callFuncQuery, e.callExprQuery
+	if filepath.Ext(filePath) == ".tsx" {
+		lang, importQ, containsQ, callFuncQ, callExprQ = e.tsxLang, e.tsxImportQ, e.tsxContainsQ, e.tsxCallFuncQ, e.tsxCallExprQ
+	}
+
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", filePath, err)
+	}
+	bt := gotreesitter.Bind(tree)
+	defer bt.Release()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	edges = append(edges, e.extractContains(bt, tree, content, relFile, containsQ)...)
+	edges = append(edges, e.extractImportsResolved(bt, tree, content, relFile, lang, importQ, ic)...)
 	edges = append(edges, e.extractCalls(bt, tree, content, relFile, callFuncQ, callExprQ)...)
 	return edges, nil
 }
@@ -225,6 +253,85 @@ func (e *TypeScriptGraphExtractor) walkRequire(bt *gotreesitter.BoundTree, node 
 	}
 	for i := 0; i < int(node.ChildCount()); i++ {
 		e.walkRequire(bt, node.Child(i), content, filePath, lang, seen, edges)
+	}
+}
+
+// extractImportsResolved mirrors extractImports but resolves each raw import
+// specifier via ic (relative/aliased specifiers become workspace-relative
+// paths; bare packages and unresolvable specifiers pass through unchanged).
+func (e *TypeScriptGraphExtractor) extractImportsResolved(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, q *gotreesitter.Query, ic ImportContext) []Edge {
+	matches := q.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			raw := bt.NodeText(cap.Node)
+			importPath := strings.Trim(raw, "\"'`")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			target, meta := resolveImport(ic, importPath, filePath)
+			edges = append(edges, Edge{
+				SourceNode: filePath,
+				TargetNode: target,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "typescript",
+				Metadata:   meta,
+			})
+		}
+	}
+
+	edges = append(edges, e.extractRequireImportsResolved(bt, tree, content, filePath, lang, seen, ic)...)
+
+	return edges
+}
+
+func (e *TypeScriptGraphExtractor) extractRequireImportsResolved(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool, ic ImportContext) []Edge {
+	root := tree.RootNode()
+	var edges []Edge
+	e.walkRequireResolved(bt, root, content, filePath, lang, seen, ic, &edges)
+	return edges
+}
+
+func (e *TypeScriptGraphExtractor) walkRequireResolved(bt *gotreesitter.BoundTree, node *gotreesitter.Node, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool, ic ImportContext, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(lang) == "call_expression" {
+		fnNode := node.ChildByFieldName("function", lang)
+		if fnNode != nil && fnNode.Type(lang) == "identifier" && bt.NodeText(fnNode) == "require" {
+			argsNode := node.ChildByFieldName("arguments", lang)
+			if argsNode != nil {
+				argNode := firstChildOfType(argsNode, lang, "string")
+				if argNode != nil {
+					raw := bt.NodeText(argNode)
+					importPath := strings.Trim(raw, "\"'`")
+					if importPath != "" && !seen[importPath] {
+						seen[importPath] = true
+						target, meta := resolveImport(ic, importPath, filePath)
+						*edges = append(*edges, Edge{
+							SourceNode: filePath,
+							TargetNode: target,
+							Kind:       EdgeImports,
+							SourceFile: filePath,
+							Line:       lineForByte(content, fnNode.StartByte()),
+							Language:   "typescript",
+							Metadata:   meta,
+						})
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		e.walkRequireResolved(bt, node.Child(i), content, filePath, lang, seen, ic, edges)
 	}
 }
 

--- a/internal/graph/vue_sfc_extractor.go
+++ b/internal/graph/vue_sfc_extractor.go
@@ -98,6 +98,8 @@ func (e *VueSFCExtractor) Supports(ext string) bool {
 	return ext == ".vue"
 }
 
+var _ ImportResolvingExtractor = (*VueSFCExtractor)(nil)
+
 func (e *VueSFCExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
 	result, err := e.ip.Parse(content, "vue")
 	if err != nil {
@@ -126,6 +128,45 @@ func (e *VueSFCExtractor) ExtractEdges(filePath string, content []byte) ([]Edge,
 
 		edges = append(edges, e.extractContains(bt, tree, content, relFile, containsQ)...)
 		edges = append(edges, e.extractImports(bt, tree, content, relFile, lang, importQ)...)
+		edges = append(edges, e.extractCalls(bt, tree, content, relFile, callFuncQ, callExprQ)...)
+
+		bt.Release()
+	}
+
+	return edges, nil
+}
+
+// ExtractEdgesWithImportContext is identical to ExtractEdges except imports
+// edges are resolved via ic (see ImportResolvingExtractor). ExtractEdges
+// itself is untouched so existing callers/tests keep seeing raw specifiers.
+func (e *VueSFCExtractor) ExtractEdgesWithImportContext(filePath string, content []byte, ic ImportContext) ([]Edge, error) {
+	result, err := e.ip.Parse(content, "vue")
+	if err != nil {
+		return nil, fmt.Errorf("parse vue sfc %s: %w", filePath, err)
+	}
+	defer func() {
+		if result != nil {
+			result.Tree.Release()
+		}
+	}()
+
+	relFile := filepath.ToSlash(filePath)
+
+	var edges []Edge
+	for _, inj := range result.Injections {
+		if inj.Tree == nil || inj.Language == "" {
+			continue
+		}
+		lang, importQ, containsQ, callFuncQ, callExprQ := e.resolveLang(inj.Language)
+		if lang == nil {
+			continue
+		}
+
+		bt := gotreesitter.Bind(inj.Tree)
+		tree := inj.Tree
+
+		edges = append(edges, e.extractContains(bt, tree, content, relFile, containsQ)...)
+		edges = append(edges, e.extractImportsResolved(bt, tree, content, relFile, lang, importQ, ic)...)
 		edges = append(edges, e.extractCalls(bt, tree, content, relFile, callFuncQ, callExprQ)...)
 
 		bt.Release()
@@ -255,6 +296,106 @@ func (e *VueSFCExtractor) walkRequire(bt *gotreesitter.BoundTree, node *gotreesi
 	for i := 0; i < int(node.ChildCount()); i++ {
 		e.walkRequire(bt, node.Child(i), content, filePath, lang, seen, edges)
 	}
+}
+
+// extractImportsResolved mirrors extractImports but resolves each raw import
+// specifier via ic (relative/aliased specifiers become workspace-relative
+// paths; bare packages and unresolvable specifiers pass through unchanged).
+// The component-import metadata marker is preserved and merged with the
+// raw_specifier metadata resolveImport may add.
+func (e *VueSFCExtractor) extractImportsResolved(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, q *gotreesitter.Query, ic ImportContext) []Edge {
+	matches := q.Execute(tree)
+	var edges []Edge
+	seen := map[string]bool{}
+
+	for _, match := range matches {
+		for _, cap := range match.Captures {
+			if cap.Name != "path" {
+				continue
+			}
+			raw := bt.NodeText(cap.Node)
+			importPath := strings.Trim(raw, "\"'`")
+			if importPath == "" || seen[importPath] {
+				continue
+			}
+			seen[importPath] = true
+			target, meta := resolveImport(ic, importPath, filePath)
+			edge := Edge{
+				SourceNode: filePath,
+				TargetNode: target,
+				Kind:       EdgeImports,
+				SourceFile: filePath,
+				Line:       lineForByte(content, cap.Node.StartByte()),
+				Language:   "vue",
+				Metadata:   meta,
+			}
+			if strings.HasSuffix(importPath, ".vue") {
+				edge.Metadata = mergeComponentMeta(edge.Metadata)
+			}
+			edges = append(edges, edge)
+		}
+	}
+
+	edges = append(edges, e.extractRequireImportsResolved(bt, tree, content, filePath, lang, seen, ic)...)
+
+	return edges
+}
+
+func (e *VueSFCExtractor) extractRequireImportsResolved(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool, ic ImportContext) []Edge {
+	root := tree.RootNode()
+	var edges []Edge
+	e.walkRequireResolved(bt, root, content, filePath, lang, seen, ic, &edges)
+	return edges
+}
+
+func (e *VueSFCExtractor) walkRequireResolved(bt *gotreesitter.BoundTree, node *gotreesitter.Node, content []byte, filePath string, lang *gotreesitter.Language, seen map[string]bool, ic ImportContext, edges *[]Edge) {
+	if node == nil {
+		return
+	}
+	if node.Type(lang) == "call_expression" {
+		fnNode := node.ChildByFieldName("function", lang)
+		if fnNode != nil && fnNode.Type(lang) == "identifier" && bt.NodeText(fnNode) == "require" {
+			argsNode := node.ChildByFieldName("arguments", lang)
+			if argsNode != nil {
+				argNode := firstChildOfType(argsNode, lang, "string")
+				if argNode != nil {
+					raw := bt.NodeText(argNode)
+					importPath := strings.Trim(raw, "\"'`")
+					if importPath != "" && !seen[importPath] {
+						seen[importPath] = true
+						target, meta := resolveImport(ic, importPath, filePath)
+						edge := Edge{
+							SourceNode: filePath,
+							TargetNode: target,
+							Kind:       EdgeImports,
+							SourceFile: filePath,
+							Line:       lineForByte(content, fnNode.StartByte()),
+							Language:   "vue",
+							Metadata:   meta,
+						}
+						if strings.HasSuffix(importPath, ".vue") {
+							edge.Metadata = mergeComponentMeta(edge.Metadata)
+						}
+						*edges = append(*edges, edge)
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		e.walkRequireResolved(bt, node.Child(i), content, filePath, lang, seen, ic, edges)
+	}
+}
+
+// mergeComponentMeta adds the {"component": true} marker (used by consumers
+// to identify Vue component imports) onto whatever metadata resolveImport
+// already produced, without discarding a raw_specifier entry.
+func mergeComponentMeta(meta map[string]any) map[string]any {
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	meta["component"] = true
+	return meta
 }
 
 func (e *VueSFCExtractor) extractCalls(bt *gotreesitter.BoundTree, tree *gotreesitter.Tree, content []byte, filePath string, funcQ, exprQ *gotreesitter.Query) []Edge {

--- a/internal/mcp/import_resolution_501_integration_test.go
+++ b/internal/mcp/import_resolution_501_integration_test.go
@@ -1,0 +1,205 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// --- Issue #501: JS/TS/Vue import specifiers stored unresolved, so reverse
+// impact (memory_impact direction:"in", edge_type:"imports") returns 0 for
+// real importers of a file reached only via an alias or relative specifier.
+//
+// These tests run the REAL TypeScriptGraphExtractor against the committed
+// testdata/import-fixture (internal/graph/testdata/import-fixture), through
+// the same ImportContext machinery internal/watcher wires at index time
+// (graph.BuildAliasIndex + graph.DiskExistsChecker), then persist the
+// resulting edges into nanobrain_test exactly as internal/watcher would,
+// and assert memory_impact finds the real importer.
+
+// importFixtureRoot resolves the shared graph-package testdata fixture used
+// by both internal/graph's unit tests and this MCP integration test.
+func importFixtureRoot(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("../graph/testdata/import-fixture")
+	if err != nil {
+		t.Fatalf("abs path: %v", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("import fixture not found at %s: %v", abs, err)
+	}
+	return abs
+}
+
+// extractFixtureImportEdges runs the real extractor + resolver against one
+// fixture file (relFile, workspace-relative to root) and returns only its
+// "imports" edges.
+func extractFixtureImportEdges(t *testing.T, root, relFile string) []graph.Edge {
+	t.Helper()
+	idx, err := graph.BuildAliasIndex(root)
+	if err != nil {
+		t.Fatalf("BuildAliasIndex: %v", err)
+	}
+	ex, err := graph.NewTypeScriptGraphExtractor()
+	if err != nil {
+		t.Fatalf("NewTypeScriptGraphExtractor: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(root, relFile))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", relFile, err)
+	}
+	ic := graph.ImportContext{
+		AliasMap: idx.AliasMapFor(relFile),
+		Exists:   graph.DiskExistsChecker(root),
+	}
+	edges, err := ex.ExtractEdgesWithImportContext(relFile, content, ic)
+	if err != nil {
+		t.Fatalf("extract %s: %v", relFile, err)
+	}
+	var imports []graph.Edge
+	for _, e := range edges {
+		if e.Kind == graph.EdgeImports {
+			imports = append(imports, e)
+		}
+	}
+	return imports
+}
+
+// AC-B1 + AC-B2 + AC-B3: index repo-a/consumer.ts (alias import, relative
+// import, bare package import) and confirm memory_impact direction:"in"
+// resolves the alias/relative importers but leaves the bare package alone.
+func TestMemoryImpact_ImportEdge_AliasAndRelativeResolved(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+	root := importFixtureRoot(t)
+
+	edges := extractFixtureImportEdges(t, root, "repo-a/consumer.ts")
+	if len(edges) == 0 {
+		t.Fatalf("no imports edges extracted for repo-a/consumer.ts")
+	}
+	for _, e := range edges {
+		meta, err := json.Marshal(e.Metadata)
+		if err != nil {
+			t.Fatalf("marshal metadata: %v", err)
+		}
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash,
+			SourceNode:    e.SourceNode,
+			TargetNode:    e.TargetNode,
+			EdgeType:      string(e.Kind),
+			SourceFile:    e.SourceFile,
+			Metadata:      meta,
+		}); err != nil {
+			t.Fatalf("upsert edge %s->%s: %v", e.SourceNode, e.TargetNode, err)
+		}
+	}
+
+	// AC-B1: alias-resolved import (~/utils/enums -> repo-a/utils/enums.ts).
+	aliasResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "repo-a/utils/enums.ts",
+		"direction": "in",
+		"edge_type": "imports",
+	})
+	aliasResp := unmarshalGraphResp(t, aliasResult)
+	aliasImpacted, _ := aliasResp["impacted"].([]any)
+	if len(aliasImpacted) != 1 {
+		t.Fatalf("AC-B1: alias import impacted count = %d, want 1: %+v", len(aliasImpacted), aliasImpacted)
+	}
+	if got := aliasImpacted[0].(map[string]any)["node"].(string); got != "repo-a/consumer.ts" {
+		t.Errorf("AC-B1: alias import impacted[0].node = %q, want repo-a/consumer.ts", got)
+	}
+
+	// AC-B2: relative-resolved import (./sibling -> repo-a/sibling.ts).
+	relResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "repo-a/sibling.ts",
+		"direction": "in",
+		"edge_type": "imports",
+	})
+	relResp := unmarshalGraphResp(t, relResult)
+	relImpacted, _ := relResp["impacted"].([]any)
+	if len(relImpacted) != 1 {
+		t.Fatalf("AC-B2: relative import impacted count = %d, want 1: %+v", len(relImpacted), relImpacted)
+	}
+	if got := relImpacted[0].(map[string]any)["node"].(string); got != "repo-a/consumer.ts" {
+		t.Errorf("AC-B2: relative import impacted[0].node = %q, want repo-a/consumer.ts", got)
+	}
+
+	// AC-B3: bare package specifier ("vue") is untouched — it is still
+	// queryable under its own raw name (unchanged behavior), never under a
+	// resolved workspace path (there is none to resolve to).
+	bareResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "vue",
+		"direction": "in",
+		"edge_type": "imports",
+	})
+	bareResp := unmarshalGraphResp(t, bareResult)
+	bareImpacted, _ := bareResp["impacted"].([]any)
+	if len(bareImpacted) != 1 {
+		t.Fatalf("AC-B3: bare package impacted count = %d, want 1: %+v", len(bareImpacted), bareImpacted)
+	}
+	if got := bareImpacted[0].(map[string]any)["node"].(string); got != "repo-a/consumer.ts" {
+		t.Errorf("AC-B3: bare package impacted[0].node = %q, want repo-a/consumer.ts", got)
+	}
+}
+
+// G3 regression guard at the MCP layer: repo-a and repo-b each define their
+// own "~/" alias root under ONE shared fixture tree. If alias resolution
+// ever regresses to a single global map, both would resolve to the same
+// target and memory_impact would return BOTH consumers for one node — a
+// fabricated cross-repo edge. This test asserts exact, non-overlapping
+// importer sets.
+func TestMemoryImpact_ImportEdge_NoCrossRepoCollision(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+	root := importFixtureRoot(t)
+
+	for _, relFile := range []string{"repo-a/consumer.ts", "repo-b/consumer.ts"} {
+		for _, e := range extractFixtureImportEdges(t, root, relFile) {
+			meta, err := json.Marshal(e.Metadata)
+			if err != nil {
+				t.Fatalf("marshal metadata: %v", err)
+			}
+			if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+				WorkspaceHash: wsHash,
+				SourceNode:    e.SourceNode,
+				TargetNode:    e.TargetNode,
+				EdgeType:      string(e.Kind),
+				SourceFile:    e.SourceFile,
+				Metadata:      meta,
+			}); err != nil {
+				t.Fatalf("upsert edge %s->%s: %v", e.SourceNode, e.TargetNode, err)
+			}
+		}
+	}
+
+	aResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "repo-a/utils/enums.ts",
+		"direction": "in",
+		"edge_type": "imports",
+	})
+	aResp := unmarshalGraphResp(t, aResult)
+	aImpacted, _ := aResp["impacted"].([]any)
+	if len(aImpacted) != 1 || aImpacted[0].(map[string]any)["node"].(string) != "repo-a/consumer.ts" {
+		t.Fatalf("repo-a/utils/enums.ts impacted = %+v, want exactly [repo-a/consumer.ts]", aImpacted)
+	}
+
+	bResult := callTool("memory_impact", map[string]any{
+		"workspace": wsHash,
+		"node":      "repo-b/src/utils/enums.ts",
+		"direction": "in",
+		"edge_type": "imports",
+	})
+	bResp := unmarshalGraphResp(t, bResult)
+	bImpacted, _ := bResp["impacted"].([]any)
+	if len(bImpacted) != 1 || bImpacted[0].(map[string]any)["node"].(string) != "repo-b/consumer.ts" {
+		t.Fatalf("repo-b/src/utils/enums.ts impacted = %+v, want exactly [repo-b/consumer.ts]", bImpacted)
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -92,8 +92,9 @@ type Watcher struct {
 	embedQueue        *embed.Queue
 	dispatcher        *chunker.Dispatcher
 
-	// aliasIndexes caches one *graph.AliasIndex per collection root
-	// (keyed by watchedCollection.dirPath), built lazily on first import
+	// aliasIndexes caches one *aliasIndexEntry (guarding a *graph.AliasIndex
+	// build with a sync.Once) per collection root, keyed by
+	// watchedCollection.dirPath, built lazily on first import
 	// extraction for that collection. A single Watcher processes many
 	// collections/workspaces against a shared graphRegistry, so the alias
 	// map cannot live on the extractor instances (see G3 in
@@ -1007,21 +1008,31 @@ func (w *Watcher) extractAndUpsertSymbols(ctx context.Context, col watchedCollec
 	return len(syms)
 }
 
+// aliasIndexEntry guards a single collection root's *graph.AliasIndex build
+// with a sync.Once, so concurrent cold-cache callers for the same dirPath
+// block on one BuildAliasIndex walk instead of each running (and discarding)
+// their own redundant disk walk.
+type aliasIndexEntry struct {
+	once sync.Once
+	idx  *graph.AliasIndex
+}
+
 // aliasIndexFor returns the cached *graph.AliasIndex for a collection root,
 // building it (once) on first use via graph.BuildAliasIndex. Building walks
 // dirPath for tsconfig.json/jsconfig.json — cheap relative to the file watch
 // itself, but still only paid once per collection rather than per file.
 func (w *Watcher) aliasIndexFor(dirPath string) *graph.AliasIndex {
-	if cached, ok := w.aliasIndexes.Load(dirPath); ok {
-		return cached.(*graph.AliasIndex)
-	}
-	idx, err := graph.BuildAliasIndex(dirPath)
-	if err != nil {
-		w.logger.Warn().Err(err).Str("dir", dirPath).Msg("alias index build failed, imports will not be resolved via aliases")
-		idx = &graph.AliasIndex{}
-	}
-	actual, _ := w.aliasIndexes.LoadOrStore(dirPath, idx)
-	return actual.(*graph.AliasIndex)
+	val, _ := w.aliasIndexes.LoadOrStore(dirPath, &aliasIndexEntry{})
+	entry := val.(*aliasIndexEntry)
+	entry.once.Do(func() {
+		idx, err := graph.BuildAliasIndex(dirPath)
+		if err != nil {
+			w.logger.Warn().Err(err).Str("dir", dirPath).Msg("alias index build failed, imports will not be resolved via aliases")
+			idx = &graph.AliasIndex{}
+		}
+		entry.idx = idx
+	})
+	return entry.idx
 }
 
 // buildEdgeMetadata merges e.Metadata (if non-nil) with {"line", "language"},

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -92,6 +92,15 @@ type Watcher struct {
 	embedQueue        *embed.Queue
 	dispatcher        *chunker.Dispatcher
 
+	// aliasIndexes caches one *graph.AliasIndex per collection root
+	// (keyed by watchedCollection.dirPath), built lazily on first import
+	// extraction for that collection. A single Watcher processes many
+	// collections/workspaces against a shared graphRegistry, so the alias
+	// map cannot live on the extractor instances (see G3 in
+	// .planning/phases/02-import-edge-fix/design.md) — it is looked up
+	// per file from this cache instead and passed in as an ImportContext.
+	aliasIndexes sync.Map
+
 	fsw         *fsnotify.Watcher
 	mu          sync.Mutex
 	collections map[string]watchedCollection
@@ -998,6 +1007,23 @@ func (w *Watcher) extractAndUpsertSymbols(ctx context.Context, col watchedCollec
 	return len(syms)
 }
 
+// aliasIndexFor returns the cached *graph.AliasIndex for a collection root,
+// building it (once) on first use via graph.BuildAliasIndex. Building walks
+// dirPath for tsconfig.json/jsconfig.json — cheap relative to the file watch
+// itself, but still only paid once per collection rather than per file.
+func (w *Watcher) aliasIndexFor(dirPath string) *graph.AliasIndex {
+	if cached, ok := w.aliasIndexes.Load(dirPath); ok {
+		return cached.(*graph.AliasIndex)
+	}
+	idx, err := graph.BuildAliasIndex(dirPath)
+	if err != nil {
+		w.logger.Warn().Err(err).Str("dir", dirPath).Msg("alias index build failed, imports will not be resolved via aliases")
+		idx = &graph.AliasIndex{}
+	}
+	actual, _ := w.aliasIndexes.LoadOrStore(dirPath, idx)
+	return actual.(*graph.AliasIndex)
+}
+
 // buildEdgeMetadata merges e.Metadata (if non-nil) with {"line", "language"},
 // giving the caller-supplied fields priority but always including line+language.
 func buildEdgeMetadata(e graph.Edge) ([]byte, error) {
@@ -1017,7 +1043,11 @@ func (w *Watcher) extractAndUpsertEdges(ctx context.Context, col watchedCollecti
 	}
 	relFile := filepath.ToSlash(relPath)
 
-	edges, err := w.graphRegistry.ExtractEdgesForFrameworks(relFile, content, col.detectedFrameworks)
+	ic := graph.ImportContext{
+		AliasMap: w.aliasIndexFor(col.dirPath).AliasMapFor(relFile),
+		Exists:   graph.DiskExistsChecker(col.dirPath),
+	}
+	edges, err := w.graphRegistry.ExtractEdgesForFrameworksWithImports(relFile, content, col.detectedFrameworks, ic)
 	if err != nil {
 		w.logger.Warn().Err(err).Str("file", filePath).Msg("graph edge extraction failed")
 		return


### PR DESCRIPTION
Closes #501

## Problem
JS/TS/Vue extractors stored the **raw import specifier** (`~/utils/enums`, `./foo`, `vue`) as the `imports` edge `target_node`. So a real file's dependents were parked under the alias-string node, disconnected from the file node — `memory_impact(direction:"in", edge_type:"imports")` returned empty for the real path (the #501 false-negative). The Go extractor already resolves intra-repo targets; JS/TS/Vue did not.

## Fix (extraction-time; no schema change, no migration)
New `internal/graph/import_resolver.go` resolves specifiers to workspace-relative paths:
- **Relative** (`./`,`../`) joined against the source file's dir.
- **Aliased** via nearest-ancestor `tsconfig.json`/`jsconfig.json` `compilerOptions.paths` **(G3: per-config maps, not a single global one — so a repo's `~/` never resolves into a sibling repo)** + built-in `~/`,`@/` convention (no `nuxt.config.ts` evaluation).
- **G2:** resolved path is canonicalized to the exact stored `source_node` format + existence-checked with `.ts/.js/.vue/.tsx/.jsx` + `/index.*` fallback; unresolved → raw specifier (fail-safe); path-escape clamp drops paths above the workspace root. Raw specifier kept in `Edge.Metadata`.
- Threaded via `registry.go` (`ExtractEdgesForFrameworksWithImports`) + `watcher.go` (per-collection alias-index cache); the shared `Extractor` interface for the other extractors is unchanged.

**Backfill of existing workspaces is a post-merge ops step** (`memory_update` / re-extract per workspace); the watcher self-heals on file change.

## Tests (nanobrain_test only; never :3100)
- `internal/graph/import_resolver_test.go` — 7 unit tests: relative, aliased, longest-prefix, bare passthrough, ext/index fallback, unresolved→raw, path-escape clamp. All PASS.
- `internal/mcp/import_resolution_501_integration_test.go` — real extractor → persist → real `memory_impact`: alias+relative resolved importer found; no cross-repo collision (two-config fixture `testdata/import-fixture/repo-a`,`repo-b`). PASS.
- `go build ./...` exit 0; `go test -race -short ./...` 31 pkgs ok.
- **smoke:e2e** — `POST /api/v1/graph/impact {node:"repo-a/utils/enums.ts",edge_type:"imports"}` → HTTP 200 `{"impacted":[{"node":"repo-a/consumer.ts",...}]}`.

Independent review verdict PASS + smoke transcript: `docs/evidence/{review-501,self-review-js-ts-import-resolution,smoke-e2e-js-ts-import-resolution}.md`.

Note: the manual `-tags=integration` suite has 9 pre-existing failures (identical on master; CI runs `-short` only, green). Flagged for a separate repo-health issue — not part of this PR.

Completes Phase 2 (`.planning/phases/02-import-edge-fix/`) with PR #554 (calls-edge requalify).