### PR TITLE
fix(vsearch): over-fetch chunks before document-dedup so multi-concept queries return enough distinct docs

### DIFF
--- a/.planning/phases/03-search-quality/design.md
+++ b/.planning/phases/03-search-quality/design.md
@@ -1,0 +1,168 @@
+# Phase 3 — Design: memory_vsearch under-retrieval on multi-concept queries
+
+Tracking: #545 (PR-C)
+
+## Root cause
+
+`registerMemoryVSearch` (`internal/mcp/tools.go:844`, formerly at line ~844
+before the fix) computed `fetchLimit := int32(offset + maxResults + 1)`
+(formerly line ~953) and fetched that many **chunks** via
+`VectorSearch`/`VectorSearchAll` (`internal/storage/queries/embeddings.sql:68`
+— `ORDER BY embedding <=> query LIMIT max_results`, no similarity
+threshold). When `group_by == "document"` (the default), those chunks were
+then collapsed to documents by `deduplicateByDocument` (`tools.go:293`).
+
+When the top-N chunks by cosine distance cluster into a handful of
+documents — e.g. a diluted compound-query embedding scores several chunks
+from the same one or two documents higher than any chunk from other
+documents — dedup collapses the page to far fewer than `max_results`
+distinct documents. #545's repro: `max_results:7` returned `total:2`.
+
+There is no similarity threshold anywhere in this path; the bug is purely
+"fetch too few chunks, then dedup," not a relevance/ranking defect.
+
+**Also found and fixed (G-C2):** the handler had a duplicated
+`if groupBy == "document" { ... deduplicateByDocument ... }` block — the
+same dedup logic appeared twice back-to-back (copy-paste), each rebuilding
+`allRows` from the previous result. Functionally harmless (idempotent) but
+dead weight; removed, one block remains.
+
+## Decisions (Gate 1.7 style, single-pass — no PR/design review loop for a
+tiny bugfix; recorded per orchestrator directive)
+
+**G-C1 — over-fetch chunks before dedup, no similarity threshold.**
+When `group_by == "document"`, fetch
+`min((offset+max_results+1) * vsearchDedupOverFetchFactor, vsearchDedupOverFetchCap)`
+chunks instead of `offset+max_results+1`. Named consts in `tools.go`:
+
+```go
+const (
+	vsearchDedupOverFetchFactor = 5
+	vsearchDedupOverFetchCap    = 200
+)
+```
+
+- **Why a multiplicative factor, not a threshold:** a similarity cutoff
+  requires picking a magic number that's wrong for some embedding
+  models/query shapes; over-fetching more *candidates* for the existing
+  exact dedup logic fixes the actual defect (too few candidates) without
+  guessing at "how similar is similar enough."
+- **Why factor=5, cap=200:** 5x covers the reported failure mode (2
+  documents dominating the top 8 chunks) with room to spare — even a
+  document contributing 4-5 near-duplicate chunks won't starve the other
+  ~(5x-5) fetched slots. The absolute cap (200) bounds worst-case query cost
+  on workspaces with very large `max_results` requests; 200 chunks is still
+  a cheap HNSW-indexed fetch (see latency note below).
+- **When `group_by != "document"`:** each chunk is already its own result
+  (no collapsing happens), so the over-fetch buys nothing — fetch stays at
+  `offset + maxResults + 1`, unchanged from today. Verified by
+  `TestMemoryVSearch_GroupByNone_FetchLimitUnaffected`.
+- **Cap has a floor at `baseFetchLimit` (R88 review #545 follow-up).** The
+  200-cap is a ceiling on the over-fetch *boost* only — it must never reduce
+  the fetch below what the page window itself needs. At deep offsets
+  (`offset+max_results+1 > 200`), a bare `min(base*factor, cap)` picks a
+  fetchLimit smaller than `baseFetchLimit`, starving the page and reporting
+  `has_more=false` when more documents exist. Fixed to
+  `max(baseFetchLimit, min(base*factor, cap))`. Verified by
+  `TestMemoryVSearch_OverFetchCapFloor_DeepPagination`.
+- **No similarity threshold (explicitly rejected).** Out of scope per
+  intake — would change *what counts as a match*, not just *how many
+  candidates dedup gets to work with*. Conflates two different fixes.
+- **No "under-retrieval signal" field on the response.** YAGNI — the fix
+  makes under-retrieval not happen (for the fetch-then-dedup shape); a
+  signal field is a workaround for a problem that no longer needs working
+  around.
+
+**G-C2 — remove duplicated dedup block.** Done; one
+`if groupBy == "document" { ... }` block remains at `tools.go` (post-fix,
+~line 1052).
+
+**G-C3 — memory_query parity: do NOT apply the same over-fetch.**
+`registerMemoryQuery` (`tools.go:305`) has a superficially similar shape —
+compute `fetchLimit := offset + maxResults + 1` (line 404), pass it to
+`HybridSearch`, then `deduplicateByDocument` the returned results
+(line 421-423) — but the *path underneath* is materially different from
+vsearch's plain `VectorSearch` LIMIT query, so the same multiplier is not
+"low-cost" there:
+
+1. `HybridSearch` (`internal/search/service.go:164`) does not use the
+   caller's `fetchLimit` as a DB `LIMIT` directly. It derives its own
+   internal leg-fetch limit — `int32(maxResults * 3)`, floor 30
+   (`service.go:196-199`) — for the BM25 and vector legs, RRF-merges
+   (`DynamicRRFMerge`), dedups exact-ID duplicates
+   (`DeduplicateResults`), and applies code-aware/extension/recency/
+   entity/pagerank boosts before an **optional external reranking API
+   call** (`internal/search/reranking/reranker.go:64`,
+   `apiReranker.Rerank`) and only then truncates to the caller's
+   `maxResults` (`service.go:625-627`) — *before* returning to
+   `registerMemoryQuery`, which then dedups by document.
+2. The reranker, when enabled (`config.RerankingConfig.Enabled`), sends
+   **every** candidate in the pre-truncation `boosted` slice to an external
+   API as document text (`reranker.go:76-86`,
+   `docTexts := make([]string, len(docs))` — no internal truncation before
+   building the request payload). Increasing the `maxResults` passed into
+   `HybridSearch` fans out through the x3 leg multiplier into a
+   proportionally larger `boosted` slice, which — with reranking enabled —
+   means proportionally larger external API payloads, latency, and cost.
+   That is not "low-cost"; it's a real, config-dependent latency/cost
+   regression on the codebase's *default first tool*.
+3. Contrast with vsearch: `VectorSearch`'s `fetchLimit` **is** the literal
+   SQL `LIMIT`, an indexed HNSW fetch with no external call downstream — a
+   5x-200 over-fetch there is genuinely cheap.
+4. The `DebugSearch` path (`memory_query mode:"debugging"` at `tools.go:408`
+   and `registerMemorySearch`'s debug branch ~`tools.go:611`, both →
+   `service.go:642`) fans out through the hybrid legs, same family as (1) —
+   not a plain `VectorSearch` LIMIT — so this exclusion covers it too. #543's
+   debugging-mode buckets (PR-D) is a separate concern and does not change
+   retrieval depth.
+
+**Decision: leave `registerMemoryQuery` (and the `DebugSearch` paths) untouched.** The task's own escape
+clause ("if it materially changes hybrid-search latency/behavior or the
+path differs, do NOT touch it") applies directly. Filing this as a
+follow-up: if #545-shaped under-retrieval is later reported against
+`memory_query` specifically, the fix should be scoped to the case
+`reranking.Enabled == false` (or given its own, smaller-multiplier
+constant), not a blind copy of vsearch's factor/cap.
+
+**G-C4 — no signal field.** Covered under G-C1; restated for parity with
+the PR-B design doc's numbering convention.
+
+## Latency note
+
+An HNSW-indexed `ORDER BY embedding <=> query LIMIT N` fetch of 5x the
+previous row count (bounded at 200 total rows) is not a meaingfully
+different query shape — same index, same predicate, larger `LIMIT`. No new
+joins, no new sequential scans. This is the reason G-C1 is safe to ship
+without a benchmark: the cost model is "fetch a few hundred more small
+rows from an index," not "add a new query."
+
+## Testing approach
+
+Integration test (`-tags=integration`, `testutil.SetupTestDB`, runs against
+`nanobrain_test`), new file
+`internal/mcp/vsearch_overfetch_545_integration_test.go`:
+
+- A fixed-vector embedder (`vsearchFixedEmbedder`) pins the query embedding
+  to `[1, 0, ..., 0]`. Chunk embeddings are constructed as
+  `[alpha, sqrt(1-alpha^2), 0, ...]` so cosine similarity to the query is
+  exactly `alpha` — deterministic ranking without depending on a real
+  embedding provider (matches the pattern already used in
+  `internal/search/isolation_test.go`'s `fakeEmbedder`/`makeVec`).
+- **Collapse repro** (`TestMemoryVSearch_OverFetch_FewDocumentsCollapse`):
+  2 "hot" documents x 5 near-identical high-similarity chunks each (alpha
+  0.99/0.98) + 10 "cold" documents x 1 lower-similarity chunk each (alpha
+  0.50 down to 0.41). Pre-fix, `max_results=7` would fetch only the top 8
+  chunks — all from the 2 hot documents — collapsing to `total=2`. Post-fix
+  it fetches all 20 chunks, dedups to `total=12`, and the page fills to the
+  requested 7 distinct documents.
+- **No-regression control**
+  (`TestMemoryVSearch_ManyDocumentsAlreadyDiverse`): 10 documents x 1 chunk
+  each at distinct similarities — dedup was never the bottleneck here;
+  confirms the over-fetch doesn't change the already-correct case.
+- **Scope control**
+  (`TestMemoryVSearch_GroupByNone_FetchLimitUnaffected`): same hot/cold
+  seed data, `group_by="none"` — asserts `total=8`
+  (`offset+max_results+1`), proving the over-fetch is applied only when
+  `group_by == "document"`.
+
+No unit test was added for `memory_query` (G-C3: not modified).

--- a/docs/evidence/review-545.md
+++ b/docs/evidence/review-545.md
@@ -1,0 +1,45 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author — implemented by separate Sonnet executors).
+Date: 2026-07-07
+Commit: 03a7f12 (branch `fix/vsearch-overfetch-dedup`)
+
+Change: `memory_vsearch` over-fetches chunks (factor 5, cap 200, floored at the
+page window) before `group_by=document` dedup so multi-concept queries return
+enough distinct documents (#545). Also removed a duplicated dedup block.
+
+### Correctness gate (R88) — FAIL → fixed → PASS
+
+- **Round 1 (commit edc6cf0): FAIL [HIGH].** Cap had no floor: when
+  `baseFetchLimit = offset+maxResults+1 > 200` (reachable — `max_results` caps at
+  100, so page-2 with offset=100 → 201), `min(base*5, 200)` picked 200 < 201,
+  fetching FEWER chunks than the page window → silent page truncation + wrong
+  `has_more` at deep pagination (a regression vs pre-fix `fetchLimit==base`).
+- **Fix (commit 03a7f12):** `fetchLimit = int32(max(baseFetchLimit, min(base*factor, cap)))`
+  — the cap bounds the over-fetch *boost* only, never reduces below the page
+  window. New test `TestMemoryVSearch_OverFetchCapFloor_DeepPagination`.
+- **Round 2: PASS / APPROVE** @ 03a7f12. Reviewer confirmed the floor fully
+  resolves the HIGH finding and introduces no new issue (`max()` only raises to
+  the caller's own page window; `min(...,cap)` still bounds the boost).
+
+### Quality axes — independent teammate reviews (all clean, no blocking)
+
+| Axis | Reviewer | Verdict |
+|---|---|---|
+| Efficiency | simplify-efficiency | Clean — over-fetch → SQL LIMIT (not post-filter), 200 cap bounds worst case, duplicate-dedup removal is a real win |
+| Simplification | simplify-simplification | Clean — consts/vars load-bearing; one pre-existing out-of-scope note (vsRow↔search.Result round-trip) |
+| Reuse | simplify-reuse | Clean — helpers reused from existing tests; pre-existing repo-wide `sha256` hash-helper duplication noted as optional follow-up |
+| Altitude | simplify-altitude | Right altitude — over-fetch at call site not inside pure dedup; consts not config; flagged DebugSearch doc gap (fixed in design.md) |
+
+### Validation (run by orchestrator)
+
+- `go test -race -tags=integration ./internal/mcp/ -run 'VSearch|Overfetch|545|Floor|Pagination'` → 6 PASS.
+- `go test -race -short ./...` → 31 pkgs ok, 0 FAIL. `go build ./...` exit 0.
+- smoke:e2e — `docs/evidence/smoke-e2e-vsearch-overfetch-dedup.md` (REST vsearch HTTP 200 with live ollama).
+- All against `nanobrain_test` — never dev DB / :3100.
+
+### Out-of-scope follow-ups (noted, not blocking)
+
+- Dedup `vsRow↔search.Result` round-trip simplification (pre-existing).
+- Shared `testutil.HashContent()` for the repo-wide `sha256` test-hash pattern.
+- `memory_query`/`DebugSearch` intentionally NOT over-fetched (G-C3: hybrid legs + reranker fan-out) — a scoped follow-up only if #545-shaped under-retrieval is reported there.

--- a/docs/evidence/self-review-vsearch-overfetch-dedup.md
+++ b/docs/evidence/self-review-vsearch-overfetch-dedup.md
@@ -1,0 +1,46 @@
+# Self-Review — Issue #545 (memory_vsearch over-fetch, Phase 3 PR-C)
+
+## Actions Taken
+
+- `memory_vsearch` (`internal/mcp/tools.go` `registerMemoryVSearch`): when
+  `group_by == "document"`, over-fetch chunks before dedup —
+  `fetchLimit = max(baseFetchLimit, min(baseFetchLimit*5, 200))` — so
+  document-dedup can yield up to `max_results` distinct docs. Named consts
+  `vsearchDedupOverFetchFactor`/`vsearchDedupOverFetchCap`.
+- Removed a duplicated `if groupBy=="document" {…deduplicateByDocument…}` block
+  (copy-paste, byte-identical) — one block remains.
+- R88 follow-up: floored the cap at `baseFetchLimit` so deep pagination
+  (`offset+max_results+1 > 200`) is never starved.
+- `group_by != "document"` path unchanged (each chunk is its own result).
+- `memory_query`/`DebugSearch` deliberately NOT changed (hybrid legs + reranker
+  fan-out — see design.md G-C3).
+
+## Files Changed
+
+- `internal/mcp/tools.go`: over-fetch + floor + duplicate-block removal.
+- `internal/mcp/vsearch_overfetch_545_integration_test.go` (new): 4 tests.
+- `.planning/phases/03-search-quality/design.md` (new): G-C1..G-C4 decisions.
+
+## Findings Summary
+
+- Root cause: fetch `offset+maxResults+1` CHUNKS then dedup-to-document → few
+  results when top chunks cluster into few docs (no similarity threshold exists;
+  purely fetch-too-few). Fixed by over-fetching candidates.
+- R88 caught a HIGH cap-starvation regression at deep pagination — fixed with a floor.
+- 4 quality-axis teammate reviews (efficiency/simplification/reuse/altitude): clean.
+
+## Resolution Status
+
+- All findings resolved. R88: FAIL (cap-floor) → fixed → PASS (`docs/evidence/review-545.md`).
+- 6 integration tests PASS; `go test -race -short ./...` 31 pkgs ok; build exit 0.
+- smoke:e2e PASS (`docs/evidence/smoke-e2e-vsearch-overfetch-dedup.md`).
+- No unresolved critical/major. Out-of-scope follow-ups noted in review-545.md.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR (one row per inline
+comment; verdict vocabulary per HARNESS.md § PR + Bot Review Loop)._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-vsearch-overfetch-dedup.md
+++ b/docs/evidence/smoke-e2e-vsearch-overfetch-dedup.md
@@ -1,0 +1,51 @@
+# smoke:e2e — Issue #545 (memory_vsearch over-fetch, Phase 3 PR-C)
+
+Live server on **:3199 / nanobrain_test** with the real **ollama** embedder
+(`nomic-embed-text`), against a workspace with ~399 real embeddings. Confirms the
+vector-search HTTP surface is healthy end-to-end (query embedded live, vector
+search, ranked JSON response).
+
+## Request / response
+
+```
+curl -sS -i -X POST http://localhost:3199/api/v1/vsearch \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace":"<ws-hash>","query":"database connection pool setup","max_results":5}'
+```
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+
+{"results":[{"score":0.5098,"source_path":".../internal/mcp/vsearch_overfetch_545_integration_test.go",...},
+            {"score":0.5014,"source_path":".../internal/mcp/tools.go?symbol=ub&kind=var",...}, ... 5 total]}
+```
+
+Query embedded via ollama (`http://host.docker.internal:11434`, nomic-embed-text),
+vector search over real embeddings, 5 ranked results returned — the vsearch HTTP
+path works end-to-end with a real embedder.
+
+## Why the fix itself is covered by integration tests, not this HTTP smoke
+
+The #545 fix (over-fetch chunks before `group_by=document` dedup, + the R88
+cap-floor) lives in the **MCP tool** `registerMemoryVSearch` (`tools.go`), on the
+`group_by=document` path. The REST `/api/v1/vsearch` handler
+(`internal/server/handlers/search.go`) is **chunk-level — it does no
+document-dedup** — so it does not exercise the fixed path (and correctly needs no
+fix). Reproducing the fix's behavior (top chunks clustering into few documents)
+requires *controlled* embeddings in a known vector space — impossible to arrange
+deterministically with a live embedder over HTTP. That is done deterministically
+by 6 integration tests driving the real MCP tool handler against `nanobrain_test`:
+
+- `TestMemoryVSearch_OverFetch_FewDocumentsCollapse` — #545 repro (2 hot docs ×5
+  chunks vs 10 cold docs ×1); asserts 7 distinct docs, not 2.
+- `TestMemoryVSearch_OverFetchCapFloor_DeepPagination` — R88 cap-floor at deep offset.
+- `TestMemoryVSearch_ManyDocumentsAlreadyDiverse`, `TestMemoryVSearch_GroupByNone_FetchLimitUnaffected` — regression/scope controls.
+- (+ existing pagination/time-filter tests.) All PASS.
+
+## Note on execution / privacy
+
+`curl` is redirected by this environment's context-mode hook; the request was
+issued via the sandbox `fetch` with identical method/path/body — status and body
+verbatim. The workspace hash is redacted (`<ws-hash>`) per the privacy rule.
+Server teardown killed only the captured PID (no broad-kill); :3199 confirmed clean.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -207,6 +207,17 @@ func requireRegisteredWorkspace(ctx context.Context, a *Adapter, args map[string
 
 const mcpSnippetLen = 200
 
+// Over-fetch factor/cap applied to vector-search fetchLimit when
+// group_by="document" collapses chunks to documents (#545). Vector search
+// ranks and fetches CHUNKS with no similarity threshold; when the top chunks
+// cluster into few documents, deduplicateByDocument can yield far fewer than
+// max_results distinct documents unless more chunks are fetched up front so
+// dedup has enough candidates to draw from.
+const (
+	vsearchDedupOverFetchFactor = 5
+	vsearchDedupOverFetchCap    = 200
+)
+
 // mcpSearchResultItem is the per-result payload returned by memory_query,
 // memory_search, and memory_vsearch over MCP. By default content is omitted;
 // agents set include_content=true (or call memory_get) to obtain full text.
@@ -950,7 +961,26 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				return errResult(fmt.Sprintf("embedding query failed: %v", err)), nil
 			}
 
-			fetchLimit := int32(offset + maxResults + 1)
+			groupBy := argString(args, "group_by")
+			if groupBy == "" {
+				groupBy = "document"
+			}
+
+			baseFetchLimit := offset + maxResults + 1
+			fetchLimit := int32(baseFetchLimit)
+			if groupBy == "document" {
+				// Over-fetch chunks so deduplicateByDocument has enough
+				// candidates to collapse into up to maxResults distinct
+				// documents (#545) — vector search has no similarity
+				// threshold, so a diluted compound-query embedding can rank
+				// many chunks from the same few documents at the top.
+				// The cap is a ceiling on the over-fetch boost, never a
+				// reduction below what the page window itself needs — at
+				// deep offsets baseFetchLimit can exceed the cap, and
+				// min()-ing straight into the cap would starve the page
+				// (R88 review #545 follow-up).
+				fetchLimit = int32(max(baseFetchLimit, min(baseFetchLimit*vsearchDedupOverFetchFactor, vsearchDedupOverFetchCap)))
+			}
 			var ca, cb, ua, ub sql.NullTime
 			if timeRange != nil {
 				ca, cb, ua, ub = timeRange.ToSqlNullTimes()
@@ -1019,34 +1049,6 @@ func registerMemoryVSearch(server *mcpsdk.Server, a *Adapter) {
 				}
 				return allRows[i].ID < allRows[j].ID
 			})
-
-			groupBy := argString(args, "group_by")
-			if groupBy == "" {
-				groupBy = "document"
-			}
-			if groupBy == "document" {
-				vsearchResults := make([]search.Result, len(allRows))
-				for i, r := range allRows {
-					vsearchResults[i] = search.Result{
-						ID: r.ID, DocumentID: r.DocumentID,
-						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
-						Content: r.Content, SourcePath: r.SourcePath,
-						Collection: r.Collection, Tags: r.Tags,
-						Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
-					}
-				}
-				deduped := deduplicateByDocument(vsearchResults)
-				allRows = make([]vsRow, len(deduped))
-				for i, r := range deduped {
-					allRows[i] = vsRow{
-						ID: r.ID, DocumentID: r.DocumentID,
-						WorkspaceHash: r.WorkspaceHash, Title: r.Title,
-						Content: r.Content, SourcePath: r.SourcePath,
-						Collection: r.Collection, Tags: r.Tags,
-						Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
-					}
-				}
-			}
 
 			if groupBy == "document" {
 				vsearchResults := make([]search.Result, len(allRows))

--- a/internal/mcp/vsearch_overfetch_545_integration_test.go
+++ b/internal/mcp/vsearch_overfetch_545_integration_test.go
@@ -1,0 +1,270 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/stdlib"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	pgvector_go "github.com/pgvector/pgvector-go"
+	"github.com/rs/zerolog"
+	"github.com/sqlc-dev/pqtype"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+)
+
+// Regression coverage for #545: memory_vsearch under-retrieval on
+// multi-concept queries. Root cause: with group_by="document" the handler
+// fetched only offset+max_results+1 CHUNKS (no similarity threshold) before
+// collapsing chunks -> documents via deduplicateByDocument. When the top
+// chunks cluster into a handful of documents, dedup yields far fewer than
+// max_results distinct documents. The fix over-fetches chunks before dedup
+// (vsearchDedupOverFetchFactor/Cap in internal/mcp/tools.go) so dedup has
+// enough candidates to draw from.
+
+const vsearchOverfetchVecDim = 768
+
+// vsearchFixedEmbedder always returns a caller-supplied vector, so tests can
+// pin the query embedding and construct chunk embeddings with a known cosine
+// similarity to it, independent of any real embedding provider.
+type vsearchFixedEmbedder struct{ vec []float32 }
+
+func (f *vsearchFixedEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return f.vec, nil
+}
+func (f *vsearchFixedEmbedder) Dimension() int { return vsearchOverfetchVecDim }
+
+// vsearchVec builds a unit vector [alpha, beta, 0, ..., 0] such that its
+// cosine similarity against the fixed query vector [1, 0, ..., 0] is exactly
+// alpha (beta fills out the remaining norm so the vector stays unit length;
+// its exact placement doesn't affect the dot product with the query).
+func vsearchVec(alpha float32) []float32 {
+	v := make([]float32, vsearchOverfetchVecDim)
+	v[0] = alpha
+	beta := 1 - float64(alpha)*float64(alpha)
+	if beta < 0 {
+		beta = 0
+	}
+	v[1] = float32(math.Sqrt(beta))
+	return v
+}
+
+// setupVSearchMCP wires an MCP server/client pair over an isolated
+// nanobrain_test schema with a fixed-vector embedder so memory_vsearch
+// exercises its real DB query path deterministically.
+func setupVSearchMCP(t *testing.T) (context.Context, *sqlc.Queries, string, func(string, map[string]any) *mcpsdk.CallToolResult) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { db.Close() })
+
+	queries := sqlc.New(db)
+	wsHash := fmt.Sprintf("%x", sha256.Sum256([]byte("test_ws_vsearch_overfetch_"+uuid.New().String())))
+	if _, err := queries.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: wsHash, Name: "test-ws-vsearch-overfetch", Path: "/tmp/" + wsHash,
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+
+	embedder := &vsearchFixedEmbedder{vec: vsearchVec(1.0)} // query vector = [1,0,...,0]
+	server := internalmcp.NewMCPServer("test")
+	adapter := internalmcp.NewAdapter(queries, db, embedder, nil, nil, config.EmbeddingConfig{}, config.SearchConfig{}, config.FlowConfig{}, nil, zerolog.Nop())
+	internalmcp.RegisterTools(server, adapter)
+
+	ct, st := mcpsdk.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+
+	callTool := func(name string, args map[string]any) *mcpsdk.CallToolResult {
+		t.Helper()
+		result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("CallTool(%s): %v", name, err)
+		}
+		return result
+	}
+	return ctx, queries, wsHash, callTool
+}
+
+// seedVSearchDoc inserts one document plus one chunk (with a pinned
+// embedding) per entry in alphas.
+func seedVSearchDoc(t *testing.T, ctx context.Context, q *sqlc.Queries, wsHash, title string, alphas []float32) {
+	t.Helper()
+	content := "content body for " + title
+	doc, err := q.UpsertDocument(ctx, sqlc.UpsertDocumentParams{
+		WorkspaceHash: wsHash,
+		ContentHash:   contentHash(content + wsHash + title),
+		Title:         title,
+		Content:       content,
+		SourcePath:    "/tmp/" + title + ".md",
+		Collection:    "memory",
+		Tags:          []string{},
+		Metadata:      pqtype.NullRawMessage{},
+	})
+	if err != nil {
+		t.Fatalf("UpsertDocument(%s): %v", title, err)
+	}
+
+	for i, alpha := range alphas {
+		chunkContent := fmt.Sprintf("%s chunk %d", title, i)
+		chunkID, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+			DocumentID:        doc.ID,
+			WorkspaceHash:     wsHash,
+			ContentHash:       contentHash(chunkContent + wsHash + title + fmt.Sprintf("%d", i)),
+			Content:           chunkContent,
+			ChunkIndex:        int32(i),
+			StartLine:         sql.NullInt32{Int32: 1, Valid: true},
+			EndLine:           sql.NullInt32{Int32: 10, Valid: true},
+			Metadata:          pqtype.NullRawMessage{},
+			ChunkType:         "raw",
+			EmbeddingStrategy: "raw_code",
+		})
+		if err != nil {
+			t.Fatalf("UpsertChunk(%s, %d): %v", title, i, err)
+		}
+		if _, err := q.InsertEmbedding(ctx, sqlc.InsertEmbeddingParams{
+			ChunkID:       chunkID,
+			WorkspaceHash: wsHash,
+			Provider:      "test",
+			Model:         "test-model",
+			Embedding:     pgvector_go.NewVector(vsearchVec(alpha)),
+		}); err != nil {
+			t.Fatalf("InsertEmbedding(%s, %d): %v", title, i, err)
+		}
+	}
+}
+
+// TestMemoryVSearch_OverFetch_FewDocumentsCollapse reproduces #545: two "hot"
+// documents contribute 5 near-identical, highly-similar chunks each (10
+// chunks total, alpha 0.99/0.98) while 10 "cold" documents contribute a
+// single, less-similar chunk each (alpha 0.50 down to 0.41). Pre-fix, the
+// handler fetched only offset+max_results+1=8 chunks before deduplicating by
+// document; since the top 8 chunks by score are entirely hot-document
+// chunks, dedup collapsed the result to 2 documents even though max_results
+// was 7 and 12 distinct documents exist. Post-fix, the over-fetch (x5,
+// capped at 200) pulls in all 20 chunks, so dedup has every document
+// available and the page fills to the requested max_results.
+func TestMemoryVSearch_OverFetch_FewDocumentsCollapse(t *testing.T) {
+	ctx, q, wsHash, callTool := setupVSearchMCP(t)
+
+	seedVSearchDoc(t, ctx, q, wsHash, "hot-doc-0", []float32{0.99, 0.99, 0.99, 0.99, 0.99})
+	seedVSearchDoc(t, ctx, q, wsHash, "hot-doc-1", []float32{0.98, 0.98, 0.98, 0.98, 0.98})
+	coldAlphas := []float32{0.50, 0.49, 0.48, 0.47, 0.46, 0.45, 0.44, 0.43, 0.42, 0.41}
+	for i, alpha := range coldAlphas {
+		seedVSearchDoc(t, ctx, q, wsHash, fmt.Sprintf("cold-doc-%d", i), []float32{alpha})
+	}
+
+	result := callTool("memory_vsearch", map[string]any{
+		"workspace": wsHash, "query": "probe concept", "max_results": 7,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	if len(resp.Results) != 7 {
+		t.Fatalf("got %d results, want 7 (over-fetch should fill the page, not collapse to 2)", len(resp.Results))
+	}
+	if resp.Total != 12 {
+		t.Fatalf("total = %d, want 12 distinct documents (2 hot + 10 cold)", resp.Total)
+	}
+
+	items := parseResultItems(t, resp)
+	seenDocs := make(map[string]bool, len(items))
+	for _, item := range items {
+		if seenDocs[item.DocumentID] {
+			t.Errorf("duplicate document_id %s in a single group_by=document page", item.DocumentID)
+		}
+		seenDocs[item.DocumentID] = true
+	}
+	if len(seenDocs) != 7 {
+		t.Fatalf("page contains %d distinct documents, want 7 (not collapsed to 2 hot documents)", len(seenDocs))
+	}
+}
+
+// TestMemoryVSearch_ManyDocumentsAlreadyDiverse checks the non-collapsing
+// case still behaves correctly after the fix: 10 documents each contribute
+// exactly one chunk at a distinct similarity, so no over-fetch is needed to
+// reach max_results distinct documents.
+func TestMemoryVSearch_ManyDocumentsAlreadyDiverse(t *testing.T) {
+	ctx, q, wsHash, callTool := setupVSearchMCP(t)
+
+	alphas := []float32{0.99, 0.90, 0.80, 0.70, 0.60, 0.50, 0.40, 0.30, 0.20, 0.10}
+	for i, alpha := range alphas {
+		seedVSearchDoc(t, ctx, q, wsHash, fmt.Sprintf("diverse-doc-%d", i), []float32{alpha})
+	}
+
+	result := callTool("memory_vsearch", map[string]any{
+		"workspace": wsHash, "query": "probe concept", "max_results": 7,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	if len(resp.Results) != 7 {
+		t.Fatalf("got %d results, want 7", len(resp.Results))
+	}
+	if resp.Total != 10 {
+		t.Fatalf("total = %d, want 10 distinct documents", resp.Total)
+	}
+
+	items := parseResultItems(t, resp)
+	seenDocs := make(map[string]bool, len(items))
+	for _, item := range items {
+		seenDocs[item.DocumentID] = true
+	}
+	if len(seenDocs) != 7 {
+		t.Fatalf("page contains %d distinct documents, want 7", len(seenDocs))
+	}
+}
+
+// TestMemoryVSearch_GroupByNone_FetchLimitUnaffected asserts the fix is
+// scoped to group_by="document": when grouping is off, each chunk is its
+// own result and the fetch limit must stay at offset+max_results+1 (no
+// over-fetch), matching pre-fix behavior exactly.
+func TestMemoryVSearch_GroupByNone_FetchLimitUnaffected(t *testing.T) {
+	ctx, q, wsHash, callTool := setupVSearchMCP(t)
+
+	seedVSearchDoc(t, ctx, q, wsHash, "hot-doc-0", []float32{0.99, 0.99, 0.99, 0.99, 0.99})
+	seedVSearchDoc(t, ctx, q, wsHash, "hot-doc-1", []float32{0.98, 0.98, 0.98, 0.98, 0.98})
+	coldAlphas := []float32{0.50, 0.49, 0.48, 0.47, 0.46, 0.45, 0.44, 0.43, 0.42, 0.41}
+	for i, alpha := range coldAlphas {
+		seedVSearchDoc(t, ctx, q, wsHash, fmt.Sprintf("cold-doc-%d", i), []float32{alpha})
+	}
+
+	result := callTool("memory_vsearch", map[string]any{
+		"workspace": wsHash, "query": "probe concept", "max_results": 7, "group_by": "none",
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	if len(resp.Results) != 7 {
+		t.Fatalf("got %d results, want 7", len(resp.Results))
+	}
+	// offset(0)+max_results(7)+1 = 8 chunk-level rows fetched, unaffected by
+	// the group_by=document over-fetch factor.
+	if resp.Total != 8 {
+		t.Fatalf("total = %d, want 8 (fetch limit must stay at offset+max_results+1 when ungrouped)", resp.Total)
+	}
+}

--- a/internal/mcp/vsearch_overfetch_cap_floor_test.go
+++ b/internal/mcp/vsearch_overfetch_cap_floor_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"fmt"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nano-brain/nano-brain/internal/search"
+)
+
+// TestMemoryVSearch_OverFetchCapFloor_DeepPagination is regression coverage for
+// the R88 review follow-up to #545: vsearchDedupOverFetchCap (200 chunks) was an
+// unconditional ceiling with no floor at baseFetchLimit. Once
+// offset+max_results+1 exceeded the 200 cap, min(base*factor, cap) picked a
+// fetchLimit SMALLER than the page window itself needed, silently truncating
+// pages and reporting has_more=false even though more documents existed.
+//
+// Seeds 210 distinct-similarity, single-chunk documents (no hot-document
+// collapse needed — this bug hits the plain page-window math, independent of
+// dedup) and pages deep enough that baseFetchLimit (206) exceeds the cap
+// (200):
+//
+//   offset=145, max_results=60 -> baseFetchLimit = 145+60+1 = 206 > 200
+//
+// Pre-fix: fetchLimit = min(206*5, 200) = 200, so only ranks 1-200 are
+// fetched. The requested page (ranks 146-205) is truncated to ranks 146-200
+// (55 items instead of 60), and has_more incorrectly reports false (200 is
+// not > 205) even though 5 more documents (ranks 206-210) exist.
+//
+// Post-fix: fetchLimit = max(206, min(206*5, 200)) = 206, so ranks 1-206 are
+// fetched. The full 60-item page (ranks 146-205) is returned and has_more
+// correctly reports true (206 > 205).
+func TestMemoryVSearch_OverFetchCapFloor_DeepPagination(t *testing.T) {
+	ctx, q, wsHash, callTool := setupVSearchMCP(t)
+
+	const totalDocs = 210
+	for i := 0; i < totalDocs; i++ {
+		alpha := float32(1.0) - float32(i)*0.004
+		seedVSearchDoc(t, ctx, q, wsHash, fmt.Sprintf("deep-doc-%03d", i), []float32{alpha})
+	}
+
+	const maxResults = 60
+	const offset = 145 // offset+maxResults+1 = 206 > vsearchDedupOverFetchCap (200)
+
+	hashInput := search.QueryHashInput{Query: "probe concept", Scope: wsHash}
+	cursor := search.EncodeCursor(offset, search.QueryHash(hashInput))
+
+	result := callTool("memory_vsearch", map[string]any{
+		"workspace": wsHash, "query": "probe concept", "max_results": maxResults, "cursor": cursor,
+	})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Content[0].(*mcpsdk.TextContent).Text)
+	}
+
+	resp, _ := parseSearchResponse(t, result)
+	items := parseResultItems(t, resp)
+
+	if len(items) != maxResults {
+		t.Fatalf("got %d results, want %d (baseFetchLimit=%d > cap=200 must not starve the page window)",
+			len(items), maxResults, offset+maxResults+1)
+	}
+	if resp.NextCursor == "" {
+		t.Fatalf("next_cursor empty, want non-empty: %d more documents exist beyond offset+max_results=%d (total seeded=%d)",
+			totalDocs-(offset+maxResults), offset+maxResults, totalDocs)
+	}
+
+	seenDocs := make(map[string]bool, len(items))
+	for _, item := range items {
+		if seenDocs[item.DocumentID] {
+			t.Errorf("duplicate document_id %s in a single group_by=document page", item.DocumentID)
+		}
+		seenDocs[item.DocumentID] = true
+	}
+	if len(seenDocs) != maxResults {
+		t.Fatalf("page contains %d distinct documents, want %d", len(seenDocs), maxResults)
+	}
+}


### PR DESCRIPTION
Closes #545

## Problem
`memory_vsearch` fetched only `offset+maxResults+1` **chunks** then `deduplicateByDocument` collapsed them to documents. When the top chunks cluster into few documents — e.g. a diluted compound/multi-concept query embedding ranks several chunks from the same 1-2 docs highest — dedup returned far fewer than `max_results` (#545: `total:2` for `max_results:7`, silently). `VectorSearch` has no similarity threshold; the defect is purely fetch-too-few-then-dedup.

## Fix
When `group_by == "document"`, over-fetch candidate chunks before dedup:
`fetchLimit = max(baseFetchLimit, min(baseFetchLimit*5, 200))`. The 200 cap bounds worst-case query cost; the `max(baseFetchLimit, …)` **floor** ensures the cap never fetches fewer chunks than the page window itself needs (deep-pagination starvation — caught in R88 review, fixed). `group_by != "document"` unchanged. Also removes a duplicated `deduplicateByDocument` block. No schema change, no threshold. `memory_query`/`DebugSearch` intentionally untouched (hybrid legs + reranker fan-out make the multiplier not low-cost there — design.md G-C3).

## Tests (nanobrain_test only; never :3100)
- `internal/mcp/vsearch_overfetch_545_integration_test.go` — #545 repro (2 hot docs ×5 chunks vs 10 cold ×1) asserts 7 distinct docs; already-diverse + group_by=none controls.
- `internal/mcp/vsearch_overfetch_cap_floor_test.go` — deep-pagination cap-floor (`baseFetchLimit > cap`).
- `go test -race -tags=integration ./internal/mcp/ -run 'VSearch|Overfetch|545|Floor|Pagination'` → 6 PASS
- `go test -race -short ./...` → 31 pkgs ok; `go build ./...` exit 0
- **smoke:e2e** — REST `/api/v1/vsearch` HTTP 200 with live ollama embedder (surface health); fix behavior is integration-tested (embedding-space-dependent, MCP-tool-internal).

Reviews: R88 correctness FAIL (cap-floor) → fixed → PASS; 4 quality-axis reviews (efficiency/simplification/reuse/altitude) clean. Evidence: `docs/evidence/{review-545,self-review-vsearch-overfetch-dedup,smoke-e2e-vsearch-overfetch-dedup}.md`.

Phase 3 of the search-quality work; #543 debugging-mode buckets (PR-D) follows.