### PR TITLE
docs: rewrite README — honest latency/impact claims, 18-tool list, fix broken links, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nano-step
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g @nano-step/nano-brain
 CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain
 ```
 
-Prefer to read the installer first? `curl -fsSL -o install.sh …/install.sh && less install.sh && bash install.sh`.
+Prefer to read the installer first? `curl -fsSL -o install.sh https://raw.githubusercontent.com/nano-step/nano-brain/master/install.sh && less install.sh && bash install.sh`.
 
 ## Start
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Built for agents. Not humans.**
 
-Agent-oriented memory and code intelligence. AI agents don't read docs — they need structured context, impact analysis, and call chains. nano-brain provides exactly that via MCP.
+Agent-oriented memory and code intelligence over MCP. AI agents don't read docs — they call tools. nano-brain gives them structured context, symbol lookup, call-chain tracing, and change-impact analysis across sessions and repos.
 
 [![Go 1.23](https://img.shields.io/badge/Go-1.23-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -11,8 +11,20 @@ Agent-oriented memory and code intelligence. AI agents don't read docs — they 
 [![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/nano-step/nano-brain)
 [![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/nano-brain)
 
+---
 
-### Install
+## What it is
+
+nano-brain is an infrastructure layer between your AI agent and your code. It solves two problems agents have:
+
+1. **Session amnesia** — agents forget everything when a session ends. nano-brain harvests, indexes, and retrieves past sessions and saved decisions.
+2. **Codebase blindness** — agents can't cheaply trace dependencies, measure blast radius, or map an execution path. nano-brain builds a code graph and exposes it as MCP tools.
+
+Self-hosted (Go binary + PostgreSQL), works with any MCP client (Claude Code, OpenCode, Cursor, …), and returns structured results — not raw file bytes.
+
+---
+
+## Install
 
 ```bash
 # Recommended — one-line installer (no Node.js needed): downloads the prebuilt
@@ -26,65 +38,87 @@ npm install -g @nano-step/nano-brain
 CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain
 ```
 
-Prefer to read the installer before running it? Download, inspect, then run:
+Prefer to read the installer first? `curl -fsSL -o install.sh …/install.sh && less install.sh && bash install.sh`.
+
+## Start
 
 ```bash
-curl -fsSL -o install.sh https://raw.githubusercontent.com/nano-step/nano-brain/master/install.sh
-less install.sh && bash install.sh
-```
-
-### Start
-
-```bash
-# One command — the interactive wizard provisions PostgreSQL (via Docker or a
-# remote URL), configures embeddings, starts the server, registers this
-# project, and sets up your MCP client.
+# One command — the interactive wizard provisions PostgreSQL (Docker or remote URL),
+# configures embeddings, starts the server, registers this project, and wires up your MCP client.
 nano-brain init
 ```
 
-For a manual, per-step setup (VPS / team, no Docker, or Windows), see [docs/SETUP_AGENT.md](docs/SETUP_AGENT.md).
----
+Manual, per-step setup (VPS / team / no Docker / Windows): [docs/SETUP_AGENT.md](docs/SETUP_AGENT.md).
 
-## Why Star This Project?
+### Connect your agent
 
-**If you've ever wished your AI agent stopped flying blind in your codebase.**
+Add to your MCP client config:
 
-Most memory tools optimize for conversation recall. nano-brain optimizes for **agent comprehension** — the ability to understand codebases, trace dependencies, and predict the blast radius of changes.
+```json
+{
+  "mcp": {
+    "nano-brain": { "type": "remote", "url": "http://localhost:3100/mcp" }
+  }
+}
+```
 
-nano-brain is:
-
-- **Agent-oriented** — Built around how agents actually work: impact analysis before edits, call chain tracing, symbol lookup. Not a document store with MCP slapped on top.
-- **Self-hosted** — Your data stays on your server. No cloud dependency.
-- **Works everywhere** — OpenCode, Claude Code, Cursor, any MCP client.
-- **Actually useful** — Not a toy demo. Production-ready with 16 MCP tools, hybrid search, code intelligence, and agent-oriented benchmarks.
-- **Built for developers** — Go binary, PostgreSQL, zero magic. You can read the code.
-- **Beating competitors** — P@5 of 80% vs LlamaIndex's 55% and Qdrant's 27% on real-world queries.
-
-Star it if you want agents that understand your code, not just search it.
+Bind a default workspace by appending `?workspace=<name-or-hash>` to the URL (e.g. `…/mcp?workspace=my-project`) so tool calls can omit the `workspace` argument. An explicit `workspace` argument always overrides it; the value must be a name or full hash (not `"all"`). Run `nano-brain workspaces list` to see registered names/hashes.
 
 ---
 
-## What It Does
+## The agent workflow
 
-nano-brain is an **agent-oriented infrastructure layer** that sits between your AI agent and your codebase.
+A cold agent should follow this order — it maps 1:1 to the tools:
 
-It solves two problems agents have:
+1. **Orient** — `memory_wake_up` for a workspace briefing (recent activity, collections, stats).
+2. **Locate the workspace** — `memory_workspaces_resolve(path)` returns a deterministic hash and whether it's registered. Registering the repo root also covers its subdirectories, so resolve the root, not a single sub-repo.
+3. **Understand** — `memory_query` (hybrid, best for natural-language questions), `memory_search` (exact identifiers/errors), or `memory_vsearch` (fuzzy concepts). Search returns 500-char snippets; fetch full text with `memory_get` only for the hits you keep.
+4. **Navigate code** — `memory_symbols` to find a definition (no indexing needed), then `memory_graph` / `memory_trace` for call chains and `memory_flow` for an HTTP route's execution.
+5. **Before a risky edit** — `memory_impact(node, direction="in")` for the blast radius (who calls / imports this).
+6. **Persist** — `memory_write` to save a decision, lesson, or handoff for the next session.
 
-1. **Session amnesia** — Agents forget everything when the session ends. nano-brain persists context across sessions via harvesting, indexing, and retrieval.
-2. **Codebase blindness** — Agents can't trace dependencies, measure blast radius, or understand control flow. nano-brain builds a live code graph and exposes it via 16 MCP tools.
+```
+wake_up → resolve ─▶ query / search / symbols ─▶ graph / trace / flow / impact ─▶ (edit) ─▶ write
+```
 
-**Why MCP?** Because agents don't read docs. They call tools. Every capability is a tool call — no REST API ceremony, no JSON parsing, no manual file reading.
+---
 
-### How agents use it
+## MCP tools (18)
 
-| Agent needs to... | Tool | What it returns |
-|---|---|---|
-| Understand a feature | `memory_query` | Hybrid search results with context |
-| Check what breaks before editing | `memory_impact` | Blast radius — all dependent files |
-| Trace an execution path | `memory_trace` | Call chain from entry point |
-| Find a function definition | `memory_symbols` | Symbol location + kind |
-| Recall a past decision | `memory_query` | Past session context |
-| Save a discovery | `memory_write` | Persisted for future sessions |
+**Search & recall**
+
+| Tool | Use it for |
+|------|------------|
+| `memory_query` | Hybrid BM25 + vector + RRF + recency — default first tool for broad questions |
+| `memory_search` | Exact keyword/BM25 — error strings, identifiers, config keys, channel/topic names |
+| `memory_vsearch` | Vector similarity — fuzzy concepts (best on single-concept queries) |
+| `memory_get` | Fetch full content (or a line range) for one known document/symbol |
+| `memory_write` | Persist a decision/lesson/handoff (supports `supersedes`) |
+| `memory_ticket` | All sessions tagged with a ticket ID (e.g. `PROJ-1234`) across the workspace |
+| `memory_wake_up` | Session-start briefing: recent memories, active collections, stats |
+| `memory_tags` | List collections and document counts |
+
+**Code intelligence**
+
+| Tool | Use it for |
+|------|------------|
+| `memory_symbols` | Find a function/type/interface/const by name (reads the filesystem — no indexing required) |
+| `memory_graph` | One-hop neighbors: direct callers/callees, imports, containment |
+| `memory_trace` | Downstream call chain from an entry symbol |
+| `memory_impact` | Reverse blast radius before an edit: who calls/imports this |
+| `memory_flow` | HTTP route execution flow (middleware → handler → downstream), Mermaid/sequence/JSON |
+| `memory_flowchart` | Control-flow graph of a single function (branches, loops, returns) |
+
+**Workspace & ops**
+
+| Tool | Use it for |
+|------|------------|
+| `memory_workspaces_resolve` | Resolve a path to its workspace hash + registration status |
+| `memory_workspaces_list` | List registered workspaces with paths, hashes, document counts |
+| `memory_status` | Server / DB / embedding-queue health |
+| `memory_update` | Trigger a delta re-scan / re-embedding for a workspace |
+
+> Every tool is self-describing over MCP — your client lists each tool's name, parameters, and description on connect.
 
 ---
 
@@ -92,479 +126,115 @@ It solves two problems agents have:
 
 ```mermaid
 graph LR
-    A[Your AI Agent] -->|MCP Protocol| B[nano-brain]
+    A[Your AI Agent] -->|MCP| B[nano-brain]
     B --> C[PostgreSQL + pgvector]
     B --> D[Session Harvesting]
     B --> E[Code Intelligence]
     B --> F[Hybrid Search]
-    
     D --> D1[OpenCode Sessions]
     D --> D2[Claude Code Sessions]
-    
     E --> E1[Symbol Graph]
     E --> E2[Flow Diagrams]
     E --> E3[Impact Analysis]
-    
     F --> F1[BM25 Full-Text]
     F --> F2[Vector Similarity]
     F --> F3[RRF Fusion]
 ```
 
----
+- **Hybrid search** — BM25 full-text + pgvector HNSW cosine similarity + Reciprocal Rank Fusion + recency decay.
+- **Code intelligence** — symbol extraction, cross-file call-chain tracing, reverse-dependency (impact) analysis, and Mermaid flow/flowchart generation. Multi-language, including Ruby/Rails route + control-flow support.
+- **Session harvesting** — auto-ingest from OpenCode and Claude Code sessions, map-reduce LLM summarization, incremental harvest with dedup.
 
-## Agent-Oriented Design
-
-nano-brain isn't a memory tool with MCP bolted on. It's designed from the ground up around **how agents actually behave**.
-
-### The agent workflow loop
-
-```
-┌─────────────┐     ┌──────────────┐     ┌─────────────┐
-│  Agent       │────▶│  memory_query │────▶│  Context     │
-│  receives    │     │  /impact/trace│     │  window      │
-│  task        │     │              │     │  filled      │
-└─────────────┘     └──────────────┘     └──────┬──────┘
-                                                 │
-                                          ┌──────▼──────┐
-                                          │  Agent       │
-                                          │  implements  │
-                                          │  change      │
-                                          └──────┬──────┘
-                                                 │
-                                          ┌──────▼──────┐
-                                          │  memory_write │
-                                          │  (persist)    │
-                                          └─────────────┘
-```
-
-### Why agent behavior matters
-
-| Human workflow | Agent workflow | nano-brain response |
-|---|---|---|
-| Opens file, reads it | `memory_get` or `memory_search` | Returns structured content, not raw bytes |
-| Traces call chain manually | `memory_trace` | Returns function-by-function chain with line numbers |
-| Greps for callers | `memory_graph(direction="in")` | Returns all callers in one call |
-| Thinks "what breaks?" | `memory_impact` | Returns full blast radius in <50ms |
-| Remembers past decisions | `memory_query` | Returns cross-session context |
-
-### The 50ms rule
-
-At 50ms latency, agents run impact analysis on every edit. At 500ms, they skip it. nano-brain is designed for the 50ms world — every code intelligence tool call is sub-50ms, making it practical for agents to use them on every operation.
-
-### What agents actually need
-
-Research from 15+ production code intelligence tools shows:
-
-1. **Impact analysis is #1** — "What breaks if I change this?" is the most common agent query
-2. **Call chains > control flow** — Agents trace across files (inter-procedural), not within functions (intra-procedural)
-3. **Component composition > internal logic** — For frontend frameworks, "who uses this component?" matters more than "what does the template do?"
-
-nano-brain optimizes for exactly these three patterns.
-
----
-
-## Key Features
-
-### Hybrid Search
-
-```mermaid
-graph LR
-    Q[Query] --> BM25[BM25 Full-Text]
-    Q --> Vector[Vector Similarity]
-    BM25 --> RRF[RRF Fusion]
-    Vector --> RRF
-    RRF --> Results[Ranked Results]
-```
-
-BM25 full-text + pgvector HNSW cosine similarity + Reciprocal Rank Fusion + recency decay.
-
-### Code Intelligence
-
-```mermaid
-graph TD
-    A[Entry Point] --> B[Function Call]
-    B --> C[Method Call]
-    B --> D[Database Query]
-    C --> E[External Service]
-    D --> F[Redis Cache]
-```
-
-- **Symbol extraction** — Functions, types, interfaces, constants
-- **Call chain tracing** — Follow execution paths across files
-- **Impact analysis** — "What breaks if I change this?"
-- **Flow diagrams** — Mermaid flowcharts and sequence diagrams
-
-### Session Harvesting
-
-```mermaid
-graph LR
-    S1[OpenCode DB] --> H[Harvester]
-    S2[Claude Code JSONL] --> H
-    H --> L[LLM Summarizer]
-    L --> I[Indexer]
-    I --> DB[PostgreSQL]
-```
-
-Auto-ingest from OpenCode and Claude Code sessions. Map-reduce LLM summarization. Incremental harvest with dedup.
-
-### 16 MCP Tools
-
-| Tool | Description |
-|------|-------------|
-| `memory_query` | Hybrid search — default first tool for broad questions |
-| `memory_search` | BM25 keyword search for exact text/errors |
-| `memory_vsearch` | Vector similarity for fuzzy concepts |
-| `memory_get` | Get document by path or ID |
-| `memory_write` | Write/update document |
-| `memory_graph` | One-hop callers/callees/imports |
-| `memory_trace` | Downstream call chain trace |
-| `memory_impact` | Pre-change blast radius analysis |
-| `memory_symbols` | Symbol search (functions, types, interfaces) |
-| `memory_flow` | HTTP route execution flow |
-| `memory_flowchart` | Function-level control-flow graph |
-| `memory_workspaces_resolve` | Resolve path to workspace hash |
-| `memory_tags` | List tags with counts |
-| `memory_status` | Server and queue health |
-| `memory_update` | Trigger re-embedding |
-| `memory_wake_up` | Session-start workspace briefing |
-
----
-
-## Quick Start
-
-### Prerequisites
-
-- **Go 1.23+** OR pre-built binary
-- **PostgreSQL 17** with **pgvector 0.8.2**
-- **Ollama** (for embeddings) or any OpenAI-compatible provider
-
-### Configure Your AI Agent
-
-Add to your MCP client config (Claude Code, OpenCode, Cursor, etc.):
-
-```json
-{
-  "mcp": {
-    "nano-brain": {
-      "type": "remote",
-      "url": "http://localhost:3100/mcp"
-    }
-  }
-}
-```
-
-Optionally bind a default workspace to the connection by appending `?workspace=<name-or-hash>` to the URL (e.g. `"url": "http://localhost:3100/mcp?workspace=nano-brain"`) — tool calls can then omit the `workspace` argument. Run `nano-brain workspaces list` to see the registered name/hash for a project. An explicit `workspace` argument always overrides the connection default; the value must be a name or full hash, not `"all"`.
-
----
-
-## Demo
-
-### Query Your Codebase
-
-```bash
-# Search for authentication patterns
-curl -X POST http://localhost:3100/api/v1/query \
-  -H "Content-Type: application/json" \
-  -d '{"workspace": "abc123", "query": "how does authentication work"}'
-```
-
-### Trace Call Chains
-
-```bash
-# Trace from entry point
-curl -X POST http://localhost:3100/api/v1/graph/trace \
-  -H "Content-Type: application/json" \
-  -d '{"workspace": "abc123", "node": "main.go::main", "max_depth": 5}'
-```
-
-### Analyze Impact
-
-```bash
-# What breaks if I change this file?
-curl -X POST http://localhost:3100/api/v1/graph/impact \
-  -H "Content-Type: application/json" \
-  -d '{"workspace": "abc123", "node": "src/auth/login.ts", "max_depth": 2}'
-```
-
-### Generate Flow Diagrams
-
-```bash
-# Get flow diagram for a controller
-curl -X POST http://localhost:3100/api/v1/graph/flow \
-  -H "Content-Type: application/json" \
-  -d '{"workspace": "abc123", "entry": "POST /users"}'
-```
-
-Returns Mermaid flowchart:
-
-```mermaid
-flowchart LR
-  POST_/users["POST /users"]
-  POST_/users --> UsersController#create
-  UsersController#create --> User.create
-  UsersController#create --> Mailer.welcome
-```
-
----
-
-## Use Cases
-
-### Agent-assisted refactoring
-Before refactoring, your agent calls `memory_impact` on the target function. Gets the full blast radius. Decides whether to split the change. After refactoring, runs affected tests only — not the full suite.
-
-### Multi-session feature development
-Session 1: Agent explores the codebase, discovers patterns. `memory_write` saves findings. Session 2: Agent recalls session 1's discoveries via `memory_query`. No context lost between sessions.
-
-### Legacy codebase onboarding
-Index a 5-year-old codebase. Your agent can now answer "what does this function do?", "why does this class exist?", "if I change this file, what else breaks?" — without reading every file.
-
-### Cross-service debugging
-Agent traces a bug from frontend to backend. `memory_trace` follows the call chain across services. `memory_graph` shows which microservices depend on the failing endpoint.
-
-### Team knowledge sharing
-One server, whole team. Every developer's AI agent connects to the same PostgreSQL. Decisions, architecture notes, code intelligence — instantly shared. New hires get full context from day one.
+Collections: `code` (indexed source + docs), `sessions` (harvested agent sessions), `memory` (agent-written decisions/notes).
 
 ---
 
 ## Performance
 
-### Search Quality vs Competitors
+Code-intelligence lookups (`memory_symbols`, `memory_graph`, `memory_impact`, `memory_vsearch`, exact `memory_search`) return in tens of milliseconds — fast enough that agents can run impact analysis on **every** edit rather than skipping it.
 
-| Metric | nano-brain | LlamaIndex | Qdrant/Mem0 | Cognee | GraphRAG | Zep |
-|--------|------------|------------|-------------|--------|----------|-----|
-| P@5 | **80%** | 55% | 27% | — | — | — |
-| MRR | **95%** | — | — | — | — | — |
-| Latency | **42ms** | — | — | — | — | — |
-| Code Intelligence | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Symbol Graph | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Impact Analysis | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Flow Diagrams | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+### Search quality vs. document-memory tools
 
-Tested on 60 domain-specific queries across 3 workspaces. nano-brain is the **only** solution with code intelligence — competitors focus on conversation memory and document retrieval.
+| Metric | nano-brain | LlamaIndex | Qdrant/Mem0 |
+|--------|------------|------------|-------------|
+| P@5 | **80%** | 55% | 27% |
+| MRR | **95%** | — | — |
+| Code intelligence (symbols / impact / flow) | ✅ | ❌ | ❌ |
 
-### Competitive Landscape
+Measured on 60 domain-specific queries across three workspaces (a Go daemon, a TypeScript service, and a Rails app). nano-brain is the only one of these with code intelligence — the others target conversation memory and document retrieval.
 
-**What competitors offer:**
-- **Mem0 / Zep** — Conversation memory, temporal ranking, chat history recall
-- **Cognee / GraphRAG** — Document-level knowledge graphs, multi-hop reasoning
-- **LlamaIndex** — Flexible RAG pipelines, document retrieval
+### Agent-oriented capability benchmarks
 
-**What nano-brain adds (agent-oriented):**
-- **Impact analysis** — "What breaks if I change this?" — the #1 question agents ask. Pre-computed blast radius in <50ms.
-- **Call chain tracing** — Follow execution paths across files. Agent gets a structured trace, not raw source.
-- **Symbol graph** — Find definitions, callers, callees. `memory_symbols` + `memory_graph`.
-- **Agent-oriented benchmarks** — Measures how well agents find context for domain tasks — not just search precision in isolation.
+Each benchmark runs a deterministic agent workflow — natural-language question → optimized query → symbol lookup — mirroring how an agent actually explores a codebase.
 
-**The difference:** Competitors optimize for "did the agent find the right document?" nano-brain optimizes for "did the agent understand the codebase well enough to make the right change?"
+| Workspace | Overall | Multi-tool | Search-QA | Symbol-Lookup |
+|-----------|---------|------------|-----------|---------------|
+| Go daemon | **1.000** | 1.000 | 1.000 | 1.000 |
+| TypeScript service | **0.885** | 1.000 | 0.817 | 1.000 |
+| Rails app | **0.795** | 1.000 | 0.726 | 0.667 |
 
-At 50ms latency, agents run impact analysis on every edit. At 500ms, they skip it. nano-brain is designed for the 50ms world.
-
-### Agent-Oriented Capability Benchmarks
-
-nano-brain is built for agents. These benchmarks measure how well agents can **find relevant context for real-world domain tasks** using nano-brain's MCP tools — not just search quality in isolation.
-
-Each benchmark runs a deterministic agent workflow:
-1. **query_question** — natural-language domain question
-2. **query_input** — optimized search query
-3. **symbols_identifiers** — symbol lookup for known identifiers
-
-This mimics how a real agent explores a codebase: broad understanding first, then targeted retrieval.
-
-#### Scores
-
-| Workspace | Domain | Overall | Multi-tool | Search-QA | Symbol-Lookup |
-|-----------|--------|---------|------------|-----------|---------------|
-| **nano-brain** | Go daemon | **1.000** | 1.000 | 1.000 | 1.000 |
-| **TypeScript** | CS2 item trading | **0.885** | 1.000 | 0.817 | 1.000 |
-| **Rails** | CS2 item trading | **0.795** | 1.000 | 0.726 | 0.667 |
-
-**What this means:**
-- **Multi-tool 1.000** — When agents combine search + symbols, they find every expected context item
-- **Overall 0.885** — TypeScript workspace: agent finds 88.5% of expected domain artifacts
-- **Fixed vs Agent** — Agent workflow improves recall by 15-40% over single-tool queries
-- **Unique capability** — No competitor offers agent-oriented benchmarks or code intelligence
-
-#### How to Run
-
-```bash
-# TypeScript workspace (CS2 item trading domain)
-NANO_BRAIN_URL=http://localhost:3100 \
-NANO_BRAIN_WORKSPACE=<your-workspace-hash> \
-go test -v -tags=capbench -run TestCapabilityBenchmark \
-  ./benchmarks/typescript/capability/
-
-# Rails workspace (CS2 item trading domain)
-NANO_BRAIN_URL=http://localhost:3100 \
-NANO_BRAIN_WORKSPACE=<your-workspace-hash> \
-go test -v -tags=capbench -run TestCapabilityBenchmark \
-  ./benchmarks/rails/capability/
-
-# nano-brain itself (Go daemon)
-NANO_BRAIN_URL=http://localhost:3100 \
-NANO_BRAIN_WORKSPACE=nano-brain \
-go test -v -tags=capbench -run TestCapabilityBenchmark \
-  ./benchmarks/capability/
-```
-
-#### Task Categories
-
-| Category | What It Tests | Tools Used |
-|----------|---------------|------------|
-| **search-qa** | Domain concept retrieval via search | `query_question`, `query_input` |
-| **symbol-lookup** | Known identifier resolution | `query_input`, `symbols_identifiers` |
-| **multi-tool** | Cross-tool workflow (search → symbols) | All three tools in sequence |
-
-See individual benchmark READMEs for full task breakdowns:
-- [`benchmarks/typescript/capability/README.md`](benchmarks/typescript/capability/README.md)
-- [`benchmarks/rails/capability/README.md`](benchmarks/rails/capability/README.md)
-- [`benchmarks/capability/README.md`](benchmarks/capability/README.md)
+Run them: see the per-suite READMEs under [`benchmarks/`](benchmarks/).
 
 ---
 
-## Ruby / Rails Support
+## Tech stack
 
-nano-brain supports Ruby and Ruby on Rails code intelligence:
-
-- **Rails routes** — `resources`, `get`/`post`/`patch`/`put`/`delete`, `namespace`
-- **Control-flow graphs** — `if`/`else`, loops, `begin`/`rescue`, method defs
-- **Cross-file resolution** — Class→file index, resolver, reconcile edges
-- **Flow diagrams** — Controller→service→model chains (20-34 nodes)
-
-Example flow for a Rails controller action:
-
-```mermaid
-flowchart LR
-  POST_/users["POST /users"]
-  POST_/users --> UsersController#create
-  UsersController#create --> User.create
-  UsersController#create --> Mailer.welcome
-```
-
----
-
-## Tech Stack
-
-- **Go 1.23** — Single static binary (`CGO_ENABLED=0`)
-- **PostgreSQL 17** — Full-text search (tsvector/tsquery)
-- **pgvector 0.8.2** — HNSW vector indexing
-- **Echo v4** — HTTP framework
-- **sqlc** — Type-safe SQL code generation
-- **goose v3** — Database migrations
-- **zerolog** — Structured JSON logging
-- **koanf** — YAML + env configuration
-- **fsnotify** — File system watching
-
----
+Go 1.23 (single static binary, `CGO_ENABLED=0`) · PostgreSQL 17 + pgvector 0.8.2 (HNSW) · Echo v4 · sqlc · goose · zerolog · koanf · fsnotify · Ollama (or any OpenAI-compatible embeddings provider).
 
 ## Configuration
 
-Config file: `~/.nano-brain/config.yml`
+`~/.nano-brain/config.yml`:
 
 ```yaml
-server:
-  host: localhost
-  port: 3100
-
-database:
-  url: postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev
-
-embedding:
-  provider: ollama
-  url: http://localhost:11434
-  model: nomic-embed-text
-
-search:
-  rrf_k: 60
-  recency_weight: 0.3
-  limit: 20
+server:   { host: localhost, port: 3100 }
+database: { url: postgres://nanobrain:nanobrain@localhost:5432/nanobrain_dev }
+embedding: { provider: ollama, url: http://localhost:11434, model: nomic-embed-text }
+search:   { rrf_k: 60, recency_weight: 0.3, limit: 20 }
 ```
 
-See [Configuration](docs/CONFIGURATION.md) for full options.
+Full options: [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
+
+## REST API
+
+Everything is available over MCP; a REST surface exists for scripting and ops (writes go through MCP). `GET /api/openapi.json` serves the live OpenAPI 3.0 spec — import it into Postman/Swagger.
+
+```bash
+# Understand
+curl -X POST http://localhost:3100/api/v1/query   -H 'Content-Type: application/json' \
+  -d '{"workspace":"<hash>","query":"how does authentication work"}'
+# Blast radius
+curl -X POST http://localhost:3100/api/v1/graph/impact -H 'Content-Type: application/json' \
+  -d '{"workspace":"<hash>","node":"src/auth/login.ts","direction":"in"}'
+```
 
 ---
 
 ## Documentation
 
-- [Getting Started](docs/GETTING_STARTED.md) — Step-by-step setup guide
-- [Configuration](docs/CONFIGURATION.md) — All config options
-- [REST API](docs/API.md) — HTTP endpoints
-- [CLI Commands](docs/CLI.md) — Command reference
-- [MCP Tools](docs/MCP.md) — Tool documentation
-- [Architecture](docs/ARCHITECTURE.md) — System design
-- [Changelog](CHANGELOG.md) — What's new
-- [Roadmap](docs/ROADMAP.md) — What's planned
-- [Feature Showcase](docs/FEATURES.md) — Visual examples
-
----
+- [Setup (agent / manual)](docs/SETUP_AGENT.md)
+- [Configuration](docs/CONFIGURATION.md)
+- [Architecture](docs/architecture.md)
+- [Features](docs/FEATURES.md)
+- [Roadmap](docs/ROADMAP.md)
+- [Changelog](CHANGELOG.md)
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
-### Development Setup
+Contributions welcome — open an issue or a PR.
 
 ```bash
-# Clone the repo
-git clone https://github.com/nano-step/nano-brain.git
-cd nano-brain
-
-# Build
+git clone https://github.com/nano-step/nano-brain.git && cd nano-brain
 CGO_ENABLED=0 go build -o nano-brain ./cmd/nano-brain
-
-# Run tests
-go test -race -short ./...
-
-# Run integration tests (requires PostgreSQL)
-go test -race -tags=integration ./...
+go test -race -short ./...                    # unit
+go test -race -tags=integration ./...         # integration (needs PostgreSQL)
 ```
 
-`GET /api/openapi.json` serves the current OpenAPI 3.0 spec for the full REST API — import it into Postman, Swagger UI, or any codegen tool to discover the endpoint surface without reading Go source. Regenerate it via `make generate-openapi` after adding or changing routes.
-
-### Project Structure
-
-```
-nano-brain/
-├── cmd/nano-brain/       # CLI dispatcher + server startup
-├── internal/
-│   ├── config/           # Configuration management
-│   ├── server/           # HTTP server + handlers
-│   ├── storage/          # PostgreSQL + sqlc
-│   ├── search/           # Hybrid search pipeline
-│   ├── embed/            # Embedding queue
-│   ├── watcher/          # File system watcher
-│   ├── harvest/          # Session harvesting
-│   ├── mcp/              # MCP protocol tools
-│   ├── graph/            # Code intelligence
-│   └── ...
-├── migrations/           # Database migrations
-└── benchmarks/           # Performance benchmarks
-```
-
----
+Regenerate the OpenAPI spec after route changes: `make generate-openapi`.
 
 ## Community
 
-- [GitHub Discussions](https://github.com/nano-step/nano-brain/discussions) — Ask questions, share ideas
-- [Discord](https://discord.gg/nano-brain) — Real-time chat
-- [Twitter](https://twitter.com/nano_brain) — Updates and announcements
-
----
+[GitHub Discussions](https://github.com/nano-step/nano-brain/discussions) · [Discord](https://discord.gg/nano-brain)
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
-
----
-
-## Acknowledgments
-
-Built with:
-- [Go](https://go.dev/) — Fast, statically typed language
-- [PostgreSQL](https://www.postgresql.org/) — The world's most advanced open source database
-- [pgvector](https://github.com/pgvector/pgvector) — Open-source vector similarity search
-- [Echo](https://echo.labstack.com/) — High performance, extensible, minimalist Go web framework
-- [sqlc](https://sqlc.dev/) — Generate type-safe code from SQL
-- [goose](https://github.com/pressly/goose) — Database migration tool
-- [zerolog](https://github.com/rs/zerolog) — Zero allocation JSON logger
-- [koanf](https://github.com/knadh/koanf) — Configuration manager
-- [fsnotify](https://github.com/fsnotify/fsnotify) — Cross-platform file system notifications
+Licensed under the MIT License.

--- a/docs/evidence/self-review-547-readme-rewrite.md
+++ b/docs/evidence/self-review-547-readme-rewrite.md
@@ -47,8 +47,8 @@ smoke:e2e nor an independent review gate; this self-review is the record.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini review: COMMENTED, CI pass, MERGEABLE/CLEAN. One inline comment.
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| README.md:41 [medium] — `curl` uses a Unicode ellipsis (`…/install.sh`) in a copy-pasteable command | VALID | The "read the installer first" one-liner is meant to be run; a literal `…` would fail on paste. (Inherited verbatim from the issue draft.) | Fixed — replaced with the real URL `https://raw.githubusercontent.com/nano-step/nano-brain/master/install.sh`. The other two `…` (line 23 prose list, line 65 illustrative URL-suffix fragment) are not runnable commands → left as-is. |

--- a/docs/evidence/self-review-547-readme-rewrite.md
+++ b/docs/evidence/self-review-547-readme-rewrite.md
@@ -1,0 +1,54 @@
+# Self-Review — Issue #547 (README rewrite + LICENSE)
+
+Change-type: **docs** · Lane: tiny · Branch: `docs/547-readme-rewrite`
+Author: kokorolx. Per harness change-type table, docs requires neither
+smoke:e2e nor an independent review gate; this self-review is the record.
+
+## Actions Taken
+
+- Rewrote `README.md` from the ready-to-merge draft in issue #547, corrected
+  against **verified current behavior** (not the draft's assumed post-fix state).
+- Dropped the "50ms rule" (stated 3×) and the "42ms" figure; the Performance
+  section now scopes fast-path wording to code-intelligence lookups only and
+  does not claim the hybrid `memory_query` path is sub-50ms.
+- Kept `memory_impact(direction:"in")` as the headline capability after
+  empirically confirming it returns real reverse callers.
+- Corrected the tool count 16 → 18 (`memory_ticket`, `memory_workspaces_list`),
+  regrouped the tool table, added an explicit ordered agent workflow.
+- Repaired broken links; created a top-level MIT `LICENSE` (badge + License
+  section now resolve). Genericized benchmark labels; trimmed 570 → 240 lines.
+
+## Files Changed
+
+- `README.md` — full rewrite (240 lines, was 570).
+- `LICENSE` — new (MIT, copyright nano-step, matches package.json `license: MIT`).
+
+## Findings Summary
+
+- **Verification before claiming.** Ran `memory_impact ExpandImpactFrontier
+  direction=in` on the live `nano-brain` workspace → 7 real reverse edges
+  (`registerMemoryImpact`, `collectImpact` via `calls`; container files via
+  `contains`; depth-2 callers). So #544 N1's "returns empty" is resolved for the
+  call/containment case → the impact claims are honest. File-level reverse
+  *import* edges remain #378's scope (still open); the README does not
+  over-claim there.
+- **Deliberate omission.** The draft's "Multi-repo & event-driven code" section
+  documents `publishes_to`/`subscribes_to`/`produces`/`consumes` edges that are
+  a **proposed** feature in #546 (not shipped) and monorepo-scoped resolution
+  that is deferred. Including it would reintroduce the false-claim problem this
+  change fixes, so it was omitted. Add once #546 lands.
+
+## Resolution Status
+
+- All in-scope items resolved. No critical/major issues.
+- `CGO_ENABLED=0 go build ./...` → exit 0 (docs-only; no code touched).
+- Link check: all 10 relative README links resolve (0 broken), incl. `LICENSE`.
+- Residual stale-string grep (`50ms`/`42ms`/`16 tools`/`publishes_to`) → none.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |


### PR DESCRIPTION
Closes #547

## Problem
Dogfooding (#542–#546) found the README's load-bearing claims drifted from actual behavior: a "50ms rule" stated 3× + a "42ms" figure implying every tool is sub-50ms (the default `memory_query` hybrid path is not), a wrong tool count ("16" vs the real 18), and ~7 broken doc links — including the MIT badge + License section both pointing at a non-existent `LICENSE`.

## Change
Applies the issue's proposed rewrite, corrected against **verified current behavior**:

- **Latency** — drop the "50ms rule"/"42ms" claims; the Performance section now scopes the fast-path wording to code-intelligence lookups (`memory_symbols`/`graph`/`impact`/`vsearch`/exact `search`) and does not claim the hybrid `memory_query` is fast. Matches #542 F4 / #543 D2.
- **Impact** — kept as the headline capability. Empirically re-verified `memory_impact(direction:"in")` returns real reverse callers (call + containment edges) on a live workspace, so #544 N1's "returns empty" no longer holds for the primary case.
- **Tool list** — 16 → **18**: adds `memory_ticket` and `memory_workspaces_list`; regrouped into search & recall / code intelligence / workspace & ops.
- **Broken links** — removed the 5 non-existent `docs/*` links + the uppercase `docs/ARCHITECTURE.md`; **added an MIT `LICENSE` file** so the badge and License section resolve.
- **Workflow** — added an explicit ordered agent workflow (`wake_up → resolve → query/search/symbols → graph/trace/flow/impact → write`).
- **Hygiene** — genericized benchmark workspace labels, dropped repetitive intro sections and empty competitor columns. **570 → 240 lines (~58% shorter).**

## Deliberately omitted from the draft
The **"Multi-repo & event-driven code"** section. Its `publishes_to`/`subscribes_to`/`produces`/`consumes` edges are a **proposed** feature in #546 (not shipped) and the monorepo-scoped call resolution is deferred — documenting them now would reintroduce the exact false-claim problem this PR fixes. Add that section only once #546 lands.

## Validation
- `CGO_ENABLED=0 go build ./...` — exit 0 (docs-only; no code touched).
- Link check: all 10 relative links in the new README resolve (0 broken), including the new `LICENSE`.
- No stale `50ms`/`42ms`/`16 tools`/`publishes_to` strings remain.
- Self-review: `docs/evidence/self-review-547-readme-rewrite.md`.

Change-type: **docs** (per harness: no smoke:e2e, no review gate). Lane: tiny.