### PR TITLE
fix(trace): memory_trace recurses to max_depth (was single-hop only)

### DIFF
--- a/docs/evidence/review-561.md
+++ b/docs/evidence/review-561.md
@@ -1,0 +1,39 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/trace-max-depth-recursion` · Issue #561 (split from #542 F3)
+
+Change: `memory_trace` BFS now recurses to `max_depth`. The traversal key is
+normalized to workspace-relative (`stripWorkspacePrefix(wsRoot, cur.node)`) at
+the edge lookup so each hop matches the relative `graph_edges.source_node`;
+previously an absolute child key (qualified from the absolute
+`documents.source_path`) missed on every hop after the first.
+
+| Concern | Verdict |
+|---|---|
+| Correctness of strip-at-lookup (all hop shapes) | PASS (HIGH) — entry (already relative) is a no-op; absolute child → stripped → matches; bare symbols / import-path targets fall through unchanged; externals hit the `matches==0` branch and are never enqueued. |
+| Display invariant | PASS (HIGH) — `paths=absolute` output byte-identical (chain nodes still stored absolute, not stripped in absolute mode); `entry` field no-op either way; `paths=relative` uses the same `wsRoot`, now computed once instead of lazily — equivalent. |
+| Cycle / seen safety | PASS (HIGH) — no infinite loop (children in `seen`, `maxDepth ≤ 10`). |
+| New test non-vacuous | PASS (HIGH) — seeds ABSOLUTE source_path (the prod case the relative-path tests missed); FAIL-on-master / PASS-with-fix confirmed; `leaf@2` assertion requires the transitive hop; comma-ok avoids the sibling test's panic trap. |
+
+Reviewer independently verified: `go build` + `go vet` OK; new test PASS with
+fix and FAIL (`chain length = 1`) against stashed-master `tools.go`.
+
+### Open items (both PRE-EXISTING, not regressions — decision: out of scope)
+
+- **[MEDIUM]** `TestMemoryTrace_RelativeInputAndOutput` (`graph_paths_integration_test.go:218`)
+  panics (`nil` chain, single-return type assertion). Reviewer confirmed it
+  panics identically on master with this change stashed → **not caused here**.
+  It aborts the `internal/mcp` integration binary, so the new #561 test passes
+  when run in isolation. **CI is unaffected** — `ci.yml` runs `go test -race
+  -short` only; integration tests are `//go:build integration`. Tracked as
+  **#556** (already filed). Not fixed here to keep the diff surgical.
+- **[LOW]** Pre-existing `seen`-key asymmetry (relative entry seed vs absolute
+  child keys) could re-list the entry once in a call cycle — bounded, no loop.
+  The diff changed neither the seed nor the child qualification → out of scope.
+
+### smoke:e2e — see `docs/evidence/smoke-e2e-trace-max-depth-recursion.md`
+Live :3100 reproduction of the depth-1-only bug + red-green integration test
+through the real MCP SDK transport + MCP-over-HTTP handshake (HTTP 200) on
+:3199 / nanobrain_test. Dev DB never touched.

--- a/docs/evidence/self-review-trace-max-depth-recursion.md
+++ b/docs/evidence/self-review-trace-max-depth-recursion.md
@@ -51,8 +51,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED, CI pass, MERGEABLE/CLEAN. One inline comment.
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| tools.go:1910 [medium] — `seen`-map key asymmetry (relative entry seed vs absolute child keys) lets a cycle back to the entry re-list it | VALID | Same item R88 raised (LOW). Bounded (no loop) but a real correctness nit in the exact traversal being fixed; two reviewers flagged it. | **Fixed** — dedup now keys on the workspace-relative form (`stripWorkspacePrefix(wsRoot, qualified)`) while keeping the absolute node for display. Locked by new red-green test `TestMemoryTrace_CycleBackToEntry_NotReListed_AbsoluteSourcePath` (RED: Main re-listed at depth 2; GREEN: deduped). |

--- a/docs/evidence/self-review-trace-max-depth-recursion.md
+++ b/docs/evidence/self-review-trace-max-depth-recursion.md
@@ -1,0 +1,58 @@
+# Self-Review — Issue #561 (memory_trace ignores max_depth)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/trace-max-depth-recursion`
+Author: kokorolx.
+
+## Actions Taken
+
+- Fixed `registerMemoryTrace` (`internal/mcp/tools.go`) so the downstream
+  call-chain BFS recurses to `max_depth` instead of stopping at depth 1.
+- Root cause: resolved calls-edge targets are qualified from
+  `documents.source_path`, which is **absolute** in production
+  (`/root/mid.go?symbol=mid`). The BFS enqueued that absolute key and looked it
+  up against `graph_edges.source_node`, which is workspace-**relative**
+  (`mid.go::mid`). Exact-match `GetOutgoingEdges` missed on every hop after the
+  first, so only the entry's direct callees were ever returned.
+- Fix: strip the workspace root from the traversal key at query time
+  (`lookupNode := stripWorkspacePrefix(wsRoot, cur.node)`), so each hop matches
+  the relative stored `source_node`. `wsRoot` is now computed once before the
+  loop (was computed lazily only for relative output). Display behavior is
+  unchanged — chain nodes stay absolute under the default `paths=absolute` and
+  are relativized only when `paths=relative`, exactly as before.
+
+## Files Changed
+
+- `internal/mcp/tools.go` — 3 surgical edits in `registerMemoryTrace`
+  (compute `wsRoot`; strip at lookup; drop the now-redundant lazy `wsRoot`).
+- `internal/mcp/trace_max_depth_561_integration_test.go` — new regression test
+  seeding an **absolute** source_path (the case the pre-existing relative-path
+  trace tests missed) and asserting depth-2 recursion.
+
+## Findings Summary
+
+- Ground-truth verified against the DB: `documents.source_path` is absolute,
+  `graph_edges.source_node` is relative — the exact mismatch the fix addresses.
+- **Red-green proven**: with the fix reverted the new test fails at
+  `chain length = 1` (the #561 symptom); with the fix it passes at count=2
+  (mid@1, leaf@2).
+- No regression: the 3 existing #539 trace tests still PASS; `go test -race
+  -short ./...` green across 31 packages.
+- `TestMemoryTrace_RelativeInputAndOutput` panics — confirmed **pre-existing**
+  (#556) by reproducing it on the clean tree with my changes stashed; unrelated
+  to this fix (it uses relative fixtures the strip leaves untouched).
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `CGO_ENABLED=0 go build ./...` → clean. `go vet ./internal/mcp/` → clean.
+- Unit: `go test -race -short ./...` → 31 pkgs ok.
+- Integration (trace subset, nanobrain_test): new test + 3 existing trace tests PASS.
+- smoke:e2e: `docs/evidence/smoke-e2e-trace-max-depth-recursion.md`.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-trace-max-depth-recursion.md
+++ b/docs/evidence/smoke-e2e-trace-max-depth-recursion.md
@@ -1,0 +1,58 @@
+# smoke:e2e — Issue #561 (memory_trace max_depth recursion)
+
+Change-type: bug-fix. The fix is exercised end-to-end at two layers below.
+
+## 1. Live reproduction of the bug (dev server :3100, real MCP tool)
+
+The bug was first observed on the running workspace via the real `memory_trace`
+MCP tool — it returned only the entry's direct callees regardless of `max_depth`:
+
+```
+memory_trace node="internal/server/handlers/impact.go::GraphImpact" max_depth=4
+→ [collectImpact @1, embed/cache.go::Get @1]   count=2   (no depth-2 node)
+
+memory_trace node="…::GraphImpact" max_depth=1
+→ IDENTICAL output — max_depth had no effect
+```
+`collectImpact` calls `ExpandImpactFrontier`, yet it never surfaced at depth 2.
+
+## 2. End-to-end proof through the MCP protocol (integration test, red-green)
+
+`TestMemoryTrace_RecursesPastDepth1_AbsoluteSourcePath`
+(`internal/mcp/trace_max_depth_561_integration_test.go`) drives the fix through
+the **real MCP SDK transport**: MCP client → server → `registerMemoryTrace`
+handler → Postgres (nanobrain_test). It seeds a `Main → mid → leaf` chain with
+an **absolute** `documents.source_path` (exactly as the watcher writes in prod —
+the reason the pre-existing relative-path trace tests never caught this).
+
+```
+RED  (fix disabled): chain length = 1, want 2 — trace did not recurse past depth 1
+                     [{depth:1 name:mid node:mid.go::mid via:entry.go::Main}]
+GREEN (fix applied):  --- PASS: TestMemoryTrace_RecursesPastDepth1_AbsoluteSourcePath
+                     chain = [mid@1, leaf@2]   count=2
+```
+The three existing #539 trace tests still PASS (no regression).
+
+## 3. HTTP transport confirmed (MCP-over-HTTP, :3199 / nanobrain_test)
+
+A standalone binary was built and started on **:3199** against **nanobrain_test**
+(`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`, dev DB/:3100 never touched — server log:
+`database pool connected … /nanobrain_test`). The MCP streamable-HTTP handshake
+and tool call round-tripped:
+
+```
+HTTP/1.1 200 OK   initialize        (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_trace
+```
+
+The depth assertion for the wire path is covered by (2) — the standalone server
+binds its own registered-workspace set from the watcher, so a hand-seeded
+synthetic workspace did not resolve to the seeded edges over HTTP; this is a
+test-fixture binding limitation, not a code path difference (the handler code is
+identical to the one (2) exercises through the MCP SDK transport).
+
+## Isolation / cleanup
+
+Server ran on :3199 / nanobrain_test only; killed by captured PID (no broad
+kill). Synthetic seed + temp binary removed. Dev DB (nanobrain_dev / :3100)
+never written.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1902,6 +1902,13 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 			pathStyle := argString(args, "paths")
 			includeExternal, _ := args["include_external"].(bool)
 
+			// Resolved child nodes are qualified from documents.source_path,
+			// which is absolute; the graph_edges.source_node they must match
+			// against is workspace-relative. Strip the root at query time so
+			// traversal recurses past depth 1 (previously every hop after the
+			// first missed and the chain stopped at the direct callees).
+			wsRoot := lookupWorkspaceRoot(ctx, a.queries, ws)
+
 			seen := map[string]bool{node: true}
 			type traceItem struct {
 				Node      string `json:"node"`
@@ -1928,16 +1935,20 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 				}
 				var edges []sqlc.GraphEdge
 				var err error
-				if strings.Contains(cur.node, "::") {
+				// Normalize to the workspace-relative form the DB stores before
+				// matching source_node; an absolute key (from a resolved child)
+				// would otherwise never match and traversal would die here.
+				lookupNode := stripWorkspacePrefix(wsRoot, cur.node)
+				if strings.Contains(lookupNode, "::") {
 					edges, err = a.queries.GetOutgoingEdges(ctx, sqlc.GetOutgoingEdgesParams{
 						WorkspaceHash: ws,
-						SourceNode:    cur.node,
+						SourceNode:    lookupNode,
 						Column3:       "calls",
 					})
 				} else {
 					edges, err = a.queries.GetOutgoingEdgesBySymbol(ctx, sqlc.GetOutgoingEdgesBySymbolParams{
 						WorkspaceHash: ws,
-						SourceNode:    cur.node,
+						SourceNode:    lookupNode,
 						Column3:       "calls",
 					})
 				}
@@ -2016,9 +2027,7 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 				}
 			}
 
-			var wsRoot string
 			if pathStyle == "relative" {
-				wsRoot = lookupWorkspaceRoot(ctx, a.queries, ws)
 				for i := range chain {
 					chain[i].Node = stripWorkspacePrefix(wsRoot, chain[i].Node)
 					chain[i].Via = stripWorkspacePrefix(wsRoot, chain[i].Via)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2011,10 +2011,17 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 							continue
 						}
 						qualified := m.SourcePath[:qIdx] + "::" + e.TargetNode
-						if seen[qualified] {
+						// Dedup on the workspace-relative form so this key is
+						// consistent with the relative entry seed and with the
+						// relative source_node used for the next-hop lookup;
+						// otherwise a cycle back to the entry (qualified absolute
+						// here, seeded relative) would re-list it. The absolute
+						// form is kept for the displayed node (see paths handling).
+						seenKey := stripWorkspacePrefix(wsRoot, qualified)
+						if seen[seenKey] {
 							continue
 						}
-						seen[qualified] = true
+						seen[seenKey] = true
 						chain = append(chain, traceItem{
 							Node:      qualified,
 							Name:      e.TargetNode,

--- a/internal/mcp/trace_max_depth_561_integration_test.go
+++ b/internal/mcp/trace_max_depth_561_integration_test.go
@@ -80,3 +80,45 @@ func TestMemoryTrace_RecursesPastDepth1_AbsoluteSourcePath(t *testing.T) {
 		t.Errorf("leaf depth = %d, want 2 (the transitive hop); got %v", byName["leaf"], chain)
 	}
 }
+
+// A cycle back to the entry symbol, with ABSOLUTE source_path, must not re-list
+// the entry (nor loop). Before the seen-key was normalized to the relative form,
+// the cycle target qualified absolute ("<root>/entry.go::Main") and missed the
+// relative entry seed ("entry.go::Main"), so Main was re-listed. (R88 + Gemini.)
+func TestMemoryTrace_CycleBackToEntry_NotReListed_AbsoluteSourcePath(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+	ws, err := q.GetWorkspaceByHash(ctx, wsHash)
+	if err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	root := ws.Path
+
+	// Both symbols carry absolute source_path; mid calls back to Main.
+	upsertSymbolDoc(t, ctx, q, wsHash, root+"/entry.go", "Main", "function", "func Main() {}", "1", "1")
+	upsertSymbolDoc(t, ctx, q, wsHash, root+"/mid.go", "mid", "function", "func mid() {}", "1", "1")
+	for _, e := range []struct{ source, target string }{
+		{"entry.go::Main", "mid"}, // Main -> mid
+		{"mid.go::mid", "Main"},   // mid -> Main (cycle)
+	} {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash, SourceNode: e.source, TargetNode: e.target,
+			EdgeType: "calls", SourceFile: "", Metadata: []byte("{}"),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+
+	resp := unmarshalGraphResp(t, callTool("memory_trace", map[string]any{
+		"workspace": wsHash, "node": "entry.go::Main", "max_depth": float64(5), "paths": "relative",
+	}))
+	chain, _ := resp["chain"].([]any)
+	for _, c := range chain {
+		if c.(map[string]any)["name"].(string) == "Main" {
+			t.Fatalf("entry 'Main' re-listed in its own trace (cycle not deduped): %+v", chain)
+		}
+	}
+	// Only mid is reachable; the mid->Main hop is correctly skipped as the entry.
+	if len(chain) != 1 {
+		t.Fatalf("chain length = %d, want 1 (just mid; Main is the entry): %+v", len(chain), chain)
+	}
+}

--- a/internal/mcp/trace_max_depth_561_integration_test.go
+++ b/internal/mcp/trace_max_depth_561_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// --- Issue #561 (split from #542 F3): memory_trace ignores max_depth ---------
+//
+// Root cause: resolved calls-edge targets were qualified from
+// documents.source_path, which is ABSOLUTE in production
+// (e.g. "/root/mid.go?symbol=mid"). The BFS enqueued that absolute key and
+// looked it up against graph_edges.source_node, which is workspace-RELATIVE
+// ("mid.go::mid"). The match failed on every hop after the first, so trace
+// only ever returned the entry's direct callees regardless of max_depth.
+//
+// The pre-existing trace tests seeded a RELATIVE source_path, so the absolute
+// key was never produced and the bug was invisible. This test seeds an
+// absolute source_path (matching prod) under the workspace root and asserts
+// the chain recurses to depth 2.
+func TestMemoryTrace_RecursesPastDepth1_AbsoluteSourcePath(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	// The workspace root is what documents.source_path is prefixed with in prod.
+	ws, err := q.GetWorkspaceByHash(ctx, wsHash)
+	if err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	root := ws.Path
+
+	// Mid + Leaf symbol docs carry ABSOLUTE source_path, exactly like the
+	// watcher writes them (filePart = <root>/<relfile>). Main is the entry and
+	// needs no doc (normalizeNodeForQuery leaves a relative path untouched).
+	upsertSymbolDoc(t, ctx, q, wsHash, root+"/mid.go", "mid", "function", "func mid() {}", "1", "1")
+	upsertSymbolDoc(t, ctx, q, wsHash, root+"/leaf.go", "leaf", "function", "func leaf() {}", "1", "1")
+
+	// Main -> mid -> leaf; source_node is workspace-RELATIVE as the watcher stores it.
+	edges := []struct{ source, target string }{
+		{"entry.go::Main", "mid"}, // depth 1
+		{"mid.go::mid", "leaf"},   // depth 2 — only reachable if the mid hop matches
+	}
+	for _, e := range edges {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash,
+			SourceNode:    e.source,
+			TargetNode:    e.target,
+			EdgeType:      "calls",
+			SourceFile:    "",
+			Metadata:      []byte("{}"),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+
+	// paths=relative so the emitted nodes are the clean "file::symbol" form.
+	resp := unmarshalGraphResp(t, callTool("memory_trace", map[string]any{
+		"workspace": wsHash,
+		"node":      "entry.go::Main",
+		"max_depth": float64(3),
+		"paths":     "relative",
+	}))
+
+	chain, _ := resp["chain"].([]any)
+	byName := map[string]int{}
+	for _, c := range chain {
+		cm := c.(map[string]any)
+		byName[cm["name"].(string)] = int(cm["depth"].(float64))
+	}
+	// Before the fix: chain == [mid@1] only (leaf never reached). After: both.
+	if len(chain) != 2 {
+		t.Fatalf("chain length = %d, want 2 (mid@1, leaf@2); trace did not recurse past depth 1: %+v", len(chain), chain)
+	}
+	if byName["mid"] != 1 {
+		t.Errorf("mid depth = %d, want 1", byName["mid"])
+	}
+	if byName["leaf"] != 2 {
+		t.Errorf("leaf depth = %d, want 2 (the transitive hop); got %v", byName["leaf"], chain)
+	}
+}


### PR DESCRIPTION
Closes #561 (split from #542 F3)

## Problem
`memory_trace` returned only the entry symbol's **direct** callees at `depth:1` and never recursed — `max_depth=1` and `max_depth=4` produced identical output. It behaved like one-hop `memory_graph` instead of the advertised transitive call chain.

## Root cause
Resolved calls-edge targets are qualified from `documents.source_path`, which is **absolute** in production (`/root/mid.go?symbol=mid`). The BFS enqueued that absolute key and matched it via exact-match `GetOutgoingEdges` against `graph_edges.source_node`, which is workspace-**relative** (`mid.go::mid`). The match missed on every hop after the first, so traversal died at depth 1. The entry worked only because `normalizeNodeForQuery` had already made it relative.

Ground-truth confirmed against the DB: `documents.source_path` absolute, `graph_edges.source_node` relative.

## Fix
Strip the workspace root from the traversal key **at query time** (`lookupNode := stripWorkspacePrefix(wsRoot, cur.node)`) for both `GetOutgoingEdges` and `GetOutgoingEdgesBySymbol`, so every hop matches the relative stored `source_node`. `wsRoot` is now computed once before the BFS (previously lazy, only for relative output). Display behavior is unchanged: chain nodes stay absolute under the default `paths=absolute` and are relativized only for `paths=relative`, exactly as before. Reuses the existing `stripWorkspacePrefix`/`lookupWorkspaceRoot` helpers — 14 insertions, 5 deletions.

## Testing (all on nanobrain_test — dev DB never touched)
- **New regression test** `TestMemoryTrace_RecursesPastDepth1_AbsoluteSourcePath` seeds an **absolute** `source_path` (the prod case the pre-existing relative-path trace tests never triggered) and asserts depth-2 recursion (`Main→mid→leaf`). **Red-green proven**: FAIL on master (`chain length = 1`), PASS with fix (`mid@1, leaf@2`).
- 3 existing #539 trace tests still PASS (no regression).
- `go test -race -short ./...` → 31 pkgs ok. `go build`/`go vet` clean.
- smoke:e2e: live :3100 reproduction of the depth-1-only bug + red-green integration test through the real MCP SDK transport + MCP-over-HTTP handshake (HTTP 200) on :3199. Evidence: `docs/evidence/smoke-e2e-trace-max-depth-recursion.md`.
- **R88 independent review: PASS** (`docs/evidence/review-561.md`) — all 4 concerns (correctness / display invariant / cycle-safety / test quality) resolve HIGH confidence.

## Known pre-existing (not touched, out of scope)
`TestMemoryTrace_RelativeInputAndOutput` panics (`graph_paths_integration_test.go:218`, nil chain / single-return type assertion) — reviewer confirmed it panics identically on master with this change stashed. Tracked as **#556**. CI is unaffected (`ci.yml` runs `-short`; integration tests are build-tagged).

Change-type: bug-fix · Lane: tiny.