### PR TITLE
fix(flow): memory_flow resolves full mounted URL to router-local key

### DIFF
--- a/docs/evidence/review-563.md
+++ b/docs/evidence/review-563.md
@@ -1,0 +1,37 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/flow-mounted-url` · Issue #563 (split from #542 F1)
+
+Change: `memory_flow` resolves the full mounted URL to the stored router-local
+HTTP key via `resolveFlowEntry` ("/"-aligned suffix, longest-wins); read-path
+only, no stored-key/index change.
+
+| Concern | Verdict |
+|---|---|
+| Suffix boundary correctness | PASS (HIGH) — `sPath` starts with `/`, so `HasSuffix(path, sPath)` forces the match to begin at a `/` segment separator → always whole trailing segments, no mid-segment false positive (pinned by the `/prefix-payment-intent` negative test). |
+| `sPath != path` guard + method equality | PASS (HIGH) — equal method+path already caught by the exact branch; method must match. |
+| No regression (exact HTTP / symbol) | PASS (HIGH) — exact → `mcpHasFlowEntry` returns the identical key, no new fields added (byte-identical); symbols → `sp<=0` → unchanged `found:false`. `BuildFlow` always gets a real stored key. |
+| Ambiguity / tie-break | PASS (HIGH) — longest-wins is deterministic (two distinct equal-length strings can't both suffix the same path); candidates deduped by `SourceNode`. |
+| Response shape | PASS (HIGH) — resolution fields only when `resolvedEntry != entry`; `candidates` gated on `>1`; `entry`/`method`/`path` coherently reflect the router-local key. |
+| Tests non-vacuous | PASS — unit table covers exact/full-URL/most-specific/method-mismatch/boundary-negative/unknown; integration asserts found + resolved_via + requested_entry + handler presence + control misses. |
+
+Reviewer independently ran `go vet` (clean), `go build -tags=integration` (OK),
+`go test -run ResolveFlowEntry` (ok). **0 blocking issues.**
+
+### Non-blocking findings
+- **[LOW] pre-existing** — two distinct routers with the same router-local route
+  collapse to one stored key (a stored-key limitation, out of scope for a
+  read-path fix; overlaps the deferred option-a mount composition).
+- **[LOW] out-of-scope** — trailing-slash / `:id` param mounts fall through to
+  `found:false` (no regression; same as prior behavior).
+- **[LOW] optional test gap** — no assertion that an exact match omits the new
+  response fields. **Addressed**: added "Control 2" to the integration test
+  asserting `resolved_via`/`requested_entry` are absent on an exact match.
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-flow-mounted-url.md` — MCP-over-HTTP on :3199 /
+nanobrain_test: full URL `POST /api/payments/payment-intent` → HTTP 200,
+`found:true`, `resolved_via:"suffix-match"`; router-local still exact. Dev DB
+never touched.

--- a/docs/evidence/self-review-flow-mounted-url.md
+++ b/docs/evidence/self-review-flow-mounted-url.md
@@ -48,8 +48,9 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED (summary only), CI pass, MERGEABLE/CLEAN. **No inline
+comments** — nothing actionable. No changes required.
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| _(no inline comments)_ | — | Gemini left a summary review with 0 inline findings. | None. |

--- a/docs/evidence/self-review-flow-mounted-url.md
+++ b/docs/evidence/self-review-flow-mounted-url.md
@@ -1,0 +1,55 @@
+# Self-Review — Issue #563 (#542 F1: memory_flow full-URL resolution)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/flow-mounted-url`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_flow` now resolves the full mounted URL an agent supplies to the
+  stored router-local HTTP key. Added `resolveFlowEntry` (`internal/mcp/tools.go`):
+  on an exact-match miss, an HTTP-shaped entry (`METHOD /path`) resolves to the
+  stored HTTP key whose path is a trailing, `/`-aligned suffix of the requested
+  path; the most specific (longest) wins. `registerMemoryFlow` builds the flow
+  from the resolved key and surfaces `requested_entry` + `resolved_via` +
+  `candidates` (when >1).
+- Read-path only — no stored-key change, no re-indexing, no schema change.
+- Deferred (noted in #563): composing `router.use`/`mount` prefixes into stored
+  keys at extraction time (correct data) needs cross-file mount resolution +
+  re-index across Express/NestJS/Rails — overlaps #542 F2, tracked separately.
+
+## Files Changed
+
+- `internal/mcp/tools.go` — `resolveFlowEntry` + wire into `registerMemoryFlow`
+  + response fields (+73/−2).
+- `internal/mcp/flow_entry_resolve_test.go` — white-box unit test (exact,
+  full-URL, most-specific, method-mismatch, boundary/no-mid-segment, candidates).
+- `internal/mcp/flow_url_563_integration_test.go` — e2e through the memory_flow
+  handler (flow enabled): full URL → found:true + resolved_via + handler in flow.
+
+## Findings Summary
+
+- Boundary safety: because a stored path starts with `/`, `strings.HasSuffix`
+  alone guarantees segment alignment — `/payment-intent` is NOT a suffix of
+  `/prefix-payment-intent` (unit-tested). No mid-segment false match.
+- **Red-green proven** at both layers: with the suffix fallback disabled, the
+  integration test returns `found:false` (exact #542 F1 symptom); with it,
+  `found:true` resolving to the router-local key.
+- No regression: exact router-local entries still match exactly (no
+  `resolved_via`); symbol entries unchanged (handled by `mcpHasFlowEntry` first).
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `CGO_ENABLED=0 go build ./...` clean. `go test -race -short ./...` all ok
+  (incl. the new white-box unit test).
+- Integration (nanobrain_test): unit + e2e handler test PASS.
+- smoke:e2e: `docs/evidence/smoke-e2e-flow-mounted-url.md` (MCP-over-HTTP on
+  :3199, full URL → found:true, resolved_via:suffix-match). Dev DB never touched.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-flow-mounted-url.md
+++ b/docs/evidence/smoke-e2e-flow-mounted-url.md
@@ -1,0 +1,41 @@
+# smoke:e2e — Issue #563 (#542 F1: memory_flow full mounted URL)
+
+Change-type: bug-fix. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Built the binary, seeded a workspace (64-hex hash) + a router-local HTTP edge
+`POST /payment-intent → createPaymentIntent` into **nanobrain_test**, started a
+standalone flow-enabled server on :3199 (`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`,
+`NANO_BRAIN_FLOW_ENABLED=true`, `NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+Server log confirmed `database pool connected … /nanobrain_test`.
+
+## MCP streamable-HTTP handshake + tool calls
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_flow  entry="POST /api/payments/payment-intent"
+HTTP/1.1 200 OK   tools/call memory_flow  entry="POST /payment-intent"
+```
+
+Decoded results:
+
+```
+FULL URL     "POST /api/payments/payment-intent"
+  → found: true | entry: "POST /payment-intent" | resolved_via: "suffix-match"
+    | requested_entry: "POST /api/payments/payment-intent"
+ROUTER-LOCAL "POST /payment-intent"
+  → found: true | entry: "POST /payment-intent" | (exact, no resolved_via)
+```
+
+**Result:** the full mounted URL an agent actually has now resolves to the
+stored router-local key end-to-end over MCP HTTP (`found:true`), reporting the
+resolved key + how it matched. Router-local entries still match exactly (no
+regression). **Before this fix** the full URL returned `found:false, "entry not
+found among flow edges"`.
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace + edge deleted, temp binary + fixture dir removed.

--- a/internal/mcp/flow_entry_resolve_test.go
+++ b/internal/mcp/flow_entry_resolve_test.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+// Issue #563 (split from #542 F1): memory_flow must resolve the full mounted URL
+// an agent supplies (e.g. "POST /api/payments/payment-intent") to the stored
+// router-local HTTP key ("POST /payment-intent") via "/"-aligned suffix match.
+func TestResolveFlowEntry(t *testing.T) {
+	edges := []graph.Edge{
+		{Kind: graph.EdgeHTTP, SourceNode: "POST /payment-intent", TargetNode: "createPaymentIntent"},
+		{Kind: graph.EdgeHTTP, SourceNode: "GET /health", TargetNode: "health"},
+		// a more specific route sharing a suffix, to test most-specific-wins
+		{Kind: graph.EdgeHTTP, SourceNode: "POST /payments/payment-intent", TargetNode: "otherHandler"},
+		{Kind: graph.EdgeCalls, SourceNode: "a.go::foo", TargetNode: "bar"},
+	}
+
+	tests := []struct {
+		name      string
+		entry     string
+		wantKey   string
+		wantOK    bool
+		wantExact bool // resolved == entry
+	}{
+		{"exact router-local still matches", "POST /payment-intent", "POST /payment-intent", true, true},
+		{"full mounted URL resolves to router-local", "POST /api/payments/payment-intent", "POST /payments/payment-intent", true, false},
+		{"most-specific suffix wins", "POST /x/payments/payment-intent", "POST /payments/payment-intent", true, false},
+		{"method must match", "GET /api/payments/payment-intent", "", false, false},
+		{"no mid-segment false match", "POST /prefix-payment-intent", "", false, false},
+		{"unknown route", "DELETE /nope", "", false, false},
+		{"unknown symbol entry", "a.go::missing", "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, ok := resolveFlowEntry(edges, tt.entry)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got key %q)", ok, tt.wantOK, got)
+			}
+			if ok && got != tt.wantKey {
+				t.Errorf("resolved key = %q, want %q", got, tt.wantKey)
+			}
+			if ok && (got == tt.entry) != tt.wantExact {
+				t.Errorf("exact = %v, want %v (key %q, entry %q)", got == tt.entry, tt.wantExact, got, tt.entry)
+			}
+		})
+	}
+}
+
+// The "/prefix-payment-intent" case above pins the boundary guarantee: because a
+// stored path starts with "/", HasSuffix cannot match mid-segment ("/payment-intent"
+// is NOT a suffix of "/prefix-payment-intent"), so we never bind a wrong route.
+func TestResolveFlowEntry_CandidatesOnAmbiguousSuffix(t *testing.T) {
+	// Two stored keys, same method, whose paths are BOTH suffixes of the request
+	// at the same length would be identical strings — so ambiguity surfaces only
+	// when a shorter and a longer both match; both are reported as candidates.
+	edges := []graph.Edge{
+		{Kind: graph.EdgeHTTP, SourceNode: "POST /payment-intent", TargetNode: "h1"},
+		{Kind: graph.EdgeHTTP, SourceNode: "POST /payments/payment-intent", TargetNode: "h2"},
+	}
+	got, candidates, ok := resolveFlowEntry(edges, "POST /api/payments/payment-intent")
+	if !ok {
+		t.Fatal("expected resolution")
+	}
+	if got != "POST /payments/payment-intent" {
+		t.Errorf("best = %q, want most-specific POST /payments/payment-intent", got)
+	}
+	if len(candidates) != 2 {
+		t.Errorf("candidates = %v, want both suffix matches reported", candidates)
+	}
+}

--- a/internal/mcp/flow_url_563_integration_test.go
+++ b/internal/mcp/flow_url_563_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/stdlib"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	"github.com/rs/zerolog"
+)
+
+// setupFlowMCP is setupFindingsMCP with flow indexing ENABLED so the
+// memory_flow handler runs (setupFindingsMCP uses a zero FlowConfig → disabled).
+func setupFlowMCP(t *testing.T) (context.Context, *sqlc.Queries, string, func(string, map[string]any) *mcpsdk.CallToolResult) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { db.Close() })
+
+	q := sqlc.New(db)
+	wsHash := fmt.Sprintf("%x", sha256.Sum256([]byte("flow_ws_"+uuid.New().String())))
+	if _, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: wsHash, Name: "flow-ws", Path: "/tmp/flow-ws-" + uuid.New().String()[:8],
+	}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+
+	server := internalmcp.NewMCPServer("test")
+	adapter := internalmcp.NewAdapter(q, db, nil, nil, nil, config.EmbeddingConfig{}, config.SearchConfig{},
+		config.FlowConfig{Enabled: true, MaxDepth: 5, MaxFanout: 20}, nil, zerolog.Nop())
+	internalmcp.RegisterTools(server, adapter)
+
+	ct, st := mcpsdk.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+
+	callTool := func(name string, args map[string]any) *mcpsdk.CallToolResult {
+		t.Helper()
+		result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("CallTool(%s): %v", name, err)
+		}
+		return result
+	}
+	return ctx, q, wsHash, callTool
+}
+
+// Issue #563 (#542 F1): the full mounted URL resolves to the router-local key.
+func TestMemoryFlow_FullMountedURLResolvesToRouterLocalKey(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFlowMCP(t)
+
+	// Route stored router-local, as the Express extractor writes it.
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "POST /payment-intent",
+		TargetNode:    "createPaymentIntent",
+		EdgeType:      "http",
+		SourceFile:    "routes/payments.js",
+		Metadata:      []byte(`{"method":"POST","path":"/payment-intent"}`),
+	}); err != nil {
+		t.Fatalf("upsert http edge: %v", err)
+	}
+
+	// The agent supplies the real mounted URL (from the network tab / contract).
+	resp := unmarshalGraphResp(t, callTool("memory_flow", map[string]any{
+		"workspace": wsHash,
+		"entry":     "POST /api/payments/payment-intent",
+		"format":    "json",
+	}))
+
+	if found, _ := resp["found"].(bool); !found {
+		t.Fatalf("found = false; full mounted URL did not resolve to the router-local key: %+v", resp)
+	}
+	if resp["resolved_via"] != "suffix-match" {
+		t.Errorf("resolved_via = %v, want suffix-match", resp["resolved_via"])
+	}
+	if resp["requested_entry"] != "POST /api/payments/payment-intent" {
+		t.Errorf("requested_entry = %v, want the full URL", resp["requested_entry"])
+	}
+	if resp["entry"] != "POST /payment-intent" {
+		t.Errorf("entry (resolved key) = %v, want POST /payment-intent", resp["entry"])
+	}
+	// The handler must be present in the flow.
+	var sawHandler bool
+	if nodes, ok := resp["nodes"].([]any); ok {
+		for _, n := range nodes {
+			if nm, _ := n.(map[string]any)["name"].(string); nm == "createPaymentIntent" {
+				sawHandler = true
+			}
+		}
+	}
+	if !sawHandler {
+		t.Errorf("handler createPaymentIntent not in flow nodes: %+v", resp["nodes"])
+	}
+
+	// Control 1: an unknown URL still returns found:false.
+	miss := unmarshalGraphResp(t, callTool("memory_flow", map[string]any{
+		"workspace": wsHash, "entry": "POST /api/nope", "format": "json",
+	}))
+	if found, _ := miss["found"].(bool); found {
+		t.Errorf("unknown route resolved unexpectedly: %+v", miss)
+	}
+
+	// Control 2: an EXACT router-local match must NOT carry the resolution
+	// fields — they are added only when the requested entry was rewritten.
+	exact := unmarshalGraphResp(t, callTool("memory_flow", map[string]any{
+		"workspace": wsHash, "entry": "POST /payment-intent", "format": "json",
+	}))
+	if found, _ := exact["found"].(bool); !found {
+		t.Fatalf("exact router-local entry not found: %+v", exact)
+	}
+	if _, ok := exact["resolved_via"]; ok {
+		t.Errorf("exact match must omit resolved_via, got: %v", exact["resolved_via"])
+	}
+	if _, ok := exact["requested_entry"]; ok {
+		t.Errorf("exact match must omit requested_entry, got: %v", exact["requested_entry"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2380,7 +2380,8 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 			// Rails/Ruby class, job, worker, or service entry that has indexed graph
 			// edges. BuildFlow always emits the entry node itself, so node count cannot
 			// distinguish a real flow from an unknown entry.
-			if !mcpHasFlowEntry(edges, entry) {
+			resolvedEntry, entryCandidates, ok := resolveFlowEntry(edges, entry)
+			if !ok {
 				return textResult(map[string]any{
 					"found":   false,
 					"entry":   entry,
@@ -2388,7 +2389,7 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 				})
 			}
 
-			f := flow.BuildFlow(edges, entry, maxDepth, a.flowCfg.MaxFanout)
+			f := flow.BuildFlow(edges, resolvedEntry, maxDepth, a.flowCfg.MaxFanout)
 
 			stitchWorkspaces := argStringSlice(args, "stitch_workspaces")
 			if len(stitchWorkspaces) > 0 {
@@ -2462,6 +2463,16 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 				"nodes":     allNodes,
 				"edges":     graphEdges,
 			}
+			// The stored HTTP key is router-local; if we resolved the caller's
+			// full mounted URL to it via suffix match, tell the caller which key
+			// was used (and any other candidates the requested path matched).
+			if resolvedEntry != entry {
+				result["requested_entry"] = entry
+				result["resolved_via"] = "suffix-match"
+				if len(entryCandidates) > 1 {
+					result["candidates"] = entryCandidates
+				}
+			}
 			if diagram := flow.Render(f, format, loadCFGsForFlow(ctx, a.queries, ws, format, f)...); diagram != "" {
 				result["mermaid"] = diagram
 			}
@@ -2500,6 +2511,66 @@ func mcpFlowSymbolPart(node string) string {
 
 func mcpFlowSymbolMatches(symbol, entry string) bool {
 	return symbol == entry || (!strings.Contains(entry, "#") && strings.HasPrefix(symbol, entry+"#"))
+}
+
+// resolveFlowEntry maps a requested flow entry to the stored edge key BuildFlow
+// should start from. It returns the resolved key, distinct candidate keys when
+// the match was fuzzy/ambiguous, and whether a usable entry was found.
+//
+// HTTP routes are keyed router-local (e.g. "POST /payment-intent"), but an agent
+// typically supplies the full mounted URL ("POST /api/payments/payment-intent")
+// since it never knows the internal router-file layout. When the exact key
+// misses, resolve to the stored HTTP key whose path is a trailing, "/"-aligned
+// suffix of the requested path; the most specific (longest) stored path wins.
+// Exact matches and symbol entries keep their existing behavior unchanged.
+func resolveFlowEntry(edges []graph.Edge, entry string) (string, []string, bool) {
+	if mcpHasFlowEntry(edges, entry) {
+		return entry, nil, true
+	}
+	// Only HTTP-shaped entries ("METHOD /path") get the suffix fallback; symbol
+	// entries were already handled (and rejected) by mcpHasFlowEntry above.
+	sp := strings.IndexByte(entry, ' ')
+	if sp <= 0 {
+		return "", nil, false
+	}
+	method, path := entry[:sp], entry[sp+1:]
+	if !strings.HasPrefix(path, "/") {
+		return "", nil, false
+	}
+	var best string
+	var bestLen int
+	seen := map[string]bool{}
+	var candidates []string
+	for _, e := range edges {
+		if e.Kind != graph.EdgeHTTP {
+			continue
+		}
+		ssp := strings.IndexByte(e.SourceNode, ' ')
+		if ssp <= 0 {
+			continue
+		}
+		sMethod, sPath := e.SourceNode[:ssp], e.SourceNode[ssp+1:]
+		if sMethod != method || !strings.HasPrefix(sPath, "/") {
+			continue
+		}
+		// sPath must be a strictly shorter, "/"-boundary-aligned trailing suffix
+		// of the requested path (an equal path would have matched exactly above).
+		// Because sPath starts with "/", HasSuffix alone guarantees the boundary.
+		if sPath != path && strings.HasSuffix(path, sPath) {
+			if !seen[e.SourceNode] {
+				seen[e.SourceNode] = true
+				candidates = append(candidates, e.SourceNode)
+			}
+			if len(sPath) > bestLen {
+				bestLen = len(sPath)
+				best = e.SourceNode
+			}
+		}
+	}
+	if best == "" {
+		return "", nil, false
+	}
+	return best, candidates, true
 }
 
 func loadCFGsForFlow(ctx context.Context, q flow.CFGQuerier, ws, format string, f flow.Flow) []flow.FlowCFGs {


### PR DESCRIPTION
Closes #563 (split from #542 F1)

## Problem
`memory_flow` keyed HTTP routes by the **router-local** path, so an agent supplying the real mounted URL got `found:false`:
```
router.use('/api/payments', paymentsRouter)
paymentsRouter.post('/payment-intent', createPaymentIntent)

memory_flow(entry="POST /api/payments/payment-intent") → found:false
memory_flow(entry="POST /payment-intent")              → found:true   (router-local only)
```
An agent knows the URL (network tab / API contract), not the internal router-file layout — so the one tool for "what happens on POST /route" failed on the only route string it has.

## Root cause
The `router.use(prefix, subRouter)` mount prefix is never composed into sub-route keys (Express extractor keys them router-local), and the flow entry lookup exact-matched HTTP entries with no suffix/fuzzy fallback.

## Fix (read-path, low-risk, no re-index)
Add `resolveFlowEntry`: on an exact-match miss, an HTTP-shaped entry (`METHOD /path`) resolves to the stored HTTP key whose path is a trailing, `/`-aligned suffix of the requested path — most-specific (longest) wins. The flow builds from the resolved key and the response surfaces `requested_entry` + `resolved_via:"suffix-match"` + `candidates` (when >1). Exact and symbol entries are unchanged; no stored-key or schema change.

Because a stored path starts with `/`, `strings.HasSuffix` alone guarantees segment alignment — `/payment-intent` is **not** a suffix of `/prefix-payment-intent`, so no mid-segment mismatch.

## Deferred (follow-up on #563)
Composing `router.use`/`mount` prefixes into stored keys at **extraction** time (correct data) needs cross-file mount resolution + re-index across Express/NestJS/Rails — overlaps #542 F2.

## Testing (nanobrain_test only — dev DB never touched)
- **White-box unit** (`flow_entry_resolve_test.go`): exact / full-URL resolve / most-specific-wins / method-mismatch / **boundary no-mid-segment** / unknown / candidates.
- **e2e through the handler** (`flow_url_563_integration_test.go`, flow enabled): full URL → `found:true` + `resolved_via` + handler in flow; controls for unknown-URL and exact-match-omits-fields. **Red-green**: `found:false` without the fallback, `found:true` with it.
- `go test -race -short ./...` all ok; `go build`/`go vet` clean.
- smoke:e2e: MCP-over-HTTP on :3199 — full URL → HTTP 200 `found:true resolved_via:suffix-match` (`docs/evidence/smoke-e2e-flow-mounted-url.md`).
- **R88 independent review: PASS** (`docs/evidence/review-563.md`), 0 blocking; the one optional test-gap it noted was added.

## #542 progress
F3 (max_depth) fixed by #562, F4 (latency) by #540, F1 (this). Remaining #542: F2/F5–F10.

Change-type: bug-fix · Lane: tiny.