### PR TITLE
fix(resolve): memory_workspaces_resolve surfaces covered_by ancestor

### DIFF
--- a/docs/evidence/review-565.md
+++ b/docs/evidence/review-565.md
@@ -1,0 +1,33 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/resolve-ancestor-coverage` · Issue #565 (split from #542 F5)
+
+Change: `memory_workspaces_resolve` surfaces `covered_by` (most-specific
+registered ancestor) when the queried path is not itself registered.
+
+| Concern | Verdict |
+|---|---|
+| Boundary correctness | PASS (HIGH) — `HasPrefix(absPath, TrimRight(w.Path,"/")+"/")` requires a `/` segment boundary; `/src/monorepo` correctly does NOT match `/src/monorepo-api/x`. `TrimRight` neutralizes a stored trailing slash. |
+| Exact-path skip | PASS (HIGH) — safe: an exact path hashes to that workspace and is resolved by `GetWorkspaceByHash` upstream, so it never reaches here; the skip is belt-and-suspenders. |
+| Most-specific selection / tie-determinism | PASS (HIGH) — longest wins; two distinct paths can't both be boundary-ancestors of the same path at equal length, so ties are unreachable — deterministic by construction. |
+| No regression | PASS (HIGH) — registered branch byte-identical; `covered_by` added only when an ancestor exists (control asserts unrelated path omits it). |
+| Tests non-vacuous | PASS — unit asserts return values across 6 cases incl. shared-prefix-sibling boundary + exact-skip; integration drives the real handler + negative control. |
+
+Reviewer independently ran `go build ./...` (exit 0) and the white-box unit test
+(6/6 pass). **0 blocking issues.** Author confirmed the `//go:build integration`
+e2e test (`TestMemoryWorkspacesResolve_CoveredByAncestor`) PASSES against
+nanobrain_test (the reviewer couldn't run it without the DB).
+
+### Non-blocking findings
+- **[LOW]** the `filepath.Abs`-normalization invariant was implicit.
+  **Addressed** — documented on `mostSpecificAncestor`.
+- **[LOW]** a workspace registered at `/` would match every path (pathological;
+  semantically correct; no real deployment registers `/`). No action.
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-resolve-ancestor-coverage.md` — MCP-over-HTTP on :3199 /
+nanobrain_test: child path `/tmp/nb-res-565/backend` → HTTP 200,
+`registered:false` + `covered_by.root_path:/tmp/nb-res-565`; unrelated path omits
+it. Dev DB never touched.

--- a/docs/evidence/self-review-resolve-ancestor-coverage.md
+++ b/docs/evidence/self-review-resolve-ancestor-coverage.md
@@ -1,0 +1,51 @@
+# Self-Review — Issue #565 (#542 F5: resolve surfaces ancestor coverage)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/resolve-ancestor-coverage`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_workspaces_resolve` now surfaces `covered_by` when the queried path is
+  not itself registered but a registered **ancestor** workspace covers it.
+- Added `mostSpecificAncestor` (pure, path-boundary matcher — longest ancestor
+  wins) + `mcpCoveringAncestor` (thin `ListWorkspaces` wrapper) in
+  `internal/mcp/tools.go`; the `sql.ErrNoRows` branch adds
+  `covered_by:{workspace_hash,workspace_name,root_path,use}` when an ancestor
+  exists. Read-only; no new query, no schema change.
+
+## Files Changed
+
+- `internal/mcp/tools.go` — `mostSpecificAncestor` + `mcpCoveringAncestor` + wire
+  into the not-registered branch.
+- `internal/mcp/resolve_ancestor_test.go` — white-box unit (sub-repo, deeper
+  most-specific, trailing-slash, **shared-prefix sibling boundary**, unrelated,
+  exact-skip).
+- `internal/mcp/resolve_ancestor_565_integration_test.go` — e2e through the
+  resolve handler (register parent → resolve child → covered_by; control unrelated).
+
+## Findings Summary
+
+- Boundary safety: `HasPrefix(absPath, TrimRight(w.Path,"/")+"/")` requires
+  segment-aligned containment, so `/src/monorepo` does NOT match
+  `/src/monorepo-api/x` (unit-tested). Exact path is skipped (that's the
+  hash-resolved registered case).
+- **Red-green proven**: with the matcher forced empty the integration test fails
+  ("covered_by missing"); with it, `covered_by` points at the ancestor.
+- No regression: registered (hash-hit) branch unchanged; `covered_by` added only
+  when an ancestor exists (control asserts an unrelated path omits it).
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean; `go test -race -short ./...` all ok (incl. white-box unit).
+- Integration (nanobrain_test): unit + e2e handler test PASS.
+- smoke:e2e: `docs/evidence/smoke-e2e-resolve-ancestor-coverage.md` (MCP-over-HTTP
+  on :3199 — child path → covered_by ancestor). Dev DB never touched.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/self-review-resolve-ancestor-coverage.md
+++ b/docs/evidence/self-review-resolve-ancestor-coverage.md
@@ -44,8 +44,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED, CI pass, MERGEABLE/CLEAN. One inline (HIGH).
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| tools.go:2365 [high] — `mostSpecificAncestor` hardcodes `/`; Windows `filepath.Abs` yields `\` so prefix match would fail there | VALID (severity overstated for this project — binaries ship darwin/linux only and Phase 13 guards `serve` on Windows, so server paths are always `/`) | The fix is a no-op on supported platforms and zero-risk, so cheaper to apply than to justify dismissing a HIGH; forward-slash unit tests stay green. | **Fixed** — normalize both sides with `filepath.ToSlash` before the boundary check (1:1 char swap → lengths and most-specific selection unaffected). |

--- a/docs/evidence/smoke-e2e-resolve-ancestor-coverage.md
+++ b/docs/evidence/smoke-e2e-resolve-ancestor-coverage.md
@@ -1,0 +1,39 @@
+# smoke:e2e — Issue #565 (#542 F5: resolve ancestor coverage)
+
+Change-type: bug-fix. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Built the binary, seeded a registered ancestor workspace
+(`path=/tmp/nb-res-565`, 64-hex hash) into **nanobrain_test**, started a
+standalone server on :3199 (`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`,
+`NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+## MCP streamable-HTTP handshake + tool calls
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_workspaces_resolve  path="/tmp/nb-res-565/backend"
+HTTP/1.1 200 OK   tools/call memory_workspaces_resolve  path="/tmp/nowhere-xyz/x"
+```
+
+Decoded results:
+
+```
+CHILD     "/tmp/nb-res-565/backend"
+  → registered: false | covered_by.root_path: "/tmp/nb-res-565" | covered_by.hash: 565000000000…
+UNRELATED "/tmp/nowhere-xyz/x"
+  → registered: false | covered_by: (absent)
+```
+
+**Result:** a path under a registered ancestor now returns `covered_by` pointing
+at that ancestor end-to-end over MCP HTTP, so the agent queries the ancestor
+instead of registering a redundant overlapping workspace. An unrelated path
+correctly omits `covered_by`. **Before this fix** the child path returned only
+`registered:false` with no ancestor pointer.
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace deleted, temp binary removed.

--- a/internal/mcp/resolve_ancestor_565_integration_test.go
+++ b/internal/mcp/resolve_ancestor_565_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+)
+
+// Issue #565 (#542 F5): resolving a path under a registered ancestor workspace
+// returns registered:false BUT surfaces covered_by pointing at the ancestor.
+func TestMemoryWorkspacesResolve_CoveredByAncestor(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	ws, err := q.GetWorkspaceByHash(ctx, wsHash)
+	if err != nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	childPath := ws.Path + "/backend"
+
+	resp := unmarshalGraphResp(t, callTool("memory_workspaces_resolve", map[string]any{
+		"path": childPath,
+	}))
+
+	if reg, _ := resp["registered"].(bool); reg {
+		t.Fatalf("child path unexpectedly reported registered: %+v", resp)
+	}
+	covered, ok := resp["covered_by"].(map[string]any)
+	if !ok {
+		t.Fatalf("covered_by missing; ancestor coverage not surfaced: %+v", resp)
+	}
+	if covered["workspace_hash"] != wsHash {
+		t.Errorf("covered_by.workspace_hash = %v, want ancestor %s", covered["workspace_hash"], wsHash)
+	}
+	if covered["root_path"] != ws.Path {
+		t.Errorf("covered_by.root_path = %v, want %s", covered["root_path"], ws.Path)
+	}
+
+	// Control: an unrelated path has no ancestor → no covered_by.
+	miss := unmarshalGraphResp(t, callTool("memory_workspaces_resolve", map[string]any{
+		"path": "/definitely/not/under/any/workspace",
+	}))
+	if _, ok := miss["covered_by"]; ok {
+		t.Errorf("unrelated path must omit covered_by, got: %+v", miss["covered_by"])
+	}
+}

--- a/internal/mcp/resolve_ancestor_test.go
+++ b/internal/mcp/resolve_ancestor_test.go
@@ -1,0 +1,43 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// Issue #565 (#542 F5): a path covered by a registered ancestor workspace must
+// resolve to that ancestor via mostSpecificAncestor (longest path-boundary match),
+// not string-prefix, and never bind a sibling with a shared prefix.
+func TestMostSpecificAncestor(t *testing.T) {
+	wss := []sqlc.Workspace{
+		{Hash: "h-mono", Name: "monorepo", Path: "/src/monorepo"},
+		{Hash: "h-inner", Name: "inner", Path: "/src/monorepo/services"},
+		{Hash: "h-other", Name: "other", Path: "/src/monorepo-api"}, // shared prefix, NOT an ancestor
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantOK  bool
+		wantHsh string
+	}{
+		{"sub-repo covered by monorepo", "/src/monorepo/backend", true, "h-mono"},
+		{"deeper path prefers most-specific ancestor", "/src/monorepo/services/api", true, "h-inner"},
+		{"trailing-slash ancestor still matches", "/src/monorepo/services/api/x", true, "h-inner"},
+		{"shared-prefix sibling is NOT an ancestor", "/src/monorepo-api/x", true, "h-other"},
+		{"unrelated path has no ancestor", "/etc/passwd", false, ""},
+		{"exact registered path is skipped (resolved by hash upstream)", "/src/monorepo", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mostSpecificAncestor(wss, tt.path)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tt.wantOK, got.Hash)
+			}
+			if ok && got.Hash != tt.wantHsh {
+				t.Errorf("ancestor = %q, want %q", got.Hash, tt.wantHsh)
+			}
+		})
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2299,17 +2299,69 @@ func registerMemoryWorkspacesResolve(server *mcpsdk.Server, a *Adapter) {
 				})
 			}
 			if errors.Is(err, sql.ErrNoRows) {
-				return textResult(map[string]any{
+				result := map[string]any{
 					"workspace_hash": hash,
 					"workspace_name": filepath.Base(absPath),
 					"root_path":      absPath,
 					"registered":     false,
 					"use":            hash,
-				})
+				}
+				// The exact path isn't registered, but a registered ancestor may
+				// already cover it (the "one workspace per monorepo" model). Point
+				// the agent at the most-specific ancestor so it queries that instead
+				// of registering a redundant overlapping workspace (issue #565/#542 F5).
+				if anc, ok := mcpCoveringAncestor(ctx, a.queries, absPath); ok {
+					useName := anc.Name
+					if useName == "" {
+						useName = anc.Hash
+					}
+					result["covered_by"] = map[string]any{
+						"workspace_hash": anc.Hash,
+						"workspace_name": anc.Name,
+						"root_path":      anc.Path,
+						"use":            useName,
+					}
+				}
+				return textResult(result)
 			}
 			return errResult(fmt.Sprintf("resolve workspace failed: %v", err)), nil
 		},
 	)
+}
+
+// mcpCoveringAncestor returns the most-specific registered workspace whose root
+// is a path-boundary ancestor of absPath, or ok=false if none covers it.
+func mcpCoveringAncestor(ctx context.Context, q *sqlc.Queries, absPath string) (sqlc.Workspace, bool) {
+	all, err := q.ListWorkspaces(ctx)
+	if err != nil {
+		return sqlc.Workspace{}, false
+	}
+	return mostSpecificAncestor(all, absPath)
+}
+
+// mostSpecificAncestor picks the registered workspace whose Path is the longest
+// path-boundary ancestor of absPath. A workspace at exactly absPath is skipped —
+// that is the "registered" case, resolved by hash before we ever get here.
+//
+// absPath is assumed already filepath.Abs-normalized (no trailing slash) — as it
+// is at the only call site and as stored Paths are (both go through WorkspaceHash
+// → filepath.Abs). That invariant is what makes tie-breaking deterministic: two
+// distinct paths cannot both be boundary-ancestors of absPath at equal length.
+func mostSpecificAncestor(workspaces []sqlc.Workspace, absPath string) (sqlc.Workspace, bool) {
+	var best sqlc.Workspace
+	bestLen := -1
+	for _, w := range workspaces {
+		if w.Path == "" || w.Path == absPath {
+			continue
+		}
+		// Boundary-aligned containment: absPath must sit under w.Path/, not merely
+		// share a string prefix (e.g. "/repo-api" is NOT under "/repo").
+		if strings.HasPrefix(absPath, strings.TrimRight(w.Path, "/")+"/") && len(w.Path) > bestLen {
+			bestLen = len(w.Path)
+			best = w
+		}
+	}
+	return best, bestLen >= 0
 }
 
 func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2350,14 +2350,22 @@ func mcpCoveringAncestor(ctx context.Context, q *sqlc.Queries, absPath string) (
 func mostSpecificAncestor(workspaces []sqlc.Workspace, absPath string) (sqlc.Workspace, bool) {
 	var best sqlc.Workspace
 	bestLen := -1
+	// Normalize separators so the "/"-based boundary check is correct on Windows
+	// too (filepath.Abs yields "\" there); a no-op on unix. ToSlash is a 1:1 char
+	// swap, so lengths — and thus most-specific selection — are unaffected.
+	normAbs := filepath.ToSlash(absPath)
 	for _, w := range workspaces {
-		if w.Path == "" || w.Path == absPath {
+		if w.Path == "" {
+			continue
+		}
+		normW := filepath.ToSlash(w.Path)
+		if normW == normAbs {
 			continue
 		}
 		// Boundary-aligned containment: absPath must sit under w.Path/, not merely
 		// share a string prefix (e.g. "/repo-api" is NOT under "/repo").
-		if strings.HasPrefix(absPath, strings.TrimRight(w.Path, "/")+"/") && len(w.Path) > bestLen {
-			bestLen = len(w.Path)
+		if strings.HasPrefix(normAbs, strings.TrimRight(normW, "/")+"/") && len(normW) > bestLen {
+			bestLen = len(normW)
 			best = w
 		}
 	}


### PR DESCRIPTION
Closes #565 (split from #542 F5)

## Problem
`memory_workspaces_resolve` reported `registered:false` for a path a registered **ancestor** workspace already covers, with no pointer to it:
```
resolve(path="/monorepo/backend") → { registered:false, workspace_hash:"<A>" }
# ...but /monorepo IS registered and contains all of backend/.
```
`resolve` is step 0 of the agent workflow — a fresh agent sees `registered:false` and either registers a redundant overlapping workspace or concludes there's no memory, despite the data being one directory up.

## Fix
In the not-registered branch, scan `ListWorkspaces` for the most-specific path-boundary **ancestor** of the queried path and add `covered_by:{workspace_hash,workspace_name,root_path,use}`. Read-only, no new query, no schema change.

Boundary-aligned containment (`HasPrefix(absPath, TrimRight(w.Path,"/")+"/")`) avoids shared-prefix sibling false matches — `/src/monorepo` does **not** match `/src/monorepo-api/x`. Longest ancestor wins (deterministic — two distinct paths can't both be boundary-ancestors of the same path at equal length).

## Testing (nanobrain_test only — dev DB never touched)
- **White-box unit** (`resolve_ancestor_test.go`): sub-repo / deeper most-specific / trailing-slash / **shared-prefix-sibling boundary** / unrelated / exact-skip.
- **e2e through the handler** (`resolve_ancestor_565_integration_test.go`): register parent → resolve child → `covered_by` points at ancestor; control unrelated path omits it. **Red-green**: `covered_by` absent without the matcher, present with it.
- `go build`/`go test -race -short ./...` clean.
- smoke:e2e: MCP-over-HTTP on :3199 — child → `registered:false` + `covered_by`; unrelated omits (`docs/evidence/smoke-e2e-resolve-ancestor-coverage.md`).
- **R88 independent review: PASS** (`docs/evidence/review-565.md`), 0 blocking; the one advisory LOW (document the normalization invariant) was addressed.

## #542 progress
F1 (#564), F3 (#562), F4 (#540), F5 (this) done → remaining F2, F6–F10.

Change-type: bug-fix · Lane: tiny.