### PR TITLE
fix(flow): drop builtin/keyword external nodes from memory_flow

### DIFF
--- a/docs/evidence/review-567.md
+++ b/docs/evidence/review-567.md
@@ -1,0 +1,38 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/flow-builtins` · Issue #567 (split from #542 F8)
+
+Change: `memory_flow` drops `RoleExternal` nodes that resolve to no workspace
+symbol (JS builtins/keywords), via `dropExternalBuiltins` + `include_external`
+param; mirrors `memory_trace`. Read-path only, `BuildFlow` untouched.
+
+| Concern | Verdict |
+|---|---|
+| Drops only unresolved externals | PASS (HIGH) — real leaves keep their symbol doc → `len(matches)>0` → kept; builtins have no doc → dropped. Symbol-doc existence is the correct discriminator. |
+| Role-gated removal / same-name collision | PASS (HIGH) — removal is `Role==External && dropName[Name]`; a non-external node sharing a name is never dropped. External IDs dedup by `nodeMap`. |
+| Error handling | PASS (HIGH) — on query error `dropName=false` (kept); presence-check avoids re-query. |
+| Slice rebuild `[:0:0]` | PASS (HIGH) — cap-0 forces fresh backing, no aliasing while ranging (the correct idiom). |
+| Edge removal consistency | PASS (HIGH) — edge dropped iff an endpoint is a dropped external; edges between kept nodes survive; externals are leaves (no outgoing edges). |
+| No regression | PASS (HIGH) — `include_external=true` skips the drop; stitched nodes are `RoleIntegration` (never dropped); runs before response mapping so #563/#564 behavior intact. |
+
+Reviewer ran `go build ./...` + `go vet ./internal/mcp/` (clean). **0 blocking
+issues.** Integration test confirmed PASS by author against nanobrain_test/:3199.
+
+### Non-blocking findings
+- **[LOW] N+1 resolver calls** (one per distinct external name, bounded by
+  maxFanout×maxDepth). Acceptable for the flow read-path; a `title = ANY($names)`
+  batch could collapse it if flow latency ever matters. Not changed.
+- **[LOW] indexing completeness** — a real symbol not yet indexed resolves to 0
+  and is dropped until indexing catches up (mirrors trace). **Addressed** —
+  caveat added to the `include_external` tool description.
+- **[LOW] test edge-removal gap** — **Addressed**: the test now asserts the edge
+  to the dropped builtin is removed AND the edge to the kept leaf survives.
+- **[LOW] wasted copy on no-builtin path** / test-file-untracked — noted; the
+  test file is `git add`ed with this commit.
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-flow-builtins.md` — MCP-over-HTTP on :3199 /
+nanobrain_test: default → builtin `Number` dropped, real leaf `realHelper` kept;
+`include_external:true` → `Number` returns. Dev DB never touched.

--- a/docs/evidence/self-review-flow-builtins.md
+++ b/docs/evidence/self-review-flow-builtins.md
@@ -45,8 +45,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED, CI pass, MERGEABLE/CLEAN. One inline (MEDIUM).
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| tools.go:2668 [medium] — `ResolveSymbolByName` error silently ignored; on context cancellation the loop keeps issuing doomed DB queries | VALID | Context cancellation (client disconnect/timeout) is a real named threat; without an early exit the loop wastes a query per remaining external node. | **Fixed** — on error, `if ctx.Err() != nil { break }` before the keep-node default; non-cancellation errors still keep the node and continue. |

--- a/docs/evidence/self-review-flow-builtins.md
+++ b/docs/evidence/self-review-flow-builtins.md
@@ -1,0 +1,52 @@
+# Self-Review — Issue #567 (#542 F8: memory_flow builtin pollution)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/flow-builtins`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_flow` now drops `RoleExternal` nodes whose bare name resolves to no
+  workspace symbol — the JS/TS builtins & keywords (`Number`, `catch`, `toFixed`,
+  `push`, `for`, `get`) that polluted the graph. Added `dropExternalBuiltins`
+  (`internal/mcp/tools.go`): resolves each distinct external name once via
+  `ResolveSymbolByName`, drops zero-match nodes + the edges referencing them,
+  keeps real leaves and non-external roles. Gated by a new `include_external`
+  param (default false) for parity with `memory_trace`.
+- `flow.BuildFlow` unchanged (still pure/edges-only); filtering is in the handler.
+  Read-path only, no extraction/schema change.
+
+## Files Changed
+
+- `internal/mcp/tools.go` — `dropExternalBuiltins` + `include_external` param +
+  schema + call after BuildFlow/stitch.
+- `internal/mcp/flow_builtins_567_integration_test.go` — e2e through the handler:
+  builtin dropped by default, real leaf kept, builtin returns with include_external.
+
+## Findings Summary
+
+- The right discriminator is symbol resolution, not a hand-maintained denylist: a
+  workspace function named `push` resolves (kept) while the builtin `push` does
+  not (dropped). Mirrors `memory_trace`.
+- **Red-green proven**: with the filter disabled the integration test fails
+  (`Number` leaks into default output); with it, `Number` is dropped and only
+  reappears under `include_external`.
+- No regression: `RoleHandler`/`Middleware`/`Integration` nodes untouched; real
+  leaf functions kept; on a resolve error the node is kept (safe default).
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean; `go test -race -short ./...` all ok.
+- Integration (nanobrain_test): builtins-drop e2e test PASS; existing flow tests
+  (#563/#564) still pass.
+- smoke:e2e: `docs/evidence/smoke-e2e-flow-builtins.md` (MCP-over-HTTP on :3199 —
+  builtin `Number` dropped by default, real leaf kept, returns with
+  include_external). Dev DB never touched.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-flow-builtins.md
+++ b/docs/evidence/smoke-e2e-flow-builtins.md
@@ -1,0 +1,40 @@
+# smoke:e2e — Issue #567 (#542 F8: memory_flow builtin pollution)
+
+Change-type: bug-fix. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Built the binary, seeded into **nanobrain_test**: a workspace (64-hex hash), an
+HTTP route `GET /x → ctrl`, two `calls` edges `a.js::ctrl → realHelper` and
+`a.js::ctrl → Number`, and a symbol document for `realHelper`
+(`metadata.source_type=symbol`, `title=realHelper`) so it resolves — while
+`Number` has no symbol. Started a flow-enabled server on :3199
+(`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`, `NANO_BRAIN_FLOW_ENABLED=true`,
+`NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+## MCP streamable-HTTP handshake + tool calls
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_flow  entry="GET /x"                        (default)
+HTTP/1.1 200 OK   tools/call memory_flow  entry="GET /x" include_external=true
+```
+
+Decoded node names:
+
+```
+DEFAULT            → ["ctrl", "realHelper", "GET /x"]        (builtin "Number" DROPPED, real leaf kept)
+include_external   → ["GET /x", "ctrl", "Number", "realHelper"]   (builtin present)
+```
+
+**Result:** the builtin `Number` (a bare `calls` target that resolves to no
+workspace symbol) is dropped from the flow by default, while the real leaf
+`realHelper` (which resolves) is kept; `include_external:true` brings the builtin
+back. **Before this fix** `Number` appeared as a `RoleExternal` node in the
+default output.
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace/edges/doc deleted, temp binary + fixture dir removed.

--- a/internal/mcp/flow_builtins_567_integration_test.go
+++ b/internal/mcp/flow_builtins_567_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// Issue #567 (#542 F8): memory_flow must drop RoleExternal nodes that are JS
+// builtins/keywords (no workspace symbol), while keeping real leaf functions,
+// mirroring memory_trace. include_external keeps them.
+func TestMemoryFlow_DropsBuiltinExternalNodes(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFlowMCP(t)
+
+	// GET /x -> ctrl (handler); ctrl calls a real workspace helper AND a builtin.
+	edges := []struct {
+		src, tgt, kind string
+	}{
+		{"GET /x", "ctrl", "http"},
+		{"a.js::ctrl", "realHelper", "calls"}, // resolves (doc seeded) -> kept
+		{"a.js::ctrl", "Number", "calls"},     // builtin, no doc -> dropped
+	}
+	for _, e := range edges {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash, SourceNode: e.src, TargetNode: e.tgt,
+			EdgeType: e.kind, SourceFile: "a.js", Metadata: []byte("{}"),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+	// Only realHelper has a symbol doc, so ResolveSymbolByName distinguishes it
+	// from the builtin Number.
+	upsertSymbolDoc(t, ctx, q, wsHash, "helpers.js", "realHelper", "function", "function realHelper(){}", "1", "1")
+
+	names := func(resp map[string]any) map[string]bool {
+		out := map[string]bool{}
+		if nodes, ok := resp["nodes"].([]any); ok {
+			for _, n := range nodes {
+				if nm, _ := n.(map[string]any)["name"].(string); nm != "" {
+					out[nm] = true
+				}
+			}
+		}
+		return out
+	}
+
+	edgeTo := func(resp map[string]any) map[string]bool {
+		out := map[string]bool{}
+		if es, ok := resp["edges"].([]any); ok {
+			for _, e := range es {
+				if to, _ := e.(map[string]any)["to"].(string); to != "" {
+					out[to] = true
+				}
+			}
+		}
+		return out
+	}
+
+	// Default: builtin dropped, real helper kept.
+	defResp := unmarshalGraphResp(t, callTool("memory_flow", map[string]any{
+		"workspace": wsHash, "entry": "GET /x", "format": "json",
+	}))
+	def := names(defResp)
+	if def["Number"] {
+		t.Errorf("builtin 'Number' should be dropped by default: %v", def)
+	}
+	if !def["realHelper"] {
+		t.Errorf("real leaf 'realHelper' should be kept: %v", def)
+	}
+	// The edge to the dropped builtin must be removed; the edge to the kept leaf survives.
+	de := edgeTo(defResp)
+	if de["Number"] {
+		t.Errorf("edge to dropped builtin 'Number' should be removed: %+v", defResp["edges"])
+	}
+	if !de["realHelper"] {
+		t.Errorf("edge to kept leaf 'realHelper' should survive: %+v", defResp["edges"])
+	}
+
+	// include_external=true: builtin reappears.
+	inc := names(unmarshalGraphResp(t, callTool("memory_flow", map[string]any{
+		"workspace": wsHash, "entry": "GET /x", "format": "json", "include_external": true,
+	})))
+	if !inc["Number"] {
+		t.Errorf("builtin 'Number' should appear with include_external=true: %v", inc)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2663,6 +2663,12 @@ func dropExternalBuiltins(ctx context.Context, q *sqlc.Queries, ws string, f *fl
 			Column2:       n.Name,
 		})
 		if err != nil {
+			// On context cancellation (client disconnect/timeout) stop — the
+			// remaining per-name queries would all fail too. Otherwise keep the
+			// node (safe default) and move on.
+			if ctx.Err() != nil {
+				break
+			}
 			dropName[n.Name] = false
 			continue
 		}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2383,6 +2383,7 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 				"max_depth":         {"type": "number", "description": "Max call-chain depth 1-10 (default: config value)"},
 				"format":            {"type": "string", "description": "Output format: 'mermaid' (default), 'sequence' (sequence diagram), or 'json'"},
 				"stitch_workspaces": {"type": "array", "description": "Target workspace hashes to stitch cross-service integration edges against", "items": map[string]any{"type": "string"}},
+				"include_external":  {"type": "boolean", "description": "Include calls to builtins/third-party names that don't resolve to a workspace symbol (default false — these are dropped as noise). Note: a real symbol not yet indexed also resolves to nothing and is dropped until indexing catches up (check memory_status.queue_pending)."},
 			}, []string{"entry"}),
 		},
 		func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
@@ -2410,6 +2411,7 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 				format = "mermaid"
 			}
 			maxDepth := argInt(args, "max_depth", a.flowCfg.MaxDepth, a.flowCfg.MaxDepth)
+			includeExternal, _ := args["include_external"].(bool)
 
 			rawEdges, err := a.queries.ListAllEdgesByWorkspace(ctx, ws)
 			if err != nil {
@@ -2456,6 +2458,14 @@ func registerMemoryFlow(server *mcpsdk.Server, a *Adapter) {
 				publishEdges := filterPublishEdges(edges)
 				stitched := flow.Stitch(ctx, publishEdges, stitchWorkspaces, a.queries)
 				appendStitchedToFlow(&f, stitched)
+			}
+
+			// External nodes with no workspace symbol are JS/TS builtins & keywords
+			// (Number, catch, toFixed, push, for, get) that pollute the flow. Drop
+			// them by default — mirrors memory_trace's ResolveSymbolByName drop; real
+			// leaf functions (which resolve) are kept. include_external keeps all.
+			if !includeExternal {
+				dropExternalBuiltins(ctx, a.queries, ws, &f)
 			}
 
 			type nodeItem struct {
@@ -2631,6 +2641,56 @@ func resolveFlowEntry(edges []graph.Edge, entry string) (string, []string, bool)
 		return "", nil, false
 	}
 	return best, candidates, true
+}
+
+// dropExternalBuiltins removes RoleExternal flow nodes whose bare name resolves
+// to no workspace symbol — JS/TS builtins and keywords (Number, catch, toFixed,
+// push, for, get, …) that would otherwise pollute the graph. Real leaf functions
+// (which resolve) and non-external roles (handler/middleware/integration) are
+// kept. Distinct names are resolved once; on a query error the node is kept
+// (safe default). Mirrors memory_trace's ResolveSymbolByName drop.
+func dropExternalBuiltins(ctx context.Context, q *sqlc.Queries, ws string, f *flow.Flow) {
+	dropName := map[string]bool{}
+	for _, n := range f.Nodes {
+		if n.Role != flow.RoleExternal {
+			continue
+		}
+		if _, done := dropName[n.Name]; done {
+			continue
+		}
+		matches, err := q.ResolveSymbolByName(ctx, sqlc.ResolveSymbolByNameParams{
+			WorkspaceHash: ws,
+			Column2:       n.Name,
+		})
+		if err != nil {
+			dropName[n.Name] = false
+			continue
+		}
+		dropName[n.Name] = len(matches) == 0
+	}
+
+	dropID := map[string]bool{}
+	kept := f.Nodes[:0:0]
+	for _, n := range f.Nodes {
+		if n.Role == flow.RoleExternal && dropName[n.Name] {
+			dropID[n.ID] = true
+			continue
+		}
+		kept = append(kept, n)
+	}
+	if len(dropID) == 0 {
+		return
+	}
+	f.Nodes = kept
+
+	keptEdges := f.Edges[:0:0]
+	for _, e := range f.Edges {
+		if dropID[e.From] || dropID[e.To] {
+			continue
+		}
+		keptEdges = append(keptEdges, e)
+	}
+	f.Edges = keptEdges
 }
 
 func loadCFGsForFlow(ctx context.Context, q flow.CFGQuerier, ws, format string, f flow.Flow) []flow.FlowCFGs {


### PR DESCRIPTION
Closes #567 (split from #542 F8)

## Problem
The `memory_flow` graph was polluted with JS builtins & keywords as nodes — `Number`, `catch`, `toFixed`, `push`, `for`, `get` — which aren't real workspace functions. `flow.BuildFlow` is pure/edges-only and turns every `calls`-target into a node (`RoleExternal` if undefined in the edge set) with no workspace-symbol check, while `memory_trace` already drops these via `ResolveSymbolByName`.

## Fix (read-path, low blast radius)
New `dropExternalBuiltins` in the `memory_flow` handler: resolve each `RoleExternal` node's bare name via `ResolveSymbolByName` (distinct names resolved once), drop the zero-match ones + the edges referencing them, keep real leaf functions (which resolve) and all non-external roles (`RoleHandler`/`Middleware`/`Integration`). Gated by a new `include_external` param (default false) for parity with `memory_trace`. `BuildFlow` stays pure; no extraction/schema change.

Symbol-doc existence — not a hand-maintained denylist — is the discriminator: a workspace function named `push` resolves (kept), the builtin `push` doesn't (dropped).

## Testing (nanobrain_test only — dev DB never touched)
- **e2e through the handler** (`flow_builtins_567_integration_test.go`): builtin `Number` dropped by default (node **and** edge), real leaf `realHelper` kept, both return with `include_external:true`. **Red-green**: `Number` leaks without the filter.
- `go build`/`go test -race -short ./...` clean.
- smoke:e2e: MCP-over-HTTP on :3199 — default drops `Number`/keeps `realHelper`; `include_external` brings `Number` back (`docs/evidence/smoke-e2e-flow-builtins.md`).
- **R88 independent review: PASS** (`docs/evidence/review-567.md`), 0 blocking; the two worthwhile LOWs (edge-removal test assertion; indexing caveat in the tool description) were addressed.

## #542 progress
F1 (#564), F3 (#562), F4 (#540), F5 (#566), F8 (this) done → remaining F2 (cross-repo collision), F6 (route→handler edge), F7/F9 (chunk_type:symbol filter), F10 (synonym).

Change-type: bug-fix · Lane: tiny.