### PR TITLE
fix(graph): memory_graph direction:in surfaces route→handler http edge

### DIFF
--- a/docs/evidence/review-569.md
+++ b/docs/evidence/review-569.md
@@ -1,0 +1,38 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/graph-route-edge` · Issue #569 (split from #542 F6)
+
+Change: `GetIncomingEdges` gains a third disjunct so `memory_graph(direction=in)`
+on a qualified handler node also matches the BARE stored target of the
+route→handler `http` edge. `.sql` + generated const hand-synced (sqlc absent).
+
+| Concern | Verdict |
+|---|---|
+| SQL correctness | PASS (HIGH) — `strpos($2,'::')>0` guard is load-bearing: for a bare query `split_part(...,'::',2)=''`, so without the guard the disjunct would degrade to `target_node=''` and over-match; the guard suppresses it. Positional `$2` reused 3× bound once — no param/injection issue. |
+| Generated-file sync | PASS (HIGH) — WHERE clause byte-identical in `.sql` and the const; signature unchanged; a future `sqlc generate` is a no-op. Build + vet exit 0. |
+| Blast radius (3 callers) | PASS (HIGH) — memory_graph (MCP + REST) + neighborhood BFS all carry identical "incoming edges" semantics; surfacing the route→handler edge is a strict completeness improvement, not over-return. |
+| Tests | PASS (HIGH) — new test is red-without/green-with (traced against both query bodies); `TestGetIncomingEdges_SymbolFallback` does not regress (guard blocks double-count on bare query). |
+
+Reviewer ran `go build` + `go vet -tags=integration` (exit 0) and hand-traced both
+tests against the exact query bodies. Integration test executed by author against
+nanobrain_test/:3199 (PASS). **0 blocking issues.**
+
+### Non-blocking findings (both LOW — no action)
+- **[LOW] cross-file bare-name collision** — a qualified query may also return
+  incoming edges whose bare stored target shares the name from another file.
+  Inherent to bare http-target storage; consistent with disjunct-2 and impact
+  #553. A true fix belongs at the extractor (store qualified http targets) — out
+  of scope; overlaps the cross-repo scoping work (#542 F2 / root-cause C).
+- **[LOW] disjunct accretion** — `GetIncomingEdges` now bridges all bare/qualified
+  permutations; root cause is heterogeneous target storage. Matches the accepted
+  #553 pattern; normalization debt noted.
+
+### Pre-existing (not this change)
+`TestMemoryGraph_Relative*` fail on clean master with this change stashed (#556).
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-graph-route-edge.md` — MCP-over-HTTP on :3199 /
+nanobrain_test: `direction:in` on the qualified handler returns the `http`
+route→handler edge + `contains`. Dev DB never touched.

--- a/docs/evidence/self-review-graph-route-edge.md
+++ b/docs/evidence/self-review-graph-route-edge.md
@@ -47,8 +47,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED (summary only), CI pass, MERGEABLE/CLEAN. **No inline comments.**
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| _(no inline comments)_ | — | Gemini left a summary review with 0 inline findings. | None. |

--- a/docs/evidence/self-review-graph-route-edge.md
+++ b/docs/evidence/self-review-graph-route-edge.md
@@ -1,0 +1,54 @@
+# Self-Review — Issue #569 (#542 F6: memory_graph reverse route edge)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/graph-route-edge`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_graph(direction="in")` now surfaces the route→handler `http` edge for a
+  handler queried by its qualified `file::symbol` node. Added a third disjunct to
+  `GetIncomingEdges`: `OR (strpos($2::text,'::') > 0 AND target_node =
+  split_part($2::text,'::',2))` — bridging a qualified query against a BARE stored
+  target (http edges store `target_node` as the bare handler name).
+- Edited both the source (`internal/storage/queries/graph.sql`) and the generated
+  const (`internal/storage/sqlc/graph.sql.go`) identically, hand-synced because
+  sqlc isn't installed here; no signature change so a future `sqlc generate` is a
+  no-op. Fixes memory_graph in/both across MCP + REST + neighborhood (all share
+  the query).
+
+## Files Changed
+
+- `internal/storage/queries/graph.sql` + `internal/storage/sqlc/graph.sql.go` —
+  `GetIncomingEdges` third disjunct (byte-identical WHERE clause in both).
+- `internal/mcp/graph_route_edge_569_integration_test.go` — e2e through the
+  memory_graph handler: qualified handler node, direction=in → http + contains.
+
+## Findings Summary
+
+- The `strpos($2,'::') > 0` guard makes the new disjunct fire only for qualified
+  queries, so a bare query never spuriously matches `target_node = ''`.
+- Broadening the reverse match is semantically correct for every caller (the
+  reverse graph SHOULD include the route→handler edge) — same fix shape as impact
+  #553 (which also touched MCP + REST).
+- **Red-green proven**: with the SQL fix stashed the integration test fails (only
+  `contains` returned); with it, both `http` + `contains` are returned.
+- `TestGetIncomingEdges_SymbolFallback` (the query's existing bare↔qualified test)
+  still passes.
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean; `go test -race -short ./...` all ok.
+- Integration (nanobrain_test): route-edge e2e test PASS.
+- Pre-existing (NOT this change): `TestMemoryGraph_Relative*` fail — confirmed
+  failing identically on clean master with this change stashed (tracked as #556).
+- smoke:e2e: `docs/evidence/smoke-e2e-graph-route-edge.md` (MCP-over-HTTP on :3199
+  — direction=in returns http + contains). Dev DB never touched.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-graph-route-edge.md
+++ b/docs/evidence/smoke-e2e-graph-route-edge.md
@@ -1,0 +1,37 @@
+# smoke:e2e — Issue #569 (#542 F6: memory_graph reverse route edge)
+
+Change-type: bug-fix. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Built the binary, seeded into **nanobrain_test**: a workspace (64-hex hash), a
+route→handler `http` edge (`POST /payment-intent → createPaymentIntent`, bare
+target) and the `contains` edge (`controllers/pay.js → controllers/pay.js::createPaymentIntent`,
+qualified target). Started a standalone server on :3199
+(`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`, `NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+## MCP streamable-HTTP handshake + tool call
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_graph  node="controllers/pay.js::createPaymentIntent" direction="in"
+```
+
+Decoded incoming edges:
+
+```
+[ {source:"controllers/pay.js", target:"controllers/pay.js::createPaymentIntent", edge_type:"contains"},
+  {source:"POST /payment-intent", target:"createPaymentIntent",                    edge_type:"http"} ]
+```
+
+**Result:** `direction:"in"` on the qualified handler node now returns the
+route→handler `http` edge (bare stored target matched against the qualified
+query) alongside the `contains` edge — end-to-end over MCP HTTP. **Before this
+fix** only the `contains` edge was returned; the `http` edge was dropped by the
+qualified-vs-bare mismatch.
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace/edges deleted, temp binary removed.

--- a/internal/mcp/graph_route_edge_569_integration_test.go
+++ b/internal/mcp/graph_route_edge_569_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// Issue #569 (#542 F6): memory_graph(direction="in") on a route handler must
+// surface the route->handler http edge, whose target is stored BARE, even when
+// queried with the qualified "file::handler" node.
+func TestMemoryGraph_IncomingSurfacesRouteHandlerHTTPEdge(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	edges := []struct{ src, tgt, kind string }{
+		{"POST /payment-intent", "createPaymentIntent", "http"},                     // bare target (as extractors store it)
+		{"controllers/pay.js", "controllers/pay.js::createPaymentIntent", "contains"}, // qualified target
+	}
+	for _, e := range edges {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash, SourceNode: e.src, TargetNode: e.tgt,
+			EdgeType: e.kind, SourceFile: "controllers/pay.js", Metadata: []byte("{}"),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+
+	resp := unmarshalGraphResp(t, callTool("memory_graph", map[string]any{
+		"workspace": wsHash,
+		"node":      "controllers/pay.js::createPaymentIntent", // qualified handler node
+		"direction": "in",
+	}))
+
+	var sawHTTP, sawContains bool
+	edgesOut, _ := resp["edges"].([]any)
+	for _, e := range edgesOut {
+		em := e.(map[string]any)
+		if em["edge_type"] == "http" && em["source"] == "POST /payment-intent" {
+			sawHTTP = true
+		}
+		if em["edge_type"] == "contains" {
+			sawContains = true
+		}
+	}
+	if !sawHTTP {
+		t.Errorf("incoming edges must include the route->handler http edge (POST /payment-intent); got %+v", edgesOut)
+	}
+	if !sawContains {
+		t.Errorf("incoming edges should still include the contains edge; got %+v", edgesOut)
+	}
+}

--- a/internal/storage/queries/graph.sql
+++ b/internal/storage/queries/graph.sql
@@ -25,7 +25,10 @@ ORDER BY edge_type, target_node;
 -- name: GetIncomingEdges :many
 SELECT id, workspace_hash, source_node, target_node, edge_type, source_file, metadata, created_at
 FROM graph_edges
-WHERE workspace_hash = $1 AND (target_node = $2 OR split_part(target_node, '::', 2) = $2)
+WHERE workspace_hash = $1
+  AND (target_node = $2
+       OR split_part(target_node, '::', 2) = $2
+       OR (strpos($2::text, '::') > 0 AND target_node = split_part($2::text, '::', 2)))
   AND ($3::text = '' OR edge_type = $3)
 ORDER BY edge_type, source_node;
 

--- a/internal/storage/sqlc/graph.sql.go
+++ b/internal/storage/sqlc/graph.sql.go
@@ -171,7 +171,10 @@ func (q *Queries) GetImpactorsByTargets(ctx context.Context, arg GetImpactorsByT
 const getIncomingEdges = `-- name: GetIncomingEdges :many
 SELECT id, workspace_hash, source_node, target_node, edge_type, source_file, metadata, created_at
 FROM graph_edges
-WHERE workspace_hash = $1 AND (target_node = $2 OR split_part(target_node, '::', 2) = $2)
+WHERE workspace_hash = $1
+  AND (target_node = $2
+       OR split_part(target_node, '::', 2) = $2
+       OR (strpos($2::text, '::') > 0 AND target_node = split_part($2::text, '::', 2)))
   AND ($3::text = '' OR edge_type = $3)
 ORDER BY edge_type, source_node
 `


### PR DESCRIPTION
Closes #569 (split from #542 F6)

## Problem
`memory_graph(node="…::createPaymentIntent", direction="in")` on a route handler returned only the `contains` edge — not the route→handler `http` edge — even though `memory_flow`/`memory_impact` know it exists.

## Root cause
`http` edges store a **bare** target (`source_node="POST /payment-intent"`, `target_node="createPaymentIntent"`). `GetIncomingEdges` matched `target_node = $2 OR split_part(target_node,'::',2) = $2`, which only bridges bare-query↔qualified-stored. A **qualified** query node (`file::createPaymentIntent`) never matched the **bare** stored target. Same qualified-vs-bare class as impact #553 / trace #561.

## Fix
Add a third disjunct to `GetIncomingEdges`:
```sql
OR (strpos($2::text,'::') > 0 AND target_node = split_part($2::text,'::',2))
```
bridging qualified-query↔bare-stored. The `strpos>0` guard is load-bearing: without it, a bare query's `split_part(...)=''` would degrade to `target_node=''` and over-match. Fixes `memory_graph` in/both across **MCP + REST + neighborhood** (all share the query). No signature change; `.sql` and the generated const are hand-synced (sqlc not installed here) — a future `sqlc generate` is a no-op.

## Testing (nanobrain_test only — dev DB never touched)
- **e2e through the handler** (`graph_route_edge_569_integration_test.go`): qualified handler node, `direction=in` → both `http` (route→handler) and `contains` returned. **Red-green**: only `contains` without the disjunct.
- `TestGetIncomingEdges_SymbolFallback` still passes (guard prevents double-count on bare queries).
- `go build`/`go test -race -short ./...` clean.
- smoke:e2e: MCP-over-HTTP on :3199 — `direction:in` returns `http` + `contains` (`docs/evidence/smoke-e2e-graph-route-edge.md`).
- **R88 independent review: PASS** (`docs/evidence/review-569.md`), 0 blocking; 2 LOW (cross-file bare-name collision + disjunct-accretion debt) accepted/out-of-scope, consistent with #553.

## Pre-existing (not this change)
`TestMemoryGraph_Relative*` fail on clean master with this change stashed (#556).

## #542 progress
F1 (#564), F3 (#562), F4 (#540), F5 (#566), F6 (this), F8 (#568) done → remaining F2 (cross-repo collision), F7/F9 (chunk_type:symbol filter), F10 (synonym).

Change-type: bug-fix · Lane: tiny.