### PR TITLE
fix(search): forward chunk_type to HybridSearch vector legs

### DIFF
--- a/docs/evidence/review-571.md
+++ b/docs/evidence/review-571.md
@@ -1,0 +1,30 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/query-chunk-type-vector` · Issue #571 (split from #542 F7)
+
+Change: added `ChunkType: chunkTypeNullStr` to all 8 `VectorSearch*` param
+structs in `HybridSearch`/`hybridSearchInner` so the vector leg honors the
+`chunk_type` filter (BM25 legs already did). Lane relevance: search-quality.
+
+| Concern | Verdict |
+|---|---|
+| Completeness (all 8 legs) | PASS (HIGH) — exactly 8 `VectorSearch` sites (4+4), all now carry ChunkType; no `VectorSearch*OR` variants exist; the only `*OR` is a BM25 leg (already had it). |
+| Correctness / NULL semantics | PASS (HIGH) — same `chunkTypeNullStr` the BM25 legs use, in scope at each site; unset → `{Valid:false}` → SQL `IS NULL` branch → no-filter path byte-for-byte unchanged. |
+| No unintended diff | PASS (HIGH) — 1 file, 8 insertions / 4 deletions (the 4 hybridSearchInner lines re-emitted with ChunkType inline); the incidental gofmt realignment of DebugSearch's var block is confirmed **reverted / not present**. |
+| Test quality | PASS (HIGH) — capturing querier overrides only the 4 vector leaves, calls the REAL `HybridSearch`; mockEmbedder returns a valid vector so the vector leg genuinely runs; all 4 permutations assert `{symbol,valid}`; non-vacuous (red without fix / green with). |
+| Recall / RRF / degrade | PASS (HIGH) — both legs now filter identically before RRF (no adverse merge); embed-failure degrade still yields BM25-filtered results. Recall change is the intended fix. |
+
+Reviewer independently ran `go build ./...` (exit 0) + the targeted test (4/4
+PASS). Author confirmed full `go test -race -short ./...` green. **0 findings at
+any severity.**
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-query-chunk-type-vector.md` — service-level red-green
+(all 4 vector legs) + MCP-over-HTTP on :3199: `chunk_type=symbol`/`raw` correctly
+filter `memory_query` results end-to-end. Dev DB never touched.
+
+### Note
+F9 (`memory_search` multi-word + chunk_type → 0, a distinct OR-fallback gap) is
+tracked separately — not in this PR.

--- a/docs/evidence/self-review-query-chunk-type-vector.md
+++ b/docs/evidence/self-review-query-chunk-type-vector.md
@@ -44,8 +44,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED (summary only), CI pass, MERGEABLE/CLEAN. **No inline comments.**
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| _(no inline comments)_ | — | Gemini left a summary review with 0 inline findings. | None. |

--- a/docs/evidence/self-review-query-chunk-type-vector.md
+++ b/docs/evidence/self-review-query-chunk-type-vector.md
@@ -1,0 +1,51 @@
+# Self-Review — Issue #571 (#542 F7: chunk_type on hybrid vector leg)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/query-chunk-type-vector`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_query` with `chunk_type:"symbol"` now actually filters. Added
+  `ChunkType: chunkTypeNullStr,` to all 8 `VectorSearch*` param structs in
+  `HybridSearch` (4) and `hybridSearchInner` (4) in `internal/search/service.go`.
+  The BM25 legs already passed it; the vector legs dropped it, so the vector half
+  of the hybrid returned raw/markdown chunks that RRF merged back in.
+- Pure wiring of an existing-but-dropped param: the `ChunkType` field already
+  exists on the sqlc vector param types and the vector SQL (`embeddings.sql`)
+  already has the `chunk_type` narg. No schema/param change.
+
+## Files Changed
+
+- `internal/search/service.go` — 8× `ChunkType: chunkTypeNullStr,` on the vector
+  legs (8 insertions; nothing else — an incidental gofmt realignment of an
+  unrelated `var` block in `DebugSearch` was reverted to keep the diff surgical).
+- `internal/search/chunk_type_vector_571_test.go` — white-box test: a capturing
+  querier records the `ChunkType` each of the 4 vector legs receives; asserts all
+  four paths (all/ws × tags/no-tags) get `{symbol,valid}`.
+
+## Findings Summary
+
+- The fix mirrors the BM25 legs exactly (same `chunkTypeNullStr`), so no
+  behavior change when `chunk_type` is unset (`{Valid:false}` → SQL `IS NULL`
+  branch → no filtering).
+- **Red-green proven** at the service level: with the fix stashed, all 4 vector
+  legs receive `{Valid:false}` (the F7 bug); with it, `{symbol,valid}`.
+- F9 (`memory_search` multi-word + chunk_type → 0, a distinct OR-fallback gap) is
+  tracked separately — not in this PR.
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean; `go test -race ./internal/search/` all ok (incl. the
+  new white-box test).
+- smoke:e2e: `docs/evidence/smoke-e2e-query-chunk-type-vector.md` — MCP-over-HTTP
+  on :3199: `chunk_type=symbol`/`raw` correctly filter `memory_query` results
+  end-to-end. Dev DB never touched.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-query-chunk-type-vector.md
+++ b/docs/evidence/smoke-e2e-query-chunk-type-vector.md
@@ -1,0 +1,49 @@
+# smoke:e2e — Issue #571 (#542 F7: memory_query chunk_type filter)
+
+Change-type: bug-fix. Verified on an isolated **:3199 / nanobrain_test** server
+(dev DB / :3100 never touched).
+
+## Behavioral proof of the vector-leg fix — service-level red-green
+
+The fix is on the VECTOR leg of `HybridSearch`. `chunk_type_vector_571_test.go`
+runs the real `HybridSearch` with a capturing querier and asserts all four vector
+legs (all/ws × tags/no-tags) receive `ChunkType={symbol,valid}`:
+
+```
+RED  (fix stashed): VectorSearch / VectorSearchAll / VectorSearchWithTags /
+                    VectorSearchAllWithTags all receive ChunkType={Valid:false}
+GREEN (fix applied): all four receive {symbol,valid}  → --- PASS
+```
+
+## End-to-end over MCP HTTP
+
+Seeded a workspace with two chunks (`chunk_type=symbol` "depositHandler" and
+`chunk_type=raw` "deposit notes", `search_vector` populated) into nanobrain_test;
+started a standalone server on :3199 (`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`,
+`NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_query  query="deposit balance"                    (no filter)
+HTTP/1.1 200 OK   tools/call memory_query  query="deposit balance" chunk_type="symbol"
+HTTP/1.1 200 OK   tools/call memory_query  query="deposit balance" chunk_type="raw"
+```
+
+Decoded result titles:
+
+```
+no filter      → ["depositHandler", "deposit notes"]
+chunk=symbol   → ["depositHandler"]          (raw chunk excluded)
+chunk=raw      → ["deposit notes"]           (symbol chunk excluded)
+```
+
+**Result:** `chunk_type` now filters `memory_query` end-to-end over MCP HTTP. The
+vector-leg-specific fix (the F7 defect) is proven by the service-level red-green
+test above; this HTTP run confirms the user-facing filtering behavior works over
+the wire (these chunks carry no embeddings, so the BM25 leg carries the filter
+here — both legs now honor `chunk_type`).
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace/docs/chunks deleted, temp binary removed.

--- a/internal/search/chunk_type_vector_571_test.go
+++ b/internal/search/chunk_type_vector_571_test.go
@@ -1,0 +1,72 @@
+package search
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/rs/zerolog"
+)
+
+// chunkTypeCapturingQuerier records the ChunkType passed to each vector-search
+// leg so the test can prove HybridSearch forwards the filter to the vector half
+// (issue #571 / #542 F7). It embeds *mockQuerier for all the other methods.
+type chunkTypeCapturingQuerier struct {
+	*mockQuerier
+	got map[string]sql.NullString
+}
+
+func (c *chunkTypeCapturingQuerier) VectorSearch(ctx context.Context, arg sqlc.VectorSearchParams) ([]sqlc.VectorSearchRow, error) {
+	c.got["VectorSearch"] = arg.ChunkType
+	return nil, nil
+}
+func (c *chunkTypeCapturingQuerier) VectorSearchAll(ctx context.Context, arg sqlc.VectorSearchAllParams) ([]sqlc.VectorSearchAllRow, error) {
+	c.got["VectorSearchAll"] = arg.ChunkType
+	return nil, nil
+}
+func (c *chunkTypeCapturingQuerier) VectorSearchWithTags(ctx context.Context, arg sqlc.VectorSearchWithTagsParams) ([]sqlc.VectorSearchWithTagsRow, error) {
+	c.got["VectorSearchWithTags"] = arg.ChunkType
+	return nil, nil
+}
+func (c *chunkTypeCapturingQuerier) VectorSearchAllWithTags(ctx context.Context, arg sqlc.VectorSearchAllWithTagsParams) ([]sqlc.VectorSearchAllWithTagsRow, error) {
+	c.got["VectorSearchAllWithTags"] = arg.ChunkType
+	return nil, nil
+}
+
+// F7: the vector leg of HybridSearch previously dropped ChunkType, so
+// memory_query chunk_type filtering was ignored on the vector half. Assert all
+// four vector paths now receive the filter.
+func TestHybridSearch_ForwardsChunkTypeToVectorLeg(t *testing.T) {
+	cases := []struct {
+		name      string
+		workspace string
+		tags      []string
+		wantKey   string
+	}{
+		{"workspace+no-tags", "ws-hash", nil, "VectorSearch"},
+		{"workspace+tags", "ws-hash", []string{"go"}, "VectorSearchWithTags"},
+		{"all+no-tags", "all", nil, "VectorSearchAll"},
+		{"all+tags", "all", []string{"go"}, "VectorSearchAllWithTags"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &chunkTypeCapturingQuerier{mockQuerier: &mockQuerier{}, got: map[string]sql.NullString{}}
+			svc := NewSearchService(q, &mockEmbedder{}, config.SearchConfig{RrfK: 60, Limit: 20}, zerolog.Nop())
+
+			_, err := svc.HybridSearch(context.Background(), "deposit error handling", tc.workspace, 10, tc.tags, nil, "symbol")
+			if err != nil {
+				t.Fatalf("HybridSearch: %v", err)
+			}
+
+			ct, ok := q.got[tc.wantKey]
+			if !ok {
+				t.Fatalf("vector leg %s was not called; captured: %v", tc.wantKey, q.got)
+			}
+			if !ct.Valid || ct.String != "symbol" {
+				t.Errorf("%s received ChunkType=%+v, want {symbol,valid}", tc.wantKey, ct)
+			}
+		})
+	}
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -378,6 +378,7 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 					QueryEmbedding: pgvector_go.NewVector(vec),
 					Tags:           tags,
 					MaxResults:     fetchLimit,
+					ChunkType:      chunkTypeNullStr,
 					CreatedAfter:   ca,
 					CreatedBefore:  cb,
 					UpdatedAfter:   ua,
@@ -409,6 +410,7 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 				rows, err := s.queries.VectorSearchAll(gctx, sqlc.VectorSearchAllParams{
 					QueryEmbedding: pgvector_go.NewVector(vec),
 					MaxResults:     fetchLimit,
+					ChunkType:      chunkTypeNullStr,
 					CreatedAfter:   ca,
 					CreatedBefore:  cb,
 					UpdatedAfter:   ua,
@@ -444,6 +446,7 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 					WorkspaceHash:  workspace,
 					Tags:           tags,
 					MaxResults:     fetchLimit,
+					ChunkType:      chunkTypeNullStr,
 					CreatedAfter:   ca,
 					CreatedBefore:  cb,
 					UpdatedAfter:   ua,
@@ -476,6 +479,7 @@ func (s *SearchService) HybridSearch(ctx context.Context, query string, workspac
 					QueryEmbedding: pgvector_go.NewVector(vec),
 					WorkspaceHash:  workspace,
 					MaxResults:     fetchLimit,
+					ChunkType:      chunkTypeNullStr,
 					CreatedAfter:   ca,
 					CreatedBefore:  cb,
 					UpdatedAfter:   ua,
@@ -892,7 +896,7 @@ func (s *SearchService) hybridSearchInner(ctx context.Context, query string, wor
 			if len(tags) > 0 {
 				rows, err := s.queries.VectorSearchAllWithTags(gctx, sqlc.VectorSearchAllWithTagsParams{
 					QueryEmbedding: pgvector_go.NewVector(vec), Tags: tags,
-					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					MaxResults: fetchLimit, ChunkType: chunkTypeNullStr, CreatedAfter: ca, CreatedBefore: cb,
 					UpdatedAfter: ua, UpdatedBefore: ub,
 				})
 				if err != nil {
@@ -912,7 +916,7 @@ func (s *SearchService) hybridSearchInner(ctx context.Context, query string, wor
 			} else {
 				rows, err := s.queries.VectorSearchAll(gctx, sqlc.VectorSearchAllParams{
 					QueryEmbedding: pgvector_go.NewVector(vec),
-					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					MaxResults:     fetchLimit, ChunkType: chunkTypeNullStr, CreatedAfter: ca, CreatedBefore: cb,
 					UpdatedAfter: ua, UpdatedBefore: ub,
 				})
 				if err != nil {
@@ -934,7 +938,7 @@ func (s *SearchService) hybridSearchInner(ctx context.Context, query string, wor
 			if len(tags) > 0 {
 				rows, err := s.queries.VectorSearchWithTags(gctx, sqlc.VectorSearchWithTagsParams{
 					QueryEmbedding: pgvector_go.NewVector(vec), WorkspaceHash: workspace, Tags: tags,
-					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					MaxResults: fetchLimit, ChunkType: chunkTypeNullStr, CreatedAfter: ca, CreatedBefore: cb,
 					UpdatedAfter: ua, UpdatedBefore: ub,
 				})
 				if err != nil {
@@ -954,7 +958,7 @@ func (s *SearchService) hybridSearchInner(ctx context.Context, query string, wor
 			} else {
 				rows, err := s.queries.VectorSearch(gctx, sqlc.VectorSearchParams{
 					QueryEmbedding: pgvector_go.NewVector(vec), WorkspaceHash: workspace,
-					MaxResults: fetchLimit, CreatedAfter: ca, CreatedBefore: cb,
+					MaxResults: fetchLimit, ChunkType: chunkTypeNullStr, CreatedAfter: ca, CreatedBefore: cb,
 					UpdatedAfter: ua, UpdatedBefore: ub,
 				})
 				if err != nil {


### PR DESCRIPTION
Closes #571 (split from #542 F7)

## Problem
`memory_query` with `chunk_type:"symbol"` still returned raw/markdown chunks — the filter appeared ignored.

## Root cause
In `HybridSearch`/`hybridSearchInner`, the BM25 legs passed `ChunkType: chunkTypeNullStr`, but the **8 `VectorSearch*` calls omitted it** → the vector leg ran unfiltered → RRF merged those raw/markdown chunks back into the final results.

## Fix
Forward the existing `chunkTypeNullStr` into all 8 vector param structs (4 in `HybridSearch`, 4 in `hybridSearchInner`). The `ChunkType` field already exists on those sqlc types and the vector SQL already has the `chunk_type` narg — pure wiring of an existing-but-dropped param. When `chunk_type` is unset it binds SQL NULL, so the no-filter path is byte-for-byte unchanged; both legs now filter identically before RRF.

## Testing (nanobrain_test only — dev DB never touched)
- **White-box service test** (`chunk_type_vector_571_test.go`): a capturing querier over the **real** `HybridSearch` asserts all 4 vector legs (all/ws × tags/no-tags) receive `{symbol,valid}`. **Red-green**: `{Valid:false}` on every leg without the fix, `{symbol,valid}` with it.
- `go build`/`go test -race -short ./...` clean.
- smoke:e2e: service-level red-green + MCP-over-HTTP on :3199 — `chunk_type=symbol`/`raw` correctly filter `memory_query` results end-to-end (`docs/evidence/smoke-e2e-query-chunk-type-vector.md`).
- **R88 independent review: PASS, 0 findings** (`docs/evidence/review-571.md`).

## #542 progress
F1 (#564), F3 (#562), F4 (#540), F5 (#566), F6 (#570), F7 (this), F8 (#568) done → remaining **F2** (cross-repo collision), **F9** (memory_search multi-word OR-fallback), **F10** (synonym conflation — inherent to semantic search).

Change-type: bug-fix · Lane: tiny.