### PR TITLE
fix(search): OR-fallback for memory_search multi-word queries

### DIFF
--- a/docs/evidence/review-573.md
+++ b/docs/evidence/review-573.md
@@ -1,0 +1,35 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/search-multiword-or-fallback` · Issue #573 (split from #542 F9)
+
+Change: `memory_search` gains an OR-relaxation fallback (mirrors HybridSearch) so
+a multi-word phrase whose `websearch_to_tsquery` AND misses is retried with an OR
+tsquery; `BuildORQuery` exported for reuse.
+
+| Concern | Verdict |
+|---|---|
+| Correctness | PASS (HIGH) — gate `len(allRows)==0 && len(tags)==0 && timeRange==nil && Fields>=2`; OR legs reuse `chunkTypeNull` (results stay filtered); no double-append (only runs on empty allRows); pagination sees the merged set. |
+| Scope | PASS (HIGH) — untagged only (no `BM25Search*WithTagsOR` variant); tagged multi-word returns 0 (safe: no result > wrong result). |
+| No regression | PASS (HIGH) — AND ≥1 row / <2 words / tags present all skip the block byte-identically; `BuildORQuery` is pure delegation (HybridSearch callers unaffected). |
+| Error handling | PASS (LOW) — OR error returns errResult, matching the AND leg's own error path (deliberate divergence from HybridSearch's Warn-and-continue; surfacing DB errors is defensible). |
+| Test | PASS (HIGH) — real handler over in-memory MCP; seeds a symbol chunk + search_vector; multi-word AND-miss; non-vacuous (red without / green with). |
+
+Reviewer ran `go build ./...` + `go vet` (all exit 0). **0 CRITICAL/HIGH.**
+
+### MEDIUM finding — addressed
+- **Time-filter dropped in fallback**: the OR SQL variants have no time-range
+  params, so with an active `timeRange` + AND-miss the fallback could surface
+  rows outside the window (worse than the prior 0). **Fixed** — the fallback is
+  now additionally gated on `timeRange == nil` (stricter than HybridSearch's
+  fallback, which lacks the guard).
+
+### LOW / informational
+- Gate is `>= 2` words (vs HybridSearch's `> 2`) — intentionally broader (a
+  2-word phrase can also AND-miss); not an exact mirror. Accepted.
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-search-multiword-or-fallback.md` — MCP-over-HTTP on
+:3199 / nanobrain_test: multi-word "deposit zzzmissing balance" (AND misses) →
+`depositController` via OR fallback. Dev DB never touched.

--- a/docs/evidence/self-review-search-multiword-or-fallback.md
+++ b/docs/evidence/self-review-search-multiword-or-fallback.md
@@ -52,8 +52,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED, CI pass, MERGEABLE/CLEAN. One inline (MEDIUM).
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| tools.go:804 [medium] — a stopword query (`"the deposit"`) passes `Fields>=2` but `BuildORQuery` yields a single term → the OR query equals the already-failed AND query (redundant round-trip) | VALID | The `" | "` check is stricter and more correct — it subsumes `Fields>=2` and skips the redundant query when <2 non-stopword terms survive. | **Fixed** — gate changed from `len(Fields(query))>=2` + `orQuery != ""` to `strings.Contains(orQuery, " | ")`. |

--- a/docs/evidence/self-review-search-multiword-or-fallback.md
+++ b/docs/evidence/self-review-search-multiword-or-fallback.md
@@ -1,0 +1,59 @@
+# Self-Review — Issue #573 (#542 F9: memory_search multi-word OR-fallback)
+
+Change-type: bug-fix · Lane: tiny · Branch: `fix/search-multiword-or-fallback`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_search` with a multi-word phrase + `chunk_type` no longer silently
+  returns 0. Its direct BM25 path uses `websearch_to_tsquery` (ANDs terms); a
+  symbol chunk rarely contains every word, so under a chunk_type filter it
+  collapsed to 0. Added the same OR-relaxation `HybridSearch` already uses.
+- `internal/search/service.go`: exported `BuildORQuery` wrapping the existing
+  unexported `buildORQuery` (stopword-filter + strip + join with " | ") so the
+  MCP handler reuses the identical logic (incl. the shared stopword list).
+- `internal/mcp/tools.go` (memory_search): after the AND BM25 populates
+  `allRows`, if `len(allRows)==0 && len(tags)==0 && len(Fields(query))>=2`,
+  rebuild an OR query and reissue via `BM25SearchAllOR` (ws=="all") /
+  `BM25SearchOR`, passing the same `chunkTypeNull` so OR results stay filtered.
+
+## Files Changed
+
+- `internal/search/service.go` — `BuildORQuery` exported wrapper (+5).
+- `internal/mcp/tools.go` — OR-fallback block in the memory_search handler (+44).
+- `internal/mcp/search_multiword_573_integration_test.go` — e2e through the
+  handler: seeds a symbol chunk, populates search_vector, searches a multi-word
+  phrase whose AND misses; asserts the OR fallback rescues it.
+
+## Findings Summary
+
+- Scope: untagged only — there is no `BM25Search*WithTagsOR` SQL variant, so a
+  tagged multi-word fallback is a follow-up (would need new queries). The
+  reported repro is untagged.
+- **Time-filter safety** (R88 MEDIUM, addressed): the OR SQL variants have no
+  time-range params, so the fallback is additionally gated on `timeRange == nil`
+  — with a time filter set it returns 0 (as before) rather than risk surfacing
+  rows outside the requested window. (This is stricter than HybridSearch's
+  fallback, which omits the guard.)
+- **Red-green proven**: with the fallback stashed, the multi-word search returns
+  `results:[] total:0` (the F9 bug); with it, the symbol chunk is returned.
+- No regression: when the AND query returns ≥1 row, or the query has <2 words,
+  or tags are present, the fallback block is skipped entirely. `BuildORQuery` is
+  a pure passthrough — HybridSearch's existing callers are unaffected. OR-query
+  failure returns an errResult (not swallowed).
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean; `go test -race -short ./...` all ok.
+- Integration (nanobrain_test): OR-fallback e2e test PASS.
+- smoke:e2e: `docs/evidence/smoke-e2e-search-multiword-or-fallback.md` (MCP-over-HTTP
+  on :3199 — multi-word AND-miss rescued by OR fallback). Dev DB never touched.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-search-multiword-or-fallback.md
+++ b/docs/evidence/smoke-e2e-search-multiword-or-fallback.md
@@ -1,0 +1,37 @@
+# smoke:e2e — Issue #573 (#542 F9: memory_search multi-word OR-fallback)
+
+Change-type: bug-fix. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Seeded into nanobrain_test: a workspace (64-hex hash) + a document/chunk
+(`chunk_type=symbol`, content "deposit account balance controller",
+`search_vector` populated). Started a standalone server on :3199
+(`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`, `NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+## MCP streamable-HTTP handshake + tool calls
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_search  query="deposit"                       chunk_type="symbol"
+HTTP/1.1 200 OK   tools/call memory_search  query="deposit zzzmissing balance"    chunk_type="symbol"
+```
+
+Decoded result titles:
+
+```
+single-word "deposit"                       → ["depositController"]
+multi-word  "deposit zzzmissing balance"    → ["depositController"]  total=1
+```
+
+The multi-word query contains `zzzmissing`, which the chunk does NOT contain, so
+the `websearch_to_tsquery` AND (`deposit & zzzmissing & balance`) matches nothing.
+The OR-fallback (`deposit | zzzmissing | balance`) rescues it → the symbol chunk
+is returned. **Before this fix** the multi-word + `chunk_type=symbol` search
+returned `results:[] total:0` (confirmed by the red-green integration test).
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace/doc/chunk deleted, temp binary removed.

--- a/internal/mcp/search_multiword_573_integration_test.go
+++ b/internal/mcp/search_multiword_573_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/stdlib"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nano-brain/nano-brain/internal/config"
+	internalmcp "github.com/nano-brain/nano-brain/internal/mcp"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	"github.com/rs/zerolog"
+)
+
+// Issue #573 (#542 F9): memory_search uses websearch_to_tsquery (ANDs terms), so
+// a multi-word query where no chunk contains every term returns 0 — worse under
+// chunk_type. The OR-fallback must rescue it. This test seeds a symbol chunk,
+// populates its search_vector (UpsertChunk doesn't), and searches a multi-word
+// phrase whose AND misses but OR hits.
+func TestMemorySearch_MultiWordORFallback(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { db.Close() })
+	q := sqlc.New(db)
+
+	wsHash := fmt.Sprintf("%x", sha256.Sum256([]byte("f9_ws_"+uuid.New().String())))
+	if _, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{Hash: wsHash, Name: "f9-ws", Path: "/tmp/f9-" + uuid.New().String()[:8]}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	doc, err := q.UpsertDocument(ctx, sqlc.UpsertDocumentParams{
+		WorkspaceHash: wsHash, ContentHash: "f9-d", Title: "depositController",
+		Content: "deposit account balance controller", SourcePath: "svc.go?symbol=depositController", Collection: "code",
+	})
+	if err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	if _, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+		DocumentID: doc.ID, WorkspaceHash: wsHash, ContentHash: "f9-c",
+		Content: "deposit account balance controller", ChunkIndex: 0,
+		ChunkType: "symbol", EmbeddingStrategy: "none",
+	}); err != nil {
+		t.Fatalf("upsert chunk: %v", err)
+	}
+	// search_vector is app-populated (UpsertChunk leaves it NULL); set it as the
+	// indexer would so BM25 can match.
+	if _, err := db.ExecContext(ctx, "UPDATE chunks SET search_vector = to_tsvector(get_tsvector_config(), content) WHERE workspace_hash=$1", wsHash); err != nil {
+		t.Fatalf("set search_vector: %v", err)
+	}
+
+	server := internalmcp.NewMCPServer("test")
+	adapter := internalmcp.NewAdapter(q, db, nil, nil, nil, config.EmbeddingConfig{}, config.SearchConfig{Limit: 20}, config.FlowConfig{}, nil, zerolog.Nop())
+	internalmcp.RegisterTools(server, adapter)
+	ct, st := mcpsdk.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "t", Version: "v1"}, nil)
+	session, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+	callTool := func(name string, args map[string]any) *mcpsdk.CallToolResult {
+		r, err := session.CallTool(ctx, &mcpsdk.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("CallTool(%s): %v", name, err)
+		}
+		return r
+	}
+
+	// Multi-word phrase whose AND misses (chunk lacks "zzzmissing"), chunk_type=symbol.
+	resp := unmarshalGraphResp(t, callTool("memory_search", map[string]any{
+		"workspace": wsHash, "query": "deposit zzzmissing balance", "chunk_type": "symbol",
+	}))
+	results, _ := resp["results"].([]any)
+	if len(results) == 0 {
+		t.Fatalf("multi-word search returned 0 — OR fallback did not rescue the AND miss: %+v", resp)
+	}
+	var sawDoc bool
+	for _, r := range results {
+		if r.(map[string]any)["title"] == "depositController" {
+			sawDoc = true
+		}
+	}
+	if !sawDoc {
+		t.Errorf("expected depositController via OR fallback; got %+v", results)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -791,6 +791,53 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 				}
 			}
 
+			// F9: memory_search uses websearch_to_tsquery, which ANDs multi-word
+			// terms, so a phrase where no single chunk contains every word returns
+			// 0 — worse under a chunk_type filter. Mirror HybridSearch's relaxation:
+			// on an empty AND result with a multi-word query, retry with an OR
+			// tsquery. (No tag-OR SQL variant exists yet, so this covers the
+			// untagged case — the reported repro.)
+			// Skipped when a time filter is set: the OR SQL variants have no
+			// time-range params, so relaxing there could surface rows outside the
+			// requested window — return 0 (as before) instead.
+			if len(allRows) == 0 && len(tags) == 0 && timeRange == nil && len(strings.Fields(query)) >= 2 {
+				if orQuery := search.BuildORQuery(query); orQuery != "" {
+					if ws == "all" {
+						rows, orErr := a.queries.BM25SearchAllOR(ctx, sqlc.BM25SearchAllORParams{
+							Query: orQuery, ChunkType: chunkTypeNull, MaxResults: fetchLimit,
+						})
+						if orErr != nil {
+							return errResult(fmt.Sprintf("bm25 OR search failed: %v", orErr)), nil
+						}
+						for _, r := range rows {
+							allRows = append(allRows, bm25Row{
+								ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+								WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+								Content: r.Content, SourcePath: r.SourcePath,
+								Collection: r.Collection, Tags: r.Tags,
+								Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+							})
+						}
+					} else {
+						rows, orErr := a.queries.BM25SearchOR(ctx, sqlc.BM25SearchORParams{
+							Query: orQuery, WorkspaceHash: ws, ChunkType: chunkTypeNull, MaxResults: fetchLimit,
+						})
+						if orErr != nil {
+							return errResult(fmt.Sprintf("bm25 OR search failed: %v", orErr)), nil
+						}
+						for _, r := range rows {
+							allRows = append(allRows, bm25Row{
+								ID: r.ID.String(), DocumentID: r.DocumentID.String(),
+								WorkspaceHash: r.WorkspaceHash, Title: r.Title,
+								Content: r.Content, SourcePath: r.SourcePath,
+								Collection: r.Collection, Tags: r.Tags,
+								Score: r.Score, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+							})
+						}
+					}
+				}
+			}
+
 			total := len(allRows)
 			hasMore := total > offset+maxResults
 			pageEnd := offset + maxResults

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -800,8 +800,11 @@ func registerMemorySearch(server *mcpsdk.Server, a *Adapter) {
 			// Skipped when a time filter is set: the OR SQL variants have no
 			// time-range params, so relaxing there could surface rows outside the
 			// requested window — return 0 (as before) instead.
-			if len(allRows) == 0 && len(tags) == 0 && timeRange == nil && len(strings.Fields(query)) >= 2 {
-				if orQuery := search.BuildORQuery(query); orQuery != "" {
+			if len(allRows) == 0 && len(tags) == 0 && timeRange == nil {
+				// Only relax when >=2 non-stopword terms survive: a single term
+				// (e.g. "the deposit" -> "deposit") yields the same query the AND
+				// leg already ran with 0 rows, so the "|" is what makes it useful.
+				if orQuery := search.BuildORQuery(query); strings.Contains(orQuery, " | ") {
 					if ws == "all" {
 						rows, orErr := a.queries.BM25SearchAllOR(ctx, sqlc.BM25SearchAllORParams{
 							Query: orQuery, ChunkType: chunkTypeNull, MaxResults: fetchLimit,

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -27,6 +27,11 @@ var bm25StopWords = map[string]bool{
 	"trace": true, "debug": true,
 }
 
+// BuildORQuery exposes buildORQuery so other packages (e.g. the memory_search
+// MCP handler) can apply the same OR-relaxation fallback the hybrid path uses:
+// stopword-filtered, punctuation-stripped terms joined with " | ".
+func BuildORQuery(query string) string { return buildORQuery(query) }
+
 func buildORQuery(query string) string {
 	words := strings.Fields(query)
 	var filtered []string


### PR DESCRIPTION
Closes #573 (split from #542 F9)

## Problem
`memory_search` with a multi-word phrase + `chunk_type:"symbol"` silently returned 0 (single-word worked).

## Root cause
`memory_search`'s direct BM25 path uses `websearch_to_tsquery`, which ANDs multi-word terms — a small symbol chunk rarely contains every word, and the `chunk_type='symbol'` restriction shrinks the pool to zero. `HybridSearch` already has an OR-relaxation fallback (`buildORQuery` → `BM25Search*OR`); `memory_search`'s handler didn't, so a 0-row AND query was returned as-is.

## Fix
Mirror the relaxation in the `memory_search` handler: on an empty AND result with a multi-word query, rebuild an OR tsquery (`buildORQuery`, exported as `BuildORQuery` for reuse) and reissue via `BM25SearchAllOR`/`BM25SearchOR`, keeping the same `chunk_type`. Minimal, surgical (AND path untouched).

**Scope + safety:**
- Untagged only — no `BM25Search*WithTagsOR` SQL variant exists (tagged multi-word returns 0 as before: no result > wrong result). Follow-up.
- Gated on `timeRange == nil`: the OR SQL variants have no time-range params, so relaxing under an active time filter could surface rows outside the window — return 0 instead. (Addresses the R88 MEDIUM; stricter than HybridSearch's own fallback.)

## Testing (nanobrain_test only — dev DB never touched)
- **e2e through the handler** (`search_multiword_573_integration_test.go`): seeds a symbol chunk + `search_vector`, searches a multi-word phrase whose AND misses; asserts the OR fallback returns it. **Red-green**: `results:[] total:0` without the fallback, the chunk with it.
- `go build`/`go test -race -short ./...` clean.
- smoke:e2e: MCP-over-HTTP on :3199 — "deposit zzzmissing balance" (AND misses) rescued by OR fallback (`docs/evidence/smoke-e2e-search-multiword-or-fallback.md`).
- **R88 independent review: PASS** (`docs/evidence/review-573.md`); the one MEDIUM (time-filter drop) was fixed with the `timeRange==nil` gate.

## #542 progress
F1 (#564), F3 (#562), F4 (#540), F5 (#566), F6 (#570), F7 (#572), F8 (#568), F9 (this) done → remaining **F2** (cross-repo bare-name collision — root-cause C) and **F10** (domain synonym conflation — inherent to semantic search).

Change-type: bug-fix · Lane: tiny.