### PR TITLE
fix(trace): resolve bare-call collisions to nearest subtree (#542 F2)

### DIFF
--- a/docs/evidence/review-575.md
+++ b/docs/evidence/review-575.md
@@ -1,0 +1,39 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/trace-proximity-disambiguation` · Issue #575 (#542 F2, root-cause C increment)
+
+Change: `memory_trace` resolves a bare-call collision to the definition sharing
+the deepest directory prefix with the caller (unique nearest → resolve + clear
+ambiguous; tie → unchanged fan-out). `sharedPathDepth` + `nearestSymbolMatch`
+helpers.
+
+| Concern | Verdict |
+|---|---|
+| Unique-strictly-deepest logic | PASS (HIGH) — `bestDepth=-1`, `>` sets winner+clears tie, `==` sets tie; empty caller / all-malformed → false; same-file wins (full depth); no off-by-one (tests confirm). |
+| Normalization | PASS (HIGH) — caller (`e.SourceFile`) and candidate (`source_path`, absolute in prod) both `stripWorkspacePrefix`'d against the same `wsRoot` (in scope at the call site) → valid in prod (absolute) and tests (relative). |
+| Recall safety | PASS w/ MEDIUM note — loss-free on ties; unique-nearest is an intentional heuristic (see below). |
+| No regression | PASS (HIGH) — `len(matches)==1` and `matches==0` paths untouched; #539 `AmbiguousSameNameSymbols…` is a genuine tie (both depth 0) → stays ambiguous, still passes. |
+| Tests non-vacuous | PASS (HIGH) — unit (cross-repo/same-file/tie/empty) + integration (collision → backend resolved, frontend dropped, not ambiguous); red without fix. |
+
+Reviewer ran `go build ./...` + `go vet` (exit 0) + the unit tests (PASS). **0 CRITICAL/HIGH.**
+
+### MEDIUM — addressed
+- Inline comment overstated the recall guarantee: "no legit cross-dir call lost"
+  holds only on a **tie**; on a unique-nearest resolution the heuristic can drop
+  a real target if a nearer same-named collision exists (the acknowledged
+  path-proximity-vs-import-graph tradeoff — precision needs a re-index). **Fixed**
+  — comment softened to state it's a heuristic and the loss-free property is
+  tie-only, pointing at the #542 import-graph follow-up.
+
+### LOW / informational
+- If a workspace ever had divergent absolute-root conventions between
+  `source_path` and edge `SourceFile`, stripping could skew depth — no evidence
+  it happens (single wsRoot/workspace) and the failure mode is graceful (→ tie →
+  ambiguous). Mental note only.
+
+### smoke:e2e — PASS
+`docs/evidence/smoke-e2e-trace-proximity-disambiguation.md` — MCP-over-HTTP on
+:3199: cross-repo `foo` resolves to `backend/svc.go::foo` (frontend dropped, not
+ambiguous). Dev DB never touched.

--- a/docs/evidence/self-review-trace-proximity-disambiguation.md
+++ b/docs/evidence/self-review-trace-proximity-disambiguation.md
@@ -1,0 +1,66 @@
+# Self-Review — Issue #575 (#542 F2: trace bare-call proximity disambiguation)
+
+Change-type: bug-fix · Lane: normal (search-quality-adjacent) · Branch: `fix/trace-proximity-disambiguation`
+Author: kokorolx.
+
+## Actions Taken
+
+- `memory_trace` no longer fans a bare call out to every same-named symbol in a
+  monorepo. When a bare calls-target resolves to multiple candidates, it now
+  resolves to the definition **nearest the caller in the directory tree**.
+- `internal/mcp/graph_paths.go`: `sharedPathDepth(a,b)` (common leading path
+  segments) + `nearestSymbolMatch(callerFile, wsRoot, matches)` — returns the
+  single candidate with the strictly-deepest shared prefix, or `(zero,false)` on
+  a tie / empty caller. Candidate `source_path` (absolute in prod) is normalized
+  via `stripWorkspacePrefix`.
+- `internal/mcp/tools.go` (`registerMemoryTrace`): on `len(matches)>1`, a unique
+  nearest → resolve to it + clear `ambiguous`; a tie → unchanged (emit all,
+  ambiguous). No new query, no re-index.
+
+## Files Changed
+
+- `internal/mcp/graph_paths.go` — `sharedPathDepth` + `nearestSymbolMatch`.
+- `internal/mcp/tools.go` — wire into the trace bare-call resolution block.
+- `internal/mcp/trace_proximity_575_test.go` — white-box unit (cross-repo /
+  same-file / tie / empty).
+- `internal/mcp/trace_proximity_575_integration_test.go` — e2e through the
+  handler (cross-repo `foo` collision → backend resolved, frontend dropped, not
+  ambiguous).
+
+## Findings Summary
+
+- **Recall-safe by design**: narrowing happens ONLY when a unique nearest exists;
+  a tie (two candidates at equal max depth) keeps today's emit-all-ambiguous
+  behavior, so a legitimate cross-dir call is never dropped. The heuristic risk
+  (a nearer same-named collision masking a farther real target) is bounded and
+  strictly better than today's all-ambiguous fan-out.
+- **Red-green proven**: without the fix the integration test returns both
+  `foo` nodes (ambiguous); with it, only `backend/svc.go::foo`.
+- No regression: `len(matches)==1` and `matches==0` (external-drop) paths
+  untouched; the existing `TestMemoryTrace_AmbiguousSameNameSymbolsYieldDistinctNodes`
+  still passes (its fixture is a genuine tie → stays ambiguous).
+
+## Scope / honest limits (from deep-design of root-cause C)
+
+- Covers **memory_trace** (the reported repro). `memory_impact`/`memory_flow`
+  ambiguity lives in the flow builder — a parallel follow-up on #542 F2.
+- Path-proximity, not import-graph-precise: import edges are file/module-level
+  and JS/TS targets aren't resolved in current data (needs a re-index), and the
+  import graph is useless for Go same-package calls — so proximity is the
+  correct no-re-index disambiguator. Import-precise JS/TS is a later increment.
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean; `go test -race -short ./...` all ok.
+- Integration (nanobrain_test): unit + 6 trace tests PASS (pre-existing
+  `TestMemoryTrace_RelativeInputAndOutput` panic is #556, unrelated).
+- smoke:e2e: `docs/evidence/smoke-e2e-trace-proximity-disambiguation.md`.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/self-review-trace-proximity-disambiguation.md
+++ b/docs/evidence/self-review-trace-proximity-disambiguation.md
@@ -59,8 +59,8 @@ Author: kokorolx.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
+Gemini: COMMENTED, CI pass, MERGEABLE/CLEAN. One inline (HIGH, 3 sub-points).
 
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| graph_paths.go:132 [high] — (1) Windows `\` not normalized in the split; (2) leading/trailing slashes can skew depth; (3) caller re-split each loop iteration | VALID (consistent with the `filepath.ToSlash` precedent set in #566) | Refactored: `relSegments` normalizes via `filepath.ToSlash` + `strings.Trim("/")` and `commonSegments` counts shared segments; caller split once outside the loop. `stripWorkspacePrefix` itself left untouched (shared helper, out of scope) — inputs are ToSlash'd before calling it. `sharedPathDepth` → `commonSegments` (test updated). | **Fixed** |

--- a/docs/evidence/smoke-e2e-trace-proximity-disambiguation.md
+++ b/docs/evidence/smoke-e2e-trace-proximity-disambiguation.md
@@ -1,0 +1,38 @@
+# smoke:e2e — Issue #575 (#542 F2: trace bare-call proximity)
+
+Change-type: bug-fix. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Seeded into nanobrain_test: a workspace (64-hex hash), two symbol docs both
+titled `foo` (`metadata.source_type=symbol`) — `backend/svc.go` and
+`frontend/util.js` (the cross-repo collision) — and a `calls` edge
+`backend/ctrl.go::Main → foo` with `source_file="backend/ctrl.go"` (the caller).
+Started a standalone server on :3199 (`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`,
+`NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+## MCP streamable-HTTP handshake + tool call
+
+```
+HTTP/1.1 200 OK   initialize            (Mcp-Session-Id issued)
+HTTP/1.1 200 OK   tools/call memory_trace  node="backend/ctrl.go::Main" max_depth=2
+```
+
+Decoded `foo` chain nodes:
+
+```
+[ {node:"backend/svc.go::foo", ambiguous:false} ]
+```
+
+**Result:** the bare call `foo` — defined in BOTH `backend/svc.go` and
+`frontend/util.js` — resolves to the **backend** definition only (shares the
+`backend/` prefix with the caller), with `ambiguous:false`. The frontend
+collision is dropped. **Before this fix** both `backend/svc.go::foo` and
+`frontend/util.js::foo` were emitted, each `ambiguous:true` — the cross-repo
+pollution reported in #542 F2.
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace/docs/edge deleted, temp binary removed.

--- a/internal/mcp/graph_paths.go
+++ b/internal/mcp/graph_paths.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
@@ -85,12 +86,21 @@ func lookupWorkspaceRoot(ctx context.Context, queries *sqlc.Queries, workspaceHa
 	return ws.Path
 }
 
-// sharedPathDepth counts the leading path segments two workspace-relative file
-// paths have in common ("a/b/x.go" vs "a/b/y.go" -> 2; "a/x.go" vs "c/y.go" -> 0).
-func sharedPathDepth(a, b string) int {
-	as, bs := strings.Split(a, "/"), strings.Split(b, "/")
+// relSegments normalizes a file path to workspace-relative, "/"-separated,
+// slash-trimmed segments. filepath.ToSlash makes it Windows-safe (backslashes),
+// and trimming avoids empty leading/trailing segments skewing the depth count.
+func relSegments(p, wsRoot string) []string {
+	rel := strings.Trim(stripWorkspacePrefix(filepath.ToSlash(wsRoot), filepath.ToSlash(p)), "/")
+	if rel == "" {
+		return nil
+	}
+	return strings.Split(rel, "/")
+}
+
+// commonSegments counts the leading path segments two segment slices share.
+func commonSegments(a, b []string) int {
 	n := 0
-	for n < len(as) && n < len(bs) && as[n] == bs[n] {
+	for n < len(a) && n < len(b) && a[n] == b[n] {
 		n++
 	}
 	return n
@@ -109,7 +119,7 @@ func nearestSymbolMatch(callerFile, wsRoot string, matches []sqlc.ResolveSymbolB
 	if callerFile == "" {
 		return zero, false
 	}
-	caller := stripWorkspacePrefix(wsRoot, callerFile)
+	callerSegs := relSegments(callerFile, wsRoot) // split once
 	bestDepth, tie := -1, false
 	var best sqlc.ResolveSymbolByNameRow
 	for _, m := range matches {
@@ -117,8 +127,7 @@ func nearestSymbolMatch(callerFile, wsRoot string, matches []sqlc.ResolveSymbolB
 		if qIdx < 0 {
 			continue
 		}
-		cf := stripWorkspacePrefix(wsRoot, m.SourcePath[:qIdx])
-		switch d := sharedPathDepth(caller, cf); {
+		switch d := commonSegments(callerSegs, relSegments(m.SourcePath[:qIdx], wsRoot)); {
 		case d > bestDepth:
 			bestDepth, best, tie = d, m, false
 		case d == bestDepth:

--- a/internal/mcp/graph_paths.go
+++ b/internal/mcp/graph_paths.go
@@ -84,3 +84,49 @@ func lookupWorkspaceRoot(ctx context.Context, queries *sqlc.Queries, workspaceHa
 	}
 	return ws.Path
 }
+
+// sharedPathDepth counts the leading path segments two workspace-relative file
+// paths have in common ("a/b/x.go" vs "a/b/y.go" -> 2; "a/x.go" vs "c/y.go" -> 0).
+func sharedPathDepth(a, b string) int {
+	as, bs := strings.Split(a, "/"), strings.Split(b, "/")
+	n := 0
+	for n < len(as) && n < len(bs) && as[n] == bs[n] {
+		n++
+	}
+	return n
+}
+
+// nearestSymbolMatch disambiguates same-named symbol candidates by directory
+// proximity to callerFile: it returns the single candidate that shares the
+// strictly-deepest path prefix with the caller, or ("", false) when the deepest
+// prefix is tied across candidates (genuinely ambiguous) or callerFile is empty.
+// Candidate files come from documents.source_path ("<relpath>?symbol=...", which
+// is absolute in production) so each is normalized to workspace-relative via
+// wsRoot before comparison. This scopes a bare call in a monorepo to the nearest
+// definition (backend over frontend) without a re-index.
+func nearestSymbolMatch(callerFile, wsRoot string, matches []sqlc.ResolveSymbolByNameRow) (sqlc.ResolveSymbolByNameRow, bool) {
+	var zero sqlc.ResolveSymbolByNameRow
+	if callerFile == "" {
+		return zero, false
+	}
+	caller := stripWorkspacePrefix(wsRoot, callerFile)
+	bestDepth, tie := -1, false
+	var best sqlc.ResolveSymbolByNameRow
+	for _, m := range matches {
+		qIdx := strings.Index(m.SourcePath, "?")
+		if qIdx < 0 {
+			continue
+		}
+		cf := stripWorkspacePrefix(wsRoot, m.SourcePath[:qIdx])
+		switch d := sharedPathDepth(caller, cf); {
+		case d > bestDepth:
+			bestDepth, best, tie = d, m, false
+		case d == bestDepth:
+			tie = true
+		}
+	}
+	if bestDepth < 0 || tie {
+		return zero, false
+	}
+	return best, true
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2051,6 +2051,19 @@ func registerMemoryTrace(server *mcpsdk.Server, a *Adapter) {
 						continue
 					}
 					ambiguous := len(matches) > 1
+					// Scope a bare-call collision to the definition nearest the
+					// caller in the directory tree (#542 F2): a unique nearest
+					// resolves the call, dropping cross-repo frontend/script noise.
+					// This is a heuristic (assumes same-subtree resolution) — a
+					// nearer same-named collision could mask a farther real target;
+					// import-graph precision is a #542 follow-up. A tie stays
+					// ambiguous (today's fan-out), so ties lose nothing.
+					if ambiguous {
+						if m, ok := nearestSymbolMatch(e.SourceFile, wsRoot, matches); ok {
+							matches = []sqlc.ResolveSymbolByNameRow{m}
+							ambiguous = false
+						}
+					}
 					for _, m := range matches {
 						// Symbol docs are stored as "<relpath>?symbol=...". Guard
 						// against a malformed source_path with no "?" (e.g. a

--- a/internal/mcp/trace_proximity_575_integration_test.go
+++ b/internal/mcp/trace_proximity_575_integration_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// Issue #575 (#542 F2): a bare call that collides across sub-repos must resolve
+// to the definition nearest the caller, not fan out to every same-named symbol.
+func TestMemoryTrace_ResolvesBareCallToNearestSubtree(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFindingsMCP(t)
+
+	// Main (backend) calls bare "foo"; "foo" is defined in both backend and frontend.
+	upsertSymbolDoc(t, ctx, q, wsHash, "backend/svc.go", "foo", "function", "func foo() {}", "1", "1")
+	upsertSymbolDoc(t, ctx, q, wsHash, "frontend/util.js", "foo", "function", "function foo() {}", "1", "1")
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "backend/ctrl.go::Main",
+		TargetNode:    "foo", // bare calls target
+		EdgeType:      "calls",
+		SourceFile:    "backend/ctrl.go", // the caller file — drives proximity
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert edge: %v", err)
+	}
+
+	resp := unmarshalGraphResp(t, callTool("memory_trace", map[string]any{
+		"workspace": wsHash,
+		"node":      "backend/ctrl.go::Main",
+		"max_depth": float64(2),
+		"paths":     "relative",
+	}))
+	chain, _ := resp["chain"].([]any)
+
+	var fooNodes []string
+	ambiguousSeen := false
+	for _, c := range chain {
+		cm := c.(map[string]any)
+		if cm["name"] == "foo" {
+			fooNodes = append(fooNodes, cm["node"].(string))
+			if amb, _ := cm["ambiguous"].(bool); amb {
+				ambiguousSeen = true
+			}
+		}
+	}
+	if len(fooNodes) != 1 {
+		t.Fatalf("expected exactly 1 'foo' node (nearest subtree), got %v", fooNodes)
+	}
+	if fooNodes[0] != "backend/svc.go::foo" {
+		t.Errorf("resolved foo = %q, want backend/svc.go::foo (frontend should be dropped)", fooNodes[0])
+	}
+	if ambiguousSeen {
+		t.Errorf("uniquely-resolved call should not be flagged ambiguous: %+v", chain)
+	}
+}

--- a/internal/mcp/trace_proximity_575_test.go
+++ b/internal/mcp/trace_proximity_575_test.go
@@ -62,19 +62,19 @@ func TestNearestSymbolMatch(t *testing.T) {
 	}
 }
 
-func TestSharedPathDepth(t *testing.T) {
+func TestCommonSegments(t *testing.T) {
 	cases := []struct {
-		a, b string
+		a, b []string
 		want int
 	}{
-		{"a/b/x.go", "a/b/y.go", 2},
-		{"a/x.go", "c/y.go", 0},
-		{"backend/ctrl.js", "backend/svc.js", 1},
-		{"a/b/c.go", "a/b/c.go", 3},
+		{[]string{"a", "b", "x.go"}, []string{"a", "b", "y.go"}, 2},
+		{[]string{"a", "x.go"}, []string{"c", "y.go"}, 0},
+		{[]string{"backend", "ctrl.js"}, []string{"backend", "svc.js"}, 1},
+		{[]string{"a", "b", "c.go"}, []string{"a", "b", "c.go"}, 3},
 	}
 	for _, c := range cases {
-		if got := sharedPathDepth(c.a, c.b); got != c.want {
-			t.Errorf("sharedPathDepth(%q,%q) = %d, want %d", c.a, c.b, got, c.want)
+		if got := commonSegments(c.a, c.b); got != c.want {
+			t.Errorf("commonSegments(%v,%v) = %d, want %d", c.a, c.b, got, c.want)
 		}
 	}
 }

--- a/internal/mcp/trace_proximity_575_test.go
+++ b/internal/mcp/trace_proximity_575_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// Issue #575 (#542 F2): a bare call must resolve to the same-named symbol nearest
+// the caller in the directory tree; genuine ties stay ambiguous.
+func TestNearestSymbolMatch(t *testing.T) {
+	sp := func(f string) sqlc.ResolveSymbolByNameRow {
+		return sqlc.ResolveSymbolByNameRow{SourcePath: f + "?symbol=foo&kind=function"}
+	}
+	tests := []struct {
+		name     string
+		caller   string
+		matches  []sqlc.ResolveSymbolByNameRow
+		wantOK   bool
+		wantFile string // source_path prefix expected (before "?")
+	}{
+		{
+			name:     "cross-repo: nearest subtree wins",
+			caller:   "backend/controllers/pay.js",
+			matches:  []sqlc.ResolveSymbolByNameRow{sp("backend/services/pay.js"), sp("frontend/net/pay.js")},
+			wantOK:   true,
+			wantFile: "backend/services/pay.js",
+		},
+		{
+			name:     "same file wins outright",
+			caller:   "backend/controllers/pay.js",
+			matches:  []sqlc.ResolveSymbolByNameRow{sp("backend/controllers/pay.js"), sp("frontend/net/pay.js")},
+			wantOK:   true,
+			wantFile: "backend/controllers/pay.js",
+		},
+		{
+			name:    "tie within same subtree stays ambiguous",
+			caller:  "backend/controllers/pay.js",
+			matches: []sqlc.ResolveSymbolByNameRow{sp("backend/services/pay.js"), sp("backend/utils/pay.js")},
+			wantOK:  false,
+		},
+		{
+			name:    "empty caller file -> no disambiguation",
+			caller:  "",
+			matches: []sqlc.ResolveSymbolByNameRow{sp("backend/services/pay.js"), sp("frontend/net/pay.js")},
+			wantOK:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := nearestSymbolMatch(tt.caller, "", tt.matches)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tt.wantOK, got.SourcePath)
+			}
+			if ok {
+				gotFile := got.SourcePath[:len(tt.wantFile)]
+				if gotFile != tt.wantFile {
+					t.Errorf("nearest = %q, want prefix %q", got.SourcePath, tt.wantFile)
+				}
+			}
+		})
+	}
+}
+
+func TestSharedPathDepth(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"a/b/x.go", "a/b/y.go", 2},
+		{"a/x.go", "c/y.go", 0},
+		{"backend/ctrl.js", "backend/svc.js", 1},
+		{"a/b/c.go", "a/b/c.go", 3},
+	}
+	for _, c := range cases {
+		if got := sharedPathDepth(c.a, c.b); got != c.want {
+			t.Errorf("sharedPathDepth(%q,%q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #575 (increment of #542 F2, root-cause C)

## Problem
A bare call `foo()` resolved to **every** symbol named `foo` in the workspace, so `memory_trace` fanned out to cross-repo false edges (frontend method, unrelated script, other service), all `ambiguous:true` — the most-impactful dogfooding finding. An agent couldn't separate the real backend chain from the noise.

## Fix (query-time, no re-index, language-agnostic)
When a bare calls-target has >1 candidate, resolve to the one sharing the **deepest directory prefix** with the caller file (`e.SourceFile`) — when that nearest is **unique**, clearing `ambiguous`. A **tie** keeps today's emit-all-ambiguous fan-out, so no legit cross-dir call is lost on a tie. In a monorepo, `backend/controllers/x` calling `foo` picks `backend/services/foo` (shares `backend/`) over `frontend/foo` (shares nothing).

New pure helpers in `graph_paths.go`: `sharedPathDepth` + `nearestSymbolMatch` (candidate `source_path`, absolute in prod, normalized via `stripWorkspacePrefix`).

## Scope / honest limits (from deep-design)
- **memory_trace only** — `memory_impact`/`memory_flow` ambiguity lives in the flow builder (parallel follow-up on #542 F2).
- **Path-proximity, not import-graph-precise** — import edges are file/module-level, JS/TS targets aren't resolved in current data (needs a re-index), and the import graph is useless for Go same-package calls. Proximity is the correct no-re-index disambiguator. Import-precise JS/TS is a later increment. The unique-nearest resolution is a heuristic (a nearer same-named collision could mask a farther real target) — bounded and strictly better than today's fan-out; ties lose nothing.

## Testing (nanobrain_test only — dev DB never touched)
- **White-box unit** (`trace_proximity_575_test.go`): cross-repo win / same-file win / same-subtree tie stays ambiguous / empty caller.
- **e2e through the handler** (`trace_proximity_575_integration_test.go`): cross-repo `foo` collision → resolves to `backend/svc.go::foo`, frontend dropped, not ambiguous. **Red-green**: both nodes (ambiguous) without the fix.
- No regression: the 6 trace tests pass incl. #539's genuine-tie ambiguity test (pre-existing `TestMemoryTrace_RelativeInputAndOutput` panic is #556, unrelated). `go build`/`go test -race -short ./...` clean.
- smoke:e2e: MCP-over-HTTP on :3199 (`docs/evidence/smoke-e2e-trace-proximity-disambiguation.md`).
- **R88 independent review: PASS** (`docs/evidence/review-575.md`); the one MEDIUM (comment overstated the recall guarantee) was fixed.

## #542 progress
F1/F3/F4/F5/F6/F7/F8/F9 shipped; **F2 now partially addressed** (trace here; impact/flow + import-precision follow-ups). Remaining: F2 impact/flow, F10 (inherent).

Change-type: bug-fix · Lane: normal.