### PR TITLE
fix: repair 3 root causes behind 9 red integration tests (#556)

### DIFF
--- a/docs/evidence/review-556.md
+++ b/docs/evidence/review-556.md
@@ -1,0 +1,33 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `fix/red-integration-suite` · Issue #556
+
+No CRITICAL / HIGH / MEDIUM findings. Two LOW/informational notes only. All
+claims independently reproduced with real build + test runs against
+`nanobrain_test` (never dev DB / :3100, no broad-kill).
+
+| Cluster | Verdict |
+|---|---|
+| A — `skipIfServerUnreachable` (5 Ruby acceptance tests) | PASS (HIGH) — confirmed genuinely external-server-dependent (`testServerURL()` defaults to `:3199`, hardcoded pre-indexed workspace hash); skip is honest, not a regression mask. All 5 SKIP cleanly. |
+| B — Express single-arg `use()` middleware fix | PASS (HIGH) — walked every edge case (`app.use(mw)`, `app.use('/api', router)`, `app.use((req,res)=>{...})`, multi-arg `router.post(path, mw1, mw2, handler)`); correct and complete, no double-count, no dedup collision. |
+| C — `setupGraphMCP` relative reseed | PASS (HIGH) — verified against production `normalizeNodeForQuery` (always normalizes to relative before matching); all 6 call sites correct; 3 sibling tests not in the original failing list still pass; `RelativeOutputStripsPrefix` rewrite genuinely exercises the strip path instead of a vacuous assertion. |
+| Pre-existing #10 (`TestMemoryWakeUp_...`) | Confirmed structurally unrelated (different file, doesn't use `setupGraphMCP`) — not a regression from this diff. |
+
+Reviewer ran `go build ./...`, `go test -race -short ./...`, and
+`go test -tags=integration ./internal/graph/... ./internal/mcp/...` (all PASS
+except the pre-existing #10, confirmed out of scope).
+
+### LOW / informational (accepted, no fix required)
+- `app.use(mw1, mw2)` (multiple global middleware, no path) is still dropped —
+  pre-existing gap, not introduced by this fix, not in the fixture. Follow-up
+  candidate only.
+- `TestMemoryGraph_RelativeNodeInputResolvesToAbsolute` is now a misnomer
+  (behavior normalizes to relative, not absolute) — pre-existing test name,
+  cosmetic, optional rename.
+
+### Evidence
+`go build ./...` clean. `go test -race -short ./...` all green.
+`go test -tags=integration ./internal/graph/... ./internal/mcp/...` green
+(9/9 originally-red tests now correct: 5 SKIP honestly, 4 PASS).

--- a/docs/evidence/self-review-red-integration-suite.md
+++ b/docs/evidence/self-review-red-integration-suite.md
@@ -93,8 +93,6 @@ this PR's `Closes #556` scope); will file as a new issue.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
-
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| ruby_integration_test.go:51 (MEDIUM) — `resp.Body.Close()` should be `defer`red immediately after the error check, per idiomatic Go | VALID | Trivial style nit, no behavioral bug in this specific function (single call site, no other exit paths), but the idiomatic form is correct and cheap to apply. | FIXED — changed to `defer resp.Body.Close()`. |

--- a/docs/evidence/self-review-red-integration-suite.md
+++ b/docs/evidence/self-review-red-integration-suite.md
@@ -1,0 +1,100 @@
+# Self-Review — Issue #556 (9 red integration tests on master)
+
+Change-type: test-only / infrastructure · Lane: normal · Branch: `fix/red-integration-suite`
+Author: kokorolx.
+
+## Root causes (3 independent clusters, verified by direct reproduction)
+
+- **Cluster A (5 tests, `internal/graph/ruby_integration_test.go`)** —
+  `TestRailRouteExtraction`, `TestRubyCrossFileResolution`, `TestRubyReconcileEdges`,
+  `TestRubyClassIndex`, `TestRubyFlowEndToEnd`. These are acceptance tests: they
+  HTTP into a **live server on `:3199` pre-indexed with the rails-app fixture**
+  under a hardcoded workspace hash — not a self-contained integration fixture.
+  With no server running they fail with `connection refused`, which looks like
+  a regression but isn't one. Fixed with a `skipIfServerUnreachable(t)` guard
+  (probes `/health` with a 2s timeout) so they skip honestly instead of failing
+  when no live server is present, matching the existing `testing.Short()` skip
+  pattern already in each test.
+- **Cluster B (1 test, `internal/graph/express_extractor.go`)** —
+  `TestExpressExtractor_Integration` expected ≥2 middleware edges, got 1. Real
+  extractor bug: `app.use(corsMiddleware)` / `app.use(loggerMiddleware)` (a
+  single-argument global middleware registration) was misread by `tsExtractPath`
+  as an unresolvable path argument (`"<var:corsMiddleware>"`) and the whole call
+  was dropped — no HTTP edge, no middleware edge. Fixed by special-casing
+  single-arg `use()` calls in `extractHTTP`: when the lone argument isn't a
+  string/template literal, resolve it as a middleware name and emit
+  `EdgeMiddleware` (`mw -> <receiver>`) instead of falling through to path
+  extraction. `router.post('/posts', authMiddleware, postController.create)`
+  (multi-arg, existing path) is untouched.
+- **Cluster C (3 tests, `internal/mcp/graph_paths_integration_test.go`)** —
+  `TestMemoryGraph_RelativeNodeInputResolvesToAbsolute`,
+  `TestMemoryGraph_RelativeOutputStripsPrefix`,
+  `TestMemoryTrace_RelativeInputAndOutput` (the last panics the whole test
+  binary: `interface conversion: interface{} is nil`). Root cause: the shared
+  `setupGraphMCP` helper seeded graph edges with **absolute** (workspace-prefixed)
+  node IDs, but `normalizeNodeForQuery` always normalizes an agent's input node
+  to **workspace-relative** before querying — the old resolve-to-absolute
+  behavior is explicitly deprecated in `graph_paths.go`. A relative query can
+  never match an absolute-stored edge, so results were empty. Fixed the test
+  helper to seed workspace-relative node IDs, matching the real watcher
+  convention already documented and used by the sibling `setupFindingsMCP`
+  (`internal/mcp/agent_ergonomics_539_integration_test.go:24-28`).
+  `TestMemoryGraph_RelativeOutputStripsPrefix` specifically exercises the
+  `paths=relative` prefix-strip feature; since the query node is always
+  normalized to relative, an edge's *source* can never be absolute-stored and
+  reachable — only a *target* can carry a legacy absolute prefix (e.g. data
+  indexed before the relative convention). Rewrote that one test to seed
+  exactly that asymmetric shape (relative source, one absolute-prefixed target)
+  so the strip logic is exercised realistically instead of vacuously.
+
+## Files Changed
+
+- `internal/graph/express_extractor.go` — single-arg `use()` middleware fix.
+- `internal/graph/ruby_integration_test.go` — `skipIfServerUnreachable` guard,
+  applied to all 5 acceptance tests.
+- `internal/mcp/graph_paths_integration_test.go` — `setupGraphMCP` seeds
+  workspace-relative edges; `TestMemoryGraph_RelativeOutputStripsPrefix`
+  rewritten with a realistic legacy-absolute-target seed; all 6 call sites
+  updated for the new `(ctx, q, wsHash, wsPath, session, callTool)` signature.
+
+## Red-green proof
+
+- Cluster A: reproduced `connection refused` on all 5 before the fix; after the
+  fix they `SKIP` cleanly with a descriptive reason (no live server in this run).
+- Cluster B: reproduced `expected at least 2 middleware edges, got 1` before the
+  fix; after the fix, 3 middleware edges extracted
+  (`corsMiddleware`, `loggerMiddleware`, `authMiddleware`) — test PASS.
+- Cluster C: reproduced `count=0` / `edges=0` / panic before the fix (matches
+  #556 exactly); after the fix all 3 PASS, no panic, and the 6 sibling tests in
+  the same file (`TestMemoryGraph_AbsoluteNodeInputUnchanged`,
+  `TestMemoryGraph_InvalidWorkspaceHashErrorsClearly`,
+  `TestMemoryImpact_RelativeInputAndOutput`, plus 3 unrelated trace tests) still
+  pass unchanged.
+
+## New finding (out of scope, filed separately)
+
+While running the full `internal/mcp` integration package, found a 10th
+pre-existing red test not in #556's original list:
+`TestMemoryWakeUp_OnlyReturnsMemoryAndSessionSummaryDocs`
+(`recent_memories len = 2, want 3`). Confirmed pre-existing and unrelated by
+stashing this branch's changes and re-running against clean master — identical
+failure. Not touched here (different root cause, different file, would blur
+this PR's `Closes #556` scope); will file as a new issue.
+
+## Resolution Status
+
+- All 9 tests named in #556 now behave correctly: 5 skip honestly (no live
+  server), 4 pass (real fixes).
+- `go build ./...` clean; `go test -race -short ./...` all green (see below).
+- `go test -tags=integration ./internal/graph/... ./internal/mcp/...` green
+  (excluding the pre-existing, out-of-scope #10 above).
+- No regression: full graph package unit tests pass; all other tests in
+  `graph_paths_integration_test.go` unaffected.
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/internal/graph/express_extractor.go
+++ b/internal/graph/express_extractor.go
@@ -67,6 +67,39 @@ func (e *ExpressExtractor) ExtractEdges(filePath string, content []byte) ([]Edge
 			return
 		}
 
+		argsNode := n.ChildByFieldName("arguments", lang)
+		// A single-argument use() call (app.use(corsMiddleware)) registers global
+		// middleware, not a route — there is no path/handler pair to extract, and
+		// tsExtractPath would otherwise misread the middleware reference as an
+		// (unresolvable) path argument and skip the call entirely.
+		if method == "USE" && tsCountArgs(argsNode, lang) == 1 {
+			arg := tsArgNode(argsNode, lang, 0)
+			if arg == nil {
+				return
+			}
+			if t := arg.Type(lang); t == "string" || t == "template_string" {
+				return
+			}
+			name := tsResolveMiddlewareName(bt, arg, lang)
+			if name == "" {
+				return
+			}
+			edgeKey := "middleware:" + name + "-><" + receiver + ">"
+			if seen[edgeKey] {
+				return
+			}
+			seen[edgeKey] = true
+			edges = append(edges, Edge{
+				SourceNode: name,
+				TargetNode: "<" + receiver + ">",
+				Kind:       EdgeMiddleware,
+				SourceFile: relFile,
+				Line:       lineForByte(content, n.StartByte()),
+				Language:   langStr,
+			})
+			return
+		}
+
 		path := tsExtractPath(bt, n, lang)
 		if path == "" {
 			e.logger.Warn().Str("file", filePath).Str("method", method).Msg("empty path in route")

--- a/internal/graph/ruby_integration_test.go
+++ b/internal/graph/ruby_integration_test.go
@@ -35,6 +35,21 @@ func testWorkspace() string {
 
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
+// skipIfServerUnreachable skips the test when no live server is reachable at
+// testServerURL(). These are acceptance tests: they exercise the full
+// extraction pipeline via a running nano-brain server pre-indexed with the
+// rails-app fixture (testWorkspace()), not a self-contained fixture — there
+// is no server to connect to in a default CI run.
+func skipIfServerUnreachable(t *testing.T) {
+	t.Helper()
+	probe := &http.Client{Timeout: 2 * time.Second}
+	resp, err := probe.Get(testServerURL() + "/health")
+	if err != nil {
+		t.Skipf("skipping: no live server at %s (%v) — this acceptance test needs a running nano-brain server pre-indexed with the rails-app fixture (see NANO_BRAIN_TEST_SERVER_URL / NANO_BRAIN_TEST_WORKSPACE)", testServerURL(), err)
+	}
+	resp.Body.Close()
+}
+
 type apiResponse struct {
 	Found      bool          `json:"found"`
 	Entry      string        `json:"entry"`
@@ -138,6 +153,7 @@ func TestRailRouteExtraction(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfServerUnreachable(t)
 
 	ws := testWorkspace()
 	resp := apiGet(t, fmt.Sprintf("/api/v1/graph/flow/endpoints?workspace=%s", ws))
@@ -195,6 +211,7 @@ func TestRubyCrossFileResolution(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfServerUnreachable(t)
 
 	ws := testWorkspace()
 
@@ -246,6 +263,7 @@ func TestRubyReconcileEdges(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfServerUnreachable(t)
 
 	ws := testWorkspace()
 
@@ -288,6 +306,7 @@ func TestRubyClassIndex(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfServerUnreachable(t)
 
 	ws := testWorkspace()
 
@@ -339,6 +358,7 @@ func TestRubyFlowEndToEnd(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+	skipIfServerUnreachable(t)
 
 	ws := testWorkspace()
 

--- a/internal/graph/ruby_integration_test.go
+++ b/internal/graph/ruby_integration_test.go
@@ -47,7 +47,7 @@ func skipIfServerUnreachable(t *testing.T) {
 	if err != nil {
 		t.Skipf("skipping: no live server at %s (%v) — this acceptance test needs a running nano-brain server pre-indexed with the rails-app fixture (see NANO_BRAIN_TEST_SERVER_URL / NANO_BRAIN_TEST_WORKSPACE)", testServerURL(), err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 }
 
 type apiResponse struct {

--- a/internal/mcp/graph_paths_integration_test.go
+++ b/internal/mcp/graph_paths_integration_test.go
@@ -21,7 +21,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func setupGraphMCP(t *testing.T) (context.Context, string, *mcpsdk.ClientSession, func(string, map[string]any) *mcpsdk.CallToolResult) {
+// setupGraphMCP seeds graph edges following the real watcher convention
+// (workspace-relative source/target nodes, e.g. filepath.Rel + ToSlash — see
+// internal/watcher/watcher.go relPath/relFile). normalizeNodeForQuery always
+// converts an agent-supplied node to this relative form before matching, so
+// relative-stored edges (not absolute-prefixed ones) are what a real query
+// actually finds.
+func setupGraphMCP(t *testing.T) (context.Context, *sqlc.Queries, string, string, *mcpsdk.ClientSession, func(string, map[string]any) *mcpsdk.CallToolResult) {
 	t.Helper()
 	pool := testutil.SetupTestDB(t)
 	ctx := context.Background()
@@ -40,10 +46,10 @@ func setupGraphMCP(t *testing.T) (context.Context, string, *mcpsdk.ClientSession
 	edges := []struct {
 		source, target, etype string
 	}{
-		{wsPath + "/internal/storage/migrate.go::RunMigrations", "context", "calls"},
-		{wsPath + "/internal/storage/migrate.go::RunMigrations", wsPath + "/internal/storage/migrate.go::GetCurrentVersion", "calls"},
-		{wsPath + "/internal/storage/migrate.go", wsPath + "/internal/storage/migrate.go::RunMigrations", "contains"},
-		{wsPath + "/cmd/main.go::startServer", wsPath + "/internal/storage/migrate.go::RunMigrations", "calls"},
+		{"internal/storage/migrate.go::RunMigrations", "context", "calls"},
+		{"internal/storage/migrate.go::RunMigrations", "internal/storage/migrate.go::GetCurrentVersion", "calls"},
+		{"internal/storage/migrate.go", "internal/storage/migrate.go::RunMigrations", "contains"},
+		{"cmd/main.go::startServer", "internal/storage/migrate.go::RunMigrations", "calls"},
 	}
 	for _, e := range edges {
 		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
@@ -81,7 +87,7 @@ func setupGraphMCP(t *testing.T) (context.Context, string, *mcpsdk.ClientSession
 		}
 		return result
 	}
-	return ctx, wsHash, session, callTool
+	return ctx, q, wsHash, wsPath, session, callTool
 }
 
 func unmarshalGraphResp(t *testing.T, result *mcpsdk.CallToolResult) map[string]any {
@@ -97,7 +103,7 @@ func unmarshalGraphResp(t *testing.T, result *mcpsdk.CallToolResult) map[string]
 }
 
 func TestMemoryGraph_RelativeNodeInputResolvesToAbsolute(t *testing.T) {
-	_, wsHash, _, callTool := setupGraphMCP(t)
+	_, _, wsHash, _, _, callTool := setupGraphMCP(t)
 
 	rel := callTool("memory_graph", map[string]any{
 		"workspace": wsHash,
@@ -113,7 +119,7 @@ func TestMemoryGraph_RelativeNodeInputResolvesToAbsolute(t *testing.T) {
 }
 
 func TestMemoryGraph_AbsoluteNodeInputUnchanged(t *testing.T) {
-	ctx, wsHash, _, callTool := setupGraphMCP(t)
+	ctx, _, wsHash, _, _, callTool := setupGraphMCP(t)
 	_ = ctx
 
 	abs := callTool("memory_graph", map[string]any{
@@ -127,8 +133,25 @@ func TestMemoryGraph_AbsoluteNodeInputUnchanged(t *testing.T) {
 	}
 }
 
+// TestMemoryGraph_RelativeOutputStripsPrefix verifies the paths=relative strip
+// logic. normalizeNodeForQuery always normalizes the query NODE to relative
+// before matching, so a query can never reach an edge whose SOURCE is stored
+// absolute — but a TARGET can still carry a legacy absolute prefix (e.g. data
+// indexed before the relative convention). Seed exactly that shape.
 func TestMemoryGraph_RelativeOutputStripsPrefix(t *testing.T) {
-	_, wsHash, _, callTool := setupGraphMCP(t)
+	ctx, q, wsHash, wsPath, _, callTool := setupGraphMCP(t)
+
+	legacyTarget := wsPath + "/internal/storage/migrate.go::LegacyHelper"
+	if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+		WorkspaceHash: wsHash,
+		SourceNode:    "internal/storage/migrate.go::RunMigrations",
+		TargetNode:    legacyTarget,
+		EdgeType:      "calls",
+		SourceFile:    "",
+		Metadata:      []byte("{}"),
+	}); err != nil {
+		t.Fatalf("upsert legacy edge: %v", err)
+	}
 
 	abs := callTool("memory_graph", map[string]any{
 		"workspace": wsHash,
@@ -137,13 +160,19 @@ func TestMemoryGraph_RelativeOutputStripsPrefix(t *testing.T) {
 		"edge_type": "calls",
 	})
 	absResp := unmarshalGraphResp(t, abs)
-	edgesAbs := absResp["edges"].([]any)
+	edgesAbs, _ := absResp["edges"].([]any)
+	if len(edgesAbs) != 3 {
+		t.Fatalf("default output: edges=%d, want 3 (context + GetCurrentVersion + legacy)", len(edgesAbs))
+	}
+	var sawLegacyAbs bool
 	for _, e := range edgesAbs {
 		em := e.(map[string]any)
-		src := em["source"].(string)
-		if !strings.HasPrefix(src, "/tmp/test-ws-") {
-			t.Errorf("default (absolute) should return absolute source, got %q", src)
+		if em["target"].(string) == legacyTarget {
+			sawLegacyAbs = true
 		}
+	}
+	if !sawLegacyAbs {
+		t.Errorf("default (absolute) should return the legacy target unstripped: %+v", edgesAbs)
 	}
 
 	rel := callTool("memory_graph", map[string]any{
@@ -154,26 +183,28 @@ func TestMemoryGraph_RelativeOutputStripsPrefix(t *testing.T) {
 		"paths":     "relative",
 	})
 	relResp := unmarshalGraphResp(t, rel)
-	edgesRel := relResp["edges"].([]any)
-	if len(edgesRel) != 2 {
-		t.Fatalf("relative output: edges=%d, want 2", len(edgesRel))
+	edgesRel, _ := relResp["edges"].([]any)
+	if len(edgesRel) != 3 {
+		t.Fatalf("relative output: edges=%d, want 3", len(edgesRel))
 	}
-	var contextSeen, getCurrentSeen bool
+	var contextSeen, getCurrentSeen, legacySeen bool
 	for _, e := range edgesRel {
 		em := e.(map[string]any)
 		src := em["source"].(string)
 		tgt := em["target"].(string)
-		if strings.HasPrefix(src, "/tmp/") {
-			t.Errorf("relative output: source still has workspace prefix: %q", src)
+		if strings.HasPrefix(src, "/tmp/") || strings.HasPrefix(tgt, "/tmp/") {
+			t.Errorf("relative output: edge still has workspace prefix: source=%q target=%q", src, tgt)
 		}
 		if src != "internal/storage/migrate.go::RunMigrations" {
 			t.Errorf("relative output: source = %q, want stripped", src)
 		}
-		if tgt == "context" {
+		switch tgt {
+		case "context":
 			contextSeen = true
-		}
-		if tgt == "internal/storage/migrate.go::GetCurrentVersion" {
+		case "internal/storage/migrate.go::GetCurrentVersion":
 			getCurrentSeen = true
+		case "internal/storage/migrate.go::LegacyHelper":
+			legacySeen = true
 		}
 	}
 	if !contextSeen {
@@ -182,10 +213,13 @@ func TestMemoryGraph_RelativeOutputStripsPrefix(t *testing.T) {
 	if !getCurrentSeen {
 		t.Error("relative output: workspace-local symbol should have prefix stripped")
 	}
+	if !legacySeen {
+		t.Error("relative output: legacy absolute-prefixed target should have prefix stripped")
+	}
 }
 
 func TestMemoryGraph_InvalidWorkspaceHashErrorsClearly(t *testing.T) {
-	_, _, _, callTool := setupGraphMCP(t)
+	_, _, _, _, _, callTool := setupGraphMCP(t)
 
 	result := callTool("memory_graph", map[string]any{
 		"workspace": "nonexistent_workspace_hash_xxxxxx",
@@ -202,7 +236,7 @@ func TestMemoryGraph_InvalidWorkspaceHashErrorsClearly(t *testing.T) {
 }
 
 func TestMemoryTrace_RelativeInputAndOutput(t *testing.T) {
-	_, wsHash, _, callTool := setupGraphMCP(t)
+	_, _, wsHash, _, _, callTool := setupGraphMCP(t)
 
 	result := callTool("memory_trace", map[string]any{
 		"workspace": wsHash,
@@ -233,7 +267,7 @@ func TestMemoryTrace_RelativeInputAndOutput(t *testing.T) {
 }
 
 func TestMemoryImpact_RelativeInputAndOutput(t *testing.T) {
-	_, wsHash, _, callTool := setupGraphMCP(t)
+	_, _, wsHash, _, _, callTool := setupGraphMCP(t)
 
 	result := callTool("memory_impact", map[string]any{
 		"workspace": wsHash,


### PR DESCRIPTION
Closes #556

## Problem
The manual `-tags=integration` suite was red on master with 9 failures across 3 independent root causes (CI only runs `-short`, so these never gate).

## Root causes

**Cluster A (5 tests, `internal/graph/ruby_integration_test.go`)** — `TestRailRouteExtraction`, `TestRubyCrossFileResolution`, `TestRubyReconcileEdges`, `TestRubyClassIndex`, `TestRubyFlowEndToEnd`. These are acceptance tests that HTTP into a **live server on :3199 pre-indexed with the rails-app fixture**, not a self-contained fixture. `connection refused` with no server running looked like a regression but isn't one. Added `skipIfServerUnreachable(t)` (probes `/health`, 2s timeout) so they skip honestly instead of failing.

**Cluster B (1 test, `internal/graph/express_extractor.go`)** — `TestExpressExtractor_Integration` expected ≥2 middleware edges, got 1. Real extractor bug: single-arg `app.use(corsMiddleware)` was misread by `tsExtractPath` as an unresolvable path argument and the whole call was silently dropped. Fixed by special-casing single-arg `use()` calls to resolve as global middleware and emit `EdgeMiddleware` instead of falling through to path extraction.

**Cluster C (3 tests, `internal/mcp/graph_paths_integration_test.go`)** — the shared `setupGraphMCP` test helper seeded graph edges with **absolute** node IDs, but production's `normalizeNodeForQuery` always normalizes the query to **workspace-relative** before matching (resolve-to-absolute is explicitly deprecated). Relative queries never matched the absolute-seeded edges → `count=0` and a nil-chain panic. Fixed the helper to seed relative node IDs, matching the convention already used by the sibling `setupFindingsMCP`.

## New finding (filed separately, not in this PR)
A 10th pre-existing failing test, `TestMemoryWakeUp_OnlyReturnsMemoryAndSessionSummaryDocs`, was found while running the full package — confirmed unrelated (different file, doesn't touch `setupGraphMCP`, fails identically on clean master).

## Test plan
- [x] `go build ./...`
- [x] `go test -race -short ./...` — all green
- [x] `go test -tags=integration ./internal/graph/... ./internal/mcp/...` against `nanobrain_test` — all 9 originally-red tests now correct (5 SKIP honestly, 4 PASS); no regression in sibling tests
- [x] Independent R88 review (`docs/evidence/review-556.md`) — PASS, 0 CRITICAL/HIGH/MEDIUM