### PR TITLE
feat(flow): link Bull/BullMQ queue.add/process producer-consumer (#546 E2)

### DIFF
--- a/docs/evidence/review-581.md
+++ b/docs/evidence/review-581.md
@@ -1,0 +1,23 @@
+## Review Verdict: PASS
+
+Reviewer: oh-my-claudecode:code-reviewer (R88 independent correctness gate, spawned; ≠ author).
+Date: 2026-07-07
+Branch: `feat/bull-queue-flow` · Issue #581 (#546 increment 2)
+
+Change: Bull/BullMQ `queue.add("jobName", data)` emits a `queue_publish` edge
+and `queue.process("jobName", handler)` emits a `CONSUME <jobName>` consumer
+entry — the same shape #578's Redis pub/sub stitching already consumes, so
+`memory_flow` auto-links producer to consumer with zero changes to
+`tools.go`/`stitch.go`.
+
+| Concern | Verdict |
+|---|---|
+| Placement/ordering (no map overlap with Redis/HTTP/generic bus checks) | PASS (HIGH) — read all 5 relevant map literals directly; neither "add" nor "process" appears in any of them. |
+| False-positive blast radius | PASS (LOW note) — substring "queue" naming hint could mislabel a non-Bull `RequestQueue.add(...)`-style API; contained impact (adds an edge, never breaks extraction); accepted documented tradeoff. |
+| Argument-index correctness | PASS (HIGH) — verified `echoArgNode`/`jsStringArgOrVar` return arg[0]; `tsCountArgs` counts correctly. |
+| Red-green claim | PASS (HIGH) — reproduced directly: reverted extractor only, producer/consumer sub-tests FAIL, guard sub-tests PASS; restored, working tree clean. |
+| Integration + smoke validity | PASS (HIGH) — reran `TestMemoryFlow_AutoStitchesBullQueueProducerConsumer` fresh (PASS); confirmed `flow.Stitch` keys purely on `Metadata["topic"]`, making the zero-change claim true at the code level, not just asserted. |
+| Full regression | PASS — `go build`, `go test -race -short ./...`, `go test -tags=integration ./internal/graph/... ./internal/mcp/...` all green (excluding the pre-existing, unrelated #580). |
+
+**Recommendation: APPROVE.** No CRITICAL/HIGH findings. One LOW note accepted
+as a documented tradeoff, no fix required.

--- a/docs/evidence/self-review-bull-queue-flow.md
+++ b/docs/evidence/self-review-bull-queue-flow.md
@@ -59,8 +59,6 @@ call — invisible to `memory_graph`/`memory_trace`/`memory_flow`.
 
 ## Gemini Verification Triage
 
-_Pending — populate after the Gemini bot reviews the PR._
-
 | Comment ref | Agent verdict | Reasoning | Action |
 | --- | --- | --- | --- |
-| _(none yet)_ | | | |
+| js_integration_extractor.go:441 (MEDIUM) — reorder condition so `methodName` check short-circuits before `isBullQueueReceiver`'s string allocation, since this branch runs on every member expression | VALID | Correct: `isBullQueueReceiver` calls `strings.ToLower` unconditionally; checking the cheap method-name equality first avoids that allocation on the vast majority of calls (console.log, array.length, etc.) that never reach this branch. | FIXED — swapped to `(methodName == "add" \|\| methodName == "process") && isBullQueueReceiver(receiverName)`. |

--- a/docs/evidence/self-review-bull-queue-flow.md
+++ b/docs/evidence/self-review-bull-queue-flow.md
@@ -1,0 +1,66 @@
+# Self-Review — Issue #581 (#546 increment 2: Bull queue producer/consumer)
+
+Change-type: user-feature · Lane: normal · Branch: `feat/bull-queue-flow`
+Author: kokorolx.
+
+## Actions Taken
+
+E1 (Redis pub/sub) was closed by #577/#578. This increment covers E2 from
+#546: Bull/BullMQ couples a producer `queue.add("jobName", data)` to a
+consumer `queue.process("jobName", handler)` via the job-name string, not a
+call — invisible to `memory_graph`/`memory_trace`/`memory_flow`.
+
+- **`internal/graph/js_integration_extractor.go`** — added `isBullQueueReceiver`
+  (a "queue" substring naming hint — Bull has no fixed client name to key off
+  of, unlike Redis's exact-match `jsRedisReceivers`) and a producer/consumer
+  branch in `handleMemberExpression`: `<queueVar>.add("jobName", data)` emits
+  a `queue_publish` edge (`Metadata["topic"]=jobName`); `<queueVar>.process("jobName", handler)`
+  emits a `"CONSUME <jobName>"` consumer entry — the exact same shape the
+  Redis/generic bus paths already produce, so `flow.Stitch` and
+  `ListConsumerEntryNodesByWorkspace` require **zero changes**.
+- Gated on requiring a literal string/template job-name argument (argCount≥2)
+  to avoid misreading an unrelated `Set.add()`/`Map`-like `.process()` call as
+  a queue op when the receiver name happens to contain "queue".
+- **`internal/mcp/flow_bull_546_integration_test.go`** (new) — proves the #578
+  stitching plumbing generalizes to Bull with no `tools.go`/`stitch.go`
+  changes: seeds a route → producer → consumer chain, asserts `memory_flow`
+  auto-links them via a `cross_service` edge without `stitch_workspaces`.
+
+## Files Changed
+
+- `internal/graph/js_integration_extractor.go` — Bull producer/consumer edges.
+- `internal/graph/js_integration_extractor_test.go` — `TestJSIntegrationExtractor_BullQueue`:
+  producer edge, consumer edge, non-queue-receiver `.add()` unaffected,
+  single-arg `.process()` (no job name) not misread.
+- `internal/mcp/flow_bull_546_integration_test.go` — new integration test.
+
+## Findings Summary
+
+- No changes needed outside the extractor — this is the direct payoff of
+  #578's generic, topic-based stitching design.
+- Out of scope (documented in #581, not this increment): webhook dispatch
+  (URL-string coupling across services, different stitch shape) and Bull's
+  single-arg `queue.process(handler)` ("process all jobs", no job-name topic
+  to stitch on).
+- **Red-green proven**: reverted the extractor change only (kept the new
+  tests), confirmed `queue.add`/`queue.process` sub-tests FAIL
+  (`expected at least one EdgeIntegration edge`); reapplied, confirmed PASS.
+  The two guard sub-tests (non-queue receiver, single-arg process) passed in
+  both states, proving they don't just trivially pass.
+- No regression: `go test -race -short ./...` all green;
+  `go test -tags=integration ./internal/graph/... ./internal/mcp/...` green.
+
+## Resolution Status
+
+- In scope resolved. No critical/major issues.
+- `go build ./...` clean.
+- Integration (nanobrain_test): new Bull stitch test PASS; full graph+mcp
+  integration suite PASS (excluding the pre-existing, unrelated #580).
+
+## Gemini Verification Triage
+
+_Pending — populate after the Gemini bot reviews the PR._
+
+| Comment ref | Agent verdict | Reasoning | Action |
+| --- | --- | --- | --- |
+| _(none yet)_ | | | |

--- a/docs/evidence/smoke-e2e-bull-queue-flow.md
+++ b/docs/evidence/smoke-e2e-bull-queue-flow.md
@@ -1,0 +1,53 @@
+# smoke:e2e — Issue #581 (#546 E2: Bull queue producer/consumer flow linking)
+
+Change-type: user-feature. Verified over the real MCP-over-HTTP transport on an
+isolated **:3199 / nanobrain_test** server (dev DB / :3100 never touched).
+
+## Setup (isolated)
+
+Seeded into nanobrain_test: a workspace (64-hex hash), an HTTP route
+`POST /schedule → scheduleEmail`, a producer edge
+`svc.js::scheduleEmail → produce:emailJob` (`metadata.kind=queue_publish`,
+`metadata.topic=emailJob`, as `queue.add("emailJob", ...)` now emits), and a
+consumer entry `CONSUME emailJob → sendEmailWorker`
+(`metadata.kind=queue_consumer`, as `queue.process("emailJob", ...)` now
+emits). Started a flow-enabled server on :3199
+(`NANO_BRAIN_ALLOW_DUPLICATE_SERVER=1`, `NANO_BRAIN_FLOW_ENABLED=true`,
+`NANO_BRAIN_DATABASE_URL=…/nanobrain_test`).
+
+## MCP streamable-HTTP handshake + tool call
+
+```
+HTTP/1.1 200 OK   initialize                (Mcp-Session-Id issued)
+202                notifications/initialized
+HTTP/1.1 200 OK   tools/call memory_flow  entry="POST /schedule"   (NO stitch_workspaces arg)
+```
+
+Decoded response:
+
+```json
+{
+  "found": true,
+  "nodes": [
+    {"id": "POST /schedule", "role": "entry"},
+    {"id": "scheduleEmail", "role": "handler"},
+    {"id": "CONSUME emailJob", "role": "integration"}
+  ],
+  "edges": [
+    {"from": "POST /schedule", "to": "scheduleEmail", "kind": "http"},
+    {"from": "scheduleEmail", "to": "CONSUME emailJob", "kind": "cross_service"}
+  ]
+}
+```
+
+**Result:** `memory_flow` on the route now crosses the Bull queue boundary —
+the producer `scheduleEmail` is linked to the `CONSUME emailJob` consumer
+entry by job-name, **without** the caller passing `stitch_workspaces`. This
+confirms the #578 stitching plumbing (built for Redis pub/sub) generalizes to
+Bull with zero changes to `memory_flow`/`flow.Stitch` — only the extractor
+needed to emit the same edge shape.
+
+## Isolation / cleanup
+
+Server on :3199 / nanobrain_test only; killed by captured PID (no broad kill).
+Seeded workspace/edges deleted, temp binary removed.

--- a/internal/graph/js_integration_extractor.go
+++ b/internal/graph/js_integration_extractor.go
@@ -438,7 +438,7 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 	// call, so it needs the same topic-based edge the generic bus/Redis paths
 	// use. Gated on a "queue" naming hint plus a literal job-name argument, to
 	// avoid misreading an unrelated Set/Map .add()/.process() call as a queue op.
-	if isBullQueueReceiver(receiverName) && (methodName == "add" || methodName == "process") {
+	if (methodName == "add" || methodName == "process") && isBullQueueReceiver(receiverName) {
 		firstArg := echoArgNode(argsNode, lang, 0)
 		if firstArg != nil && tsCountArgs(argsNode, lang) >= 2 {
 			if t := firstArg.Type(lang); t == "string" || t == "template_string" {

--- a/internal/graph/js_integration_extractor.go
+++ b/internal/graph/js_integration_extractor.go
@@ -122,6 +122,15 @@ var jsRedisReceivers = map[string]bool{
 	"db":          true,
 }
 
+// isBullQueueReceiver matches variable/class names that follow the common
+// Bull/BullMQ queue naming convention (mainQueue, ScreenshotQueue,
+// taskQueue, ...). Bull has no fixed client name to key off of like Redis's
+// jsRedisReceivers, so this is a substring heuristic rather than an
+// exact-match set.
+func isBullQueueReceiver(name string) bool {
+	return strings.Contains(strings.ToLower(name), "queue")
+}
+
 // JSIntegrationExtractor implements graph.Extractor for JS/TS outbound
 // integration calls (HTTP, queue publish, event emit, consumer patterns).
 type JSIntegrationExtractor struct {
@@ -421,6 +430,44 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 		if isUnambiguous || isKnownReceiver {
 			x.handleRedisCall(bt, callNode, methodName, receiverName, argsNode, lang, langLabel, relFile, source, line, edges)
 			return
+		}
+	}
+
+	// Bull/BullMQ queue producer/consumer: queue.add("jobName", data) couples to
+	// queue.process("jobName", handler) by the job-name string (#546 E2) — not a
+	// call, so it needs the same topic-based edge the generic bus/Redis paths
+	// use. Gated on a "queue" naming hint plus a literal job-name argument, to
+	// avoid misreading an unrelated Set/Map .add()/.process() call as a queue op.
+	if isBullQueueReceiver(receiverName) && (methodName == "add" || methodName == "process") {
+		firstArg := echoArgNode(argsNode, lang, 0)
+		if firstArg != nil && tsCountArgs(argsNode, lang) >= 2 {
+			if t := firstArg.Type(lang); t == "string" || t == "template_string" {
+				jobName := jsStringArgOrVar(bt, argsNode, lang, 0)
+				if methodName == "add" {
+					target := "produce:" + jobName
+					*edges = append(*edges, Edge{
+						SourceNode: source,
+						TargetNode: target,
+						Kind:       EdgeIntegration,
+						SourceFile: relFile,
+						Line:       line,
+						Language:   langLabel,
+						Metadata:   map[string]any{"kind": "queue_publish", "method": methodName, "receiver": receiverName, "topic": jobName},
+					})
+				} else {
+					consumeNode := "CONSUME " + jobName
+					*edges = append(*edges, Edge{
+						SourceNode: consumeNode,
+						TargetNode: source,
+						Kind:       EdgeIntegration,
+						SourceFile: relFile,
+						Line:       line,
+						Language:   langLabel,
+						Metadata:   map[string]any{"kind": "queue_consumer", "method": methodName, "receiver": receiverName, "topic": jobName},
+					})
+				}
+				return
+			}
 		}
 	}
 

--- a/internal/graph/js_integration_extractor_test.go
+++ b/internal/graph/js_integration_extractor_test.go
@@ -400,6 +400,100 @@ func TestJSIntegrationExtractor_Consumer(t *testing.T) {
 	}
 }
 
+// #546 E2: Bull/BullMQ couples queue.add("jobName", data) to
+// queue.process("jobName", handler) by the job-name string, not a call.
+func TestJSIntegrationExtractor_BullQueue(t *testing.T) {
+	ex, err := graph.NewJSIntegrationExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("queue.add producer", func(t *testing.T) {
+		src := `function schedule() { mainQueue.add("emailJob", { to: "a@b.com" }); }`
+		edges, err := ex.ExtractEdges("test.js", []byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var matching []graph.Edge
+		for _, e := range edges {
+			if e.Kind == graph.EdgeIntegration {
+				matching = append(matching, e)
+			}
+		}
+		if len(matching) == 0 {
+			t.Fatal("expected at least one EdgeIntegration edge")
+		}
+		e := matching[0]
+		if e.TargetNode != "produce:emailJob" {
+			t.Errorf("TargetNode = %q, want %q", e.TargetNode, "produce:emailJob")
+		}
+		if e.Metadata["kind"] != "queue_publish" {
+			t.Errorf("Metadata[kind] = %v, want %q", e.Metadata["kind"], "queue_publish")
+		}
+		if e.Metadata["topic"] != "emailJob" {
+			t.Errorf("Metadata[topic] = %v, want %q", e.Metadata["topic"], "emailJob")
+		}
+	})
+
+	t.Run("queue.process consumer", func(t *testing.T) {
+		src := `function setup() { screenshotQueue.process("captureJob", (job) => { capture(job); }); }`
+		edges, err := ex.ExtractEdges("test.js", []byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var matching []graph.Edge
+		for _, e := range edges {
+			if e.Kind == graph.EdgeIntegration {
+				matching = append(matching, e)
+			}
+		}
+		if len(matching) == 0 {
+			t.Fatal("expected at least one EdgeIntegration edge")
+		}
+		e := matching[0]
+		if e.SourceNode != "CONSUME captureJob" {
+			t.Errorf("SourceNode = %q, want %q", e.SourceNode, "CONSUME captureJob")
+		}
+		if e.Metadata["kind"] != "queue_consumer" {
+			t.Errorf("Metadata[kind] = %v, want %q", e.Metadata["kind"], "queue_consumer")
+		}
+		if e.Metadata["topic"] != "captureJob" {
+			t.Errorf("Metadata[topic] = %v, want %q", e.Metadata["topic"], "captureJob")
+		}
+	})
+
+	t.Run("non-queue receiver unaffected", func(t *testing.T) {
+		// A plain Set/Map .add() on a receiver without a "queue" naming hint must
+		// not be misread as a Bull producer.
+		src := `function track() { seenIds.add("emailJob"); }`
+		edges, err := ex.ExtractEdges("test.js", []byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range edges {
+			if e.Kind == graph.EdgeIntegration {
+				t.Errorf("expected no integration edge for seenIds.add(), got %+v", e)
+			}
+		}
+	})
+
+	t.Run("single-arg process not misread", func(t *testing.T) {
+		// queue.process(handler) (no job name) is a real Bull pattern ("process
+		// all jobs") but out of scope — it must not fall through and misread the
+		// handler function as a job-name topic.
+		src := `function setup() { mainQueue.process((job) => { run(job); }); }`
+		edges, err := ex.ExtractEdges("test.js", []byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range edges {
+			if e.Kind == graph.EdgeIntegration && e.Metadata["kind"] == "queue_consumer" {
+				t.Errorf("expected no queue_consumer edge for single-arg process(), got %+v", e)
+			}
+		}
+	})
+}
+
 func TestJSIntegrationExtractor_BareFunctionCall(t *testing.T) {
 	ex, err := graph.NewJSIntegrationExtractor()
 	if err != nil {

--- a/internal/mcp/flow_bull_546_integration_test.go
+++ b/internal/mcp/flow_bull_546_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+)
+
+// Issue #546 E2: memory_flow auto-stitches a Bull queue producer
+// (queue.add("jobName", data)) to its consumer (queue.process("jobName",
+// handler)) by job-name, the same way #577/#578 linked Redis pub/sub — since
+// both extractors emit the same "CONSUME <topic>" / Metadata["topic"] shape,
+// flow.Stitch requires no changes for this producer/consumer pair.
+func TestMemoryFlow_AutoStitchesBullQueueProducerConsumer(t *testing.T) {
+	ctx, q, wsHash, callTool := setupFlowMCP(t)
+
+	edges := []struct {
+		src, tgt, kind, meta string
+	}{
+		// POST /schedule -> scheduleEmail (route handler)
+		{"POST /schedule", "scheduleEmail", "http", `{"method":"POST","path":"/schedule"}`},
+		// scheduleEmail enqueues a Bull job "emailJob" (queue.add)
+		{"svc.js::scheduleEmail", "produce:emailJob", "integration", `{"kind":"queue_publish","method":"add","receiver":"mainQueue","topic":"emailJob"}`},
+		// a worker consumes "emailJob" (queue.process, as the extractor now emits)
+		{"CONSUME emailJob", "sendEmailWorker", "integration", `{"kind":"queue_consumer","method":"process","receiver":"mainQueue","topic":"emailJob"}`},
+	}
+	for _, e := range edges {
+		if err := q.UpsertGraphEdge(ctx, sqlc.UpsertGraphEdgeParams{
+			WorkspaceHash: wsHash, SourceNode: e.src, TargetNode: e.tgt,
+			EdgeType: e.kind, SourceFile: "svc.js", Metadata: []byte(e.meta),
+		}); err != nil {
+			t.Fatalf("upsert edge %+v: %v", e, err)
+		}
+	}
+
+	resp := unmarshalGraphResp(t, callTool("memory_flow", map[string]any{
+		"workspace": wsHash, "entry": "POST /schedule", "format": "json",
+	}))
+	if found, _ := resp["found"].(bool); !found {
+		t.Fatalf("flow not found: %+v", resp)
+	}
+
+	var sawConsumer bool
+	if nodes, ok := resp["nodes"].([]any); ok {
+		for _, n := range nodes {
+			if n.(map[string]any)["id"] == "CONSUME emailJob" {
+				sawConsumer = true
+			}
+		}
+	}
+	if !sawConsumer {
+		t.Fatalf("consumer entry not linked into the flow (auto-stitch failed): nodes=%+v", resp["nodes"])
+	}
+
+	var sawCrossService bool
+	if es, ok := resp["edges"].([]any); ok {
+		for _, e := range es {
+			em := e.(map[string]any)
+			if em["kind"] == "cross_service" {
+				sawCrossService = true
+				if from := em["from"].(string); from != "scheduleEmail" {
+					t.Errorf("cross_service edge must originate from the in-flow node %q, got %q", "scheduleEmail", from)
+				}
+			}
+		}
+	}
+	if !sawCrossService {
+		t.Errorf("expected a cross_service edge linking producer to consumer: edges=%+v", resp["edges"])
+	}
+}


### PR DESCRIPTION
Closes #581 (increment 2 of #546: event-driven coupling). E1 (Redis pub/sub) was closed by #577/#578.

## Problem
Bull couples a producer `queue.add("jobName", data)` to a consumer `queue.process("jobName", handler)` via the job-name string — not a call. `memory_graph`/`memory_trace`/`memory_flow` see no edge between them.

## Fix
Extended the JS/TS integration extractor to recognize `<queueVar>.add("jobName", data)` and `<queueVar>.process("jobName", handler)`, gated on a "queue" naming hint on the receiver (Bull has no fixed client name to exact-match, unlike Redis) plus a literal job-name argument. Emits the exact same edge shapes the #578 Redis pub/sub stitching already consumes (`queue_publish` with `Metadata["topic"]`, `"CONSUME <jobName>"` consumer entry) — so `memory_flow` auto-links producer→consumer with **zero changes** to `internal/mcp/tools.go` or `internal/flow/stitch.go`.

## Out of scope (documented in #581)
- Webhook dispatch (URL-string coupling across services, different stitch shape).
- Bull's single-arg `queue.process(handler)` ("process all jobs", no job-name topic to stitch on).

## Test plan
- [x] `go build ./...`
- [x] `go test -race -short ./...` — all green
- [x] New extractor unit test (producer, consumer, non-queue-receiver guard, single-arg guard) — red without the fix, green with it
- [x] New integration test proving `memory_flow` auto-stitches without `stitch_workspaces`
- [x] Live MCP-over-HTTP smoke test on :3199/nanobrain_test (`docs/evidence/smoke-e2e-bull-queue-flow.md`)
- [x] Independent R88 review (`docs/evidence/review-581.md`) — PASS, 0 CRITICAL/HIGH