### PR TITLE
fix(embed): prevent stale embedding insert errors

### DIFF
--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -1,0 +1,11 @@
+# Test Matrix
+
+| Story | Change type | Unit | Integration | User flow | Review |
+| --- | --- | --- | --- | --- | --- |
+| US-600 embedding insert race | bug-fix | Queue and handler stale-result tests | Deleted-chunk and locking tests in isolated PostgreSQL | Direct embed endpoint with deterministic local provider | Pending |
+
+## Evidence Rules
+
+- Store command output under `docs/evidence/<change>/`.
+- Use `nanobrain_test` and port 3199 for integration and smoke tests.
+- Update the row with the final review verdict and PR after merge.

--- a/docs/evidence/fix-embedding-insert-race/independent-review.md
+++ b/docs/evidence/fix-embedding-insert-race/independent-review.md
@@ -1,0 +1,17 @@
+# Independent Review — fix-embedding-insert-race
+
+## Verdict
+
+**PASS.** Five independent lanes reviewed the committed change. Two initial findings identified the missing concurrent-ordering regression; it was added, repeatedly verified, and reviewed again by fresh goal and QA reviewers.
+
+| Lane | Result | Evidence |
+| --- | --- | --- |
+| Goal and contract | PASS | OpenSpec acceptance criteria and both production writers match the final behavior. |
+| Hands-on QA | PASS | Concurrent-ordering regression passed 10 race-enabled runs; full storage integration passed. |
+| Code quality | PASS | SQL parameter mapping, writer state transitions, and batch accounting were verified. |
+| Security and data integrity | PASS | Workspace-scoped parameterized SQL and cascade behavior introduce no new security or integrity risk. |
+| Caller and deletion audit | PASS | Queue and direct endpoint are the only production embedding writers; relevant deletion paths are covered. |
+
+## Resolved review finding
+
+The final storage regression blocks the insert after the CTE key-share lock is acquired, observes the concurrent delete waiting, then asserts no foreign-key violation and zero embeddings after the delete cascade. It uses an isolated test schema only.

--- a/docs/evidence/fix-embedding-insert-race/openspec-gap-analysis.md
+++ b/docs/evidence/fix-embedding-insert-race/openspec-gap-analysis.md
@@ -1,0 +1,29 @@
+# OpenSpec Gap Analysis — fix-embedding-insert-race
+
+Date: 2026-07-17
+Issue: #600
+Lane: normal
+Change type: bug-fix
+
+## Readiness
+
+- Existing owning change: none found.
+- Proposal, design, specification, and tasks: complete.
+- Strict validation: `Change 'fix-embedding-insert-race' is valid`.
+
+## Resolved Gaps
+
+| Gap | Resolution |
+| --- | --- |
+| Could a Go-side recheck prevent the race? | No. The design uses one SQL statement with a `FOR KEY SHARE` parent-row guard. |
+| Which writers need handling? | Queue and direct HTTP endpoint are the only production callers. |
+| Could the lock block a provider request? | No. It is acquired only for final persistence, after embedding completes. |
+| Is a database migration necessary? | No; this changes query behavior only. |
+
+## Independent Design Verdict
+
+PASS — `FOR KEY SHARE` makes deletion and final vector persistence serializable at the relevant row without holding a lock over the provider call. A prior deletion produces `sql.ErrNoRows`; a later deletion waits and then cascades the completed embedding.
+
+## Harness Note
+
+`harness-check.sh` currently accepts `in-progress` but does not implement the skill-documented `--change` option. This is recorded here only; it is outside issue #600's product scope.

--- a/docs/evidence/fix-embedding-insert-race/self-review-fix-embedding-insert-race.md
+++ b/docs/evidence/fix-embedding-insert-race/self-review-fix-embedding-insert-race.md
@@ -11,6 +11,7 @@
 | Criterion | Review result |
 |---|---|
 | A deleted `(chunk_id, workspace_hash)` produces `sql.ErrNoRows`, not SQLSTATE 23503 | PASS — the CTE selects the live chunk with `FOR KEY SHARE`; the isolated PostgreSQL regression passes. |
+| A delete that begins during persistence waits for the CTE key-share lock and cascades the committed embedding | PASS — a trigger pauses the insert after CTE locking, `pg_stat_activity` observes the delete waiting on a lock, and the isolated integration regression proves no SQLSTATE 23503 then a zero embedding count after delete. |
 | Queue finishes a no-row write without retrying or marking the chunk embedded | PASS — the no-row branch decrements pending work, clears retries, and returns; the unit regression passes. |
 | Direct batch skips only the stale chunk, persists the next chunk, and reports actual pending work | PASS — the no-row branch continues, stale skips are excluded from non-paginated `remaining`, and the regression verifies both insert attempts and only the live chunk is marked embedded. |
 | Generated API remains compatible | PASS — sqlc preserves `ChunkID` and `WorkspaceHash`; only internal parameter order changed. |
@@ -24,6 +25,7 @@
 - Green package scopes: `go test -count=1 -race -tags=integration ./internal/storage` (`2.125s`) and `go test -count=1 -race ./internal/embed ./internal/server/handlers` (embed `1.481s`, handlers `2.495s`), using only `nanobrain_test`.
 - Red accounting correction: the revised direct-handler regression observed `{Embedded:1 Remaining:1}` where the stale chunk was already deleted.
 - Green accounting correction: the focused handler test passed, then storage integration (`2.343s`), embed (`1.715s`), and handlers (`2.711s`) passed with `-race` using only `nanobrain_test`.
+- Concurrent delete ordering: the test-only insert trigger provides a deterministic post-CTE barrier. The focused isolated test passed once (`2.134s`) and five consecutive `-race` runs (`1.994s`); the full storage integration package passed (`2.196s`). A red run was not possible because the regression was added after the CTE fix; removing the production CTE solely to manufacture one would violate scope.
 
 ## Finding disposition
 

--- a/docs/evidence/fix-embedding-insert-race/self-review-fix-embedding-insert-race.md
+++ b/docs/evidence/fix-embedding-insert-race/self-review-fix-embedding-insert-race.md
@@ -1,0 +1,34 @@
+# Author Self-Review — fix-embedding-insert-race
+
+## Scope reviewed
+
+- `InsertEmbedding` SQL and regenerated sqlc output.
+- Queue and direct endpoint stale-result handling.
+- New storage, queue, and direct-endpoint regressions.
+
+## Acceptance criteria
+
+| Criterion | Review result |
+|---|---|
+| A deleted `(chunk_id, workspace_hash)` produces `sql.ErrNoRows`, not SQLSTATE 23503 | PASS — the CTE selects the live chunk with `FOR KEY SHARE`; the isolated PostgreSQL regression passes. |
+| Queue finishes a no-row write without retrying or marking the chunk embedded | PASS — the no-row branch decrements pending work, clears retries, and returns; the unit regression passes. |
+| Direct batch skips only the stale chunk, persists the next chunk, and reports actual pending work | PASS — the no-row branch continues, stale skips are excluded from non-paginated `remaining`, and the regression verifies both insert attempts and only the live chunk is marked embedded. |
+| Generated API remains compatible | PASS — sqlc preserves `ChunkID` and `WorkspaceHash`; only internal parameter order changed. |
+
+## Red → green proof
+
+- Red storage test: the old query returned `embeddings_chunk_id_fkey` / SQLSTATE `23503`, not `sql.ErrNoRows`.
+- Red queue test: stale retry state remained present.
+- Red direct-handler test: response was `{Embedded:0 Remaining:2}` rather than continuing to the second chunk.
+- Green focused tests: storage `1.869s`, embed `1.648s`, handlers `2.114s`, all with `-race`.
+- Green package scopes: `go test -count=1 -race -tags=integration ./internal/storage` (`2.125s`) and `go test -count=1 -race ./internal/embed ./internal/server/handlers` (embed `1.481s`, handlers `2.495s`), using only `nanobrain_test`.
+- Red accounting correction: the revised direct-handler regression observed `{Embedded:1 Remaining:1}` where the stale chunk was already deleted.
+- Green accounting correction: the focused handler test passed, then storage integration (`2.343s`), embed (`1.715s`), and handlers (`2.711s`) passed with `-race` using only `nanobrain_test`.
+
+## Finding disposition
+
+- Resolved — non-paginated `remaining` now subtracts stale skips. The direct-handler regression expects and proves `{Embedded:1 Remaining:0}` after one stale skip and one successful write.
+
+## Conclusion
+
+**PASS.** The requested storage integrity, stale-result handling, batch continuation, and response accounting are implemented and verified. No unresolved author-review findings remain.

--- a/docs/evidence/fix-embedding-insert-race/smoke-e2e-fix-embedding-insert-race.md
+++ b/docs/evidence/fix-embedding-insert-race/smoke-e2e-fix-embedding-insert-race.md
@@ -1,0 +1,22 @@
+# Smoke E2E — fix-embedding-insert-race
+
+## Environment
+
+- Built the server from this change and ran it with `config.test.yml` on port `3199`.
+- Used only the isolated `nanobrain_test` database with duplicate-server protection enabled.
+- Used the configured local embedding provider; the production dev server and database were not contacted.
+
+## API smoke
+
+```text
+GET  /health       -> 200
+POST /api/v1/init  -> 200
+POST /api/v1/write -> 201 {"collection":"memory","chunk_count":1}
+POST /api/v1/embed -> 200 {"embedded":1,"remaining":0}
+```
+
+The workspace identifier and generated document identifier were deliberately redacted from this evidence. The ordinary endpoint path wrote one pending chunk and persisted its embedding successfully. The deterministic stale-result behavior is covered by the isolated PostgreSQL and handler regressions.
+
+## UI route check
+
+The service binary does not register a static web UI route: both `/` and `/ui/` returned `404`. `scripts/smoke-ui.sh` is not present, so a browser/UI smoke is not applicable to this handler-only server change.

--- a/docs/evidence/fix-embedding-insert-race/validation.md
+++ b/docs/evidence/fix-embedding-insert-race/validation.md
@@ -1,0 +1,33 @@
+# Validation — fix-embedding-insert-race
+
+## Passing change-specific checks
+
+```text
+go build ./... && go test -race -short ./...                         PASS
+go test -race -tags=integration ./internal/storage                    PASS
+go test -race ./internal/embed ./internal/server/handlers             PASS
+go test -race -tags=integration ./internal/storage \
+  -run '^TestInsertEmbedding_returnsNoRows_when_sourceChunkWasDeleted$' PASS
+```
+
+All database-backed checks used `nanobrain_test`; the focused storage test uses an isolated schema. The API smoke is recorded in `smoke-e2e-fix-embedding-insert-race.md`.
+
+## Full integration sweep
+
+`go test -race -tags=integration ./...` was run twice: once without a test server and once with an isolated `:3199` test server. The second run removed the server-dependent benchmark failure, but both runs still failed in unrelated existing areas:
+
+- `cmd/nano-brain`: backfill-summary fixture expectations and the orphan-cleanup schema fixture.
+- `internal/storage/sqlc`: stale raw OpenCode cleanup expectations.
+- `internal/summarize`: persisted-session collection and filename expectations.
+
+The change-specific storage, queue, and handler packages passed in that full sweep.
+
+## Base-revision comparison
+
+A clean detached worktree at the unchanged base revision was checked with the same isolated server and test database:
+
+```text
+go test -race -tags=integration ./cmd/nano-brain ./internal/storage/sqlc ./internal/summarize
+```
+
+It reproduced the same failures in all three areas, confirming they are not introduced by this change. The temporary comparison worktree and test server were removed after verification.

--- a/docs/evidence/fix-embedding-insert-race/validation.md
+++ b/docs/evidence/fix-embedding-insert-race/validation.md
@@ -12,6 +12,8 @@ go test -race -tags=integration ./internal/storage \
 
 All database-backed checks used `nanobrain_test`; the focused storage test uses an isolated schema. The API smoke is recorded in `smoke-e2e-fix-embedding-insert-race.md`.
 
+The deterministic concurrent-ordering regression passed five consecutive race-enabled runs (`2.345s`). It pauses the insert after the CTE has acquired `FOR KEY SHARE`, observes the concurrent delete waiting on a PostgreSQL lock, then proves the insert has no `23503` error and the delete cascade leaves zero embeddings.
+
 ## Full integration sweep
 
 `go test -race -tags=integration ./...` was run twice: once without a test server and once with an isolated `:3199` test server. The second run removed the server-dependent benchmark failure, but both runs still failed in unrelated existing areas:

--- a/docs/stories/fix-embedding-insert-race.md
+++ b/docs/stories/fix-embedding-insert-race.md
@@ -1,0 +1,45 @@
+---
+story_id: US-600
+title: Prevent stale embedding insert FK violations
+status: in-progress
+lane: normal
+change_type: bug-fix
+github_issue: nano-step/nano-brain#600
+openspec_change: openspec/changes/fix-embedding-insert-race/
+validation:
+  unit: pass
+  integration: pass-with-baseline-failures
+  e2e: pass
+review:
+  verdict: pending
+  reviewer: ""
+pr:
+  url: ""
+  bot_rounds: 0
+---
+
+# US-600 Prevent stale embedding insert FK violations
+
+## Product Contract
+
+Embedding persistence must skip a deleted source chunk without causing a PostgreSQL foreign-key error, and a direct embedding batch must continue after that skipped item.
+
+## Acceptance Criteria
+
+- A deleted source chunk causes `InsertEmbedding` to return `sql.ErrNoRows`, not SQLSTATE 23503.
+- The queue finishes a stale job without retrying or error-level logging.
+- The direct endpoint continues later chunks in the same batch after a stale result.
+
+## Validation
+
+| Layer | Expected proof |
+| --- | --- |
+| Unit | Queue and endpoint stale-result tests |
+| Integration | Isolated PostgreSQL stale chunk and lock-race tests |
+| E2E | Direct embedding endpoint against a local deterministic embed provider |
+
+## Evidence
+
+- OpenSpec: `docs/evidence/fix-embedding-insert-race/openspec-gap-analysis.md`
+- Validation: `docs/evidence/fix-embedding-insert-race/validation.md`
+- Smoke E2E: `docs/evidence/fix-embedding-insert-race/smoke-e2e-fix-embedding-insert-race.md`

--- a/docs/stories/fix-embedding-insert-race.md
+++ b/docs/stories/fix-embedding-insert-race.md
@@ -11,8 +11,8 @@ validation:
   integration: pass-with-baseline-failures
   e2e: pass
 review:
-  verdict: pending
-  reviewer: ""
+  verdict: pass
+  reviewer: independent-five-lane
 pr:
   url: ""
   bot_rounds: 0
@@ -43,3 +43,4 @@ Embedding persistence must skip a deleted source chunk without causing a Postgre
 - OpenSpec: `docs/evidence/fix-embedding-insert-race/openspec-gap-analysis.md`
 - Validation: `docs/evidence/fix-embedding-insert-race/validation.md`
 - Smoke E2E: `docs/evidence/fix-embedding-insert-race/smoke-e2e-fix-embedding-insert-race.md`
+- Independent review: `docs/evidence/fix-embedding-insert-race/independent-review.md`

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -351,6 +351,12 @@ func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
 		Embedding:     pgvector.NewVector(vec),
 	})
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			q.logger.Debug().Str("chunk_id", chunkID.String()).Msg("chunk deleted before embedding insert, skipping stale chunk")
+			q.pending.Add(-1)
+			q.clearRetries(chunkID)
+			return
+		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
 			q.logger.Warn().Str("chunk_id", chunkID.String()).Msg("chunk deleted before embedding insert, skipping stale chunk")

--- a/internal/embed/queue.go
+++ b/internal/embed/queue.go
@@ -355,6 +355,7 @@ func (q *Queue) processChunk(ctx context.Context, chunkID uuid.UUID) {
 			q.logger.Debug().Str("chunk_id", chunkID.String()).Msg("chunk deleted before embedding insert, skipping stale chunk")
 			q.pending.Add(-1)
 			q.clearRetries(chunkID)
+			q.publishStatus()
 			return
 		}
 		var pgErr *pgconn.PgError

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -512,6 +512,35 @@ func TestQueue_PendingDecrementsOnInsertEmbeddingError(t *testing.T) {
 	}
 }
 
+func TestQueue_ProcessChunk_skipsStaleEmbeddingResult(t *testing.T) {
+	// Given
+	chunkID := uuid.New()
+	mq := &mockQuerier{
+		insertEmbeddingFn: func(_ context.Context, _ sqlc.InsertEmbeddingParams) (sqlc.Embedding, error) {
+			return sqlc.Embedding{}, sql.ErrNoRows
+		},
+	}
+	q := newTestQueue(&mockEmbedder{}, mq)
+	q.pending.Store(1)
+	q.retries[chunkID] = 2
+
+	// When
+	q.processChunk(context.Background(), chunkID)
+
+	// Then
+	if got := q.pending.Load(); got != 0 {
+		t.Fatalf("pending = %d, want 0", got)
+	}
+	if _, ok := q.retries[chunkID]; ok {
+		t.Fatalf("stale chunk retry state was not cleared")
+	}
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+	if mq.markChunkEmbeddedCalls != 0 {
+		t.Fatalf("MarkChunkEmbedded calls = %d, want 0", mq.markChunkEmbeddedCalls)
+	}
+}
+
 func TestQueue_Depth(t *testing.T) {
 	eq := newTestQueue(&mockEmbedder{}, &mockQuerier{})
 	if eq.Depth() != 0 {

--- a/internal/embed/queue_test.go
+++ b/internal/embed/queue_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/nano-brain/nano-brain/internal/eventbus"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/rs/zerolog"
 )
@@ -20,6 +21,14 @@ type mockEmbedder struct {
 	mu       sync.Mutex
 	embedFn  func(ctx context.Context, text string) ([]float32, error)
 	calls    int
+}
+
+type mockPublisher struct {
+	events []eventbus.Event
+}
+
+func (m *mockPublisher) Publish(event eventbus.Event) {
+	m.events = append(m.events, event)
 }
 
 func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
@@ -521,6 +530,8 @@ func TestQueue_ProcessChunk_skipsStaleEmbeddingResult(t *testing.T) {
 		},
 	}
 	q := newTestQueue(&mockEmbedder{}, mq)
+	pub := &mockPublisher{}
+	q.WithPublisher(pub)
 	q.pending.Store(1)
 	q.retries[chunkID] = 2
 
@@ -538,6 +549,9 @@ func TestQueue_ProcessChunk_skipsStaleEmbeddingResult(t *testing.T) {
 	defer mq.mu.Unlock()
 	if mq.markChunkEmbeddedCalls != 0 {
 		t.Fatalf("MarkChunkEmbedded calls = %d, want 0", mq.markChunkEmbeddedCalls)
+	}
+	if len(pub.events) != 1 {
+		t.Fatalf("published status events = %d, want 1", len(pub.events))
 	}
 }
 

--- a/internal/server/handlers/embed.go
+++ b/internal/server/handlers/embed.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"net/http"
 	"time"
 	"unicode/utf8"
@@ -86,6 +88,7 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, provider, model strin
 		defer loopCancel()
 
 		embedded := 0
+		skippedStale := 0
 		for _, chunk := range chunks {
 			embedCtx, cancel := context.WithTimeout(loopCtx, 30*time.Second)
 			content := truncateToMaxChars(chunk.Content, maxChars)
@@ -110,6 +113,11 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, provider, model strin
 				Model:         model,
 				Embedding:     pgvector.NewVector(vec),
 			}); insertErr != nil {
+				if errors.Is(insertErr, sql.ErrNoRows) {
+					logger.Debug().Str("chunk_id", chunk.ID.String()).Msg("chunk deleted before embedding insert, skipping stale chunk")
+					skippedStale++
+					continue
+				}
 				logger.Error().Err(insertErr).Str("chunk_id", chunk.ID.String()).Msg("insert embedding failed")
 				break
 			}
@@ -133,7 +141,7 @@ func TriggerEmbed(q EmbedQuerier, embedder embed.Embedder, provider, model strin
 				logger.Error().Err(countErr).Msg("failed to count remaining pending chunks")
 			}
 		} else {
-			remaining = int64(len(chunks) - embedded)
+			remaining = int64(len(chunks) - embedded - skippedStale)
 			if remaining < 0 {
 				remaining = 0
 			}

--- a/internal/server/handlers/embed_test.go
+++ b/internal/server/handlers/embed_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -239,6 +240,56 @@ func TestTriggerEmbed_PartialFailure(t *testing.T) {
 	}
 	if resp.Remaining != 2 {
 		t.Errorf("remaining = %d, want 2", resp.Remaining)
+	}
+}
+
+func TestTriggerEmbed_continuesAfterStaleEmbeddingResult(t *testing.T) {
+	// Given
+	chunks := makeChunks(2, "ws1")
+	var insertedIDs []uuid.UUID
+	var markedIDs []uuid.UUID
+	q := &mockEmbedQuerier{
+		getPendingChunksFn: func(_ context.Context, _ sqlc.GetPendingChunksParams) ([]sqlc.Chunk, error) {
+			return chunks, nil
+		},
+		insertEmbeddingFn: func(_ context.Context, arg sqlc.InsertEmbeddingParams) (sqlc.Embedding, error) {
+			insertedIDs = append(insertedIDs, arg.ChunkID)
+			if arg.ChunkID == chunks[0].ID {
+				return sqlc.Embedding{}, sql.ErrNoRows
+			}
+			return sqlc.Embedding{}, nil
+		},
+		markChunkEmbeddedFn: func(_ context.Context, arg sqlc.MarkChunkEmbeddedParams) error {
+			markedIDs = append(markedIDs, arg.ID)
+			return nil
+		},
+	}
+	emb := &mockEmbedder{
+		embedFn:   func(_ context.Context, _ string) ([]float32, error) { return testVector(), nil },
+		dimension: 3,
+	}
+	e := echo.New()
+	c, rec := newEmbedContext(e, `{"workspace":"ws1"}`, "ws1")
+
+	// When
+	err := handlers.TriggerEmbed(q, emb, "p", "m", 3000, zerolog.Nop())(c)
+
+	// Then
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	var response handlers.EmbedResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Embedded != 1 || response.Remaining != 0 {
+		t.Fatalf("response = %+v, want embedded=1 remaining=0", response)
+	}
+	if len(insertedIDs) != 2 {
+		t.Fatalf("InsertEmbedding calls = %d, want 2", len(insertedIDs))
+	}
+	if len(markedIDs) != 1 || markedIDs[0] != chunks[1].ID {
+		t.Fatalf("marked chunk IDs = %v, want [%s]", markedIDs, chunks[1].ID)
 	}
 }
 

--- a/internal/storage/embeddings_integration_test.go
+++ b/internal/storage/embeddings_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
+	"github.com/nano-brain/nano-brain/internal/testutil"
+	pgvector "github.com/pgvector/pgvector-go"
+)
+
+func TestInsertEmbedding_returnsNoRows_when_sourceChunkWasDeleted(t *testing.T) {
+	// Given
+	pool := testutil.SetupTestDB(t)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	q := sqlc.New(db)
+	workspaceHash := uuid.NewString()
+	_, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: workspaceHash,
+		Name: "embedding-race-test",
+		Path: "/tmp/embedding-race-test",
+	})
+	if err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	document, err := q.UpsertDocument(ctx, sqlc.UpsertDocumentParams{
+		WorkspaceHash: workspaceHash,
+		ContentHash:   uuid.NewString(),
+		Title:         "source.txt",
+		Content:       "source content",
+		SourcePath:    "source.txt",
+		Collection:    "code",
+	})
+	if err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	chunkID, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+		DocumentID:        document.ID,
+		WorkspaceHash:     workspaceHash,
+		ContentHash:       uuid.NewString(),
+		Content:           "chunk content",
+		ChunkType:         "text",
+		EmbeddingStrategy: "default",
+	})
+	if err != nil {
+		t.Fatalf("upsert chunk: %v", err)
+	}
+	if err := q.DeleteChunksByIDs(ctx, []uuid.UUID{chunkID}); err != nil {
+		t.Fatalf("delete source chunk: %v", err)
+	}
+
+	// When
+	_, err = q.InsertEmbedding(ctx, sqlc.InsertEmbeddingParams{
+		ChunkID:       chunkID,
+		WorkspaceHash: workspaceHash,
+		Provider:      "test",
+		Model:         "test-model",
+		Embedding:     pgvector.NewVector(make([]float32, 768)),
+	})
+
+	// Then
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("InsertEmbedding error = %v, want sql.ErrNoRows", err)
+	}
+	count, err := q.CountEmbeddingsByWorkspace(ctx, workspaceHash)
+	if err != nil {
+		t.Fatalf("count embeddings: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("embedding count = %d, want 0", count)
+	}
+}

--- a/internal/storage/embeddings_integration_test.go
+++ b/internal/storage/embeddings_integration_test.go
@@ -7,8 +7,10 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/nano-brain/nano-brain/internal/testutil"
@@ -77,5 +79,156 @@ func TestInsertEmbedding_returnsNoRows_when_sourceChunkWasDeleted(t *testing.T) 
 	}
 	if count != 0 {
 		t.Fatalf("embedding count = %d, want 0", count)
+	}
+}
+
+func TestInsertEmbedding_preventsForeignKeyRace_when_deleteStartsDuringPersistence(t *testing.T) {
+	// Given
+	pool := testutil.SetupTestDB(t)
+	db := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	q := sqlc.New(db)
+	workspaceHash := uuid.NewString()
+	_, err := q.UpsertWorkspace(ctx, sqlc.UpsertWorkspaceParams{
+		Hash: workspaceHash,
+		Name: "embedding-lock-test",
+		Path: "/tmp/embedding-lock-test",
+	})
+	if err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	document, err := q.UpsertDocument(ctx, sqlc.UpsertDocumentParams{
+		WorkspaceHash: workspaceHash,
+		ContentHash:   uuid.NewString(),
+		Title:         "source.txt",
+		Content:       "source content",
+		SourcePath:    "source.txt",
+		Collection:    "code",
+	})
+	if err != nil {
+		t.Fatalf("upsert document: %v", err)
+	}
+	chunkID, err := q.UpsertChunk(ctx, sqlc.UpsertChunkParams{
+		DocumentID:        document.ID,
+		WorkspaceHash:     workspaceHash,
+		ContentHash:       uuid.NewString(),
+		Content:           "chunk content",
+		ChunkType:         "text",
+		EmbeddingStrategy: "default",
+	})
+	if err != nil {
+		t.Fatalf("upsert chunk: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		CREATE FUNCTION block_embedding_insert() RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(600);
+			RETURN NEW;
+		END;
+		$$;
+		CREATE TRIGGER block_embedding_insert
+		BEFORE INSERT ON embeddings
+		FOR EACH ROW EXECUTE FUNCTION block_embedding_insert();
+	`); err != nil {
+		t.Fatalf("create insert blocker: %v", err)
+	}
+	holder, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire advisory-lock holder: %v", err)
+	}
+	t.Cleanup(func() { holder.Release() })
+	if _, err := holder.Exec(ctx, "SELECT pg_advisory_lock(600)"); err != nil {
+		t.Fatalf("acquire advisory lock: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = holder.Exec(context.Background(), "SELECT pg_advisory_unlock(600)")
+	})
+	deleteConn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire delete connection: %v", err)
+	}
+	t.Cleanup(func() { deleteConn.Release() })
+
+	// When
+	deadline, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	insertDone := make(chan error, 1)
+	go func() {
+		_, insertErr := q.InsertEmbedding(deadline, sqlc.InsertEmbeddingParams{
+			ChunkID:       chunkID,
+			WorkspaceHash: workspaceHash,
+			Provider:      "test",
+			Model:         "test-model",
+			Embedding:     pgvector.NewVector(make([]float32, 768)),
+		})
+		insertDone <- insertErr
+	}()
+
+	for {
+		var waiting bool
+		if err := pool.QueryRow(deadline, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_locks
+				WHERE locktype = 'advisory' AND objid = 600 AND NOT granted
+			)`).Scan(&waiting); err != nil {
+			t.Fatalf("check insert blocker: %v", err)
+		}
+		if waiting {
+			break
+		}
+		select {
+		case <-deadline.Done():
+			t.Fatalf("InsertEmbedding did not reach its post-lock insert trigger: %v", deadline.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	deleteDone := make(chan error, 1)
+	deletePID := deleteConn.Conn().PgConn().PID()
+	go func() {
+		_, deleteErr := deleteConn.Exec(deadline, "DELETE FROM chunks WHERE id = $1", chunkID)
+		deleteDone <- deleteErr
+	}()
+	for {
+		var waiting bool
+		if err := pool.QueryRow(deadline, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_stat_activity
+				WHERE pid = $1 AND wait_event_type = 'Lock'
+			)`, deletePID).Scan(&waiting); err != nil {
+			t.Fatalf("check delete lock: %v", err)
+		}
+		if waiting {
+			break
+		}
+		select {
+		case <-deadline.Done():
+			t.Fatalf("DELETE did not block on InsertEmbedding's key-share lock: %v", deadline.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if _, err := holder.Exec(ctx, "SELECT pg_advisory_unlock(600)"); err != nil {
+		t.Fatalf("release insert blocker: %v", err)
+	}
+
+	// Then
+	if err := <-insertDone; err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			t.Fatalf("InsertEmbedding returned forbidden foreign-key violation: %v", err)
+		}
+		t.Fatalf("InsertEmbedding: %v", err)
+	}
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("delete chunk: %v", err)
+	}
+	count, err := q.CountEmbeddingsByWorkspace(ctx, workspaceHash)
+	if err != nil {
+		t.Fatalf("count embeddings: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("embedding count after cascading delete = %d, want 0", count)
 	}
 }

--- a/internal/storage/embeddings_integration_test.go
+++ b/internal/storage/embeddings_integration_test.go
@@ -134,6 +134,12 @@ func TestInsertEmbedding_preventsForeignKeyRace_when_deleteStartsDuringPersisten
 	`); err != nil {
 		t.Fatalf("create insert blocker: %v", err)
 	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `
+			DROP TRIGGER IF EXISTS block_embedding_insert ON embeddings;
+			DROP FUNCTION IF EXISTS block_embedding_insert();
+		`)
+	})
 	holder, err := pool.Acquire(ctx)
 	if err != nil {
 		t.Fatalf("acquire advisory-lock holder: %v", err)

--- a/internal/storage/queries/embeddings.sql
+++ b/internal/storage/queries/embeddings.sql
@@ -1,6 +1,17 @@
 -- name: InsertEmbedding :one
+WITH live_chunk AS (
+    SELECT c.id, c.workspace_hash
+    FROM chunks c
+    WHERE c.id = sqlc.arg(chunk_id) AND c.workspace_hash = sqlc.arg(workspace_hash)
+    FOR KEY SHARE
+)
 INSERT INTO embeddings (chunk_id, workspace_hash, provider, model, embedding)
-VALUES ($1, $2, $3, $4, $5)
+SELECT live_chunk.id,
+       live_chunk.workspace_hash,
+       sqlc.arg(provider),
+       sqlc.arg(model),
+       sqlc.arg(embedding)
+FROM live_chunk
 ON CONFLICT (chunk_id) DO UPDATE SET
     embedding = EXCLUDED.embedding,
     provider = EXCLUDED.provider,

--- a/internal/storage/sqlc/embeddings.sql.go
+++ b/internal/storage/sqlc/embeddings.sql.go
@@ -249,8 +249,19 @@ func (q *Queries) GetPendingChunksAllWorkspaces(ctx context.Context, limit int32
 }
 
 const insertEmbedding = `-- name: InsertEmbedding :one
+WITH live_chunk AS (
+    SELECT c.id, c.workspace_hash
+    FROM chunks c
+    WHERE c.id = $4 AND c.workspace_hash = $5
+    FOR KEY SHARE
+)
 INSERT INTO embeddings (chunk_id, workspace_hash, provider, model, embedding)
-VALUES ($1, $2, $3, $4, $5)
+SELECT live_chunk.id,
+       live_chunk.workspace_hash,
+       $1,
+       $2,
+       $3
+FROM live_chunk
 ON CONFLICT (chunk_id) DO UPDATE SET
     embedding = EXCLUDED.embedding,
     provider = EXCLUDED.provider,
@@ -260,20 +271,20 @@ RETURNING id, chunk_id, workspace_hash, provider, model, embedding, created_at, 
 `
 
 type InsertEmbeddingParams struct {
-	ChunkID       uuid.UUID
-	WorkspaceHash string
 	Provider      string
 	Model         string
 	Embedding     interface{}
+	ChunkID       uuid.UUID
+	WorkspaceHash string
 }
 
 func (q *Queries) InsertEmbedding(ctx context.Context, arg InsertEmbeddingParams) (Embedding, error) {
 	row := q.db.QueryRowContext(ctx, insertEmbedding,
-		arg.ChunkID,
-		arg.WorkspaceHash,
 		arg.Provider,
 		arg.Model,
 		arg.Embedding,
+		arg.ChunkID,
+		arg.WorkspaceHash,
 	)
 	var i Embedding
 	err := row.Scan(

--- a/openspec/changes/fix-embedding-insert-race/.openspec.yaml
+++ b/openspec/changes/fix-embedding-insert-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/fix-embedding-insert-race/design.md
+++ b/openspec/changes/fix-embedding-insert-race/design.md
@@ -1,0 +1,43 @@
+## Context
+
+Both embedding writers read a chunk, call an external embedder, and then persist the vector. Document rewrites, reindexing, force-wipe, workspace removal, and explicit deletion can remove that chunk during the provider call. The queue currently catches the resulting foreign-key error, but PostgreSQL has already emitted the reported error; the direct endpoint treats it as an ordinary failed batch item.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent an embedding insert from attempting to reference an already-deleted chunk.
+- Preserve deletion throughput by not locking a chunk during the external embedding request.
+- Give both production writers the same benign stale-result semantics.
+
+**Non-Goals:**
+
+- Change queue deduplication, retry policy, provider behavior, or the HTTP response schema.
+- Introduce a migration or recover embeddings for chunks that no longer exist.
+
+## Decisions
+
+1. Make `InsertEmbedding` select the live `(id, workspace_hash)` row in a CTE with `FOR KEY SHARE`, then insert from that CTE. The short lock makes the existence check and FK write atomic: a deletion that committed first yields no returned row; a later deletion waits until the insert completes and then cascades it away.
+
+   Alternative: re-read the chunk in Go before inserting. Rejected because deletion can still occur between that check and the insert. Catching SQLSTATE 23503 alone is also rejected because it leaves the PostgreSQL ERROR reported in #600.
+
+2. Preserve sqlc's `:one` query contract. A stale chunk returns `sql.ErrNoRows`, which both writers explicitly classify as a benign skip.
+
+   Alternative: add a new result type or separate existence query. Rejected because the existing no-row signal is precise and keeps the storage API small.
+
+3. The direct endpoint continues the current batch after a stale result; non-stale database failures retain the existing stop-and-log behavior. The queue clears its retry state and finishes the stale job as it does for its existing FK handling.
+
+## Risks / Trade-offs
+
+- [A delete waits briefly on the final insert] → The key-share lock exists only for the database statement, never during the provider call.
+- [Callers could miss the new no-row result] → Audit both production `InsertEmbedding` callers and add regression tests for each.
+- [Generated SQL drifts] → Regenerate sqlc and verify generated output is committed with the query change.
+
+## Migration Plan
+
+1. Deploy the query and both caller updates together; no schema migration is required.
+2. Roll back by restoring the prior query and caller handling. Existing vectors remain valid because chunk deletion cascades embedding deletion.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/fix-embedding-insert-race/proposal.md
+++ b/openspec/changes/fix-embedding-insert-race/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Tracking: #600
+
+Embedding work runs asynchronously from document lifecycle operations. A chunk can be deleted after either embedding path has read it but before it persists the vector, causing PostgreSQL to reject `embeddings.chunk_id` with SQLSTATE 23503 and emit a database error.
+
+## What Changes
+
+- Make the shared embedding insert conditional on the source chunk still existing in the same workspace.
+- Treat an absent source chunk as a benign stale-job result in both the background queue and the direct embedding endpoint.
+- Add regression coverage for the SQL race and both production write paths.
+
+## Capabilities
+
+### New Capabilities
+
+- `embedding-write-integrity`: Vector writes remain safe when document lifecycle operations delete a chunk during embedding.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `internal/storage/queries/embeddings.sql` and regenerated sqlc output.
+- `internal/embed/queue.go` and `internal/server/handlers/embed.go` stale-result handling.
+- Unit and isolated PostgreSQL integration tests; no migration, provider, or public response-shape change.

--- a/openspec/changes/fix-embedding-insert-race/specs/embedding-write-integrity/spec.md
+++ b/openspec/changes/fix-embedding-insert-race/specs/embedding-write-integrity/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Embedding inserts are conditional on a live source chunk
+
+The storage layer SHALL insert or update an embedding only when its source chunk with the requested workspace still exists. The existence check and embedding write SHALL be protected from concurrent chunk deletion within one database statement. When the chunk was already deleted, the storage call SHALL return `sql.ErrNoRows` rather than a foreign-key violation.
+
+#### Scenario: Chunk was deleted before vector persistence
+
+- **GIVEN** an embedding worker or direct endpoint has already generated a vector for chunk `c1`
+- **AND** another lifecycle operation deletes `c1` before vector persistence
+- **WHEN** the writer persists the vector
+- **THEN** no embedding row is written
+- **AND** the storage call returns `sql.ErrNoRows`
+- **AND** PostgreSQL does not raise a foreign-key violation for `embeddings.chunk_id`
+
+#### Scenario: Chunk deletion starts during vector persistence
+
+- **GIVEN** chunk `c1` exists when the embedding insert begins
+- **WHEN** a concurrent lifecycle operation deletes `c1`
+- **THEN** the embedding insert completes against the live chunk
+- **AND** the deletion completes after the insert and cascades the embedding removal
+- **AND** PostgreSQL does not raise a foreign-key violation
+
+### Requirement: Stale embedding results are benign in all production writers
+
+The background queue and direct embedding endpoint SHALL treat `sql.ErrNoRows` from embedding persistence as a stale result, not a database failure. The queue SHALL finish the job without retrying it. The direct endpoint SHALL skip only the stale chunk and continue processing remaining pending chunks.
+
+#### Scenario: Queue persists a vector after its chunk is deleted
+
+- **GIVEN** a queue worker has generated a vector for chunk `c1`
+- **WHEN** embedding persistence returns `sql.ErrNoRows`
+- **THEN** the queue decrements its pending count and clears retry state for `c1`
+- **AND** it does not log an error or retry `c1`
+
+#### Scenario: Direct endpoint encounters a stale chunk in a batch
+
+- **GIVEN** the direct embedding endpoint has pending chunks `c1` and `c2`
+- **AND** persistence for `c1` returns `sql.ErrNoRows`
+- **WHEN** the endpoint processes the batch
+- **THEN** it skips `c1` without an error-level log
+- **AND** it continues to embed and persist `c2`

--- a/openspec/changes/fix-embedding-insert-race/tasks.md
+++ b/openspec/changes/fix-embedding-insert-race/tasks.md
@@ -1,0 +1,14 @@
+## 1. Race-Safe Storage Contract
+
+- [x] 1.1 Add a failing isolated-PostgreSQL regression test for inserting after the source chunk is deleted.
+- [x] 1.2 Make the embedding upsert conditional on a locked live source chunk and regenerate sqlc.
+
+## 2. Production Writer Handling
+
+- [x] 2.1 Add a failing queue test for a no-row embedding insert and handle it as a stale job.
+- [x] 2.2 Add a failing direct-endpoint batch test for a no-row embedding insert and continue the batch.
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit and integration tests, including the controlled stale-chunk scenario.
+- [ ] 3.2 Run the normal-lane validation, smoke test, and independent review; record evidence.

--- a/openspec/changes/fix-embedding-insert-race/tasks.md
+++ b/openspec/changes/fix-embedding-insert-race/tasks.md
@@ -11,4 +11,4 @@
 ## 3. Verification
 
 - [x] 3.1 Run focused unit and integration tests, including the controlled stale-chunk scenario.
-- [ ] 3.2 Run the normal-lane validation, smoke test, and independent review; record evidence.
+- [x] 3.2 Run the normal-lane validation, smoke test, and independent review; record evidence.


### PR DESCRIPTION
## Summary

Fixes a stale chunk lifecycle race that could make embedding persistence attempt a child insert after its source chunk was deleted.

- Make `InsertEmbedding` conditional on a locked live chunk, returning `sql.ErrNoRows` when it is already gone.
- Treat that result as a benign stale job in the queue and continue direct embed batches.
- Add isolated PostgreSQL regressions for deleted-before-insert and concurrent delete ordering.

Closes #600

## Validation

- `go build ./... && go test -race -short ./...`
- Focused queue and handler race regressions
- Isolated storage integration suite, including 10 race-enabled concurrent-ordering runs
- API smoke on the test configuration
- Five-lane independent review: PASS

The full integration sweep retains pre-existing failures in unrelated CLI, summary-persistence, and SQLC-cleanup tests; the same failures reproduce at the unchanged base revision.
