### PR TITLE
docs: close dogfooding report tracker #542

### DIFF
--- a/docs/evidence/close-dogfooding-report-542.md
+++ b/docs/evidence/close-dogfooding-report-542.md
@@ -1,0 +1,42 @@
+# Closure Record — Issue #542 Dogfooding Report
+
+## Scope
+
+Issue #542 reported ten frictions encountered while reconstructing an HTTP
+flow through nano-brain's MCP tools. This record closes the tracker without
+claiming that its remaining graph-quality work is complete.
+
+All links below were verified on 2026-07-17.
+
+## Finding Disposition
+
+| Finding | Disposition | Evidence |
+| --- | --- | --- |
+| F1 — mounted HTTP URL was not resolvable | Fixed | [#563](https://github.com/nano-step/nano-brain/issues/563) · [PR #564](https://github.com/nano-step/nano-brain/pull/564) |
+| F2 — cross-repository bare-name call collisions | Mitigated and handed off | [#575](https://github.com/nano-step/nano-brain/issues/575) · [PR #576](https://github.com/nano-step/nano-brain/pull/576) · remaining root cause: [#609](https://github.com/nano-step/nano-brain/issues/609) |
+| F3 — trace ignored `max_depth` | Fixed | [#561](https://github.com/nano-step/nano-brain/issues/561) · [PR #562](https://github.com/nano-step/nano-brain/pull/562) |
+| F4 — hybrid query latency | Fixed | [#539](https://github.com/nano-step/nano-brain/issues/539) · [PR #540](https://github.com/nano-step/nano-brain/pull/540) |
+| F5 — workspace resolution hid ancestor coverage | Fixed | [#565](https://github.com/nano-step/nano-brain/issues/565) · [PR #566](https://github.com/nano-step/nano-brain/pull/566) |
+| F6 — reverse graph omitted route-to-handler edge | Fixed | [#569](https://github.com/nano-step/nano-brain/issues/569) · [PR #570](https://github.com/nano-step/nano-brain/pull/570) |
+| F7 — hybrid query ignored `chunk_type` on vector legs | Fixed | [#571](https://github.com/nano-step/nano-brain/issues/571) · [PR #572](https://github.com/nano-step/nano-brain/pull/572) |
+| F8 — flow emitted builtin and keyword nodes | Fixed | [#567](https://github.com/nano-step/nano-brain/issues/567) · [PR #568](https://github.com/nano-step/nano-brain/pull/568) |
+| F9 — filtered multi-word search returned a false negative | Fixed | [#573](https://github.com/nano-step/nano-brain/issues/573) · [PR #574](https://github.com/nano-step/nano-brain/pull/574) |
+| F10 — embedding conflated distinct domain terms | Won't fix / by design | Semantic distinction requires product-owned vocabulary and ranking policy; no correctness defect exists in generic embedding retrieval. |
+
+## F2 Boundary
+
+PR #576 adds a query-time path-proximity rule: when exactly one candidate is
+nearest to the caller, trace uses it; a tie remains explicit ambiguity. That
+is intentionally not proof that the candidate is source-reachable, and it
+does not remove false call edges at extraction time or resolve flow and impact
+ambiguity.
+
+Issue #609 owns the required high-risk work: source-scoped JS/TS call
+resolution using actual imports, same-module declarations, and known receiver
+types, together with reindex and regression evidence. The tracker is therefore
+complete as a report; F2's root cause remains open in its own lifecycle.
+
+## Closure Decision
+
+Close #542 after this record merges. F1 and F3–F9 are shipped, F2 has a clear
+follow-up owner, and F10 is a documented product boundary.

--- a/docs/evidence/review-close-dogfooding-report-542.md
+++ b/docs/evidence/review-close-dogfooding-report-542.md
@@ -1,0 +1,30 @@
+# Independent Review — Close Dogfooding Report #542
+
+## Verdict
+
+**PASS** after one scope correction and an independent re-review.
+
+| Lane | Verdict | Evidence |
+| --- | --- | --- |
+| Goal and constraints | Pass | All F1–F10 dispositions are present; F2 remains a handoff to #609 and F10 has a by-design rationale. |
+| QA | Pass | Strict OpenSpec validation, whitespace check, ten-row coverage, F2/#609 status, F10 rationale, and all delivery links were verified. |
+| Documentation quality | Pass after re-review | The initial review rejected an over-broad repository-wide requirement. The remediation limits the capability, requirements, and tasks to issue #542. |
+| Security | Pass | Docs-only diff; no executable configuration, secrets, private workspace identifiers, or unsafe links. |
+| Context | Pass | Git/GitHub checks confirmed #609 is distinct from the #501 import-target change and that the tracker has the required tiny/docs classification. |
+
+## Resolved Finding
+
+The initial quality review found that the proposed capability and requirements
+claimed a durable policy for every completed dogfooding tracker, while this
+change creates only the #542 record. Commit `4f5e058` narrowed the capability
+and requirements to issue #542 and reworded the task list to distinguish F2's
+mitigation from the shipped findings. A fresh independent quality review passed
+the remediation.
+
+## Validation
+
+- `openspec validate close-dogfooding-report-542 --strict` → valid.
+- `git diff --check` → clean.
+- `./scripts/harness-check.sh in-progress` → passed all in-progress checks.
+
+No runtime source, dependency, API, schema, or configuration files changed.

--- a/docs/evidence/self-review-close-dogfooding-report-542.md
+++ b/docs/evidence/self-review-close-dogfooding-report-542.md
@@ -1,0 +1,29 @@
+# Self-Review — Close Dogfooding Report #542
+
+## Scope
+
+Documentation and OpenSpec artifacts only. No runtime source files, generated
+files, dependencies, schema, or API contracts changed.
+
+## Requirement Check
+
+| Requirement | Evidence | Result |
+| --- | --- | --- |
+| Every F1–F10 has a disposition | `close-dogfooding-report-542.md` table contains ten rows | Pass |
+| Shipped findings link to verified delivery | F1 and F3–F9 link to closed issues and merged PRs | Pass |
+| F2 is not falsely marked fixed | F2 is marked “Mitigated and handed off”; #575/#576 and #609 are linked | Pass |
+| F10 records the decision rationale | F10 identifies the product-owned vocabulary/ranking boundary | Pass |
+| No behavior change is implied | Proposal, design, and closure record explicitly state docs-only scope | Pass |
+
+## Validation Evidence
+
+- `openspec validate close-dogfooding-report-542 --strict` → `Change
+  'close-dogfooding-report-542' is valid`
+- `git diff --check` → passed with no output.
+- `./scripts/harness-check.sh in-progress` → passed branch and active-phase
+  checks.
+
+## Review Focus
+
+An independent reviewer must verify the linked GitHub records, the F2 boundary,
+and that closing #542 does not close or weaken #609.

--- a/docs/evidence/self-review-close-dogfooding-report-542.md
+++ b/docs/evidence/self-review-close-dogfooding-report-542.md
@@ -14,6 +14,7 @@ files, dependencies, schema, or API contracts changed.
 | F2 is not falsely marked fixed | F2 is marked “Mitigated and handed off”; #575/#576 and #609 are linked | Pass |
 | F10 records the decision rationale | F10 identifies the product-owned vocabulary/ranking boundary | Pass |
 | No behavior change is implied | Proposal, design, and closure record explicitly state docs-only scope | Pass |
+| OpenSpec scope matches the implementation | Capability and requirements are limited to issue #542 | Pass |
 
 ## Validation Evidence
 

--- a/openspec/changes/close-dogfooding-report-542/.openspec.yaml
+++ b/openspec/changes/close-dogfooding-report-542/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/close-dogfooding-report-542/design.md
+++ b/openspec/changes/close-dogfooding-report-542/design.md
@@ -1,0 +1,52 @@
+## Context
+
+Issue #542 collects ten observations from one agent-facing dogfooding exercise.
+The shipped work was intentionally split into narrow issues and pull requests.
+The final tracker state must distinguish a delivered fix from a partial
+mitigation, a separately owned follow-up, and a deliberate product boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Publish one auditable finding-to-disposition table for #542.
+- Transfer F2's remaining extraction-time work to #609 without losing the
+  limits of the #575 query-time mitigation.
+- Make the F10 by-design decision discoverable at the tracker.
+
+**Non-Goals:**
+
+- Implement or redefine the high-risk call-resolution work in #609.
+- Change search ranking, graph extraction, MCP behavior, or persistence.
+- Reopen delivered fixes to consolidate their implementation history.
+
+## Decisions
+
+### Use a repository evidence record plus GitHub links
+
+The closure record lives under `docs/evidence/` and links each finding to its
+issue and merged pull request. GitHub is the operational tracker, while the
+repository record remains reviewable with the OpenSpec change.
+
+### Treat F2 as handed off, not complete
+
+#575 mitigates one trace-time ambiguity case by proximity. It does not prove a
+callee's source-level identity and it does not fix extraction, flow, or impact.
+The record therefore marks F2 as handed off to #609 rather than falsely calling
+it fixed.
+
+### Record F10 as by-design
+
+Embedding similarity cannot encode every product-specific distinction without
+an explicit vocabulary and ranking policy. Adding that policy is product work,
+not a corrective change to this dogfooding report, so F10 is closed as
+won't-fix/by-design.
+
+## Risks / Trade-offs
+
+- [Stale links or an incomplete finding table] → Validate every issue/PR URL
+  before review and include all ten F1–F10 rows.
+- [Tracker closure hides unfinished graph quality work] → Link #609 from the
+  F2 row and final GitHub comment, and state its high-risk scope explicitly.
+- [A documentation record looks like a runtime promise] → State that no
+  runtime behavior changes in this change.

--- a/openspec/changes/close-dogfooding-report-542/proposal.md
+++ b/openspec/changes/close-dogfooding-report-542/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Issue #542 is a dogfooding tracker whose nine actionable findings have shipped
+as focused fixes or a bounded mitigation. Its remaining extraction-time
+call-resolution work is high-risk and needs an independently scoped issue;
+the final embedding-ranking finding is an intentional product boundary.
+Closing the tracker without recording those dispositions would make the
+remaining work and the won't-fix decision hard to discover.
+
+## What Changes
+
+- Add a closure record that maps every #542 finding to its delivered fix,
+  follow-up issue, or explicit by-design decision.
+- Link F2's remaining extraction-time JS/TS call-resolution work to #609,
+  which owns its high-risk proposal and implementation lifecycle.
+- Record F10 as won't-fix/by-design because embedding retrieval cannot safely
+  infer domain-specific distinctions without product-owned vocabulary.
+- Close the tracker after publishing the disposition record and GitHub handoff.
+
+## Capabilities
+
+### New Capabilities
+
+- `dogfooding-report-disposition`: Preserve the final disposition of every
+  finding in a completed dogfooding tracker, including shipped fixes, deferred
+  follow-ups, and by-design decisions.
+
+### Modified Capabilities
+
+<!-- None. This change does not alter a runtime product requirement. -->
+
+## Impact
+
+- Documentation and OpenSpec artifacts only; no Go code, API, schema, or
+  runtime behavior changes.
+- GitHub issue #542 receives its final status and links to the new #609
+  high-risk follow-up.

--- a/openspec/changes/close-dogfooding-report-542/proposal.md
+++ b/openspec/changes/close-dogfooding-report-542/proposal.md
@@ -21,9 +21,9 @@ remaining work and the won't-fix decision hard to discover.
 
 ### New Capabilities
 
-- `dogfooding-report-disposition`: Preserve the final disposition of every
-  finding in a completed dogfooding tracker, including shipped fixes, deferred
-  follow-ups, and by-design decisions.
+- `issue-542-dogfooding-report-disposition`: Preserve the final disposition of
+  every finding in issue #542, including shipped fixes, deferred follow-ups,
+  and by-design decisions.
 
 ### Modified Capabilities
 

--- a/openspec/changes/close-dogfooding-report-542/specs/dogfooding-report-disposition/spec.md
+++ b/openspec/changes/close-dogfooding-report-542/specs/dogfooding-report-disposition/spec.md
@@ -1,10 +1,10 @@
 ## ADDED Requirements
 
-### Requirement: Completed dogfooding trackers have a finding disposition record
-The repository SHALL retain an evidence record for a completed dogfooding
-tracker that lists every reported finding and its final disposition. Each row
-MUST identify the associated shipped change, a separately owned follow-up, or
-an explicit by-design decision.
+### Requirement: Issue #542 has a finding disposition record
+The repository SHALL retain an evidence record for issue #542 that lists every
+reported finding and its final disposition. Each row MUST identify the
+associated shipped change, a separately owned follow-up, or an explicit
+by-design decision.
 
 #### Scenario: A finding was fixed in a focused change
 - **WHEN** a tracker finding shipped through a focused issue and pull request
@@ -15,9 +15,9 @@ an explicit by-design decision.
 - **THEN** its disposition record links to the follow-up issue and does not
   describe the finding as fixed
 
-### Requirement: Tracker closure preserves explicit non-fix decisions
-The repository SHALL state the rationale when a tracker finding is closed as
-won't-fix or by-design.
+### Requirement: Issue #542 closure preserves its non-fix decision
+The repository SHALL state the rationale for issue #542's finding when it is
+closed as won't-fix or by-design.
 
 #### Scenario: A product boundary is retained
 - **WHEN** a finding is outside the intended product behavior

--- a/openspec/changes/close-dogfooding-report-542/specs/dogfooding-report-disposition/spec.md
+++ b/openspec/changes/close-dogfooding-report-542/specs/dogfooding-report-disposition/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Completed dogfooding trackers have a finding disposition record
+The repository SHALL retain an evidence record for a completed dogfooding
+tracker that lists every reported finding and its final disposition. Each row
+MUST identify the associated shipped change, a separately owned follow-up, or
+an explicit by-design decision.
+
+#### Scenario: A finding was fixed in a focused change
+- **WHEN** a tracker finding shipped through a focused issue and pull request
+- **THEN** its disposition record links to that issue and pull request
+
+#### Scenario: A finding requires separately scoped work
+- **WHEN** a tracker finding is not safely implementable within the tracker
+- **THEN** its disposition record links to the follow-up issue and does not
+  describe the finding as fixed
+
+### Requirement: Tracker closure preserves explicit non-fix decisions
+The repository SHALL state the rationale when a tracker finding is closed as
+won't-fix or by-design.
+
+#### Scenario: A product boundary is retained
+- **WHEN** a finding is outside the intended product behavior
+- **THEN** the disposition record names that boundary and the tracker closure
+  communicates the decision

--- a/openspec/changes/close-dogfooding-report-542/tasks.md
+++ b/openspec/changes/close-dogfooding-report-542/tasks.md
@@ -1,0 +1,16 @@
+## 1. Validate the tracker handoff
+
+- [x] 1.1 Verify the shipped issue and pull-request records for F1–F9.
+- [x] 1.2 Create #609 for the remaining high-risk F2 root-cause work.
+
+## 2. Publish the final disposition
+
+- [x] 2.1 Add a complete F1–F10 disposition record under `docs/evidence/`.
+- [x] 2.2 State F2's #575 mitigation limits and its #609 handoff.
+- [x] 2.3 State F10's won't-fix/by-design rationale.
+
+## 3. Validate and close
+
+- [x] 3.1 Run strict OpenSpec validation and documentation checks.
+- [ ] 3.2 Obtain an independent review verdict and address findings.
+- [ ] 3.3 Publish the documentation change, comment on #542, and close it.

--- a/openspec/changes/close-dogfooding-report-542/tasks.md
+++ b/openspec/changes/close-dogfooding-report-542/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Validate the tracker handoff
 
-- [x] 1.1 Verify the shipped issue and pull-request records for F1–F9.
+- [x] 1.1 Verify F1 and F3–F9 delivery records plus F2's mitigation record.
 - [x] 1.2 Create #609 for the remaining high-risk F2 root-cause work.
 
 ## 2. Publish the final disposition

--- a/openspec/changes/close-dogfooding-report-542/tasks.md
+++ b/openspec/changes/close-dogfooding-report-542/tasks.md
@@ -12,5 +12,5 @@
 ## 3. Validate and close
 
 - [x] 3.1 Run strict OpenSpec validation and documentation checks.
-- [ ] 3.2 Obtain an independent review verdict and address findings.
+- [x] 3.2 Obtain an independent review verdict and address findings.
 - [ ] 3.3 Publish the documentation change, comment on #542, and close it.


### PR DESCRIPTION
## Summary

- add a verified F1–F10 closure record for the #542 dogfooding tracker
- hand F2 root-cause extraction work to high-risk follow-up #609 without claiming it is fixed
- record F10 as a by-design product boundary and preserve independent review evidence

## Validation

- `openspec validate close-dogfooding-report-542 --strict`
- `git diff --check`
- `./scripts/harness-check.sh in-progress`
- independent goal, QA, quality, security, and context review (all PASS after scope correction)

Closes #542