### PR TITLE
feat(graph): model Redis Pub/Sub event topology

### DIFF
--- a/internal/flow/stitch.go
+++ b/internal/flow/stitch.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/nano-brain/nano-brain/internal/graph"
@@ -10,6 +11,10 @@ import (
 
 type StitchQuerier interface {
 	ListConsumerEntryNodesByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.GraphEdge, error)
+}
+
+type allEdgesQuerier interface {
+	ListAllEdgesByWorkspace(ctx context.Context, workspaceHash string) ([]sqlc.GraphEdge, error)
 }
 
 type consumerEntry struct {
@@ -33,6 +38,7 @@ func Stitch(ctx context.Context, publishEdges []graph.Edge, targetWorkspaces []s
 	}
 
 	consumers := make(map[string][]consumerEntry)
+	emitters := make(map[string][]graph.Edge)
 	for _, ws := range unique {
 		edges, err := querier.ListConsumerEntryNodesByWorkspace(ctx, ws)
 		if err != nil {
@@ -49,6 +55,19 @@ func Stitch(ctx context.Context, publishEdges []graph.Edge, targetWorkspaces []s
 					workspaceHash: wsID,
 					sourceNode:    e.SourceNode,
 				})
+				continue
+			}
+		}
+		if aq, ok := querier.(allEdgesQuerier); ok {
+			all, err := aq.ListAllEdgesByWorkspace(ctx, ws)
+			if err == nil {
+				for _, e := range all {
+					var metadata map[string]any
+					_ = json.Unmarshal(e.Metadata, &metadata)
+					if topic, ok := metadata["topic"].(string); ok && topic != "" && metadata["event_role"] == "emit" {
+						emitters[topic] = append(emitters[topic], graph.Edge{SourceNode: e.SourceNode, TargetNode: e.TargetNode, Kind: graph.EdgeKind(e.EdgeType), SourceFile: e.SourceFile})
+					}
+				}
 			}
 		}
 	}
@@ -71,6 +90,12 @@ func Stitch(ctx context.Context, publishEdges []graph.Edge, targetWorkspaces []s
 					Kind:                  "cross_service",
 					CrossServiceWorkspace: t.workspaceHash,
 				})
+				for _, emitter := range emitters[topic] {
+					if emitter.SourceNode != t.sourceNode {
+						continue
+					}
+					result = append(result, FlowEdge{From: t.sourceNode, To: emitter.TargetNode, Kind: "event_emit", CrossServiceWorkspace: t.workspaceHash})
+				}
 			}
 		}
 	}

--- a/internal/graph/js_integration_extractor.go
+++ b/internal/graph/js_integration_extractor.go
@@ -334,7 +334,7 @@ func (x *JSIntegrationExtractor) handleIdentifier(bt *gotreesitter.BoundTree, ca
 			SourceFile: relFile,
 			Line:       line,
 			Language:   langLabel,
-			Metadata:   map[string]any{"kind": "queue_publish", "method": funcName, "topic": topic},
+			Metadata:   map[string]any{"kind": "queue_publish", "event_role": "publish", "method": funcName, "topic": topic},
 		})
 		return
 	}
@@ -350,7 +350,7 @@ func (x *JSIntegrationExtractor) handleIdentifier(bt *gotreesitter.BoundTree, ca
 			SourceFile: relFile,
 			Line:       line,
 			Language:   langLabel,
-			Metadata:   map[string]any{"kind": "queue_consumer", "method": funcName, "topic": topic},
+			Metadata:   map[string]any{"kind": "queue_consumer", "event_role": "subscribe", "method": funcName, "topic": topic},
 		})
 	}
 }
@@ -391,7 +391,7 @@ func (x *JSIntegrationExtractor) handleRedisCall(bt *gotreesitter.BoundTree, cal
 				SourceFile: relFile,
 				Line:       line,
 				Language:   langLabel,
-				Metadata:   map[string]any{"kind": "queue_consumer", "method": methodName, "topic": topic},
+				Metadata:   map[string]any{"kind": "queue_consumer", "event_role": "subscribe", "method": methodName, "topic": topic},
 			})
 			return consumeNode
 		}
@@ -403,7 +403,7 @@ func (x *JSIntegrationExtractor) handleRedisCall(bt *gotreesitter.BoundTree, cal
 			SourceFile: relFile,
 			Line:       line,
 			Language:   langLabel,
-			Metadata:   map[string]any{"kind": kind, "method": methodName, "receiver": receiverName, "topic": topic},
+			Metadata:   map[string]any{"kind": kind, "event_role": "publish", "method": methodName, "receiver": receiverName, "topic": topic},
 		})
 		return target
 	}
@@ -458,7 +458,7 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 						SourceFile: relFile,
 						Line:       line,
 						Language:   langLabel,
-						Metadata:   map[string]any{"kind": "queue_publish", "method": methodName, "receiver": receiverName, "topic": jobName},
+						Metadata:   map[string]any{"kind": "queue_publish", "event_role": "publish", "method": methodName, "receiver": receiverName, "topic": jobName},
 					})
 				} else {
 					consumeNode := "CONSUME " + jobName
@@ -469,7 +469,7 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 						SourceFile: relFile,
 						Line:       line,
 						Language:   langLabel,
-						Metadata:   map[string]any{"kind": "queue_consumer", "method": methodName, "receiver": receiverName, "topic": jobName},
+						Metadata:   map[string]any{"kind": "queue_consumer", "event_role": "subscribe", "method": methodName, "receiver": receiverName, "topic": jobName},
 					})
 				}
 				return
@@ -534,7 +534,7 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 			SourceFile: relFile,
 			Line:       line,
 			Language:   langLabel,
-			Metadata:   map[string]any{"kind": "queue_publish", "method": methodName, "receiver": receiverName, "topic": topic},
+			Metadata:   map[string]any{"kind": "queue_publish", "event_role": eventRole(methodName), "method": methodName, "receiver": receiverName, "topic": topic},
 		})
 		return
 	}
@@ -550,7 +550,7 @@ func (x *JSIntegrationExtractor) handleMemberExpression(bt *gotreesitter.BoundTr
 			SourceFile: relFile,
 			Line:       line,
 			Language:   langLabel,
-			Metadata:   map[string]any{"kind": "queue_consumer", "method": methodName, "receiver": receiverName, "topic": topic},
+			Metadata:   map[string]any{"kind": "queue_consumer", "event_role": "subscribe", "method": methodName, "receiver": receiverName, "topic": topic},
 		})
 	}
 }
@@ -566,6 +566,13 @@ func jsReceiverText(bt *gotreesitter.BoundTree, node *gotreesitter.Node, lang *g
 	default:
 		return bt.NodeText(node)
 	}
+}
+
+func eventRole(method string) string {
+	if method == "emit" || method == "broadcast" || method == "notify" {
+		return "emit"
+	}
+	return "publish"
 }
 
 // jsStringArgOrVar returns the string value of the nth argument if it is a string

--- a/internal/graph/redis_pubsub_event_topology_test.go
+++ b/internal/graph/redis_pubsub_event_topology_test.go
@@ -1,0 +1,36 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func TestJSRedisPubSubEventRoles(t *testing.T) {
+	extractor, err := graph.NewJSIntegrationExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte(`
+redis.publish("tradestate", payload)
+socket.on("tradestate", (state) => io.emit("tradestate", state))
+`)
+	edges, err := extractor.ExtractEdges("socket.js", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roles := map[string]bool{}
+	for _, edge := range edges {
+		if edge.Metadata == nil {
+			continue
+		}
+		if role, ok := edge.Metadata["event_role"].(string); ok {
+			roles[role] = true
+		}
+	}
+	for _, role := range []string{"publish", "subscribe", "emit"} {
+		if !roles[role] {
+			t.Errorf("missing event role %q in extracted edges: %#v", role, edges)
+		}
+	}
+}

--- a/internal/graph/vue_pubsub_event_topology_test.go
+++ b/internal/graph/vue_pubsub_event_topology_test.go
@@ -1,0 +1,27 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/nano-brain/nano-brain/internal/graph"
+)
+
+func TestVueSFCExtractsSocketEventRole(t *testing.T) {
+	extractor, err := graph.NewVueSFCExtractor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges, err := extractor.ExtractEdges("SocketInstance.vue", []byte(`<template><div /></template>
+<script>
+socket.on('tradestate', (state) => setTradeState(state))
+</script>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, edge := range edges {
+		if edge.Metadata != nil && edge.Metadata["event_role"] == "subscribe" && edge.Metadata["topic"] == "tradestate" {
+			return
+		}
+	}
+	t.Fatalf("missing tradestate subscribe edge: %#v", edges)
+}

--- a/internal/graph/vue_sfc_extractor.go
+++ b/internal/graph/vue_sfc_extractor.go
@@ -19,17 +19,17 @@ const vueInjectionQuery = `
 var _ Extractor = (*VueSFCExtractor)(nil)
 
 type VueSFCExtractor struct {
-	ip            *gotreesitter.InjectionParser
-	tsImportQ     *gotreesitter.Query
-	tsContainsQ   *gotreesitter.Query
-	tsCallFuncQ   *gotreesitter.Query
-	tsCallExprQ   *gotreesitter.Query
-	jsImportQ     *gotreesitter.Query
-	jsContainsQ   *gotreesitter.Query
-	jsCallFuncQ   *gotreesitter.Query
-	jsCallExprQ   *gotreesitter.Query
-	tsLang        *gotreesitter.Language
-	jsLang        *gotreesitter.Language
+	ip          *gotreesitter.InjectionParser
+	tsImportQ   *gotreesitter.Query
+	tsContainsQ *gotreesitter.Query
+	tsCallFuncQ *gotreesitter.Query
+	tsCallExprQ *gotreesitter.Query
+	jsImportQ   *gotreesitter.Query
+	jsContainsQ *gotreesitter.Query
+	jsCallFuncQ *gotreesitter.Query
+	jsCallExprQ *gotreesitter.Query
+	tsLang      *gotreesitter.Language
+	jsLang      *gotreesitter.Language
 }
 
 func NewVueSFCExtractor() (*VueSFCExtractor, error) {
@@ -132,6 +132,7 @@ func (e *VueSFCExtractor) ExtractEdges(filePath string, content []byte) ([]Edge,
 
 		bt.Release()
 	}
+	edges = append(edges, e.extractIntegrationEdges(relFile, content)...)
 
 	return edges, nil
 }
@@ -171,8 +172,49 @@ func (e *VueSFCExtractor) ExtractEdgesWithImportContext(filePath string, content
 
 		bt.Release()
 	}
+	edges = append(edges, e.extractIntegrationEdges(relFile, content)...)
 
 	return edges, nil
+}
+
+func (e *VueSFCExtractor) extractIntegrationEdges(filePath string, content []byte) []Edge {
+	extractor, err := NewJSIntegrationExtractor()
+	if err != nil {
+		return nil
+	}
+	virtualPath := filePath + ".js"
+	script := vueScriptContent(content)
+	if len(script) == 0 {
+		return nil
+	}
+	edges, err := extractor.ExtractEdges(virtualPath, script)
+	if err != nil {
+		return nil
+	}
+	for i := range edges {
+		edges[i].SourceFile = filePath
+		edges[i].SourceNode = strings.TrimPrefix(edges[i].SourceNode, virtualPath)
+		edges[i].SourceNode = filePath + edges[i].SourceNode
+	}
+	return edges
+}
+
+func vueScriptContent(content []byte) []byte {
+	text := string(content)
+	start := strings.Index(text, "<script")
+	if start < 0 {
+		return nil
+	}
+	openEnd := strings.IndexByte(text[start:], '>')
+	if openEnd < 0 {
+		return nil
+	}
+	start += openEnd + 1
+	end := strings.Index(text[start:], "</script>")
+	if end < 0 {
+		return nil
+	}
+	return []byte(text[start : start+end])
 }
 
 func (e *VueSFCExtractor) resolveLang(langName string) (*gotreesitter.Language, *gotreesitter.Query, *gotreesitter.Query, *gotreesitter.Query, *gotreesitter.Query) {


### PR DESCRIPTION
## Summary
- add explicit event roles for JavaScript/TypeScript publish, subscribe, and emit integration edges
- extend flow stitching to connect matching publisher → consumer → emit paths
- add Redis/Socket.IO event-role regression coverage

## Why
Redis Pub/Sub and Socket.IO events are event topology, not direct calls. The graph needs explicit roles so trade-state flows can be traced without misrepresenting cross-process delivery as a function call.

## Validation
- `CGO_ENABLED=0 go build ./...`
- `go test -race ./internal/graph ./internal/flow`

Closes #612
