### PR TITLE
fix(harvest): check for an existing summary before parsing the session file

### DIFF
--- a/internal/harvest/claudecode.go
+++ b/internal/harvest/claudecode.go
@@ -112,21 +112,12 @@ func (h *ClaudeCodeHarvester) HarvestAll(ctx context.Context, enqueuer ChunkEnqu
 }
 
 func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile string, enqueuer ChunkEnqueuer) (harvestResult, error) {
-	msgs, err := parseJSONLFile(sessionFile)
-	if err != nil {
-		return harvestSkipped, fmt.Errorf("parse JSONL: %w", err)
-	}
-
-	if len(msgs) == 0 {
-		return harvestSkipped, nil
-	}
-
+	// The session's identity comes from its filename, so the presence check that
+	// decides whether this file needs any work is answerable without reading it.
+	// It runs first for that reason: the parse, render and hash below are pure
+	// waste on the skip path, which is every already-harvested session on every
+	// cycle. Ordering matches OpenCodeSQLiteHarvester.HarvestAll.
 	sessionID := strings.TrimSuffix(filepath.Base(sessionFile), ".jsonl")
-	md := renderClaudeCodeMarkdown(sessionID, msgs)
-
-	sum := sha256.Sum256([]byte(md))
-	contentHash := hex.EncodeToString(sum[:])
-
 	sourcePath := "summary://claude/" + sessionID
 
 	queries := sqlc.New(h.db)
@@ -164,6 +155,21 @@ func (h *ClaudeCodeHarvester) harvestSession(ctx context.Context, sessionFile st
 		}
 		return harvestSkipped, nil
 	}
+
+	// Only now is the file's content needed.
+	msgs, parseErr := parseJSONLFile(sessionFile)
+	if parseErr != nil {
+		return harvestSkipped, fmt.Errorf("parse JSONL: %w", parseErr)
+	}
+
+	if len(msgs) == 0 {
+		return harvestSkipped, nil
+	}
+
+	md := renderClaudeCodeMarkdown(sessionID, msgs)
+
+	sum := sha256.Sum256([]byte(md))
+	contentHash := hex.EncodeToString(sum[:])
 
 	// Find createdAt from the first message that actually carries a timestamp.
 	// Leading records (type=="mode", "file-history-snapshot", etc.) have no


### PR DESCRIPTION
Fixes #619.

## What

`harvestSession` parsed, rendered and hashed every session JSONL **before** the DB lookup that decides whether any of that work was needed. The skip predicate is presence-based, so the answer was "not needed" for every already-harvested session — meaning each cycle re-read the whole session corpus and discarded the result.

This moves `GetDocumentBySourcePath` above `parseJSONLFile`. Pure reorder, no new state.

## Why it is safe

The document identity does not depend on file contents:

```go
sessionID  := strings.TrimSuffix(filepath.Base(sessionFile), ".jsonl")
sourcePath := "summary://claude/" + sessionID
```

`sessionID` comes from the filename, so the presence check is answerable with zero bytes read. The `EnsureSummaryOnDisk` backfill on the skip path uses `existing.Content` from the DB, not the parsed messages, so it does not need `msgs` either. The only content-dependent guard that moved below the lookup is `len(msgs) == 0`, which only affects files that have no stored document anyway.

`OpenCodeSQLiteHarvester.HarvestAll` already ordered it this way — the two harvesters had the same logic with two steps transposed, and `claudecode.go` even carried the comment *"Presence-based dedup (mirrors OpenCodeSQLiteHarvester)"*. It mirrored the predicate but not its position.

## Measured

7 registered workspaces, 385 session files / 889MB of JSONL, `session_poll: 120`. Daemon otherwise idle (embed queue `pending: 0`). Sampling `ps -o %cpu,rss` every 5s:

| | before | after |
|---|---|---|
| cold-start peak RSS | 2755 MB | **472 MB** |
| one harvest cycle (triggered) | 128 MB → ~2.6 GB | 128 MB → **342 MB** |
| avg RSS over sample window | 1477 MB | **286 MB** |

Harvest output unchanged: `0 harvested, 1893 skipped, 0 errors` before and after.

## Rejected alternative

An in-memory `map[path]"mtime-size"` guard in front of the parse. It works while the process is up, but the map is cold on restart, so a restart still re-reads the entire corpus — measured at 2755MB on exactly that path. It also adds per-harvester state that the sibling implementation does not need. The reorder makes the DB the state, which is already durable.

## Verification

- `go build ./...` — pass
- `go vet ./internal/harvest/` — pass
- `go test ./internal/harvest/` — pass
- Ran the rebuilt daemon, triggered a harvest, confirmed identical skip counts at the reduced footprint

## Not addressed here

Two things found while measuring, noted in #619:

1. A pathological parse holds one core at ~100% indefinitely inside `gotreesitter` GLR stack-merge frames, with no parse timeout anywhere in `internal/chunker` or `internal/symbol`. Independent of this change; root cause not yet identified.
2. The skip path still `SELECT`s the full document `Content` to test `ContentHash != ""` — the remaining per-cycle allocation. `EnsureSummaryOnDisk` needs that column, but only when a summarizer is configured.
