### PR TITLE
fix(parser): bound tree-sitter parses with a timeout

### DIFF
--- a/internal/chunker/symbol.go
+++ b/internal/chunker/symbol.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -72,11 +73,19 @@ func (s *SymbolAwareChunker) Chunk(content string, sourcePath string) []Chunk {
 	}
 
 	contentBytes := []byte(content)
-	parser := gotreesitter.NewParser(pl.lang)
+	parser := tsparse.NewParser(pl.lang)
 	tree, err := parser.Parse(contentBytes)
 	if err != nil {
 		s.logger.Warn().Err(err).Str("file", sourcePath).Msg("tree-sitter parse failed, using fallback")
 		return s.fallback.Chunk(content, sourcePath)
+	}
+	// An early stop yields a partial tree with a nil error, so without this the
+	// file would be chunked from incomplete syntax with nothing to show for it.
+	if tree.ParseStoppedEarly() {
+		s.logger.Warn().
+			Str("file", sourcePath).
+			Str("reason", string(tree.ParseStopReason())).
+			Msg("tree-sitter stopped early, chunking a partial tree")
 	}
 	bt := gotreesitter.Bind(tree)
 	defer bt.Release()

--- a/internal/graph/call_resolver_exports.go
+++ b/internal/graph/call_resolver_exports.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -85,7 +86,7 @@ func parseDirectExports(filePath string, content []byte) map[string]directExport
 	if lang == nil {
 		return nil
 	}
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil

--- a/internal/graph/echo_extractor.go
+++ b/internal/graph/echo_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -38,7 +39,7 @@ func (e *EchoRouteExtractor) RequiresFrameworks() []string {
 // ExtractEdges parses content as Go source and returns http + middleware edges
 // for any Echo route/group/Use registrations found.
 func (e *EchoRouteExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/express_extractor.go
+++ b/internal/graph/express_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	zerolog "github.com/rs/zerolog"
@@ -40,7 +41,7 @@ func (e *ExpressExtractor) ExtractEdges(filePath string, content []byte) ([]Edge
 	}
 	relFile := filepath.ToSlash(filePath)
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("express parse %s: %w", filePath, err)

--- a/internal/graph/gin_extractor.go
+++ b/internal/graph/gin_extractor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -34,7 +35,7 @@ func (e *GinExtractor) RequiresFrameworks() []string {
 }
 
 func (e *GinExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/go_extractor.go
+++ b/internal/graph/go_extractor.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -79,7 +80,7 @@ func (e *GoGraphExtractor) Supports(ext string) bool {
 }
 
 func (e *GoGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/integration_extractor.go
+++ b/internal/graph/integration_extractor.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -101,7 +102,7 @@ func (x *IntegrationExtractor) ExtractEdges(filePath string, content []byte) ([]
 	lang := x.lang
 	relFile := filepath.ToSlash(filePath)
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, err

--- a/internal/graph/javascript_extractor.go
+++ b/internal/graph/javascript_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -73,7 +74,7 @@ func (e *JavaScriptGraphExtractor) Supports(ext string) bool {
 var _ ImportResolvingExtractor = (*JavaScriptGraphExtractor)(nil)
 
 func (e *JavaScriptGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)
@@ -95,7 +96,7 @@ func (e *JavaScriptGraphExtractor) ExtractEdges(filePath string, content []byte)
 // edges are resolved via ic (see ImportResolvingExtractor). ExtractEdges
 // itself is untouched so existing callers/tests keep seeing raw specifiers.
 func (e *JavaScriptGraphExtractor) ExtractEdgesWithImportContext(filePath string, content []byte, ic ImportContext) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/js_cflow.go
+++ b/internal/graph/js_cflow.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -44,7 +45,7 @@ func (x *JSControlFlowExtractor) ExtractCFGs(filePath string, content []byte) ([
 	ext := filepath.Ext(filePath)
 	lang, _ := x.langForExt(ext)
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/js_integration_extractor.go
+++ b/internal/graph/js_integration_extractor.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -159,7 +160,7 @@ func (x *JSIntegrationExtractor) ExtractEdges(filePath string, content []byte) (
 	lang, langLabel := x.langForExt(filepath.Ext(filePath))
 	relFile := filepath.ToSlash(filePath)
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, err

--- a/internal/graph/nestjs_extractor.go
+++ b/internal/graph/nestjs_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	zerolog "github.com/rs/zerolog"
@@ -50,7 +51,7 @@ func (e *NestJSExtractor) ExtractEdges(filePath string, content []byte) ([]Edge,
 	}
 	relFile := filepath.ToSlash(filePath)
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("nestjs parse %s: %w", filePath, err)

--- a/internal/graph/nethttp_extractor.go
+++ b/internal/graph/nethttp_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -29,7 +30,7 @@ func (e *NetHTTPExtractor) RequiresFrameworks() []string {
 }
 
 func (e *NetHTTPExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/python_extractor.go
+++ b/internal/graph/python_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -79,7 +80,7 @@ func (e *PythonGraphExtractor) Supports(ext string) bool {
 }
 
 func (e *PythonGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/python_integration_extractor.go
+++ b/internal/graph/python_integration_extractor.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -56,7 +57,7 @@ func (x *PythonIntegrationExtractor) ExtractEdges(filePath string, content []byt
 	lang := x.lang
 	relFile := filepath.ToSlash(filePath)
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, err

--- a/internal/graph/rails_dsl_extractor.go
+++ b/internal/graph/rails_dsl_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -69,7 +70,7 @@ func (x *RailsDSLEdgeExtractor) Language() string {
 }
 
 func (x *RailsDSLEdgeExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(x.lang)
+	parser := tsparse.NewParser(x.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("rails_dsl parse %s: %w", filePath, err)

--- a/internal/graph/rails_extractor.go
+++ b/internal/graph/rails_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	zerolog "github.com/rs/zerolog"
@@ -51,7 +52,7 @@ func (e *RailsExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, 
 	relFile := filepath.ToSlash(filePath)
 	lang := grammars.RubyLanguage()
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("rails parse %s: %w", filePath, err)

--- a/internal/graph/ruby_cflow.go
+++ b/internal/graph/ruby_cflow.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	"github.com/rs/zerolog"
@@ -29,7 +30,7 @@ func (x *RubyControlFlowExtractor) SupportsCFG(ext string) bool {
 }
 
 func (x *RubyControlFlowExtractor) ExtractCFGs(filePath string, content []byte) ([]CFG, error) {
-	parser := gotreesitter.NewParser(x.lang)
+	parser := tsparse.NewParser(x.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/ruby_extractor.go
+++ b/internal/graph/ruby_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -68,7 +69,7 @@ func (e *RubyGraphExtractor) RequiresFrameworks() []string {
 }
 
 func (e *RubyGraphExtractor) ExtractEdges(filePath string, content []byte) ([]Edge, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/graph/ruby_resolver.go
+++ b/internal/graph/ruby_resolver.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	zerolog "github.com/rs/zerolog"
@@ -58,7 +59,7 @@ func (r *RubyCrossFileResolver) ResolveEdges(edges []Edge, fileContents map[stri
 }
 
 func (r *RubyCrossFileResolver) resolveFileAST(filePath string, content []byte) []Edge {
-	parser := gotreesitter.NewParser(r.lang)
+	parser := tsparse.NewParser(r.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil

--- a/internal/graph/typescript_extractor.go
+++ b/internal/graph/typescript_extractor.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -109,7 +110,7 @@ func (e *TypeScriptGraphExtractor) ExtractEdges(filePath string, content []byte)
 		lang, importQ, containsQ, callFuncQ, callExprQ = e.tsxLang, e.tsxImportQ, e.tsxContainsQ, e.tsxCallFuncQ, e.tsxCallExprQ
 	}
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)
@@ -136,7 +137,7 @@ func (e *TypeScriptGraphExtractor) ExtractEdgesWithImportContext(filePath string
 		lang, importQ, containsQ = e.tsxLang, e.tsxImportQ, e.tsxContainsQ
 	}
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/symbol/go_extractor.go
+++ b/internal/symbol/go_extractor.go
@@ -3,6 +3,7 @@ package symbol
 import (
 	"fmt"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -34,7 +35,7 @@ func (e *GoExtractor) Supports(ext string) bool {
 }
 
 func (e *GoExtractor) Extract(filePath string, content []byte) ([]Symbol, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/symbol/javascript_extractor.go
+++ b/internal/symbol/javascript_extractor.go
@@ -3,6 +3,7 @@ package symbol
 import (
 	"fmt"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -33,7 +34,7 @@ func (e *JavaScriptExtractor) Supports(ext string) bool {
 }
 
 func (e *JavaScriptExtractor) Extract(filePath string, content []byte) ([]Symbol, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/symbol/python_extractor.go
+++ b/internal/symbol/python_extractor.go
@@ -3,6 +3,7 @@ package symbol
 import (
 	"fmt"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -31,7 +32,7 @@ func (e *PythonExtractor) Supports(ext string) bool {
 }
 
 func (e *PythonExtractor) Extract(filePath string, content []byte) ([]Symbol, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/symbol/ruby_extractor.go
+++ b/internal/symbol/ruby_extractor.go
@@ -3,6 +3,7 @@ package symbol
 import (
 	"fmt"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -34,7 +35,7 @@ func (e *RubySymbolExtractor) Supports(ext string) bool {
 }
 
 func (e *RubySymbolExtractor) Extract(filePath string, content []byte) ([]Symbol, error) {
-	parser := gotreesitter.NewParser(e.lang)
+	parser := tsparse.NewParser(e.lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/symbol/typescript_extractor.go
+++ b/internal/symbol/typescript_extractor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/nano-brain/nano-brain/internal/tsparse"
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
@@ -48,7 +49,7 @@ func (e *TypeScriptExtractor) Extract(filePath string, content []byte) ([]Symbol
 		lang, q = e.tsxLang, e.tsxQ
 	}
 
-	parser := gotreesitter.NewParser(lang)
+	parser := tsparse.NewParser(lang)
 	tree, err := parser.Parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", filePath, err)

--- a/internal/tsparse/tsparse.go
+++ b/internal/tsparse/tsparse.go
@@ -1,0 +1,36 @@
+// Package tsparse constructs tree-sitter parsers that give up on a single file
+// instead of running unbounded.
+package tsparse
+
+import (
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// DefaultTimeout bounds one file's parse.
+//
+// gotreesitter caps a parse's memory (512MB by default, see
+// GOT_PARSE_MEMORY_BUDGET_MB) but not its running time: SetTimeoutMicros(0)
+// disables the check and Parser.reset leaves it at 0. Its GLR stack merging can
+// spin in node-equivalence lookups without allocating past that budget, which
+// is how a single input held a core for 30 hours. The timeout is tested once
+// per iteration of the parse loop, so it ends that spin.
+//
+// The value is deliberately loose. This is a backstop for a parse that will
+// never finish, not a latency target, and it is wall-clock — so it has to stay
+// clear of legitimate large files on a slow or loaded machine. At 5s it cut off
+// real parses in graph's *_cflow_test.go large-input cases once -race slowed
+// them down (8.0s and 5.1s). Those tests are the guard against setting this too
+// tight; if they start failing, raise this rather than weaken them.
+const DefaultTimeout = 30 * time.Second
+
+// NewParser returns a parser for lang that stops after DefaultTimeout.
+//
+// A parse that hits the timeout returns a partial tree rather than an error —
+// callers that care can check Tree.ParseStoppedEarly.
+func NewParser(lang *gotreesitter.Language) *gotreesitter.Parser {
+	parser := gotreesitter.NewParser(lang)
+	parser.SetTimeoutMicros(uint64(DefaultTimeout / time.Microsecond))
+	return parser
+}

--- a/internal/tsparse/tsparse_test.go
+++ b/internal/tsparse/tsparse_test.go
@@ -1,0 +1,18 @@
+package tsparse
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// The whole point of this package is that the parser comes back bounded. A
+// parser with no timeout is what held a core and multiple GB of heap, and
+// gotreesitter's own default is 0 (unbounded), so an unset timeout is silent.
+func TestNewParserIsBounded(t *testing.T) {
+	parser := NewParser(grammars.GoLanguage())
+
+	if got := parser.TimeoutMicros(); got == 0 {
+		t.Fatal("NewParser returned a parser with no timeout; a runaway parse would be unbounded")
+	}
+}


### PR DESCRIPTION
Fixes #621.

## What

`gotreesitter` bounds a parse's **memory** (512MB by default, via `GOT_PARSE_MEMORY_BUDGET_MB`) but not its **running time**: `SetTimeoutMicros(0)` disables the check and `Parser.reset()` leaves it at 0. Its GLR stack merging can spin in node-equivalence lookups without allocating past that budget — which is how a single input held a core for **30 hours** on my machine while memory grew from other work.

nano-brain never set a timeout at any of its 27 parser construction sites. This adds `internal/tsparse.NewParser`, which returns a parser bounded to `DefaultTimeout`, and routes all 27 sites through it. The timeout is tested once per iteration of the parse loop, so it ends the spin.

## Measured

Same machine, same 7 workspaces, daemon started fresh both times.

| | before | after |
|---|---|---|
| CPU | pegged 90–100%, never idle | avg **12.2%**, **11 of 18 samples at 0.0%** |
| RSS | 2166MB while only 19.7% CPU | peak **69MB**, min **19MB** |
| physical footprint (peak) | **6.3GB** | — |
| swapped out | 3.2GB | — |

The old daemon held ~95% CPU across 30 hours of uptime and never returned to idle. The new one sits at 0.0% and 19MB whenever there is nothing to index.

`vmmap` on the old live process showed the retention was Go heap, not cgo or mapped files (the binary is `CGO_ENABLED=0`):

```
REGION TYPE          VIRTUAL  RESIDENT   DIRTY  SWAPPED  COUNT
VM_ALLOCATE             7.8G      2.2G    2.2G     1.1G    837
MALLOC_NANO           512.0M       48K     48K    2496K      1
```

A `SIGQUIT` goroutine dump ruled out a goroutine leak — 33 goroutines, one runnable.

## Why 30s and not something tight

First attempt used 5s. `go test -race -short ./...` then failed two **legitimate** cases:

```
FAIL: TestJSControlFlowExtractor_LargeFunctionTruncated (8.03s)  expected 1 CFG, got 0
FAIL: TestRubyControlFlowExtractor_LargeMethodTruncated (5.14s)  expected 1 CFG, got 0
```

Both parse large-but-valid input, and `-race` slows the parse enough to cross 5s. Those tests pass without `-race`, so this only shows up in the full ladder — which is exactly what the ladder is for.

The lesson is that this bound is wall-clock and therefore machine-dependent: a value tuned on an idle machine will truncate real files on a loaded or slower one. 30s keeps clear of that while still turning a 30-hour spin into 30 seconds. It is a backstop for a parse that will never finish, not a latency target, and the comment on the const says so, along with a pointer to those two tests as the guard against tightening it.

## Also: report early stops instead of silently indexing partial syntax

A parse that hits the bound returns a **partial tree with a nil error**, so without this the file would be chunked from incomplete syntax and nothing would say so. `internal/chunker/symbol.go` — the path every indexed file goes through, which already has the logger and the path — now logs the file and `ParseStopReason` when `ParseStoppedEarly()` is true.

That log is also the diagnostic that has been missing all along: it names the file that triggers this, which nothing so far has identified. Note it fires for any early stop, including the pre-existing 512MB memory budget, not only the new timeout.

## Notes

- `SetCancellationFlag` exists too and is unused here; a timeout needs no lifecycle plumbing and is sufficient for the indexing path.
- The library's other bounds (`GOT_GLR_MAX_STACKS`, `GOT_PARSE_NODE_LIMIT_SCALE`, `GOT_PARSE_MEMORY_BUDGET_MB`) are process-global env vars, so they are not appropriate to set from library code.
- A 30s bound still means a pathological file can burn a core for 30s each time it is re-indexed. The new log line is what makes it possible to identify and exclude that file properly.
- Pre-existing gofmt drift in some touched files (struct field over-alignment) is left alone.

## Verification

- `go build ./...` — pass
- `go test -race -short ./...` — pass (the exact command the repo's pre-commit harness gate runs as check 2.3)
- `TestNewParserIsBounded` fails if the timeout is ever dropped, since an unset timeout is otherwise silent
- Ran the rebuilt daemon against all 7 workspaces and sampled for 90s (numbers above)
