### PR TITLE
fix(harvest): skip an opencode DB whose file is unchanged

### DIFF
--- a/internal/harvest/opencode_sqlite.go
+++ b/internal/harvest/opencode_sqlite.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -27,6 +28,10 @@ type OpenCodeSQLiteHarvester struct {
 	dbPath     string
 	logger     zerolog.Logger
 	summarizer SessionSummarizer
+	// lastStamp is the "mtime-size" of dbPath as of the last cycle that opened
+	// it without error. Guarded by Runner.RunOnce's mutex, which serializes
+	// every HarvestAll call.
+	lastStamp string
 }
 
 func (h *OpenCodeSQLiteHarvester) setSummarizer(s SessionSummarizer) { h.summarizer = s }
@@ -94,6 +99,20 @@ func (h *OpenCodeSQLiteHarvester) RenderSession(ctx context.Context, sessionID, 
 }
 
 func (h *OpenCodeSQLiteHarvester) HarvestAll(ctx context.Context, enqueuer ChunkEnqueuer) (harvested, skipped, errCount int) {
+	// New sessions and messages can only appear by writing to the SQLite file, so
+	// an unchanged file has nothing to harvest. Checking that first matters
+	// because the alternative is not a cheap query: the driver is pure Go, so
+	// opening and scanning these DBs (hundreds of MB each, one per project)
+	// allocates their page cache on the Go heap every cycle, for files that
+	// typically have not been touched in weeks.
+	//
+	// The stamp lives in memory only. A restart re-opens each DB once, which is
+	// the correct cost — it is one cycle, not every cycle.
+	stamp := h.dbStamp()
+	if stamp != "" && stamp == h.lastStamp {
+		return 0, 0, 0
+	}
+
 	h.logger.Info().Str("db", h.dbPath).Msg("opening opencode sqlite db")
 
 	sqdb, owned, err := h.openSQLite(ctx)
@@ -252,6 +271,11 @@ func (h *OpenCodeSQLiteHarvester) HarvestAll(ctx context.Context, enqueuer Chunk
 	}
 
 	harvested = summarySuccess + summaryFallback
+	// Only a clean cycle is recorded. Leaving the stamp unchanged after an error
+	// means the next cycle retries this DB rather than assuming it was handled.
+	if errCount == 0 {
+		h.lastStamp = stamp
+	}
 	h.logger.Info().
 		Str("source", "opencode").
 		Int("summary_success", summarySuccess).
@@ -261,6 +285,21 @@ func (h *OpenCodeSQLiteHarvester) HarvestAll(ctx context.Context, enqueuer Chunk
 		Int("errors", errCount).
 		Msg("harvest cycle complete")
 	return
+}
+
+// dbStamp returns a change token for the SQLite file, or "" when there is
+// nothing to stamp — an injected connection (dbPath is then meaningless) or a
+// file that cannot be stat'd. An empty stamp disables the skip, so an
+// unstattable DB still gets opened and reports a real error.
+func (h *OpenCodeSQLiteHarvester) dbStamp() string {
+	if h.sqdb != nil || h.dbPath == "" {
+		return ""
+	}
+	info, err := os.Stat(h.dbPath)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%d-%d", info.ModTime().UnixNano(), info.Size())
 }
 
 type SqSession struct {

--- a/internal/harvest/opencode_sqlite_stamp_test.go
+++ b/internal/harvest/opencode_sqlite_stamp_test.go
@@ -1,0 +1,43 @@
+package harvest
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// dbStamp is the signal the harvest skip depends on. If it stops changing when
+// the file changes, new sessions are silently never harvested; if it stops
+// being stable, every cycle re-opens every DB and the page-cache churn returns.
+func TestDBStamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "opencode.db")
+	if err := os.WriteFile(path, []byte("one"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := NewOpenCodeSQLiteHarvester(nil, zerolog.Nop(), path)
+
+	first := h.dbStamp()
+	if first == "" {
+		t.Fatal("stamp is empty for a file that exists, which disables the skip entirely")
+	}
+	if again := h.dbStamp(); again != first {
+		t.Fatalf("stamp is not stable for an unchanged file: %q then %q", first, again)
+	}
+
+	if err := os.WriteFile(path, []byte("one plus more"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if changed := h.dbStamp(); changed == first {
+		t.Fatal("stamp did not change after the file was written; new sessions would never be harvested")
+	}
+
+	// An injected connection makes dbPath meaningless, so the skip must not
+	// engage. dbStamp only tests the pointer for nil, so an empty DB suffices.
+	h.sqdb = &sql.DB{}
+	if s := h.dbStamp(); s != "" {
+		t.Fatalf("stamp should be empty when a connection is injected, got %q", s)
+	}
+}


### PR DESCRIPTION
## What

`OpenCodeSQLiteHarvester.HarvestAll` opened and scanned its SQLite DB on every cycle before anything could tell it there was nothing to do. New sessions and messages can only appear by writing to that file, so an unchanged file has nothing to harvest — this skips the cycle when the file's mtime and size are unchanged since the last clean cycle.

## Why it was expensive

The driver is `modernc.org/sqlite` — pure Go, so a connection's page cache is **Go heap**. One harvester exists per project DB, and on this machine that is:

```
17 DBs · 2046MB total · reopened every 120s (intervals.session_poll)
largest: 719MB, 601MB, 531MB
```

Measured over 9 hours of daemon uptime:

```
2240 opencode harvest cycles
   0 produced any work        ← 100% waste
```

The DB files had not been written in **4–6 weeks** (mtimes Jun 28, Jul 3, Jul 6, Jul 14 — measured Aug 14). So every two minutes the daemon allocated the page cache for 2GB of SQLite, found nothing, and dropped it as garbage.

## Measured

Daemon otherwise idle. `ps -o %cpu,rss` sampled every 5s.

| | RSS peak | RSS avg | steady |
|---|---|---|---|
| before | 416MB | 204MB | climbed to ~415MB and **held 150s at 0% CPU** |
| after | — | — | **17–19MB, flat** |

For reference, a diagnostic run with `db_root` pointed at an empty directory (no DBs at all) measured peak 78MB / avg 35MB — so the gated version with all 17 DBs present is *better* than removing them was, because the startup cycle is the only one that opens them.

Direct confirmation that the gate engages rather than the ticker having stopped:

```
tick at 22:37:35
  claudecode cycles: 8     ← ticker firing normally
  opencode DB opens: 0     ← 17 DBs skipped
  opencode cycles:   0
```

Only the startup cycle opens them (16 opens clustered in the first ~10s), which is the correct cost — one cycle, not every cycle.

## Design notes

- **The stamp is in-memory only.** A restart re-opens each DB once. That is deliberate: the alternative is persisting a watermark, and re-reading once per process start is not the problem — re-reading every 120s was.
- **Only a clean cycle records the stamp.** `if errCount == 0` leaves it unchanged after an error so the next cycle retries rather than assuming the DB was handled.
- **An empty stamp disables the skip**, which keeps two cases honest: an injected connection (`h.sqdb != nil`, used by tests) makes `dbPath` meaningless, and a DB that cannot be `Stat`'d should still be opened so it reports a real error instead of being silently skipped forever.
- This is the same shape as the fix in #619, one layer up. The difference matters: in #619 a Postgres lookup was already the cheap, durable check, so an mtime cache was the wrong tool and was rejected. Here, *opening the SQLite file is itself the expensive step*, so the file's own mtime is the only signal that avoids it.

## Verification

- `go build ./...` — pass
- `go test -race -short ./...` — pass (the command the repo's pre-commit harness runs as check 2.3)
- `TestDBStamp` covers the signal the skip depends on: stable for an unchanged file, changes after a write, empty for an injected connection. Mutation-checked — replacing the mtime/size stamp with a constant fails it on the "did not change after the file was written" assertion.
- Ran the rebuilt daemon against all 17 DBs with claudecode harvesting enabled and confirmed the numbers above.

## Not addressed here

`harvester.opencode.db_root: ""` does **not** disable the source, despite the generated config saying *"Leave blank to disable a source"* — `cmd/nano-brain/main.go` auto-detects a root when it is blank. `ClaudeCodeHarvesterConfig` has an `Enabled` flag; `OpenCodeHarvesterConfig` has none. Worth reconciling, but it is a config-contract change rather than part of this fix.
