### PR TITLE
fix(reindex): skip logical collections in incremental walk and orphan deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to nano-brain are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Data-loss trap in incremental reindex.** `memory` and `sessions` are DB-backed collections whose documents carry synthetic (`summary://…`) or empty source paths, never real files. Reindex previously walked their nominal, normally-nonexistent filesystem roots (`~/.nano-brain/memory`, `~/.nano-brain/sessions`) as if they held real files; if either root existed and contained even one file (e.g. Finder's `.DS_Store`, or an operator running `mkdir -p` to silence the recurring `root path inaccessible` warning), the orphan-deletion pass would delete every indexed document in that collection. `memory` and `sessions` are now skipped by the walk and are unreachable from orphan deletion — **operators must still not create `~/.nano-brain/memory` or `~/.nano-brain/sessions`, or otherwise make those paths walkable**, since that is what triggered the bug, not the fix for it.
+
+### Breaking
+- **`POST /api/v1/init` now validates `root_path`.** A path that does not exist, is not a directory, or cannot be read is rejected with `400` instead of being registered as a permanently-empty collection. Registrations against a *remote* daemon must use a path resolvable on the daemon's own filesystem — a local-only path is now rejected rather than silently accepted.
+
 ## [2026.6.22] — 2026-06-22
 
 ### Added

--- a/internal/server/handlers/collection.go
+++ b/internal/server/handlers/collection.go
@@ -102,6 +102,9 @@ func AddCollection(q CollectionQuerier, fw *watcher.Watcher, watcherCfg config.W
 		if !validCollectionName.MatchString(req.Name) {
 			return echo.NewHTTPError(http.StatusBadRequest, "name must be 1-128 characters: letters, digits, underscores, hyphens only")
 		}
+		if isLogicalCollection(req.Name) {
+			return echo.NewHTTPError(http.StatusBadRequest, "name is reserved for an internal collection")
+		}
 		if req.Path == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "path is required")
 		}
@@ -245,6 +248,9 @@ func RenameCollectionHandler(q CollectionQuerier, fw *watcher.Watcher, watcherCf
 		}
 	if !validCollectionName.MatchString(req.NewName) {
 		return echo.NewHTTPError(http.StatusBadRequest, "new_name must be 1-128 characters: letters, digits, underscores, hyphens only")
+	}
+	if isLogicalCollection(req.NewName) {
+		return echo.NewHTTPError(http.StatusBadRequest, "new_name is reserved for an internal collection")
 	}
 
 	if err := q.UpdateDocumentsCollection(c.Request().Context(), sqlc.UpdateDocumentsCollectionParams{

--- a/internal/server/handlers/collection_test.go
+++ b/internal/server/handlers/collection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -154,6 +155,28 @@ func TestAddCollection_MissingName(t *testing.T) {
 	}
 }
 
+func TestAddCollection_ReservedName(t *testing.T) {
+	for _, name := range []string{"memory", "sessions"} {
+		q := &mockCollectionQuerier{}
+		e := echo.New()
+		body := fmt.Sprintf(`{"workspace":"ws-test","name":%q,"path":"/tmp"}`, name)
+		c, _ := newCollectionContext(e, http.MethodPost, "/api/v1/collections", body, "ws-test")
+
+		h := handlers.AddCollection(q, nil, config.WatcherConfig{}, zerolog.Nop())
+		err := h(c)
+		if err == nil {
+			t.Fatalf("expected error for reserved name %q", name)
+		}
+		he, ok := err.(*echo.HTTPError)
+		if !ok {
+			t.Fatalf("expected echo.HTTPError, got %T", err)
+		}
+		if he.Code != http.StatusBadRequest {
+			t.Errorf("name %q: expected 400, got %d", name, he.Code)
+		}
+	}
+}
+
 func TestListCollections_Success(t *testing.T) {
 	col := fixedCollection("codebase", "/tmp")
 	q := &mockCollectionQuerier{
@@ -222,6 +245,30 @@ func TestRenameCollection_Success(t *testing.T) {
 	}
 	if resp.Name != "renamed" {
 		t.Errorf("expected name=renamed, got %s", resp.Name)
+	}
+}
+
+func TestRenameCollection_ReservedNewName(t *testing.T) {
+	for _, name := range []string{"memory", "sessions"} {
+		q := &mockCollectionQuerier{}
+		e := echo.New()
+		body := fmt.Sprintf(`{"workspace":"ws-test","new_name":%q}`, name)
+		c, _ := newCollectionContext(e, http.MethodPut, "/api/v1/collections/old-name", body, "ws-test")
+		c.SetParamNames("name")
+		c.SetParamValues("old-name")
+
+		h := handlers.RenameCollectionHandler(q, nil, config.WatcherConfig{}, zerolog.Nop())
+		err := h(c)
+		if err == nil {
+			t.Fatalf("expected error renaming to reserved name %q", name)
+		}
+		he, ok := err.(*echo.HTTPError)
+		if !ok {
+			t.Fatalf("expected echo.HTTPError, got %T", err)
+		}
+		if he.Code != http.StatusBadRequest {
+			t.Errorf("name %q: expected 400, got %d", name, he.Code)
+		}
 	}
 }
 

--- a/internal/server/handlers/reindex.go
+++ b/internal/server/handlers/reindex.go
@@ -152,6 +152,15 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 	var watcherTriggered bool
 
 	for _, col := range targets {
+		// Logical collections hold documents whose source_path is an identifier
+		// (summary://…) or empty, never a file. Walking them would put every one
+		// of those documents into the orphan loop below, where os.Stat can never
+		// succeed — deleting the whole corpus. Skipping the walk closes that path
+		// structurally; force-wipe still targets these collections by name.
+		if isLogicalCollection(col.Name) {
+			continue
+		}
+
 		diskFiles, err := walkCollectionFiles(col)
 		if err != nil {
 			reqLog := LoggerFromCtx(c, logger)
@@ -284,6 +293,21 @@ func triggerIncremental(c echo.Context, queries ReindexQuerier, w *watcher.Watch
 		DurationMs:       time.Since(start).Milliseconds(),
 		Message:          fmt.Sprintf("Incremental reindex queued for workspace %s", workspace),
 	})
+}
+
+// Logical (DB-backed) collection names, shared with initWorkspace so the two
+// places that need to know "memory" and "sessions" are logical stay in sync.
+const (
+	collectionNameMemory   = "memory"
+	collectionNameSessions = "sessions"
+)
+
+// isLogicalCollection reports whether a collection is DB-backed rather than
+// disk-backed. Its nominal path is vestigial: no code path creates
+// ~/.nano-brain/{memory,sessions}, and both watcher attach points already skip
+// collections whose path does not exist.
+func isLogicalCollection(name string) bool {
+	return name == collectionNameMemory || name == collectionNameSessions
 }
 
 func walkCollectionFiles(col sqlc.Collection) (map[string]string, error) {

--- a/internal/server/handlers/reindex_test.go
+++ b/internal/server/handlers/reindex_test.go
@@ -269,6 +269,118 @@ func TestIncrementalReindex_DeletedFile(t *testing.T) {
 	}
 }
 
+func TestIncrementalReindex_LogicalCollectionSkipsOrphanDeletion(t *testing.T) {
+	dir := t.TempDir()
+	// A non-empty root so the "disk walk returned empty" guard would not be
+	// what saves this collection — the logical-collection skip must be what
+	// keeps it out of the orphan loop entirely.
+	if err := os.WriteFile(filepath.Join(dir, "unrelated.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{{Name: "sessions", Path: dir}},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"sessions": {
+				{ID: uuid.New(), SourcePath: "summary://claude/session-1", ContentHash: "h1"},
+				{ID: uuid.New(), SourcePath: "summary://claude/session-2", ContentHash: "h2"},
+			},
+		},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["deleted"] != float64(0) {
+		t.Errorf("expected deleted=0, got %v", resp["deleted"])
+	}
+	if mq.deleteChunksCalled != 0 {
+		t.Errorf("expected no DeleteChunks calls, got %d", mq.deleteChunksCalled)
+	}
+	if mq.deleteDocCalled != 0 {
+		t.Errorf("expected no DeleteDoc calls, got %d", mq.deleteDocCalled)
+	}
+}
+
+func TestIncrementalReindex_MissingSessionsRootLogsNoWarning(t *testing.T) {
+	var logBuf strings.Builder
+	logger := zerolog.New(&logBuf)
+
+	e := echo.New()
+	body := `{"workspace":"ws123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{
+			{Name: "sessions", Path: filepath.Join(t.TempDir(), "does-not-exist")},
+		},
+		indexedDocs: map[string][]sqlc.ListDocumentSourcePathsAndHashesRow{
+			"sessions": {
+				{ID: uuid.New(), SourcePath: "summary://claude/session-1", ContentHash: "h1"},
+			},
+		},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, logger)
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	logs := logBuf.String()
+	if strings.Contains(logs, "root path inaccessible") {
+		t.Errorf("expected no root-path-inaccessible warning, got logs: %s", logs)
+	}
+	if strings.Contains(logs, "disk walk returned empty for non-empty collection") {
+		t.Errorf("expected no empty-disk-walk warning, got logs: %s", logs)
+	}
+}
+
+func TestTriggerReindex_ForceWipeIncludesSessions(t *testing.T) {
+	e := echo.New()
+	body := `{"workspace":"ws123","force_wipe":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/reindex", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("workspace", "ws123")
+
+	mq := &mockReindexQuerier{
+		collections: []sqlc.Collection{{Name: "sessions", Path: "/nonexistent"}},
+	}
+	w := newTestWatcherForHandler()
+
+	h := handlers.TriggerReindex(mq, w, nil, nil, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !mq.forceWipeCalled {
+		t.Fatal("expected ResetAndReturnChunkIDsByCollection to be called for force-wipe")
+	}
+	if mq.forceWipeLastParams.Collection != "sessions" {
+		t.Errorf("expected force-wipe to target sessions, got %q", mq.forceWipeLastParams.Collection)
+	}
+}
+
 func TestTriggerReindex_ForceWipe(t *testing.T) {
 	dir := t.TempDir()
 	fakeIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}

--- a/internal/server/handlers/workspace.go
+++ b/internal/server/handlers/workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -74,7 +75,7 @@ func initWorkspace(ctx context.Context, q WorkspaceQuerier, hash, name, absPath 
 
 	if _, err := q.UpsertCollection(ctx, sqlc.UpsertCollectionParams{
 		WorkspaceHash: ws.Hash,
-		Name:          "memory",
+		Name:          collectionNameMemory,
 		Path:          memoryPath,
 		GlobPattern:   "**/*",
 		UpdateMode:    "auto",
@@ -84,7 +85,7 @@ func initWorkspace(ctx context.Context, q WorkspaceQuerier, hash, name, absPath 
 
 	if _, err := q.UpsertCollection(ctx, sqlc.UpsertCollectionParams{
 		WorkspaceHash: ws.Hash,
-		Name:          "sessions",
+		Name:          collectionNameSessions,
 		Path:          sessionsPath,
 		GlobPattern:   "**/*",
 		UpdateMode:    "auto",
@@ -103,6 +104,32 @@ func initWorkspace(ctx context.Context, q WorkspaceQuerier, hash, name, absPath 
 	}
 
 	return ws, nil
+}
+
+// validateRootPath rejects a root_path that the daemon cannot walk. The
+// watcher and walkCollectionFiles both stat col.Path on the daemon's own
+// filesystem, so a path the daemon cannot read can never be indexed —
+// registering it anyway would only create a permanently-empty collection.
+func validateRootPath(path string) error {
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("root_path does not exist: %s", path)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("root_path cannot be read: %s", path)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("root_path cannot be read: %s", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("root_path is not a directory: %s", path)
+	}
+	if _, err := f.Readdirnames(1); err != nil && err != io.EOF {
+		return fmt.Errorf("root_path cannot be read: %s", path)
+	}
+	return nil
 }
 
 // InitWorkspace godoc
@@ -129,6 +156,10 @@ func InitWorkspace(q WorkspaceQuerier, db *sql.DB, fw *watcher.Watcher, watcherC
 		absPath, err := filepath.Abs(req.RootPath)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, "invalid root_path")
+		}
+
+		if err := validateRootPath(absPath); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
 		hash, err := storage.WorkspaceHash(absPath)
@@ -163,22 +194,13 @@ func InitWorkspace(q WorkspaceQuerier, db *sql.DB, fw *watcher.Watcher, watcherC
 		}
 
 		if fw != nil {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				logger.Warn().Err(err).Msg("failed to get home directory for watcher paths")
-				home = "~"
-			}
-			type colSpec struct{ name, path, glob string }
-			cols := []colSpec{
-				{"memory", filepath.Join(home, ".nano-brain", "memory"), "**/*"},
-				{"sessions", filepath.Join(home, ".nano-brain", "sessions"), "**/*"},
-				{"code", absPath, "**/*"},
-			}
+			// Only disk-backed collections are watched. memory and sessions are
+			// DB-backed; attaching them here made init-time behaviour disagree
+			// with daemon startup, which already skips a collection whose path
+			// does not exist.
 			cfgExclude, cfgExtensions := watcherCfg.ResolveFilterForPath(absPath)
-			for _, col := range cols {
-				if err := fw.WatchWithFilter(col.name, col.path, hash, col.glob, cfgExclude, cfgExtensions); err != nil {
-					logger.Warn().Err(err).Str("collection", col.name).Msg("failed to attach watcher after init")
-				}
+			if err := fw.WatchWithFilter("code", absPath, hash, "**/*", cfgExclude, cfgExtensions); err != nil {
+				logger.Warn().Err(err).Str("collection", "code").Msg("failed to attach watcher after init")
 			}
 		}
 

--- a/internal/server/handlers/workspace_test.go
+++ b/internal/server/handlers/workspace_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,6 +22,18 @@ import (
 	"github.com/nano-brain/nano-brain/internal/storage/sqlc"
 	"github.com/rs/zerolog"
 )
+
+// ensureTestDir makes path exist for the duration of the test. InitWorkspace
+// now validates root_path against the filesystem, so fixture paths used only
+// to exercise registration mechanics (not path validation itself) must be
+// real directories.
+func ensureTestDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	t.Cleanup(func() { os.RemoveAll(path) })
+}
 
 type mockQuerier struct {
 	upsertWorkspaceFn          func(ctx context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error)
@@ -67,6 +82,7 @@ func TestWorkspaceHashDifferentPaths(t *testing.T) {
 }
 
 func TestInitWorkspaceHandler(t *testing.T) {
+	ensureTestDir(t, "/tmp/test-project")
 	fixedHash, err := storage.WorkspaceHash("/tmp/test-project")
 	if err != nil {
 		t.Fatalf("WorkspaceHash: %v", err)
@@ -154,6 +170,159 @@ func TestInitWorkspaceHandlerMissingRootPath(t *testing.T) {
 	}
 }
 
+func TestInitWorkspaceHandlerNonexistentRootPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	q := &mockQuerier{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/init", strings.NewReader(fmt.Sprintf(`{"root_path":%q}`, missing)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.InitWorkspace(q, nil, nil, config.WatcherConfig{}, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for nonexistent root_path")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+	if msg, _ := he.Message.(string); !strings.Contains(msg, "does not exist") {
+		t.Errorf("expected message to mention 'does not exist', got %v", he.Message)
+	}
+}
+
+func TestInitWorkspaceHandlerRootPathIsFile(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "not-a-dir.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	q := &mockQuerier{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/init", strings.NewReader(fmt.Sprintf(`{"root_path":%q}`, filePath)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.InitWorkspace(q, nil, nil, config.WatcherConfig{}, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for a root_path that is a regular file")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+	if msg, _ := he.Message.(string); !strings.Contains(msg, "not a directory") {
+		t.Errorf("expected message to mention 'not a directory', got %v", he.Message)
+	}
+}
+
+func TestInitWorkspaceHandlerRootPathUnreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: directory permissions are not enforced")
+	}
+	dir := filepath.Join(t.TempDir(), "unreadable")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	q := &mockQuerier{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/init", strings.NewReader(fmt.Sprintf(`{"root_path":%q}`, dir)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.InitWorkspace(q, nil, nil, config.WatcherConfig{}, zerolog.Nop())
+	err := h(c)
+	if err == nil {
+		t.Fatal("expected error for an unreadable root_path")
+	}
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("expected echo.HTTPError, got %T", err)
+	}
+	if he.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", he.Code)
+	}
+	if msg, _ := he.Message.(string); !strings.Contains(msg, "cannot be read") {
+		t.Errorf("expected message to mention 'cannot be read', got %v", he.Message)
+	}
+}
+
+func TestInitWorkspaceHandlerRelativeRootPathStoredAbsolute(t *testing.T) {
+	base := t.TempDir()
+	relDir := "relative-project"
+	if err := os.Mkdir(filepath.Join(base, relDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(base); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origWd) })
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := &mockQuerier{
+		upsertWorkspaceFn: func(_ context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error) {
+			return sqlc.Workspace{
+				ID: uuid.New(), Hash: arg.Hash, Name: arg.Name, Path: arg.Path,
+				CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			}, nil
+		},
+		upsertCollectionFn: func(_ context.Context, arg sqlc.UpsertCollectionParams) (sqlc.Collection, error) {
+			return sqlc.Collection{
+				ID: uuid.New(), WorkspaceHash: arg.WorkspaceHash,
+				Name: arg.Name, Path: arg.Path, GlobPattern: arg.GlobPattern,
+				UpdateMode: arg.UpdateMode, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			}, nil
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/init", strings.NewReader(fmt.Sprintf(`{"root_path":%q}`, relDir)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	h := handlers.InitWorkspace(q, nil, nil, config.WatcherConfig{}, zerolog.Nop())
+	if err := h(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	wantAbs := filepath.Join(cwd, relDir)
+	gotPath, _ := resp["root_path"].(string)
+	if gotPath != wantAbs {
+		t.Errorf("expected root_path %q, got %q", wantAbs, gotPath)
+	}
+	if !filepath.IsAbs(gotPath) {
+		t.Errorf("expected root_path to be absolute, got %q", gotPath)
+	}
+}
+
 func TestListWorkspacesHandler(t *testing.T) {
 	now := time.Now()
 	q := &mockQuerier{
@@ -213,6 +382,7 @@ func mapKeys(m map[string]interface{}) []string {
 }
 
 func TestInitWorkspaceCreatesCodeCollection(t *testing.T) {
+	ensureTestDir(t, "/tmp/test-project")
 	var collectionNames []string
 	q := &mockQuerier{
 		upsertWorkspaceFn: func(_ context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error) {
@@ -261,6 +431,7 @@ func TestInitWorkspaceCreatesCodeCollection(t *testing.T) {
 }
 
 func TestInitWorkspaceCodeCollectionIdempotent(t *testing.T) {
+	ensureTestDir(t, "/tmp/test-project")
 	var callCount atomic.Int32
 	q := &mockQuerier{
 		upsertWorkspaceFn: func(_ context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error) {
@@ -300,6 +471,7 @@ func TestInitWorkspaceCodeCollectionIdempotent(t *testing.T) {
 }
 
 func TestInitWorkspaceCodeCollectionErrorRollback(t *testing.T) {
+	ensureTestDir(t, "/tmp/test-project")
 	var collectionCallCount int
 	q := &mockQuerier{
 		upsertWorkspaceFn: func(_ context.Context, arg sqlc.UpsertWorkspaceParams) (sqlc.Workspace, error) {

--- a/openspec/changes/fix-install-ux-regressions/.openspec.yaml
+++ b/openspec/changes/fix-install-ux-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/fix-install-ux-regressions/design.md
+++ b/openspec/changes/fix-install-ux-regressions/design.md
@@ -1,0 +1,105 @@
+# Design — fix-install-ux-regressions
+
+## Context
+
+Four defects, one of which (logical-collection walking) sits next to a mechanism that deletes documents. The design decisions below were settled by two independent adversarial reviews plus live probes; each records the alternatives that were rejected and why, so the Review Gate does not re-litigate them.
+
+Live measurements referenced throughout: `sessions` holds 2003 documents, 2002 with `summary://…` source paths; `memory` holds 185, 98 with empty source paths.
+
+## Goals
+
+1. Make the orphan-deletion loop structurally unreachable for DB-backed collections.
+2. Make `printUsage()` and the dispatcher unable to drift apart in either direction, and bring root `SKILL.md` under the same guarantee.
+3. Make `nano-brain init` parse its full flag set, and reject a `--root` that cannot be indexed.
+4. Make npm postinstall fail actionably at unpublished versions, with integrity enforcement intact.
+
+## Non-goals
+
+- **`~/.nano-brain/memory` and `~/.nano-brain/sessions` MUST NOT be created and their roots MUST NOT become walkable.** That is the trigger, not the fix.
+- Deleting logical-collection rows. Consumers filter on the names (`internal/server/handlers/wakeup.go:130`, `internal/mcp/tools.go:1791`) and deletion is irreversible.
+- Restoring the six commands documented in `SKILL.md` but absent from the dispatcher. `git log -S 'case "<cmd>":' -- cmd/nano-brain/main.go` returns **0 commits** for all six (`update`, `embed`, `focus`, `graph-stats`, `symbols`, `impact`) — they were never implemented. The fix is to correct the docs.
+
+## Decision 1 — Skip logical collections inside `triggerIncremental`, keyed on reserved names
+
+**Chosen:** a guard at the top of the `for _, col := range targets` body in `triggerIncremental` (`internal/server/handlers/reindex.go:154`), before `walkCollectionFiles`, skipping collections named `memory` or `sessions`.
+
+**Why this and not the alternatives:**
+
+| Option | Force-wipe | Warning removed | Migration | Registration determinism |
+|---|---|---|---|---|
+| Do not register absent roots *(original proposal)* | **Breaks** — no row, so `triggerForceWipe` never resets chunks | yes | no | **No** — depends on incidental FS state |
+| Filter in `collectionsToReindex` (`:330-354`) | **Breaks** — `targets` is computed once at `:83` and passed to *both* branches (`:94-95` force, `:98` incremental) | yes | no | yes |
+| `path = ''` | intact | **No** — trades `root path inaccessible` for `disk walk returned empty for non-empty collection`, `indexed: 2003`, every reindex | one-statement | yes |
+| `update_mode` sentinel | intact | yes | **Yes** — `NOT NULL DEFAULT 'auto'` (`migrations/00001_initial_schema.sql:64`), existing rows need backfill | yes |
+| **Skip inside `triggerIncremental`** | **intact** — `triggerForceWipe` untouched | **yes — neither warning fires** | **none** | yes |
+
+The chosen option is the only one satisfying all four constraints. It also leaves `internal/server/handlers/workspace_test.go:249-251` (exactly three `UpsertCollection` calls) green, because registration is not modified.
+
+Keying on the reserved names adds no new coupling: `memory` and `sessions` are already load-bearing string constants in at least six places — `wakeup.go:130`, `mcp/tools.go:1791`, `ticket.go:31`, `workspace.go:87,173-174`, `harvest/engine.go:264`, `summarize/persist.go:128,174`.
+
+**Paired edit, required regardless of mechanism:** `internal/server/handlers/workspace.go:171-176` builds the post-init watcher attach list from hardcoded literals, not from the DB, and attaches all three unconditionally at `:178-182`. `memory` and `sessions` must be dropped from that list. Without this they are watched immediately after init but not after a daemon restart — `cmd/nano-brain/main.go:532` and `internal/watcher/watcher.go:334-338` both already skip collections whose path fails `os.Stat`. Those two skips are evidence that the DB-only intent is already encoded in production code; the reindex walker is the only component that does not know it.
+
+**Why the current state is not safe to leave alone.** Today no deletion occurs, but only because two conjuncts are accidentally false. The trigger condition is four conjuncts: (1) non-empty `path` — else `:290-292` early-returns; (2) the directory exists — else the stat guard at `:297-299` errors and the caller warns and continues at `:155-160`; (3) it contains ≥1 file ≤10 MiB (`maxIncrementalFileSize`, `:24`, applied at `:312`) — else the guard at `:182-189` fires, whose condition `len(diskFiles) == 0 && len(indexedRows) > 0` a single file defeats; (4) an incremental reindex runs. `walkCollectionFiles` (`:300-326`) applies **no ignore filter at all** — no `.nano-brainignore`, no `.gitignore` — so an ignored file still disarms the guard. On macOS, opening `~/.nano-brain/memory` in Finder writes a `.DS_Store` and satisfies conjunct 3; `~/.nano-brain` is an Obsidian vault on the reporting machine, so `memory/` is a visible, invitingly-named empty folder inside a vault the user already browses.
+
+`triggerIncremental` is the **sole** mass-deletion vector: `cleanupDeletedDocument` (`internal/watcher/watcher.go:683-731`) and `cleanupIgnoredDocument` (`:639-678`) resolve one specific path each, and `cleanupPathPrefix` (`:736+`) deletes by prefix, which `summary://…` never matches.
+
+## Decision 2 — AST-parse the dispatch switch in the test; do not refactor the dispatcher
+
+**Chosen:** `cmd/nano-brain/ops_usage_test.go` parses `cmd/nano-brain/main.go` with `go/parser`, walks to the `switch` inside `func main`, and collects the `case` label string literals as the expected set. Assertions anchor on the command column of a usage line, not `strings.Contains`.
+
+**Rejected:** a `[]struct{name, summary, run}` command table that `main` dispatches from and `printUsage` renders. It kills the bug class outright, but it is a 35-arm refactor of the dispatch switch — and `runXCmd` signatures are not uniform (`runServeCmd(args, configPath)` `main.go:78`, `runInitCmd(args, configPath)` `:93`, `runConfigCmd` `:132`, `runDoctorCmd` `:135` take `configPath`; ~30 others take only `args`), so it needs an adapter closure per entry or a signature change. That is the highest-regression-risk work in the change, undertaken for a help-text bug, on the branch that ships #615. It also cannot be a pure render: `ops.go:557` `(no command)`, `:559` `serve -d`, `:566-567` `config show`/`config check`, `:571` `(alias: ls)` are not dispatch cases and must survive, so the table needs a free-form preamble in which drift can still live. A CI gate that fails on drift is prevention for this class — you cannot merge with drift.
+
+**Substring matching must be fixed in the same change**, not deferred: `get` is matched by `multi-get` (`ops.go:579`) and `config` by the `--config` global-flags line (`ops.go:596`). (`serve` is *not* matched by `service` — after `serv` comes `i`, not `e` — and `ops.go:558` has a literal `serve` line anyway.) Column anchoring requires the indentation at `ops.go:576-584` to be normalized first: those lines use three leading spaces where the rest use two.
+
+**Reverse direction (root `SKILL.md` ⟷ dispatch) is a separate requirement, not the same test.** `printUsage` ⟷ dispatch is a Go test in one package; SKILL.md ⟷ dispatch is a markdown-table lint against a Go source file — different tooling and failure mode. Bundling them invites an implementer to do the easy half.
+
+## Decision 3 — Validate `--root` at the HTTP handler, with `os.Stat` + `IsDir`
+
+**Chosen:** validate in `internal/server/handlers/workspace.go`, after `filepath.Abs` (`:129`) and before `WorkspaceHash` (`:134`). Three distinct errors: path does not exist; path is a regular file; path is a directory that cannot be read.
+
+**Why the handler and not the CLI:** it is the single choke point covering the CLI, the interactive wizard (`cmd/nano-brain/init.go:190-193`), the MCP tools, and raw API callers. A CLI-only check leaves the API hole open.
+
+**Why validation is required at all:** `internal/storage/workspace.go:9-16` is `filepath.Abs` + `sha256` with no filesystem access, and the handler rejects only an empty `root_path` (`:125-127`). Once `--root` parses, `init --root /typo/path` registers a `code` collection whose root fails `reindex.go:297-299` on every reindex — reopening the exact defect Decision 1 closes, through a newly-working command.
+
+**Remote-daemon constraint, considered and dismissed as a blocker:** `docs/SETUP_AGENT.md:393-409` documents a VPS topology where the daemon is remote. A local path sent to a remote daemon will now be rejected. That is correct: the watcher walks `col.Path` on the daemon's filesystem (`internal/watcher/watcher.go:587`), as does `walkCollectionFiles`, so a path the daemon cannot stat can never be indexed. A clear error beats a permanently-empty ghost workspace. The one ambiguous case — a shared mount present on both sides under different prefixes — is misconfiguration, and the same argument applies.
+
+## Decision 4 — `init` parses once, both flag forms; copy the existing house pattern
+
+**Chosen:** collapse `cmd/nano-brain/commands.go:19-40` and `:70-96` into a single pass handling `--`, `--yes`, `--root`, `--workspace`, `--json`, `--force`, accepting both `--flag value` and `--flag=value` for value-taking flags. Extract a pure `parseInitArgs(args) (initOpts, error)` so the parser is testable without `os.Exit` (currently called at `:34,38,76,84,94`).
+
+**`=`-form support is copying the house pattern, not inventing one.** Seven commands already split on `=`: `cmd_get.go:27-28`, `cmd_tags.go:25-26`, `cmd_multi_get.go:26-27` (plus `--paths=` `:45`, `--ids=` `:54`), `cmd_backfill_summaries.go:34-35` (plus `--since=` `:37`), `cmd_reset_embeddings.go:27-28`, `cmd_workspace_remove.go:34-35`. `cmd_reset_embeddings.go:27-41` supports **both forms for the same flag** — exactly the shape needed here — and `ops.go:589` advertises `--workspace=<hash>` for that command. Adding `=` to `init` restores consistency; it does not break it.
+
+The `--` case at `commands.go:21-27` already uses the correct `i++`-then-consume idiom, which is what makes the `--root` omission a bug rather than a design choice. `init -- opencode` must keep working.
+
+## Decision 5 — npm: export a pure planner; preserve every integrity path
+
+**Chosen:** extract `planDownload(version, assetName) → { candidates, message }` from `npm/postinstall.js` and export it (`module.exports` at `:373` currently omits `candidateTagsForVersion`, so the buggy function cannot be unit-tested at all). Detect a non-release placeholder before attempting any download and print the tags tried plus `install.sh`, `NANO_BRAIN_BIN`, and the source build as alternatives.
+
+**Hard constraints on the refactor — the failure mode is folding a `SECURITY:` error into the new summary string:**
+- `postinstall.js:329` rethrows `SECURITY:`-prefixed errors unwrapped from inside the candidate loop.
+- `:340-343` deliberately does *not* wrap the API-fallback attempt, with the comment at `:341` explaining that a SECURITY error must propagate.
+- `verifySHA256` `:164-175` `safeUnlink`s on mismatch; the comment at `:165-167` explains that an unrelated fs error must not downgrade a SHA mismatch.
+- `main()` `:354-359` exits 1 on any `SECURITY:` message.
+
+**The diagnostic MUST NOT recommend `NANO_BRAIN_SKIP_SHA_VERIFY`** (`:286-289`, used at `:314-319`). It is unrelated to a 404 and would be a security regression in guidance form — and `openspec/specs/skill-distribution-docs/spec.md` requires SKILL.md to document that variable, so a spec-blessed escape hatch is sitting in easy reach of a naive author.
+
+**Scope correction:** the published npm path is not broken. `0.0.0-dev` is the on-master placeholder (`AGENTS.md:515`), rewritten by CI before publish (`.github/workflows/release.yml:96`) and gated by `scripts/check-npm-release.sh:166-193`. Registry check: `nano-brain` and `@nano-step/nano-brain` are both live at `2026.8.1201`, same repo and maintainer; that version has an all-digit 4-char patch, so it resolves on the first candidate tag. No README caveat will be added.
+
+**`npm/run.js` is in scope**: `run.js:105-112` calls `ensureBinary()` and prints `err.message`, so changing the throw at `postinstall.js:345` changes what the lazy first-invocation path prints.
+
+## Decision 6 — Wire the npm suite into CI
+
+`.github/workflows/ci.yml:29-39` is Go-only: checkout, setup-go, build, `go test`. `npm/postinstall.test.js` (425 lines) and `npm/run.test.js` (167) have never run in CI. `docs/evidence/review-npm.md:21` recorded this and recommended `node --test npm/` as a follow-up; it was not done. Adding the test without the job repeats that. The job goes in this change.
+
+The suite is offline-capable — `postinstall.test.js:36-44` drives a full `ensureBinary()` rejection by patching `os.platform`, `:18-32` stubs a binary at `binaryPath()`, `:67-77` forces `ECONNREFUSED` — so no network or published release is needed. **No assertion may depend on a real GitHub 404.**
+
+## Risks
+
+- **Decision 3 is a live API contract change.** Existing automation that registers a path the daemon cannot see now gets a 400. Mitigated by explicit scenarios and a release note.
+- **Decision 1 is a name-keyed skip.** If a future workspace legitimately wants a disk-backed collection named `memory` or `sessions`, it is silently excluded. Accepted: those names are already reserved by six other call sites.
+- **Decision 2 couples a test to source layout.** An AST test breaks if `main.go`'s dispatch moves. Accepted as cheaper than the refactor; the failure is a loud test error, not a silent drift.
+
+## Open questions
+
+- Root `SKILL.md` has no owning spec and does not ship via npm (`package.json` `files` = `['npm/', 'README.md', 'LICENSE']`). This change brings it under `cli-usage-parity`, but the question of which artifact *should* own it is left open.
+- Fix #1 documents a command introduced by the branch this change sits on (`feat/615-daemon-service-install-ux`). If #615 is unmerged, the honest home for the help-text and recommendation-path work is #615's own `tasks.md` — whose task 7.1 (`openspec/changes/archive/2026-08-08-cross-platform-daemon-auto-start/tasks.md:45`) documented `service` in `README.md` and `docs/SETUP_AGENT.md` but not in `nano-brain help`. That is where the defect was born.

--- a/openspec/changes/fix-install-ux-regressions/proposal.md
+++ b/openspec/changes/fix-install-ux-regressions/proposal.md
@@ -1,0 +1,88 @@
+## Why
+
+Dogfooding nano-brain on a real multi-repo workspace surfaced four install/first-run defects. Adversarial review then established that one of them is not a cosmetic defect at all — it is a live data-loss trap, and the original framing of the fix pointed straight at the trigger.
+
+### The trap (found during review, now the primary driver)
+
+`memory` and `sessions` are **DB-backed logical collections**. Their documents are inserted directly by the harvester and summarizer (`internal/harvest/engine.go:264`, `internal/summarize/persist.go:128,174`, `internal/server/handlers/ticket.go:31`) and carry source paths that are identifiers, not files — `buildSourcePath` returns `summary://claude/<session-id>` (`internal/summarize/persist.go:254-263`), and CLI-written memory documents pass an empty `source_path` straight through (`internal/server/handlers/document.go:145`). A full audit of every non-test `MkdirAll` in `internal/` and `cmd/` confirms **no code path ever creates `~/.nano-brain/memory` or `~/.nano-brain/sessions`**; the summarizer's on-disk output goes to `~/.nano-brain/summaries` (`internal/config/defaults.go:95`).
+
+Yet `POST /api/v1/init` registers both as ordinary filesystem-backed collections (`internal/server/handlers/workspace.go:72-93`), so reindex walks them. The reindex orphan loop deletes every indexed document whose `source_path` fails `os.Stat` (`internal/server/handlers/reindex.go:227-252`). `os.Stat("summary://…")` and `os.Stat("")` can never succeed.
+
+Two accidents are all that stand between that loop and the corpus:
+
+1. `~/.nano-brain/sessions` does not exist, so `walkCollectionFiles` errors at its stat guard (`reindex.go:295-299`) and the caller warns and `continue`s (`:155-160`).
+2. `~/.nano-brain/memory` exists but is empty, so the catastrophic-deletion guard fires — and that guard's condition is `len(diskFiles) == 0 && len(indexedRows) > 0` (`reindex.go:182-189`), which **a single file defeats**.
+
+Measured on a live install: `sessions` holds 2003 documents, 2002 with `summary://…` paths; `memory` holds 185, 98 with empty paths. So `mkdir -p ~/.nano-brain/sessions && touch ~/.nano-brain/sessions/x` — the obvious way an operator silences a recurring warning — deletes ~2100 documents and their chunks on the next reindex. `collectionsToReindex` returns *all* collections when the requested root matches nothing (`reindex.go:351-353`), so a plain workspace-root reindex sweeps them too.
+
+**The recurring `root path inaccessible` warning is therefore load-bearing.** It is the guard reporting, not noise.
+
+### The three install defects
+
+- **`nano-brain service …` is invisible.** Shipped by #615 and dispatched at `cmd/nano-brain/main.go:86`, it is absent from `printUsage()` (`cmd/nano-brain/ops.go:551-601`). This is a recurrence of issue #527, and `cmd/nano-brain/ops_usage_test.go` — written to prevent exactly that — cannot catch it: its `dispatchedCommands` slice is hand-maintained (`:13-20`, 34 of 35 commands, `service` missing) and its assertion is `strings.Contains` (`:27-31`). The test passes green today with the drift present (verified by running it). Worse, the gap is not only help text: **nothing in the product ever recommends `service install`.** Every start affordance points at the unsupervised `serve -d` — `suggestStartCommand()` (`cmd/nano-brain/client_helpers.go:67-72`), the dead-daemon message (`:76-83`), both wizard branches (`cmd/nano-brain/init_serve.go:72,82`), and the wizard itself, which has no service step at all (`cmd/nano-brain/init.go:128-215`). A user who follows `install.sh` → `nano-brain init` is handed a daemon that does not survive reboot and is never told otherwise.
+- **`nano-brain init` cannot parse its own flags.** `cmd/nano-brain/commands.go:19-40` pre-scans for booleans and never consumes the value after `--root`, so the path falls to `default:` and exits. The correct parser at `:70-96` is **entirely unreachable** — not just for `--root` but for `--workspace`, `--json`, and `--force`, the last of which fronts a destructive reset-workspace flow (`:98-117`). Verified against a HEAD build: all six invocation forms exit 1. The `=` form is documented in the agent-facing skill (`SKILL.md:56`), the team runbook (`docs/SETUP_AGENT.md:279,410`), and the V1 migration note (`CHANGELOG.md:541`), and has never worked in any code path.
+- **npm postinstall dead-ends at unpublished versions.** `candidateTagsForVersion()` (`npm/postinstall.js:182-193`) requires an all-digit patch segment, so `0.0.0-dev` produces one candidate tag, the API fallback finds nothing (`:215-228`), and the run aborts at `:345` with no next step.
+
+## What Changes
+
+- **Logical collections are never walked.** `memory` and `sessions` are excluded from filesystem walking and from orphan deletion, so the deletion path is unreachable for documents whose source paths are synthetic or empty. Their rows are kept — consumers filter on the names (`internal/server/handlers/wakeup.go:130`, `internal/mcp/tools.go:1791`) and `triggerForceWipe` operates on rows by name (`reindex.go:105-129`).
+- **`printUsage()` and the dispatcher cannot drift, in either direction.** Every dispatched command is documented, every documented command is dispatched, enforced by a test whose expected set comes from the dispatcher rather than a maintained slice, and whose assertion anchors on the command column instead of a substring.
+- **`service install` is recommended, not merely referenced.** Where the platform supports it, the install path surfaces the supervised option instead of only `serve -d`.
+- **`nano-brain init` parses all of its flags in one pass** — `--`, `--yes`, `--root`, `--workspace`, `--json`, `--force` — accepting both `--flag value` and `--flag=value` for value-taking flags, and rejects a `--root` that does not resolve to a readable directory.
+- **npm postinstall fails actionably.** When no release asset matches the package version it reports the tags it tried and the supported alternatives, while preserving the existing hard-fail on integrity errors.
+- **The npm test suite runs in CI.** `.github/workflows/ci.yml` is Go-only today, so `npm/postinstall.test.js` and `npm/run.test.js` have never run in CI — recorded at `docs/evidence/review-npm.md:21` and never actioned.
+
+### Non-goals
+
+- **`~/.nano-brain/memory` and `~/.nano-brain/sessions` MUST NOT be created, and their collection roots MUST NOT be made walkable.** This is the trigger, not the fix.
+- Collection rows for logical collections MUST NOT be deleted — consumers filter on the names and deletion is irreversible.
+
+### Breaking changes
+
+**BREAKING — `POST /api/v1/init` contract.** Root validation means inputs that returned `200` now return `400`: a `root_path` that does not exist, is a regular file, or is an unreadable directory. This is deliberate — the watcher and `walkCollectionFiles` both walk `col.Path` on the *daemon's* filesystem, so a path the daemon cannot stat can never be indexed, and registration would only have created a permanently-empty ghost workspace. The remote-daemon topology (`docs/SETUP_AGENT.md:393-409`) is the case to watch: a developer running `init --root <local-path>` against a remote daemon is now rejected rather than silently registered, which is the correct outcome for the same reason.
+
+No currently-working CLI invocation changes behavior — every `init` flag form fails today. Registration behavior is unchanged, so `internal/server/handlers/workspace_test.go:215-262` (which asserts exactly three `UpsertCollection` calls at `:249-251`) stays green; the walk exclusion is applied at read time, not at registration.
+
+## Capabilities
+
+### New Capabilities
+- `logical-collection-isolation`: `memory` and `sessions` are DB-backed namespaces that are never walked from disk and are unreachable from orphan deletion, regardless of whether their nominal root exists.
+- `cli-usage-parity`: bidirectional parity between the command dispatcher, `printUsage()`, and the agent-facing skill docs, enforced by a derived, column-anchored test.
+- `cli-init-argument-parsing`: `nano-brain init` parses its full flag set in a single pass, in both space and `=` forms, and validates `--root`.
+- `npm-install-fallback`: postinstall produces an actionable, tag-aware diagnostic when no release asset matches the package version, without weakening integrity enforcement.
+
+### Modified Capabilities
+
+None. Two candidates were raised in review and both were rejected on evidence:
+
+- **`managed-daemon-service` — rejected.** `spec.md:8-13` requires the CLI to "expose" the service subcommands, and it does: dispatched at `cmd/nano-brain/main.go:86-88`, implemented at `cmd/nano-brain/service.go:85-105`, platform-guarded at `:93-98`. Its scenarios cover install targets and platform guards, not discoverability. Reading "expose" as "document in help" would retroactively make an archived, PASSed change non-compliant against a definition it never used. Discoverability belongs to the new `cli-usage-parity`.
+- **`skill-distribution-docs` — rejected, and the finding is worse than a misattribution.** That spec names `README.md`, `.opencode/skills/nano-brain/SKILL.md`, and the copy shipped via `@nano-step/skill-manager`. Root `SKILL.md` — the file carrying the broken command table — is **none of those**: `package.json` `files` is `['npm/', 'README.md', 'LICENSE']`, and no workflow references it. It is an **unowned user-facing surface**. This change brings it under `cli-usage-parity` rather than attaching it to a spec that does not cover it.
+
+## Impact
+
+- `internal/server/handlers/reindex.go` — walk target selection and orphan-deletion reachability
+- `internal/server/handlers/workspace.go` — collection registration, watcher attach loop (`:167-183`), root validation on `POST /api/v1/init` (`:121-133`)
+- `internal/server/handlers/workspace_test.go` — the 3-collection contract test must be rewritten
+- `cmd/nano-brain/main.go` (dispatch), `cmd/nano-brain/ops.go` (`printUsage`), `cmd/nano-brain/ops_usage_test.go`
+- `cmd/nano-brain/commands.go` (`init` parsing), `cmd/nano-brain/client_helpers.go` + `cmd/nano-brain/init_serve.go` + `cmd/nano-brain/init.go` (service recommendation)
+- `npm/postinstall.js`, `npm/postinstall.test.js`, `npm/run.js`, `npm/run.test.js` — `run.js` shares `ensureBinary` for the lazy first-invocation download and prints the same thrown message
+- `.github/workflows/ci.yml` — add a Node job
+- `SKILL.md`, `skills/nano-brain/SKILL.md`
+- No database migration: the exclusion applies at read time to rows that already exist. No HTTP contract change, no MCP tool signature change.
+
+### Corrections to earlier drafts of this proposal
+
+Recorded so the Review Gate does not re-litigate them:
+
+- **The published npm path is not broken.** `0.0.0-dev` is the intentional on-master placeholder; CI rewrites it before publish (`AGENTS.md:515`, `.github/workflows/release.yml:96`) and `scripts/check-npm-release.sh:166-193` gates on version-equals-tag. Registry check: both `nano-brain` and `@nano-step/nano-brain` are live at `2026.8.1201`, same repo and maintainer, and that version resolves on the first candidate tag. The failure is confined to postinstall running inside a source checkout. **No README caveat will be added** — it would warn users away from a working path.
+- **`POST /api/v1/init` is not the only working registration path.** The interactive wizard registers an arbitrary path (`cmd/nano-brain/init.go:190-193`). The accurate gap is that no *non-interactive* CLI registration exists: the wizard is TTY-gated (`:137-142`) and `--yes` ignores `--root` (`commands.go:55-58`). Scripts, CI, and agents are the affected callers.
+- **A dead daemon does not return silent empty results.** MCP is served by the daemon, so it is unreachable, and the CLI prints an explicit actionable connect error (`cmd/nano-brain/client_helpers.go:76-83`). Silent-empty-with-no-error is the signature of a live daemon over an empty index — nano-step/nano-brain#622.
+- **The `service` gap is help-text-only, not a documentation gap.** `README.md:76-80` and `docs/SETUP_AGENT.md:236-240` both document the subcommands. Note that #615's own `tasks.md:45` task 7.1 documented `service` in those two files but not in `nano-brain help` — the drift passed a full Review Gate.
+
+### Non-scope
+
+- Newly registered workspaces persist nothing while `reindex` reports non-zero counts — nano-step/nano-brain#622. Probed during review: a fresh 3-file workspace returned `watcher_triggered: true` with `docs_total: 0`, which places the failure downstream of the watcher trigger rather than in registration wiring.
+- Empty symbol table for JS/TS workspaces; no `.vue` symbol extractor — nano-step/nano-brain#624.
+- `graph/impact` returning `impacted: null` for both "no results" and "unknown node" — nano-step/nano-brain#625.
+
+**Release sequencing:** #622 must ship before the install experience is announced as fixed. A user who installs cleanly and then queries into a void has had the same experience as before, with better help text.

--- a/openspec/changes/fix-install-ux-regressions/specs/cli-init-argument-parsing/spec.md
+++ b/openspec/changes/fix-install-ux-regressions/specs/cli-init-argument-parsing/spec.md
@@ -1,0 +1,89 @@
+# cli-init-argument-parsing Specification
+
+## Purpose
+
+`nano-brain init` is the documented way to register a workspace from a script, a runbook, or an agent. Its arguments must parse on the first pass, in the flag forms the documentation already advertises, and a root that can never be indexed must be rejected rather than silently registered.
+
+## ADDED Requirements
+
+### Requirement: `init` SHALL parse its full flag set in a single pass
+
+`runInitCmd` SHALL parse `--`, `--yes`, `--root`, `--workspace`, `--json`, and `--force` in one pass. No flag SHALL be consumed by a pre-scan that leaves its value to be rejected as an unexpected argument.
+
+#### Scenario: Space form is accepted
+
+- **WHEN** the user runs `nano-brain init --root /path/to/project`
+- **THEN** the command registers that path
+- **AND** it does not print `unexpected argument`
+
+#### Scenario: Equals form is accepted
+
+- **WHEN** the user runs `nano-brain init --root=/path/to/project`
+- **THEN** the command registers that path
+- **AND** it does not print `unknown flag`
+
+#### Scenario: Value flags combine with other flags
+
+- **WHEN** the user runs `nano-brain init --root /path/to/project --json`
+- **THEN** the command registers the path and emits JSON output
+
+#### Scenario: Workspace flag parses
+
+- **WHEN** the user runs `nano-brain init --root /path/to/project --workspace my-workspace`
+- **THEN** both values are parsed and neither is reported as an unknown flag or unexpected argument
+
+#### Scenario: Force flag reaches its implementation
+
+- **WHEN** the user runs `nano-brain init --root /path/to/project --force`
+- **THEN** the reset-workspace flow is reached rather than the command exiting during argument parsing
+
+#### Scenario: Agent-target form keeps working
+
+- **WHEN** the user runs `nano-brain init -- opencode`
+- **THEN** the agent install path runs exactly as before this change
+
+#### Scenario: Yes flag with a root reports its own guidance
+
+- **WHEN** the user runs `nano-brain init --yes --root /path/to/project`
+- **THEN** the command reaches the note explaining that `--yes` only writes config and that `--root` is ignored
+- **AND** it does not exit with `unexpected argument`
+
+### Requirement: The parser SHALL be testable without process exit
+
+Argument parsing SHALL be available as a pure function returning parsed options and an error, so that every invocation form can be asserted in a unit test without spawning a subprocess.
+
+#### Scenario: Invalid input returns an error rather than exiting
+
+- **WHEN** the parser is called directly with an unrecognized flag
+- **THEN** it returns an error describing the flag
+- **AND** it does not terminate the process
+
+### Requirement: Workspace registration SHALL reject a root that cannot be indexed
+
+`POST /api/v1/init` SHALL reject a `root_path` that does not exist, is not a directory, or cannot be read, with a distinct message for each case. Validation SHALL occur at the handler so that the CLI, the interactive wizard, MCP tools, and direct API callers are all covered.
+
+#### Scenario: Nonexistent path is rejected
+
+- **WHEN** a client registers a `root_path` that does not exist on the daemon's filesystem
+- **THEN** the request fails with a client error naming the path and stating that it does not exist
+- **AND** no workspace and no collections are created
+
+#### Scenario: Regular file is rejected
+
+- **WHEN** a client registers a `root_path` that resolves to a regular file
+- **THEN** the request fails with a client error stating that the path is not a directory
+
+#### Scenario: Unreadable directory is rejected
+
+- **WHEN** a client registers a `root_path` that is a directory the daemon cannot read
+- **THEN** the request fails with a client error stating that the directory cannot be read
+
+#### Scenario: Relative path is stored absolute
+
+- **WHEN** a client registers `--root=.`
+- **THEN** the registered workspace root is the absolute resolved path
+
+#### Scenario: Remote daemon rejects a local-only path
+
+- **WHEN** a developer runs `init --root <path>` against a remote daemon and the path exists only on the developer's machine
+- **THEN** the request is rejected with the nonexistent-path error rather than registering a workspace the daemon can never index

--- a/openspec/changes/fix-install-ux-regressions/specs/cli-usage-parity/spec.md
+++ b/openspec/changes/fix-install-ux-regressions/specs/cli-usage-parity/spec.md
@@ -1,0 +1,66 @@
+# cli-usage-parity Specification
+
+## Purpose
+
+The command dispatcher, `nano-brain help`, and the agent-facing command table must never disagree about which commands exist. Drift in either direction is a silent failure: an undocumented command is undiscoverable, and a documented-but-absent command makes an agent fail with `Unknown command`.
+
+## ADDED Requirements
+
+### Requirement: `printUsage()` SHALL document every dispatched command
+
+Every `case` label in the command-dispatch switch SHALL appear as a documented command in `printUsage()` output.
+
+#### Scenario: The service command is documented
+
+- **WHEN** the user runs `nano-brain help`
+- **THEN** the output contains a `service` command line describing the managed-service subcommands
+
+#### Scenario: Parity is enforced from the dispatcher, not a maintained list
+
+- **WHEN** the usage-parity test runs
+- **THEN** its expected command set is derived by parsing the dispatch switch in `cmd/nano-brain/main.go`
+- **AND** adding a new `case` to that switch without adding a usage line causes the test to fail
+
+#### Scenario: Matching is anchored to the command column
+
+- **WHEN** the usage-parity test checks for a command named `get`
+- **THEN** it matches only a usage line whose command column is exactly `get`
+- **AND** it does not pass merely because `multi-get` appears in the output
+
+### Requirement: `printUsage()` SHALL NOT document commands that are not dispatched
+
+Every command documented in `printUsage()` SHALL have a corresponding `case` label in the dispatch switch.
+
+#### Scenario: A removed command cannot stay documented
+
+- **WHEN** a command is deleted from the dispatch switch but left in `printUsage()`
+- **THEN** the usage-parity test fails
+
+### Requirement: The agent-facing command table SHALL only name dispatched commands
+
+The command table in root `SKILL.md` SHALL NOT list a command that the dispatcher does not accept.
+
+#### Scenario: Phantom commands are removed
+
+- **WHEN** the skill command table is checked against the dispatch switch
+- **THEN** `update`, `embed`, `focus`, `graph-stats`, `symbols`, and `impact` are absent from the table, because no dispatch case exists for any of them
+
+#### Scenario: An agent following the skill does not hit an unknown command
+
+- **WHEN** an agent executes every command listed in the skill's command table
+- **THEN** none of them exits with `Unknown command`
+
+### Requirement: The install path SHALL recommend the supervised service, not only reference it
+
+On a platform where the managed-service backend is usable, the setup wizard and the start-command suggestion SHALL surface `nano-brain service install` rather than presenting the unsupervised `serve -d` as the only option.
+
+#### Scenario: Wizard offers the supervised option
+
+- **WHEN** the interactive wizard reaches its serve step on a platform whose service backend reports usable
+- **THEN** it offers or points at `nano-brain service install`
+- **AND** its closing summary tells the user whether the daemon will survive a reboot
+
+#### Scenario: Unsupported platform keeps the current behavior
+
+- **WHEN** the service backend reports not usable
+- **THEN** the wizard suggests `serve -d` exactly as before, with no mention of the service subcommand

--- a/openspec/changes/fix-install-ux-regressions/specs/logical-collection-isolation/spec.md
+++ b/openspec/changes/fix-install-ux-regressions/specs/logical-collection-isolation/spec.md
@@ -1,0 +1,66 @@
+# logical-collection-isolation Specification
+
+## Purpose
+
+`memory` and `sessions` are DB-backed namespaces whose documents carry identifiers rather than file paths. They must never be walked from disk, so the reindex orphan-deletion loop can never reach them, while remaining fully targetable by force-wipe and by every consumer that filters on the collection name.
+
+## ADDED Requirements
+
+### Requirement: Incremental reindex SHALL NOT walk logical collections
+
+`triggerIncremental` SHALL skip any collection named `memory` or `sessions` before calling `walkCollectionFiles`, regardless of whether that collection's `path` exists, is empty, or contains files.
+
+#### Scenario: Logical collection with a missing root produces no warning
+
+- **WHEN** an incremental reindex runs for a workspace whose `sessions` collection has `path = ~/.nano-brain/sessions` and that directory does not exist
+- **THEN** no `walk collection "sessions": root path inaccessible` warning is logged
+- **AND** the reindex response counts no scan, skip, or delete for that collection
+
+#### Scenario: Logical collection with a populated root deletes nothing
+
+- **WHEN** `~/.nano-brain/sessions` exists and contains one or more files, and the workspace has indexed `sessions` documents whose `source_path` values begin with `summary://`
+- **THEN** an incremental reindex deletes **zero** documents and **zero** chunks from that collection
+- **AND** no `disk walk returned empty for non-empty collection` warning is logged
+
+#### Scenario: Documents with an empty source path are not deletion-eligible
+
+- **WHEN** the `memory` collection contains documents whose `source_path` is the empty string, and `~/.nano-brain/memory` contains at least one file
+- **THEN** an incremental reindex deletes **zero** of those documents
+
+#### Scenario: The code collection is still walked
+
+- **WHEN** an incremental reindex runs for a workspace whose `code` collection root exists and contains files
+- **THEN** that collection is walked, scanned, and orphan-swept exactly as before this change
+
+### Requirement: Force-wipe SHALL still target logical collections
+
+`triggerForceWipe` SHALL continue to reset and re-enqueue chunks for `memory` and `sessions`. The walk exclusion applies only to the incremental path.
+
+#### Scenario: Force-wipe resets session chunks
+
+- **WHEN** a reindex is requested with force-wipe for a workspace holding `sessions` documents
+- **THEN** `ResetAndReturnChunkIDsByCollection` is called for the `sessions` collection
+- **AND** its chunks are re-enqueued for embedding
+
+### Requirement: Logical collection rows SHALL be registered unconditionally
+
+`POST /api/v1/init` SHALL create `memory`, `sessions`, and `code` collection rows for every workspace, independent of whether any of those directories exists. Registration SHALL NOT depend on filesystem state.
+
+#### Scenario: Registration is deterministic across machines
+
+- **WHEN** two machines register the same workspace root, one with `~/.nano-brain/memory` present and one without
+- **THEN** both produce the same three collection rows
+
+#### Scenario: Logical collection rows are never deleted by reindex
+
+- **WHEN** any reindex runs, incremental or force-wipe
+- **THEN** the `memory` and `sessions` collection rows still exist afterwards
+
+### Requirement: Logical collections SHALL NOT be attached to the filesystem watcher
+
+The post-init watcher attach list SHALL contain only disk-backed collections. `memory` and `sessions` SHALL NOT be watched at init time, matching the behavior already applied at daemon startup.
+
+#### Scenario: Init-time attach matches restart-time attach
+
+- **WHEN** a workspace is registered and the daemon is then restarted
+- **THEN** the set of watched collections is identical before and after the restart

--- a/openspec/changes/fix-install-ux-regressions/specs/npm-install-fallback/spec.md
+++ b/openspec/changes/fix-install-ux-regressions/specs/npm-install-fallback/spec.md
@@ -1,0 +1,84 @@
+# npm-install-fallback Specification
+
+## Purpose
+
+When the npm postinstall runs at a version with no matching release asset — a source checkout at the `0.0.0-dev` placeholder, or any prerelease string — it must tell the user what it tried and what to do instead, rather than surfacing a bare HTTP status. Integrity enforcement must survive the change untouched.
+
+## ADDED Requirements
+
+### Requirement: Tag planning SHALL be an exported pure function
+
+The logic that turns a package version into candidate release tags SHALL be exported so it can be unit-tested without performing any network request.
+
+#### Scenario: Planner is callable from a test
+
+- **WHEN** a test imports the postinstall module
+- **THEN** the tag planner is available on the module exports
+- **AND** calling it performs no network access
+
+#### Scenario: Release version resolves on the first candidate
+
+- **WHEN** the planner is called with a published version whose patch segment is four digits
+- **THEN** the first candidate tag is the canonical `v<version>` form
+
+#### Scenario: Short-patch version yields a zero-padded candidate
+
+- **WHEN** the planner is called with a version whose patch segment is one to three digits
+- **THEN** the candidate list also contains the zero-padded four-digit reconstruction
+
+#### Scenario: Placeholder version yields no usable candidate
+
+- **WHEN** the planner is called with `0.0.0-dev`
+- **THEN** it reports that no release tag can be derived from that version
+
+### Requirement: An unresolvable version SHALL produce actionable guidance
+
+When no candidate tag and no API-resolved tag yields a downloadable asset, postinstall SHALL report the tags it attempted and name the supported alternatives: the one-line installer, the `NANO_BRAIN_BIN` override, and building from source.
+
+#### Scenario: Source-checkout install explains itself
+
+- **WHEN** postinstall runs with the package version set to the on-master placeholder
+- **THEN** the failure message names the tags that were tried
+- **AND** it names the installer script, the binary-override environment variable, and the source build as alternatives
+- **AND** it does not present the failure as an unexplained HTTP status
+
+#### Scenario: The diagnostic never recommends skipping verification
+
+- **WHEN** any postinstall failure message is produced
+- **THEN** it does not mention the checksum-skip environment variable as a workaround
+
+#### Scenario: The lazy first-invocation path shows the same guidance
+
+- **WHEN** the binary is missing and the npm wrapper triggers a download that cannot resolve a tag
+- **THEN** the wrapper prints the same actionable message rather than a bare error
+
+### Requirement: Integrity enforcement SHALL remain hard-failing
+
+A checksum mismatch SHALL continue to delete the downloaded file, propagate as a security failure without being folded into any aggregated diagnostic, and exit non-zero.
+
+#### Scenario: Checksum mismatch is not absorbed by the tag summary
+
+- **WHEN** a candidate tag downloads an asset whose SHA-256 does not match the published sums
+- **THEN** the process reports the security failure, removes the downloaded file, and exits non-zero
+- **AND** the failure is not reported as part of a "tags tried" summary
+- **AND** no further candidate tag is attempted
+
+#### Scenario: API-fallback integrity failure also hard-fails
+
+- **WHEN** the API-resolved tag downloads an asset failing checksum verification
+- **THEN** the security failure propagates and the process exits non-zero
+
+### Requirement: The npm test suite SHALL run in continuous integration
+
+The repository CI workflow SHALL execute the Node test suite, so that postinstall regressions are caught before merge.
+
+#### Scenario: CI runs the Node tests
+
+- **WHEN** the CI workflow runs on a pull request
+- **THEN** it executes the Node test suite under `npm/`
+- **AND** a failing postinstall test fails the build
+
+#### Scenario: Tests need no network or published release
+
+- **WHEN** the Node test suite runs on a machine with no network access
+- **THEN** every postinstall test passes or fails on its own logic, with no assertion depending on a live release download

--- a/openspec/changes/fix-install-ux-regressions/tasks.md
+++ b/openspec/changes/fix-install-ux-regressions/tasks.md
@@ -1,0 +1,70 @@
+# Tasks — fix-install-ux-regressions
+
+Ordered by dependency. Group 1 closes the data-loss path and goes first.
+
+## 1. Logical-collection isolation
+
+- [x] 1.1 Add a reserved-name helper identifying `memory` and `sessions` as logical (DB-backed) collections, in `internal/server/handlers/reindex.go`.
+- [x] 1.2 Guard the top of the `for _, col := range targets` body in `triggerIncremental` (`internal/server/handlers/reindex.go:154`) to `continue` for logical collections, before `walkCollectionFiles` is called. Do not touch `collectionsToReindex` and do not touch `triggerForceWipe`.
+- [x] 1.3 Drop `memory` and `sessions` from the hardcoded `colSpec` watcher-attach list at `internal/server/handlers/workspace.go:171-176` so init-time attach matches the startup skip at `cmd/nano-brain/main.go:532`.
+- [x] 1.4 Add a regression test: a collection with a valid, non-empty root whose indexed documents carry `summary://…` source paths deletes **zero** documents on incremental reindex. This is the test that would have caught the trap.
+- [x] 1.5 Add a test asserting incremental reindex on a workspace with a missing `sessions` root logs neither `root path inaccessible` nor `disk walk returned empty for non-empty collection`.
+- [x] 1.6 Add a test asserting force-wipe still calls `ResetAndReturnChunkIDsByCollection` for `sessions`.
+- [x] 1.7 Verify `internal/server/handlers/workspace_test.go:215-262` still passes unmodified — registration behavior must be unchanged.
+- [x] 1.8 Add a release note: operators must not create `~/.nano-brain/memory` or `~/.nano-brain/sessions`, and must not otherwise make those roots walkable.
+
+## 2. Root validation at the registration handler
+
+- [x] 2.1 In `internal/server/handlers/workspace.go`, after `filepath.Abs` and before `WorkspaceHash`, reject a `root_path` that fails `os.Stat`, is not a directory, or cannot be read — with a distinct message per case.
+- [x] 2.2 Add handler tests for nonexistent path, regular file, and unreadable directory, each asserting the status code and the message.
+- [x] 2.3 Add a test asserting a relative root is stored as its absolute resolved form.
+- [x] 2.4 Document the `POST /api/v1/init` contract change (200 → 400 for unusable roots) in the release note, calling out the remote-daemon topology explicitly.
+
+## 3. `init` argument parsing
+
+- [ ] 3.1 Extract `parseInitArgs(args) (initOpts, error)` from `cmd/nano-brain/commands.go`, handling `--`, `--yes`, `--root`, `--workspace`, `--json`, `--force` in one pass, accepting both `--flag value` and `--flag=value`. Copy the dual-form shape already used at `cmd/nano-brain/cmd_reset_embeddings.go:27-41`.
+- [ ] 3.2 Replace the two-pass structure at `commands.go:19-40` and `:70-96` with a single call to the new parser; keep `os.Exit` at the call site only.
+- [ ] 3.3 Add a table-driven `TestParseInitArgs` covering every form in the spec, including `-- opencode` and `--yes --root <path>`.
+- [ ] 3.4 Verify `nano-brain init --root=<path>` — the form documented in `SKILL.md:56`, `docs/SETUP_AGENT.md:279,410`, and `CHANGELOG.md:541` — now succeeds.
+
+## 4. Usage parity
+
+- [ ] 4.1 Normalize the three-space indentation at `cmd/nano-brain/ops.go:576-584` to two spaces so a column matcher can be strict.
+- [ ] 4.2 Add a `service` line to `printUsage()` describing the managed-service subcommands.
+- [ ] 4.3 Rewrite `cmd/nano-brain/ops_usage_test.go` to derive its expected set by parsing the dispatch switch in `cmd/nano-brain/main.go` with `go/parser`, replacing the hand-maintained `dispatchedCommands` slice.
+- [ ] 4.4 Replace the `strings.Contains` assertion with a command-column match, and add the reverse assertion: every documented command is dispatched.
+- [ ] 4.5 Verify the rewritten test fails when `service` is removed from `printUsage()`, and fails when a fake `case "zzz":` is added to the dispatch switch.
+
+## 5. Skill command table
+
+- [ ] 5.1 Remove `update`, `embed`, `focus`, `graph-stats`, `symbols`, and `impact` from the command table in root `SKILL.md`. `git log -S` confirms none was ever implemented, so this is a docs correction, not a removal of shipped behavior.
+- [ ] 5.2 Correct the `--root=<path>` row's description — it registers or re-registers a workspace; it does not "re-index a workspace".
+- [ ] 5.3 Add a check that the skill command table names only dispatched commands, runnable in CI.
+- [ ] 5.4 Align the package name used in skill examples with the scoped form used by `README.md:68` and `cmd/nano-brain/client_helpers.go:69`.
+
+## 6. Service recommendation path
+
+- [ ] 6.1 In the interactive wizard's serve step (`cmd/nano-brain/init_serve.go`), offer `nano-brain service install` when the platform service backend reports usable; fall back to the current `serve -d` suggestion otherwise.
+- [ ] 6.2 Extend the wizard's closing summary (`cmd/nano-brain/init.go:206-214`) to state whether the daemon will survive a reboot.
+- [ ] 6.3 Extend `TestSuggestStartCommand` (`cmd/nano-brain/commands_test.go:284`) and `TestRunInteractiveInit_Summary` (`cmd/nano-brain/init_test.go:336`) to assert the supervised option is surfaced on a service-capable platform and absent otherwise.
+
+## 7. npm diagnostic
+
+- [ ] 7.1 Extract and export `planDownload(version, assetName)` from `npm/postinstall.js`, returning the candidate tags and the guidance message.
+- [ ] 7.2 Detect a version from which no release tag can be derived before attempting any download, and emit the guidance message naming the installer script, `NANO_BRAIN_BIN`, and the source build.
+- [ ] 7.3 Preserve every integrity path unchanged: the unwrapped `SECURITY:` rethrow inside the candidate loop, the deliberately unwrapped API-fallback attempt, `safeUnlink` on mismatch, and the non-zero exit. No `SECURITY:` error may be folded into the tags-tried summary.
+- [ ] 7.4 Ensure the guidance never mentions the checksum-skip environment variable.
+- [ ] 7.5 Verify `npm/run.js`'s lazy first-invocation path prints the new message, and update `npm/run.test.js` accordingly.
+- [ ] 7.6 Add offline tests to `npm/postinstall.test.js` for the placeholder version, a short-patch version, a canonical four-digit-patch version, and a checksum mismatch that must still hard-fail.
+
+## 8. CI
+
+- [ ] 8.1 Add a Node job to `.github/workflows/ci.yml` running `node --test npm/`.
+- [ ] 8.2 Confirm the job fails the build when a postinstall test fails, and that no test depends on network access or a published release.
+
+## 9. Validation
+
+- [ ] 9.1 `go build ./...` and `go test -race -count=1 ./...` pass.
+- [ ] 9.2 `node --test npm/` passes locally and in CI.
+- [ ] 9.3 `openspec validate fix-install-ux-regressions --strict` passes.
+- [ ] 9.4 Manually verify on a live daemon: register a fresh workspace, run an incremental reindex, and confirm the logs contain neither collection warning and that `sessions`/`memory` document counts are unchanged.


### PR DESCRIPTION
## Summary
- `memory` and `sessions` are DB-backed collections whose documents carry synthetic (`summary://...`) or empty `source_path`, never real files. Incremental reindex previously walked their nominal filesystem roots as if they held real files — if either root existed and contained even one file, the orphan-deletion pass would delete every indexed document in that collection.
- Adds `isLogicalCollection()` to skip `memory`/`sessions` in the reindex walk and orphan-deletion loop, and drops them from the watcher-attach list at init time (matching daemon-startup behavior, which already skips a nonexistent path).
- `POST /api/v1/init` now validates `root_path` (rejects nonexistent/non-directory/unreadable paths with 400) instead of registering a permanently-empty collection.
- `POST /api/v1/collections` and the rename endpoint now reject `memory`/`sessions` as a collection name, closing a name-collision gap found during review: a disk-backed collection created or renamed to one of those reserved names would otherwise be silently skipped by future incremental reindex.

## Status
This is a **WIP snapshot** of Group 1+2 from `openspec/changes/fix-install-ux-regressions/tasks.md`. Groups 3-8 (CLI init flag parsing, usage-parity test, skill command table, service-install recommendation, npm postinstall diagnostic, CI) are not yet implemented.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -short ./...` — full suite passes
- [x] New regression tests: logical-collection skip, missing-root no-warning, force-wipe still targets `sessions`, root-path validation (nonexistent/file/unreadable/relative), reserved-name rejection on add + rename
- [x] `/simplify` pass (4 reviewers: reuse/simplification/efficiency/altitude) applied
- [x] Independent code-review pass (correctness) applied — found and fixed the reserved-name collision gap above