### PR TITLE
fix(release): use env: block for GOOS/GOARCH/CGO_ENABLED so Windows PowerShell can parse the build command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,18 @@ jobs:
           go-version: "1.23"
 
       - name: Build
-        run: CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -X main.Version=${{ github.ref_name }}" -o nano-brain-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/nano-brain
+        # Env vars live in `env:` (not as command-prefix `VAR=value`) so the
+        # step works on every runner shell — bash/zsh on Linux/macOS and
+        # PowerShell 7 on windows-latest. PowerShell doesn't recognize
+        # bash-style `FOO=bar command` syntax and rejects the prefix
+        # (`The term 'CGO_ENABLED=0' is not recognized…`), which made the
+        # matrix windows entries added in #638 fail with exit 1 (#638
+        # follow-up).
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -ldflags="-s -w -X main.Version=${{ github.ref_name }}" -o nano-brain-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/nano-brain
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Intent

Follow-up to #638 — the Windows build matrix entries added in that PR failed because `windows-latest` defaults to PowerShell 7, which doesn't parse the bash-style `CGO_ENABLED=0 GOOS=... go build` env-var prefix:

```
The term 'CGO_ENABLED=0' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

This cancelled the entire build matrix and skipped the `release` + `npm-publish` jobs. The first release run for `v2026.9.0701` (auto-tagged right after merging #638) produced no binaries and no npm publish.

## Lane

tiny — single-step env-var syntax change, no behavior change on existing platforms.

## Change Type

bug-fix

## Fix

Move `CGO_ENABLED`, `GOOS`, `GOARCH` from the bash-style command prefix into the Build step's `env:` block. This works identically on bash/zsh (Linux/macOS) and PowerShell 7 (Windows).

## Validation

```
$ gh run view 34110059544 --log-failed
build (windows-latest, windows, amd64, .exe)  Build  ...
  CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ...
              ~~~~~~~~~~~~~
              The term 'CGO_ENABLED=0' is not recognized ...
```

After the fix, the YAML renders correctly:
```
Build step env: {'CGO_ENABLED': '0', 'GOOS': '${{ matrix.goos }}', 'GOARCH': '${{ matrix.goarch }}'}
Build step run: go build -ldflags=... -o nano-brain-... ... ./cmd/nano-brain
```

## Acceptance Criteria

- [ ] `v2026.9.0702` (or whichever tag this commit gets) release run completes all 6 matrix entries
- [ ] GitHub Release `v2026.9.0701` is deleted (or left alone, no binaries inside); the next auto-tag publishes the missing Windows binaries + npm package

## Progress

- [x] Feature Intake (follow-up of #638, not new issue — same root cause)
- [x] Implementation
- [ ] PR opened + merged
- [ ] Release pipeline verified (Windows binaries published, npm tag bumped)
