### PR TITLE
ci(manual-publish): bump package.json to tag version + add debug step

### DIFF
--- a/.github/workflows/manual-npm-publish.yml
+++ b/.github/workflows/manual-npm-publish.yml
@@ -1,0 +1,84 @@
+name: Manual npm publish
+
+# One-off workflow to publish a specific git tag to npm. Used when the
+# automatic release.yml npm-publish job fails (npm 11.x OIDC 404 against
+# classic NPM_TOKEN — see #213 and PR #639 follow-up).
+#
+# Trigger: Actions tab → "Manual npm publish" → Run workflow →
+#   tag: v{YYYY}.{M}.{DDNN} (e.g. v2026.9.0702)
+#
+# This workflow:
+#  - Pins Node 22 (npm 10.x) to avoid the npm 11 OIDC auto-detect 404
+#  - Bumps package.json to the requested tag's version (auto-tag bumps in
+#    place but never commits — release.yml re-bumps from $GITHUB_REF_NAME)
+#  - Publishes @nano-step/nano-brain (scoped) and nano-brain (unscoped alias)
+#  - Never auto-runs — `workflow_dispatch` only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v2026.9.0702)"
+        required: true
+        type: string
+        default: "v2026.9.0702"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Resolve the workflow input tag to its commit. The tag itself
+          # points to a master HEAD commit that has package.json version
+          # "0.0.0-dev" (auto-tag bumps in place but does NOT commit —
+          # see .github/workflows/auto-tag.yml "Bump package.json to match
+          # tag (no commit)"). We re-bump below.
+          ref: ${{ inputs.tag }}
+
+      # Pin Node 22 (npm 10.x) to avoid the npm 11.x OIDC auto-detect 404
+      # bug that breaks classic NPM_TOKEN publish (#213, actions/setup-node
+      # #1551, npm/cli#8730).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
+      - name: Bump package.json to match tag version
+        # `npm version` strips leading zeros from numeric semver components
+        # (the tag's 4-digit patch {DDNN} becomes the published version's
+        # 3-segment semver with the day/run numbers collapsed). This is
+        # the same transform release.yml applies.
+        run: npm version --no-git-tag-version "${TAG#v}"
+        env:
+          TAG: ${{ inputs.tag }}
+
+      - name: Debug: confirm auth + version state
+        run: |
+          echo "node: $(node -v)"
+          echo "npm:  $(npm -v)"
+          echo "tag:  ${{ inputs.tag }}"
+          echo "published version: $(node -e "console.log(require('./package.json').version)")"
+          echo "registry: $(npm config get registry)"
+          echo "---npmrc---"
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            cat "$NPM_CONFIG_USERCONFIG"
+          fi
+          echo "---/npmrc---"
+
+      - name: Publish @nano-step/nano-brain
+        run: npm publish --tag latest --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish nano-brain (unscoped alias)
+        run: |
+          node -e "const p=require('./package.json'); p.name='nano-brain'; delete p.publishConfig; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          npm publish --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Intent

Iteration on PR #640 — the first manual-publish attempt checked out the tag but `package.json` still had `0.0.0-dev`. The 404 happened with a misleading message (`'@nano-step/nano-brain@0.0.0-dev' is not in this registry.`) that obscured the real issue. Auto-tag bumps `package.json` in place but **does not commit** (`.github/workflows/auto-tag.yml` step "Bump package.json to match tag (no commit)"), so the tag points at a commit whose `package.json` is unchanged. release.yml re-bumps from `$GITHUB_REF_NAME` — my v1 manual workflow was missing that step.

## Change

- Add `npm version --no-git-tag-version "${TAG#v}"` step (same transform release.yml uses; collapses the tag's 4-digit `{DD}{NN}` patch into npm's 3-segment semver with leading-zero stripping).
- Add a debug step that prints `node -v`, `npm -v`, registry URL, the final published version, and the .npmrc contents so the next failure has visible state instead of a bare 404.

## Lane

tiny — single workflow file update.

## Acceptance

- [ ] Manual publish `v2026.9.0702` succeeds
- [ ] `npm view @nano-step/nano-brain@2026.9.702` returns 200
- [ ] `npm view nano-brain@2026.9.702` returns 200
- [ ] Both contain the Windows-aware `npm/postinstall.js` (`PLATFORM_MAP` has `win32: "windows"`)

## Progress

- [x] Implementation
- [ ] PR opened + merged
- [ ] Manual publish run, npm registry verified
